### PR TITLE
Extensible erasure with the `erasable` attribute

### DIFF
--- a/examples/micro-benchmarks/Erasable.fst
+++ b/examples/micro-benchmarks/Erasable.fst
@@ -1,0 +1,26 @@
+module Erasable
+
+[@erasable]
+type t =
+  | This of int
+  | That of bool
+
+[@(expect_failure [34])]
+let test0_fail (x:t) : Tot int =
+  match x with
+  | This i -> i
+  | That _ -> 0
+
+let test (x:t) : GTot int =
+  match x with
+  | This i -> i
+  | That _ -> 0
+
+[@(expect_failure [34])]
+let test1_fail (x:t{This? x}) : Tot int = This?._0 x
+let test1 (x:t{This? x}) : GTot int = This?._0 x
+
+let test_promotion (x:t) : Tot t =
+  match x with
+  | This i -> This (-i)
+  | That b -> That (not b)

--- a/examples/micro-benchmarks/Erasable.ml.expected
+++ b/examples/micro-benchmarks/Erasable.ml.expected
@@ -1,0 +1,7 @@
+open Prims
+
+
+
+
+
+

--- a/examples/micro-benchmarks/Makefile
+++ b/examples/micro-benchmarks/Makefile
@@ -32,7 +32,7 @@ all-pos: Unit1.Basic.uver Unit1.Projectors2.uver Unit1.WPsAndTriples.uver Unit1.
 	 OccursCheckOnArrows.uver Test.Integers.uver AnotType.uver Test.ReifyNBE.uver TestHasEq.uver \
 	 PatAnnot.uver TupleSyntax.uver Test.FunctionalExtensionality.uver ArgsAndQuals.uver Test.Printf.uver \
 	 MustEraseForExtraction.uver UnifyReify.uver NestedLemma.uver NormTypesForSMT.uver \
-	 StrictUnfolding.uver GhostImplicits.uver
+	 StrictUnfolding.uver GhostImplicits.uver Erasable.ml
 
 basictests: $(VERFILES)
 	$(FSTAR) --explicit_deps $(STDLIB) $(call add_stdlib_prefix, FStar.Int32.fst) $^
@@ -45,3 +45,7 @@ inverse:
 
 testghost:
 	$(FSTAR) testghost.fst
+
+Erasable.ml: Erasable.fst
+	$(FSTAR) --codegen OCaml --extract Erasable $^
+	cmp $@ $@.expected

--- a/src/ocaml-output/FStar_Const.ml
+++ b/src/ocaml-output/FStar_Const.ml
@@ -1,7 +1,7 @@
 open Prims
 type signedness =
   | Unsigned 
-  | Signed [@@deriving yojson,show]
+  | Signed [@@deriving yojson,show,yojson,show]
 let (uu___is_Unsigned : signedness -> Prims.bool) =
   fun projectee  ->
     match projectee with | Unsigned  -> true | uu____8 -> false
@@ -14,7 +14,7 @@ type width =
   | Int8 
   | Int16 
   | Int32 
-  | Int64 [@@deriving yojson,show]
+  | Int64 [@@deriving yojson,show,yojson,show]
 let (uu___is_Int8 : width -> Prims.bool) =
   fun projectee  -> match projectee with | Int8  -> true | uu____30 -> false 
 let (uu___is_Int16 : width -> Prims.bool) =
@@ -39,7 +39,7 @@ type sconst =
   | Const_set_range_of 
   | Const_range of FStar_Range.range 
   | Const_reify 
-  | Const_reflect of FStar_Ident.lid [@@deriving yojson,show]
+  | Const_reflect of FStar_Ident.lid [@@deriving yojson,show,yojson,show]
 let (uu___is_Const_effect : sconst -> Prims.bool) =
   fun projectee  ->
     match projectee with | Const_effect  -> true | uu____144 -> false

--- a/src/ocaml-output/FStar_Extraction_ML_Modul.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Modul.ml
@@ -894,25 +894,32 @@ let (extract_bundle_iface :
            | (env1,ctor) -> (env1, (iface_of_bindings [ctor])))
       | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____2415),quals) ->
           let uu____2429 =
-            bundle_as_inductive_families env ses quals
-              se.FStar_Syntax_Syntax.sigattrs
+            FStar_Syntax_Util.has_attribute se.FStar_Syntax_Syntax.sigattrs
+              FStar_Parser_Const.erasable_attr
              in
-          (match uu____2429 with
-           | (env1,ifams) ->
-               let uu____2446 =
-                 FStar_Util.fold_map extract_one_family env1 ifams  in
-               (match uu____2446 with
-                | (env2,td) ->
-                    let uu____2487 =
-                      let uu____2488 =
-                        let uu____2489 =
-                          FStar_List.map (fun x  -> x.ifv) ifams  in
-                        iface_of_type_names uu____2489  in
-                      iface_union uu____2488
-                        (iface_of_bindings (FStar_List.flatten td))
-                       in
-                    (env2, uu____2487)))
-      | uu____2498 -> failwith "Unexpected signature element"
+          if uu____2429
+          then (env, empty_iface)
+          else
+            (let uu____2438 =
+               bundle_as_inductive_families env ses quals
+                 se.FStar_Syntax_Syntax.sigattrs
+                in
+             match uu____2438 with
+             | (env1,ifams) ->
+                 let uu____2455 =
+                   FStar_Util.fold_map extract_one_family env1 ifams  in
+                 (match uu____2455 with
+                  | (env2,td) ->
+                      let uu____2496 =
+                        let uu____2497 =
+                          let uu____2498 =
+                            FStar_List.map (fun x  -> x.ifv) ifams  in
+                          iface_of_type_names uu____2498  in
+                        iface_union uu____2497
+                          (iface_of_bindings (FStar_List.flatten td))
+                         in
+                      (env2, uu____2496)))
+      | uu____2507 -> failwith "Unexpected signature element"
   
 let (extract_type_declaration :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -930,29 +937,29 @@ let (extract_type_declaration :
         fun attrs  ->
           fun univs1  ->
             fun t  ->
-              let uu____2573 =
-                let uu____2575 =
+              let uu____2582 =
+                let uu____2584 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_some
-                       (fun uu___6_2581  ->
-                          match uu___6_2581 with
+                       (fun uu___6_2590  ->
+                          match uu___6_2590 with
                           | FStar_Syntax_Syntax.Assumption  -> true
-                          | uu____2584 -> false))
+                          | uu____2593 -> false))
                    in
-                Prims.op_Negation uu____2575  in
-              if uu____2573
+                Prims.op_Negation uu____2584  in
+              if uu____2582
               then (g, empty_iface, [])
               else
-                (let uu____2599 = FStar_Syntax_Util.arrow_formals t  in
-                 match uu____2599 with
-                 | (bs,uu____2623) ->
+                (let uu____2608 = FStar_Syntax_Util.arrow_formals t  in
+                 match uu____2608 with
+                 | (bs,uu____2632) ->
                      let fv =
                        FStar_Syntax_Syntax.lid_as_fv lid
                          FStar_Syntax_Syntax.delta_constant
                          FStar_Pervasives_Native.None
                         in
                      let lb =
-                       let uu____2646 =
+                       let uu____2655 =
                          FStar_Syntax_Util.abs bs FStar_Syntax_Syntax.t_unit
                            FStar_Pervasives_Native.None
                           in
@@ -962,7 +969,7 @@ let (extract_type_declaration :
                          FStar_Syntax_Syntax.lbtyp = t;
                          FStar_Syntax_Syntax.lbeff =
                            FStar_Parser_Const.effect_Tot_lid;
-                         FStar_Syntax_Syntax.lbdef = uu____2646;
+                         FStar_Syntax_Syntax.lbdef = uu____2655;
                          FStar_Syntax_Syntax.lbattrs = attrs;
                          FStar_Syntax_Syntax.lbpos =
                            (t.FStar_Syntax_Syntax.pos)
@@ -982,18 +989,18 @@ let (extract_reifiable_effect :
           FStar_Syntax_Syntax.lid_as_fv lid
             FStar_Syntax_Syntax.delta_equational FStar_Pervasives_Native.None
            in
-        let uu____2709 =
+        let uu____2718 =
           FStar_Extraction_ML_UEnv.extend_fv' g1 fv ml_name tysc false false
            in
-        match uu____2709 with
+        match uu____2718 with
         | (g2,mangled_name,exp_binding) ->
-            ((let uu____2731 =
+            ((let uu____2740 =
                 FStar_All.pipe_left
                   (FStar_TypeChecker_Env.debug
                      g2.FStar_Extraction_ML_UEnv.env_tcenv)
                   (FStar_Options.Other "ExtractionReify")
                  in
-              if uu____2731
+              if uu____2740
               then FStar_Util.print1 "Mangled name: %s\n" mangled_name
               else ());
              (let lb =
@@ -1011,80 +1018,80 @@ let (extract_reifiable_effect :
                    (FStar_Extraction_ML_Syntax.NonRec, [lb])))))
          in
       let rec extract_fv tm =
-        (let uu____2767 =
+        (let uu____2776 =
            FStar_All.pipe_left
              (FStar_TypeChecker_Env.debug
                 g.FStar_Extraction_ML_UEnv.env_tcenv)
              (FStar_Options.Other "ExtractionReify")
             in
-         if uu____2767
+         if uu____2776
          then
-           let uu____2772 = FStar_Syntax_Print.term_to_string tm  in
-           FStar_Util.print1 "extract_fv term: %s\n" uu____2772
+           let uu____2781 = FStar_Syntax_Print.term_to_string tm  in
+           FStar_Util.print1 "extract_fv term: %s\n" uu____2781
          else ());
-        (let uu____2777 =
-           let uu____2778 = FStar_Syntax_Subst.compress tm  in
-           uu____2778.FStar_Syntax_Syntax.n  in
-         match uu____2777 with
-         | FStar_Syntax_Syntax.Tm_uinst (tm1,uu____2786) -> extract_fv tm1
+        (let uu____2786 =
+           let uu____2787 = FStar_Syntax_Subst.compress tm  in
+           uu____2787.FStar_Syntax_Syntax.n  in
+         match uu____2786 with
+         | FStar_Syntax_Syntax.Tm_uinst (tm1,uu____2795) -> extract_fv tm1
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              let mlp =
                FStar_Extraction_ML_Syntax.mlpath_of_lident
                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                 in
-             let uu____2793 = FStar_Extraction_ML_UEnv.lookup_fv g fv  in
-             (match uu____2793 with
-              | { FStar_Extraction_ML_UEnv.exp_b_name = uu____2798;
-                  FStar_Extraction_ML_UEnv.exp_b_expr = uu____2799;
+             let uu____2802 = FStar_Extraction_ML_UEnv.lookup_fv g fv  in
+             (match uu____2802 with
+              | { FStar_Extraction_ML_UEnv.exp_b_name = uu____2807;
+                  FStar_Extraction_ML_UEnv.exp_b_expr = uu____2808;
                   FStar_Extraction_ML_UEnv.exp_b_tscheme = tysc;
-                  FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____2801;_} ->
-                  let uu____2804 =
+                  FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____2810;_} ->
+                  let uu____2813 =
                     FStar_All.pipe_left
                       (FStar_Extraction_ML_Syntax.with_ty
                          FStar_Extraction_ML_Syntax.MLTY_Top)
                       (FStar_Extraction_ML_Syntax.MLE_Name mlp)
                      in
-                  (uu____2804, tysc))
-         | uu____2805 ->
-             let uu____2806 =
-               let uu____2808 =
+                  (uu____2813, tysc))
+         | uu____2814 ->
+             let uu____2815 =
+               let uu____2817 =
                  FStar_Range.string_of_range tm.FStar_Syntax_Syntax.pos  in
-               let uu____2810 = FStar_Syntax_Print.term_to_string tm  in
-               FStar_Util.format2 "(%s) Not an fv: %s" uu____2808 uu____2810
+               let uu____2819 = FStar_Syntax_Print.term_to_string tm  in
+               FStar_Util.format2 "(%s) Not an fv: %s" uu____2817 uu____2819
                 in
-             failwith uu____2806)
+             failwith uu____2815)
          in
       let extract_action g1 a =
-        (let uu____2838 =
+        (let uu____2847 =
            FStar_All.pipe_left
              (FStar_TypeChecker_Env.debug
                 g1.FStar_Extraction_ML_UEnv.env_tcenv)
              (FStar_Options.Other "ExtractionReify")
             in
-         if uu____2838
+         if uu____2847
          then
-           let uu____2843 =
+           let uu____2852 =
              FStar_Syntax_Print.term_to_string
                a.FStar_Syntax_Syntax.action_typ
               in
-           let uu____2845 =
+           let uu____2854 =
              FStar_Syntax_Print.term_to_string
                a.FStar_Syntax_Syntax.action_defn
               in
-           FStar_Util.print2 "Action type %s and term %s\n" uu____2843
-             uu____2845
+           FStar_Util.print2 "Action type %s and term %s\n" uu____2852
+             uu____2854
          else ());
-        (let uu____2850 = FStar_Extraction_ML_UEnv.action_name ed a  in
-         match uu____2850 with
+        (let uu____2859 = FStar_Extraction_ML_UEnv.action_name ed a  in
+         match uu____2859 with
          | (a_nm,a_lid) ->
              let lbname =
-               let uu____2870 =
+               let uu____2879 =
                  FStar_Syntax_Syntax.new_bv
                    (FStar_Pervasives_Native.Some
                       ((a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos))
                    FStar_Syntax_Syntax.tun
                   in
-               FStar_Util.Inl uu____2870  in
+               FStar_Util.Inl uu____2879  in
              let lb =
                FStar_Syntax_Syntax.mk_lb
                  (lbname, (a.FStar_Syntax_Syntax.action_univs),
@@ -1101,28 +1108,28 @@ let (extract_reifiable_effect :
                  FStar_Pervasives_Native.None
                  (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
                 in
-             let uu____2900 =
+             let uu____2909 =
                FStar_Extraction_ML_Term.term_as_mlexpr g1 action_lb  in
-             (match uu____2900 with
-              | (a_let,uu____2916,ty) ->
-                  ((let uu____2919 =
+             (match uu____2909 with
+              | (a_let,uu____2925,ty) ->
+                  ((let uu____2928 =
                       FStar_All.pipe_left
                         (FStar_TypeChecker_Env.debug
                            g1.FStar_Extraction_ML_UEnv.env_tcenv)
                         (FStar_Options.Other "ExtractionReify")
                        in
-                    if uu____2919
+                    if uu____2928
                     then
-                      let uu____2924 =
+                      let uu____2933 =
                         FStar_Extraction_ML_Code.string_of_mlexpr a_nm a_let
                          in
                       FStar_Util.print1 "Extracted action term: %s\n"
-                        uu____2924
+                        uu____2933
                     else ());
-                   (let uu____2929 =
+                   (let uu____2938 =
                       match a_let.FStar_Extraction_ML_Syntax.expr with
                       | FStar_Extraction_ML_Syntax.MLE_Let
-                          ((uu____2952,mllb::[]),uu____2954) ->
+                          ((uu____2961,mllb::[]),uu____2963) ->
                           (match mllb.FStar_Extraction_ML_Syntax.mllb_tysc
                            with
                            | FStar_Pervasives_Native.Some tysc ->
@@ -1130,77 +1137,77 @@ let (extract_reifiable_effect :
                                  tysc)
                            | FStar_Pervasives_Native.None  ->
                                failwith "No type scheme")
-                      | uu____2994 -> failwith "Impossible"  in
-                    match uu____2929 with
+                      | uu____3003 -> failwith "Impossible"  in
+                    match uu____2938 with
                     | (exp,tysc) ->
-                        ((let uu____3032 =
+                        ((let uu____3041 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug
                                  g1.FStar_Extraction_ML_UEnv.env_tcenv)
                               (FStar_Options.Other "ExtractionReify")
                              in
-                          if uu____3032
+                          if uu____3041
                           then
-                            ((let uu____3038 =
+                            ((let uu____3047 =
                                 FStar_Extraction_ML_Code.string_of_mlty a_nm
                                   (FStar_Pervasives_Native.snd tysc)
                                  in
                               FStar_Util.print1 "Extracted action type: %s\n"
-                                uu____3038);
+                                uu____3047);
                              FStar_List.iter
                                (fun x  ->
                                   FStar_Util.print1 "and binders: %s\n" x)
                                (FStar_Pervasives_Native.fst tysc))
                           else ());
-                         (let uu____3054 = extend_env g1 a_lid a_nm exp tysc
+                         (let uu____3063 = extend_env g1 a_lid a_nm exp tysc
                              in
-                          match uu____3054 with
+                          match uu____3063 with
                           | (env,iface1,impl) -> (env, (iface1, impl))))))))
          in
-      let uu____3076 =
-        let uu____3083 =
+      let uu____3085 =
+        let uu____3092 =
           extract_fv
             (FStar_Pervasives_Native.snd ed.FStar_Syntax_Syntax.return_repr)
            in
-        match uu____3083 with
+        match uu____3092 with
         | (return_tm,ty_sc) ->
-            let uu____3100 =
+            let uu____3109 =
               FStar_Extraction_ML_UEnv.monad_op_name ed "return"  in
-            (match uu____3100 with
+            (match uu____3109 with
              | (return_nm,return_lid) ->
                  extend_env g return_lid return_nm return_tm ty_sc)
          in
-      match uu____3076 with
+      match uu____3085 with
       | (g1,return_iface,return_decl) ->
-          let uu____3125 =
-            let uu____3132 =
+          let uu____3134 =
+            let uu____3141 =
               extract_fv
                 (FStar_Pervasives_Native.snd ed.FStar_Syntax_Syntax.bind_repr)
                in
-            match uu____3132 with
+            match uu____3141 with
             | (bind_tm,ty_sc) ->
-                let uu____3149 =
+                let uu____3158 =
                   FStar_Extraction_ML_UEnv.monad_op_name ed "bind"  in
-                (match uu____3149 with
+                (match uu____3158 with
                  | (bind_nm,bind_lid) ->
                      extend_env g1 bind_lid bind_nm bind_tm ty_sc)
              in
-          (match uu____3125 with
+          (match uu____3134 with
            | (g2,bind_iface,bind_decl) ->
-               let uu____3174 =
+               let uu____3183 =
                  FStar_Util.fold_map extract_action g2
                    ed.FStar_Syntax_Syntax.actions
                   in
-               (match uu____3174 with
+               (match uu____3183 with
                 | (g3,actions) ->
-                    let uu____3211 = FStar_List.unzip actions  in
-                    (match uu____3211 with
+                    let uu____3220 = FStar_List.unzip actions  in
+                    (match uu____3220 with
                      | (actions_iface,actions1) ->
-                         let uu____3238 =
+                         let uu____3247 =
                            iface_union_l (return_iface :: bind_iface ::
                              actions_iface)
                             in
-                         (g3, uu____3238, (return_decl :: bind_decl ::
+                         (g3, uu____3247, (return_decl :: bind_decl ::
                            actions1)))))
   
 let (extract_let_rec_types :
@@ -1213,55 +1220,55 @@ let (extract_let_rec_types :
   fun se  ->
     fun env  ->
       fun lbs  ->
-        let uu____3269 =
+        let uu____3278 =
           FStar_Util.for_some
             (fun lb  ->
-               let uu____3274 =
+               let uu____3283 =
                  FStar_Extraction_ML_Term.is_arity env
                    lb.FStar_Syntax_Syntax.lbtyp
                   in
-               Prims.op_Negation uu____3274) lbs
+               Prims.op_Negation uu____3283) lbs
            in
-        if uu____3269
+        if uu____3278
         then
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_ExtractionUnsupported,
               "Mutually recursively defined typed and terms cannot yet be extracted")
             se.FStar_Syntax_Syntax.sigrng
         else
-          (let uu____3297 =
+          (let uu____3306 =
              FStar_List.fold_left
-               (fun uu____3332  ->
+               (fun uu____3341  ->
                   fun lb  ->
-                    match uu____3332 with
+                    match uu____3341 with
                     | (env1,iface_opt,impls) ->
-                        let uu____3373 =
+                        let uu____3382 =
                           extract_let_rec_type env1
                             se.FStar_Syntax_Syntax.sigquals
                             se.FStar_Syntax_Syntax.sigattrs lb
                            in
-                        (match uu____3373 with
+                        (match uu____3382 with
                          | (env2,iface1,impl) ->
                              let iface_opt1 =
                                match iface_opt with
                                | FStar_Pervasives_Native.None  ->
                                    FStar_Pervasives_Native.Some iface1
                                | FStar_Pervasives_Native.Some iface' ->
-                                   let uu____3407 = iface_union iface' iface1
+                                   let uu____3416 = iface_union iface' iface1
                                       in
-                                   FStar_Pervasives_Native.Some uu____3407
+                                   FStar_Pervasives_Native.Some uu____3416
                                 in
                              (env2, iface_opt1, (impl :: impls))))
                (env, FStar_Pervasives_Native.None, []) lbs
               in
-           match uu____3297 with
+           match uu____3306 with
            | (env1,iface_opt,impls) ->
-               let uu____3447 = FStar_Option.get iface_opt  in
-               let uu____3448 =
+               let uu____3456 = FStar_Option.get iface_opt  in
+               let uu____3457 =
                  FStar_All.pipe_right (FStar_List.rev impls)
                    FStar_List.flatten
                   in
-               (env1, uu____3447, uu____3448))
+               (env1, uu____3456, uu____3457))
   
 let (extract_sigelt_iface :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1270,84 +1277,84 @@ let (extract_sigelt_iface :
   fun g  ->
     fun se  ->
       match se.FStar_Syntax_Syntax.sigel with
-      | FStar_Syntax_Syntax.Sig_bundle uu____3480 ->
+      | FStar_Syntax_Syntax.Sig_bundle uu____3489 ->
           extract_bundle_iface g se
-      | FStar_Syntax_Syntax.Sig_inductive_typ uu____3489 ->
+      | FStar_Syntax_Syntax.Sig_inductive_typ uu____3498 ->
           extract_bundle_iface g se
-      | FStar_Syntax_Syntax.Sig_datacon uu____3506 ->
+      | FStar_Syntax_Syntax.Sig_datacon uu____3515 ->
           extract_bundle_iface g se
       | FStar_Syntax_Syntax.Sig_declare_typ (lid,univs1,t) when
           FStar_Extraction_ML_Term.is_arity g t ->
-          let uu____3525 =
+          let uu____3534 =
             extract_type_declaration g lid se.FStar_Syntax_Syntax.sigquals
               se.FStar_Syntax_Syntax.sigattrs univs1 t
              in
-          (match uu____3525 with | (env,iface1,uu____3540) -> (env, iface1))
-      | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____3546) when
+          (match uu____3534 with | (env,iface1,uu____3549) -> (env, iface1))
+      | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____3555) when
           FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp ->
-          let uu____3555 =
+          let uu____3564 =
             extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
               se.FStar_Syntax_Syntax.sigattrs lb
              in
-          (match uu____3555 with | (env,iface1,uu____3570) -> (env, iface1))
-      | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____3576) when
+          (match uu____3564 with | (env,iface1,uu____3579) -> (env, iface1))
+      | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____3585) when
           FStar_Util.for_some
             (fun lb  ->
                FStar_Extraction_ML_Term.is_arity g
                  lb.FStar_Syntax_Syntax.lbtyp) lbs
           ->
-          let uu____3589 = extract_let_rec_types se g lbs  in
-          (match uu____3589 with | (env,iface1,uu____3604) -> (env, iface1))
+          let uu____3598 = extract_let_rec_types se g lbs  in
+          (match uu____3598 with | (env,iface1,uu____3613) -> (env, iface1))
       | FStar_Syntax_Syntax.Sig_declare_typ (lid,_univs,t) ->
           let quals = se.FStar_Syntax_Syntax.sigquals  in
-          let uu____3615 =
+          let uu____3624 =
             (FStar_All.pipe_right quals
                (FStar_List.contains FStar_Syntax_Syntax.Assumption))
               &&
-              (let uu____3621 =
+              (let uu____3630 =
                  FStar_TypeChecker_Util.must_erase_for_extraction
                    g.FStar_Extraction_ML_UEnv.env_tcenv t
                   in
-               Prims.op_Negation uu____3621)
+               Prims.op_Negation uu____3630)
              in
-          if uu____3615
+          if uu____3624
           then
-            let uu____3628 =
-              let uu____3639 =
-                let uu____3640 =
-                  let uu____3643 = always_fail lid t  in [uu____3643]  in
-                (false, uu____3640)  in
-              FStar_Extraction_ML_Term.extract_lb_iface g uu____3639  in
-            (match uu____3628 with
+            let uu____3637 =
+              let uu____3648 =
+                let uu____3649 =
+                  let uu____3652 = always_fail lid t  in [uu____3652]  in
+                (false, uu____3649)  in
+              FStar_Extraction_ML_Term.extract_lb_iface g uu____3648  in
+            (match uu____3637 with
              | (g1,bindings) -> (g1, (iface_of_bindings bindings)))
           else (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_let (lbs,uu____3669) ->
-          let uu____3674 = FStar_Extraction_ML_Term.extract_lb_iface g lbs
+      | FStar_Syntax_Syntax.Sig_let (lbs,uu____3678) ->
+          let uu____3683 = FStar_Extraction_ML_Term.extract_lb_iface g lbs
              in
-          (match uu____3674 with
+          (match uu____3683 with
            | (g1,bindings) -> (g1, (iface_of_bindings bindings)))
-      | FStar_Syntax_Syntax.Sig_main uu____3703 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____3704 ->
+      | FStar_Syntax_Syntax.Sig_main uu____3712 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____3713 ->
           (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_assume uu____3705 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_sub_effect uu____3712 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_effect_abbrev uu____3713 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_assume uu____3714 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_sub_effect uu____3721 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_effect_abbrev uu____3722 -> (g, empty_iface)
       | FStar_Syntax_Syntax.Sig_pragma p ->
           (FStar_Syntax_Util.process_pragma p se.FStar_Syntax_Syntax.sigrng;
            (g, empty_iface))
-      | FStar_Syntax_Syntax.Sig_splice uu____3728 ->
+      | FStar_Syntax_Syntax.Sig_splice uu____3737 ->
           failwith "impossible: trying to extract splice"
       | FStar_Syntax_Syntax.Sig_new_effect ed ->
-          let uu____3741 =
+          let uu____3750 =
             (FStar_TypeChecker_Env.is_reifiable_effect
                g.FStar_Extraction_ML_UEnv.env_tcenv
                ed.FStar_Syntax_Syntax.mname)
               && (FStar_List.isEmpty ed.FStar_Syntax_Syntax.binders)
              in
-          if uu____3741
+          if uu____3750
           then
-            let uu____3754 = extract_reifiable_effect g ed  in
-            (match uu____3754 with | (env,iface1,uu____3769) -> (env, iface1))
+            let uu____3763 = extract_reifiable_effect g ed  in
+            (match uu____3763 with | (env,iface1,uu____3778) -> (env, iface1))
           else (g, empty_iface)
   
 let (extract_iface' :
@@ -1356,34 +1363,34 @@ let (extract_iface' :
   =
   fun g  ->
     fun modul  ->
-      let uu____3791 = FStar_Options.interactive ()  in
-      if uu____3791
+      let uu____3800 = FStar_Options.interactive ()  in
+      if uu____3800
       then (g, empty_iface)
       else
-        (let uu____3800 = FStar_Options.restore_cmd_line_options true  in
+        (let uu____3809 = FStar_Options.restore_cmd_line_options true  in
          let decls = modul.FStar_Syntax_Syntax.declarations  in
          let iface1 =
-           let uu___612_3804 = empty_iface  in
+           let uu___613_3813 = empty_iface  in
            {
              iface_module_name = (g.FStar_Extraction_ML_UEnv.currentModule);
-             iface_bindings = (uu___612_3804.iface_bindings);
-             iface_tydefs = (uu___612_3804.iface_tydefs);
-             iface_type_names = (uu___612_3804.iface_type_names)
+             iface_bindings = (uu___613_3813.iface_bindings);
+             iface_tydefs = (uu___613_3813.iface_tydefs);
+             iface_type_names = (uu___613_3813.iface_type_names)
            }  in
          let res =
            FStar_List.fold_left
-             (fun uu____3822  ->
+             (fun uu____3831  ->
                 fun se  ->
-                  match uu____3822 with
+                  match uu____3831 with
                   | (g1,iface2) ->
-                      let uu____3834 = extract_sigelt_iface g1 se  in
-                      (match uu____3834 with
+                      let uu____3843 = extract_sigelt_iface g1 se  in
+                      (match uu____3843 with
                        | (g2,iface') ->
-                           let uu____3845 = iface_union iface2 iface'  in
-                           (g2, uu____3845))) (g, iface1) decls
+                           let uu____3854 = iface_union iface2 iface'  in
+                           (g2, uu____3854))) (g, iface1) decls
             in
-         (let uu____3847 = FStar_Options.restore_cmd_line_options true  in
-          FStar_All.pipe_left (fun a1  -> ()) uu____3847);
+         (let uu____3856 = FStar_Options.restore_cmd_line_options true  in
+          FStar_All.pipe_left (fun a1  -> ()) uu____3856);
          res)
   
 let (extract_iface :
@@ -1392,15 +1399,15 @@ let (extract_iface :
   =
   fun g  ->
     fun modul  ->
-      let uu____3864 = FStar_Options.debug_any ()  in
-      if uu____3864
+      let uu____3873 = FStar_Options.debug_any ()  in
+      if uu____3873
       then
-        let uu____3871 =
+        let uu____3880 =
           FStar_Util.format1 "Extracted interface of %s"
             (modul.FStar_Syntax_Syntax.name).FStar_Ident.str
            in
-        FStar_Util.measure_execution_time uu____3871
-          (fun uu____3879  -> extract_iface' g modul)
+        FStar_Util.measure_execution_time uu____3880
+          (fun uu____3888  -> extract_iface' g modul)
       else extract_iface' g modul
   
 let (extend_with_iface :
@@ -1410,25 +1417,25 @@ let (extend_with_iface :
       let mlident_map =
         FStar_List.fold_left
           (fun acc  ->
-             fun uu____3909  ->
-               match uu____3909 with
-               | (uu____3920,x) ->
+             fun uu____3918  ->
+               match uu____3918 with
+               | (uu____3929,x) ->
                    FStar_Util.psmap_add acc
                      x.FStar_Extraction_ML_UEnv.exp_b_name "")
           g.FStar_Extraction_ML_UEnv.env_mlident_map iface1.iface_bindings
          in
-      let uu___635_3924 = g  in
-      let uu____3925 =
-        let uu____3928 =
-          FStar_List.map (fun _3935  -> FStar_Extraction_ML_UEnv.Fv _3935)
+      let uu___636_3933 = g  in
+      let uu____3934 =
+        let uu____3937 =
+          FStar_List.map (fun _3944  -> FStar_Extraction_ML_UEnv.Fv _3944)
             iface1.iface_bindings
            in
-        FStar_List.append uu____3928 g.FStar_Extraction_ML_UEnv.env_bindings
+        FStar_List.append uu____3937 g.FStar_Extraction_ML_UEnv.env_bindings
          in
       {
         FStar_Extraction_ML_UEnv.env_tcenv =
-          (uu___635_3924.FStar_Extraction_ML_UEnv.env_tcenv);
-        FStar_Extraction_ML_UEnv.env_bindings = uu____3925;
+          (uu___636_3933.FStar_Extraction_ML_UEnv.env_tcenv);
+        FStar_Extraction_ML_UEnv.env_bindings = uu____3934;
         FStar_Extraction_ML_UEnv.env_mlident_map = mlident_map;
         FStar_Extraction_ML_UEnv.tydefs =
           (FStar_List.append iface1.iface_tydefs
@@ -1437,22 +1444,23 @@ let (extend_with_iface :
           (FStar_List.append iface1.iface_type_names
              g.FStar_Extraction_ML_UEnv.type_names);
         FStar_Extraction_ML_UEnv.currentModule =
-          (uu___635_3924.FStar_Extraction_ML_UEnv.currentModule)
+          (uu___636_3933.FStar_Extraction_ML_UEnv.currentModule)
       }
   
 let (extract_bundle :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.sigelt ->
-      (env_t * FStar_Extraction_ML_Syntax.mlmodule1 Prims.list))
+      (FStar_Extraction_ML_UEnv.uenv * FStar_Extraction_ML_Syntax.mlmodule1
+        Prims.list))
   =
   fun env  ->
     fun se  ->
       let extract_ctor env_iparams ml_tyvars env1 ctor =
         let mlt =
-          let uu____4013 =
+          let uu____4022 =
             FStar_Extraction_ML_Term.term_as_mlty env_iparams ctor.dtyp  in
           FStar_Extraction_ML_Util.eraseTypeDeep
-            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____4013
+            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____4022
            in
         let steps =
           [FStar_TypeChecker_Env.Inlining;
@@ -1461,104 +1469,104 @@ let (extract_bundle :
           FStar_TypeChecker_Env.EraseUniverses;
           FStar_TypeChecker_Env.AllowUnboundUniverses]  in
         let names1 =
-          let uu____4021 =
-            let uu____4022 =
-              let uu____4025 =
+          let uu____4030 =
+            let uu____4031 =
+              let uu____4034 =
                 FStar_TypeChecker_Normalize.normalize steps
                   env_iparams.FStar_Extraction_ML_UEnv.env_tcenv ctor.dtyp
                  in
-              FStar_Syntax_Subst.compress uu____4025  in
-            uu____4022.FStar_Syntax_Syntax.n  in
-          match uu____4021 with
-          | FStar_Syntax_Syntax.Tm_arrow (bs,uu____4030) ->
+              FStar_Syntax_Subst.compress uu____4034  in
+            uu____4031.FStar_Syntax_Syntax.n  in
+          match uu____4030 with
+          | FStar_Syntax_Syntax.Tm_arrow (bs,uu____4039) ->
               FStar_List.map
-                (fun uu____4063  ->
-                   match uu____4063 with
+                (fun uu____4072  ->
+                   match uu____4072 with
                    | ({ FStar_Syntax_Syntax.ppname = ppname;
-                        FStar_Syntax_Syntax.index = uu____4072;
-                        FStar_Syntax_Syntax.sort = uu____4073;_},uu____4074)
+                        FStar_Syntax_Syntax.index = uu____4081;
+                        FStar_Syntax_Syntax.sort = uu____4082;_},uu____4083)
                        -> ppname.FStar_Ident.idText) bs
-          | uu____4082 -> []  in
+          | uu____4091 -> []  in
         let tys = (ml_tyvars, mlt)  in
         let fvv = FStar_Extraction_ML_UEnv.mkFvvar ctor.dname ctor.dtyp  in
-        let uu____4090 =
+        let uu____4099 =
           FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false false  in
-        match uu____4090 with
-        | (env2,uu____4117,uu____4118) ->
-            let uu____4121 =
-              let uu____4134 = lident_as_mlsymbol ctor.dname  in
-              let uu____4136 =
-                let uu____4144 = FStar_Extraction_ML_Util.argTypes mlt  in
-                FStar_List.zip names1 uu____4144  in
-              (uu____4134, uu____4136)  in
-            (env2, uu____4121)
+        match uu____4099 with
+        | (env2,uu____4126,uu____4127) ->
+            let uu____4130 =
+              let uu____4143 = lident_as_mlsymbol ctor.dname  in
+              let uu____4145 =
+                let uu____4153 = FStar_Extraction_ML_Util.argTypes mlt  in
+                FStar_List.zip names1 uu____4153  in
+              (uu____4143, uu____4145)  in
+            (env2, uu____4130)
          in
       let extract_one_family env1 ind =
-        let uu____4205 = binders_as_mlty_binders env1 ind.iparams  in
-        match uu____4205 with
+        let uu____4214 = binders_as_mlty_binders env1 ind.iparams  in
+        match uu____4214 with
         | (env_iparams,vars) ->
-            let uu____4249 =
+            let uu____4258 =
               FStar_All.pipe_right ind.idatas
                 (FStar_Util.fold_map (extract_ctor env_iparams vars) env1)
                in
-            (match uu____4249 with
+            (match uu____4258 with
              | (env2,ctors) ->
-                 let uu____4356 = FStar_Syntax_Util.arrow_formals ind.ityp
+                 let uu____4365 = FStar_Syntax_Util.arrow_formals ind.ityp
                     in
-                 (match uu____4356 with
-                  | (indices,uu____4398) ->
+                 (match uu____4365 with
+                  | (indices,uu____4407) ->
                       let ml_params =
-                        let uu____4423 =
+                        let uu____4432 =
                           FStar_All.pipe_right indices
                             (FStar_List.mapi
                                (fun i  ->
-                                  fun uu____4449  ->
-                                    let uu____4457 =
+                                  fun uu____4458  ->
+                                    let uu____4466 =
                                       FStar_Util.string_of_int i  in
-                                    Prims.op_Hat "'dummyV" uu____4457))
+                                    Prims.op_Hat "'dummyV" uu____4466))
                            in
-                        FStar_List.append vars uu____4423  in
+                        FStar_List.append vars uu____4432  in
                       let tbody =
-                        let uu____4462 =
+                        let uu____4471 =
                           FStar_Util.find_opt
-                            (fun uu___7_4467  ->
-                               match uu___7_4467 with
-                               | FStar_Syntax_Syntax.RecordType uu____4469 ->
+                            (fun uu___7_4476  ->
+                               match uu___7_4476 with
+                               | FStar_Syntax_Syntax.RecordType uu____4478 ->
                                    true
-                               | uu____4479 -> false) ind.iquals
+                               | uu____4488 -> false) ind.iquals
                            in
-                        match uu____4462 with
+                        match uu____4471 with
                         | FStar_Pervasives_Native.Some
                             (FStar_Syntax_Syntax.RecordType (ns,ids)) ->
-                            let uu____4491 = FStar_List.hd ctors  in
-                            (match uu____4491 with
-                             | (uu____4516,c_ty) ->
+                            let uu____4500 = FStar_List.hd ctors  in
+                            (match uu____4500 with
+                             | (uu____4525,c_ty) ->
                                  let fields =
                                    FStar_List.map2
                                      (fun id1  ->
-                                        fun uu____4560  ->
-                                          match uu____4560 with
-                                          | (uu____4571,ty) ->
+                                        fun uu____4569  ->
+                                          match uu____4569 with
+                                          | (uu____4580,ty) ->
                                               let lid =
                                                 FStar_Ident.lid_of_ids
                                                   (FStar_List.append ns [id1])
                                                  in
-                                              let uu____4576 =
+                                              let uu____4585 =
                                                 lident_as_mlsymbol lid  in
-                                              (uu____4576, ty)) ids c_ty
+                                              (uu____4585, ty)) ids c_ty
                                     in
                                  FStar_Extraction_ML_Syntax.MLTD_Record
                                    fields)
-                        | uu____4579 ->
+                        | uu____4588 ->
                             FStar_Extraction_ML_Syntax.MLTD_DType ctors
                          in
-                      let uu____4582 =
-                        let uu____4605 = lident_as_mlsymbol ind.iname  in
-                        (false, uu____4605, FStar_Pervasives_Native.None,
+                      let uu____4591 =
+                        let uu____4614 = lident_as_mlsymbol ind.iname  in
+                        (false, uu____4614, FStar_Pervasives_Native.None,
                           ml_params, (ind.imetadata),
                           (FStar_Pervasives_Native.Some tbody))
                          in
-                      (env2, uu____4582)))
+                      (env2, uu____4591)))
          in
       match ((se.FStar_Syntax_Syntax.sigel),
               (se.FStar_Syntax_Syntax.sigquals))
@@ -1566,28 +1574,36 @@ let (extract_bundle :
       | (FStar_Syntax_Syntax.Sig_bundle
          ({
             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-              (l,uu____4650,t,uu____4652,uu____4653,uu____4654);
-            FStar_Syntax_Syntax.sigrng = uu____4655;
-            FStar_Syntax_Syntax.sigquals = uu____4656;
-            FStar_Syntax_Syntax.sigmeta = uu____4657;
-            FStar_Syntax_Syntax.sigattrs = uu____4658;_}::[],uu____4659),(FStar_Syntax_Syntax.ExceptionConstructor
+              (l,uu____4659,t,uu____4661,uu____4662,uu____4663);
+            FStar_Syntax_Syntax.sigrng = uu____4664;
+            FStar_Syntax_Syntax.sigquals = uu____4665;
+            FStar_Syntax_Syntax.sigmeta = uu____4666;
+            FStar_Syntax_Syntax.sigattrs = uu____4667;_}::[],uu____4668),(FStar_Syntax_Syntax.ExceptionConstructor
          )::[]) ->
-          let uu____4678 = extract_ctor env [] env { dname = l; dtyp = t }
+          let uu____4687 = extract_ctor env [] env { dname = l; dtyp = t }
              in
-          (match uu____4678 with
+          (match uu____4687 with
            | (env1,ctor) -> (env1, [FStar_Extraction_ML_Syntax.MLM_Exn ctor]))
-      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____4731),quals) ->
-          let uu____4745 =
-            bundle_as_inductive_families env ses quals
-              se.FStar_Syntax_Syntax.sigattrs
+      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____4740),quals) ->
+          let uu____4754 =
+            FStar_Syntax_Util.has_attribute se.FStar_Syntax_Syntax.sigattrs
+              FStar_Parser_Const.erasable_attr
              in
-          (match uu____4745 with
-           | (env1,ifams) ->
-               let uu____4764 =
-                 FStar_Util.fold_map extract_one_family env1 ifams  in
-               (match uu____4764 with
-                | (env2,td) -> (env2, [FStar_Extraction_ML_Syntax.MLM_Ty td])))
-      | uu____4873 -> failwith "Unexpected signature element"
+          if uu____4754
+          then (env, [])
+          else
+            (let uu____4767 =
+               bundle_as_inductive_families env ses quals
+                 se.FStar_Syntax_Syntax.sigattrs
+                in
+             match uu____4767 with
+             | (env1,ifams) ->
+                 let uu____4786 =
+                   FStar_Util.fold_map extract_one_family env1 ifams  in
+                 (match uu____4786 with
+                  | (env2,td) ->
+                      (env2, [FStar_Extraction_ML_Syntax.MLM_Ty td])))
+      | uu____4895 -> failwith "Unexpected signature element"
   
 let (maybe_register_plugin :
   env_t ->
@@ -1603,43 +1619,43 @@ let (maybe_register_plugin :
       let plugin_with_arity attrs =
         FStar_Util.find_map attrs
           (fun t  ->
-             let uu____4931 = FStar_Syntax_Util.head_and_args t  in
-             match uu____4931 with
+             let uu____4953 = FStar_Syntax_Util.head_and_args t  in
+             match uu____4953 with
              | (head1,args) ->
-                 let uu____4979 =
-                   let uu____4981 =
+                 let uu____5001 =
+                   let uu____5003 =
                      FStar_Syntax_Util.is_fvar FStar_Parser_Const.plugin_attr
                        head1
                       in
-                   Prims.op_Negation uu____4981  in
-                 if uu____4979
+                   Prims.op_Negation uu____5003  in
+                 if uu____5001
                  then FStar_Pervasives_Native.None
                  else
                    (match args with
                     | ({
                          FStar_Syntax_Syntax.n =
                            FStar_Syntax_Syntax.Tm_constant
-                           (FStar_Const.Const_int (s,uu____5000));
-                         FStar_Syntax_Syntax.pos = uu____5001;
-                         FStar_Syntax_Syntax.vars = uu____5002;_},uu____5003)::[]
+                           (FStar_Const.Const_int (s,uu____5022));
+                         FStar_Syntax_Syntax.pos = uu____5023;
+                         FStar_Syntax_Syntax.vars = uu____5024;_},uu____5025)::[]
                         ->
-                        let uu____5042 =
-                          let uu____5046 = FStar_Util.int_of_string s  in
-                          FStar_Pervasives_Native.Some uu____5046  in
-                        FStar_Pervasives_Native.Some uu____5042
-                    | uu____5052 ->
+                        let uu____5064 =
+                          let uu____5068 = FStar_Util.int_of_string s  in
+                          FStar_Pervasives_Native.Some uu____5068  in
+                        FStar_Pervasives_Native.Some uu____5064
+                    | uu____5074 ->
                         FStar_Pervasives_Native.Some
                           FStar_Pervasives_Native.None))
          in
-      let uu____5067 =
-        let uu____5069 = FStar_Options.codegen ()  in
-        uu____5069 <> (FStar_Pervasives_Native.Some FStar_Options.Plugin)  in
-      if uu____5067
+      let uu____5089 =
+        let uu____5091 = FStar_Options.codegen ()  in
+        uu____5091 <> (FStar_Pervasives_Native.Some FStar_Options.Plugin)  in
+      if uu____5089
       then []
       else
-        (let uu____5079 = plugin_with_arity se.FStar_Syntax_Syntax.sigattrs
+        (let uu____5101 = plugin_with_arity se.FStar_Syntax_Syntax.sigattrs
             in
-         match uu____5079 with
+         match uu____5101 with
          | FStar_Pervasives_Native.None  -> []
          | FStar_Pervasives_Native.Some arity_opt ->
              (match se.FStar_Syntax_Syntax.sigel with
@@ -1652,20 +1668,20 @@ let (maybe_register_plugin :
                        in
                     let fv_t = lb.FStar_Syntax_Syntax.lbtyp  in
                     let ml_name_str =
-                      let uu____5121 =
-                        let uu____5122 = FStar_Ident.string_of_lid fv_lid1
+                      let uu____5143 =
+                        let uu____5144 = FStar_Ident.string_of_lid fv_lid1
                            in
-                        FStar_Extraction_ML_Syntax.MLC_String uu____5122  in
-                      FStar_Extraction_ML_Syntax.MLE_Const uu____5121  in
-                    let uu____5124 =
+                        FStar_Extraction_ML_Syntax.MLC_String uu____5144  in
+                      FStar_Extraction_ML_Syntax.MLE_Const uu____5143  in
+                    let uu____5146 =
                       FStar_Extraction_ML_Util.interpret_plugin_as_term_fun
                         g.FStar_Extraction_ML_UEnv.env_tcenv fv fv_t
                         arity_opt ml_name_str
                        in
-                    match uu____5124 with
+                    match uu____5146 with
                     | FStar_Pervasives_Native.Some
                         (interp,nbe_interp,arity,plugin1) ->
-                        let uu____5157 =
+                        let uu____5179 =
                           if plugin1
                           then
                             ("FStar_Tactics_Native.register_plugin",
@@ -1674,36 +1690,36 @@ let (maybe_register_plugin :
                             ("FStar_Tactics_Native.register_tactic",
                               [interp])
                            in
-                        (match uu____5157 with
+                        (match uu____5179 with
                          | (register,args) ->
                              let h =
-                               let uu____5194 =
-                                 let uu____5195 =
-                                   let uu____5196 =
+                               let uu____5216 =
+                                 let uu____5217 =
+                                   let uu____5218 =
                                      FStar_Ident.lid_of_str register  in
                                    FStar_Extraction_ML_Syntax.mlpath_of_lident
-                                     uu____5196
+                                     uu____5218
                                     in
                                  FStar_Extraction_ML_Syntax.MLE_Name
-                                   uu____5195
+                                   uu____5217
                                   in
                                FStar_All.pipe_left
                                  (FStar_Extraction_ML_Syntax.with_ty
                                     FStar_Extraction_ML_Syntax.MLTY_Top)
-                                 uu____5194
+                                 uu____5216
                                 in
                              let arity1 =
-                               let uu____5198 =
-                                 let uu____5199 =
-                                   let uu____5211 =
+                               let uu____5220 =
+                                 let uu____5221 =
+                                   let uu____5233 =
                                      FStar_Util.string_of_int arity  in
-                                   (uu____5211, FStar_Pervasives_Native.None)
+                                   (uu____5233, FStar_Pervasives_Native.None)
                                     in
                                  FStar_Extraction_ML_Syntax.MLC_Int
-                                   uu____5199
+                                   uu____5221
                                   in
                                FStar_Extraction_ML_Syntax.MLE_Const
-                                 uu____5198
+                                 uu____5220
                                 in
                              let app =
                                FStar_All.pipe_left
@@ -1718,7 +1734,7 @@ let (maybe_register_plugin :
                     | FStar_Pervasives_Native.None  -> []  in
                   FStar_List.collect mk_registration
                     (FStar_Pervasives_Native.snd lbs)
-              | uu____5240 -> []))
+              | uu____5262 -> []))
   
 let rec (extract_sig :
   env_t ->
@@ -1729,59 +1745,59 @@ let rec (extract_sig :
     fun se  ->
       FStar_Extraction_ML_UEnv.debug g
         (fun u  ->
-           let uu____5268 = FStar_Syntax_Print.sigelt_to_string se  in
-           FStar_Util.print1 ">>>> extract_sig %s \n" uu____5268);
+           let uu____5290 = FStar_Syntax_Print.sigelt_to_string se  in
+           FStar_Util.print1 ">>>> extract_sig %s \n" uu____5290);
       (match se.FStar_Syntax_Syntax.sigel with
-       | FStar_Syntax_Syntax.Sig_bundle uu____5277 -> extract_bundle g se
-       | FStar_Syntax_Syntax.Sig_inductive_typ uu____5286 ->
+       | FStar_Syntax_Syntax.Sig_bundle uu____5299 -> extract_bundle g se
+       | FStar_Syntax_Syntax.Sig_inductive_typ uu____5308 ->
            extract_bundle g se
-       | FStar_Syntax_Syntax.Sig_datacon uu____5303 -> extract_bundle g se
+       | FStar_Syntax_Syntax.Sig_datacon uu____5325 -> extract_bundle g se
        | FStar_Syntax_Syntax.Sig_new_effect ed when
            FStar_TypeChecker_Env.is_reifiable_effect
              g.FStar_Extraction_ML_UEnv.env_tcenv
              ed.FStar_Syntax_Syntax.mname
            ->
-           let uu____5320 = extract_reifiable_effect g ed  in
-           (match uu____5320 with | (env,_iface,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_splice uu____5344 ->
+           let uu____5342 = extract_reifiable_effect g ed  in
+           (match uu____5342 with | (env,_iface,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_splice uu____5366 ->
            failwith "impossible: trying to extract splice"
-       | FStar_Syntax_Syntax.Sig_new_effect uu____5358 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_new_effect uu____5380 -> (g, [])
        | FStar_Syntax_Syntax.Sig_declare_typ (lid,univs1,t) when
            FStar_Extraction_ML_Term.is_arity g t ->
-           let uu____5364 =
+           let uu____5386 =
              extract_type_declaration g lid se.FStar_Syntax_Syntax.sigquals
                se.FStar_Syntax_Syntax.sigattrs univs1 t
               in
-           (match uu____5364 with | (env,uu____5380,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____5389) when
+           (match uu____5386 with | (env,uu____5402,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____5411) when
            FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp
            ->
-           let uu____5398 =
+           let uu____5420 =
              extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
                se.FStar_Syntax_Syntax.sigattrs lb
               in
-           (match uu____5398 with | (env,uu____5414,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____5423) when
+           (match uu____5420 with | (env,uu____5436,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____5445) when
            FStar_Util.for_some
              (fun lb  ->
                 FStar_Extraction_ML_Term.is_arity g
                   lb.FStar_Syntax_Syntax.lbtyp) lbs
            ->
-           let uu____5436 = extract_let_rec_types se g lbs  in
-           (match uu____5436 with | (env,uu____5452,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let (lbs,uu____5461) ->
+           let uu____5458 = extract_let_rec_types se g lbs  in
+           (match uu____5458 with | (env,uu____5474,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let (lbs,uu____5483) ->
            let attrs = se.FStar_Syntax_Syntax.sigattrs  in
            let quals = se.FStar_Syntax_Syntax.sigquals  in
-           let uu____5472 =
-             let uu____5481 =
+           let uu____5494 =
+             let uu____5503 =
                FStar_Syntax_Util.extract_attr'
                  FStar_Parser_Const.postprocess_extr_with attrs
                 in
-             match uu____5481 with
+             match uu____5503 with
              | FStar_Pervasives_Native.None  ->
                  (attrs, FStar_Pervasives_Native.None)
              | FStar_Pervasives_Native.Some
-                 (ats,(tau,FStar_Pervasives_Native.None )::uu____5510) ->
+                 (ats,(tau,FStar_Pervasives_Native.None )::uu____5532) ->
                  (ats, (FStar_Pervasives_Native.Some tau))
              | FStar_Pervasives_Native.Some (ats,args) ->
                  (FStar_Errors.log_issue se.FStar_Syntax_Syntax.sigrng
@@ -1789,7 +1805,7 @@ let rec (extract_sig :
                       "Ill-formed application of `postprocess_for_extraction_with`");
                   (attrs, FStar_Pervasives_Native.None))
               in
-           (match uu____5472 with
+           (match uu____5494 with
             | (attrs1,post_tau) ->
                 let postprocess_lb tau lb =
                   let lbdef =
@@ -1798,24 +1814,24 @@ let rec (extract_sig :
                       lb.FStar_Syntax_Syntax.lbtyp
                       lb.FStar_Syntax_Syntax.lbdef
                      in
-                  let uu___865_5596 = lb  in
+                  let uu___867_5618 = lb  in
                   {
                     FStar_Syntax_Syntax.lbname =
-                      (uu___865_5596.FStar_Syntax_Syntax.lbname);
+                      (uu___867_5618.FStar_Syntax_Syntax.lbname);
                     FStar_Syntax_Syntax.lbunivs =
-                      (uu___865_5596.FStar_Syntax_Syntax.lbunivs);
+                      (uu___867_5618.FStar_Syntax_Syntax.lbunivs);
                     FStar_Syntax_Syntax.lbtyp =
-                      (uu___865_5596.FStar_Syntax_Syntax.lbtyp);
+                      (uu___867_5618.FStar_Syntax_Syntax.lbtyp);
                     FStar_Syntax_Syntax.lbeff =
-                      (uu___865_5596.FStar_Syntax_Syntax.lbeff);
+                      (uu___867_5618.FStar_Syntax_Syntax.lbeff);
                     FStar_Syntax_Syntax.lbdef = lbdef;
                     FStar_Syntax_Syntax.lbattrs =
-                      (uu___865_5596.FStar_Syntax_Syntax.lbattrs);
+                      (uu___867_5618.FStar_Syntax_Syntax.lbattrs);
                     FStar_Syntax_Syntax.lbpos =
-                      (uu___865_5596.FStar_Syntax_Syntax.lbpos)
+                      (uu___867_5618.FStar_Syntax_Syntax.lbpos)
                   }  in
                 let lbs1 =
-                  let uu____5605 =
+                  let uu____5627 =
                     match post_tau with
                     | FStar_Pervasives_Native.Some tau ->
                         FStar_List.map (postprocess_lb tau)
@@ -1823,176 +1839,176 @@ let rec (extract_sig :
                     | FStar_Pervasives_Native.None  ->
                         FStar_Pervasives_Native.snd lbs
                      in
-                  ((FStar_Pervasives_Native.fst lbs), uu____5605)  in
-                let uu____5623 =
-                  let uu____5630 =
+                  ((FStar_Pervasives_Native.fst lbs), uu____5627)  in
+                let uu____5645 =
+                  let uu____5652 =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_let
                          (lbs1, FStar_Syntax_Util.exp_false_bool))
                       FStar_Pervasives_Native.None
                       se.FStar_Syntax_Syntax.sigrng
                      in
-                  FStar_Extraction_ML_Term.term_as_mlexpr g uu____5630  in
-                (match uu____5623 with
-                 | (ml_let,uu____5647,uu____5648) ->
+                  FStar_Extraction_ML_Term.term_as_mlexpr g uu____5652  in
+                (match uu____5645 with
+                 | (ml_let,uu____5669,uu____5670) ->
                      (match ml_let.FStar_Extraction_ML_Syntax.expr with
                       | FStar_Extraction_ML_Syntax.MLE_Let
-                          ((flavor,bindings),uu____5657) ->
+                          ((flavor,bindings),uu____5679) ->
                           let flags = FStar_List.choose flag_of_qual quals
                              in
                           let flags' = extract_metadata attrs1  in
-                          let uu____5674 =
+                          let uu____5696 =
                             FStar_List.fold_left2
-                              (fun uu____5700  ->
+                              (fun uu____5722  ->
                                  fun ml_lb  ->
-                                   fun uu____5702  ->
-                                     match (uu____5700, uu____5702) with
+                                   fun uu____5724  ->
+                                     match (uu____5722, uu____5724) with
                                      | ((env,ml_lbs),{
                                                        FStar_Syntax_Syntax.lbname
                                                          = lbname;
                                                        FStar_Syntax_Syntax.lbunivs
-                                                         = uu____5724;
+                                                         = uu____5746;
                                                        FStar_Syntax_Syntax.lbtyp
                                                          = t;
                                                        FStar_Syntax_Syntax.lbeff
-                                                         = uu____5726;
+                                                         = uu____5748;
                                                        FStar_Syntax_Syntax.lbdef
-                                                         = uu____5727;
+                                                         = uu____5749;
                                                        FStar_Syntax_Syntax.lbattrs
-                                                         = uu____5728;
+                                                         = uu____5750;
                                                        FStar_Syntax_Syntax.lbpos
-                                                         = uu____5729;_})
+                                                         = uu____5751;_})
                                          ->
-                                         let uu____5754 =
+                                         let uu____5776 =
                                            FStar_All.pipe_right
                                              ml_lb.FStar_Extraction_ML_Syntax.mllb_meta
                                              (FStar_List.contains
                                                 FStar_Extraction_ML_Syntax.Erased)
                                             in
-                                         if uu____5754
+                                         if uu____5776
                                          then (env, ml_lbs)
                                          else
                                            (let lb_lid =
-                                              let uu____5771 =
-                                                let uu____5774 =
+                                              let uu____5793 =
+                                                let uu____5796 =
                                                   FStar_Util.right lbname  in
-                                                uu____5774.FStar_Syntax_Syntax.fv_name
+                                                uu____5796.FStar_Syntax_Syntax.fv_name
                                                  in
-                                              uu____5771.FStar_Syntax_Syntax.v
+                                              uu____5793.FStar_Syntax_Syntax.v
                                                in
                                             let flags'' =
-                                              let uu____5778 =
-                                                let uu____5779 =
+                                              let uu____5800 =
+                                                let uu____5801 =
                                                   FStar_Syntax_Subst.compress
                                                     t
                                                    in
-                                                uu____5779.FStar_Syntax_Syntax.n
+                                                uu____5801.FStar_Syntax_Syntax.n
                                                  in
-                                              match uu____5778 with
+                                              match uu____5800 with
                                               | FStar_Syntax_Syntax.Tm_arrow
-                                                  (uu____5784,{
+                                                  (uu____5806,{
                                                                 FStar_Syntax_Syntax.n
                                                                   =
                                                                   FStar_Syntax_Syntax.Comp
                                                                   {
                                                                     FStar_Syntax_Syntax.comp_univs
                                                                     =
-                                                                    uu____5785;
+                                                                    uu____5807;
                                                                     FStar_Syntax_Syntax.effect_name
                                                                     = e;
                                                                     FStar_Syntax_Syntax.result_typ
                                                                     =
-                                                                    uu____5787;
+                                                                    uu____5809;
                                                                     FStar_Syntax_Syntax.effect_args
                                                                     =
-                                                                    uu____5788;
+                                                                    uu____5810;
                                                                     FStar_Syntax_Syntax.flags
                                                                     =
-                                                                    uu____5789;_};
+                                                                    uu____5811;_};
                                                                 FStar_Syntax_Syntax.pos
                                                                   =
-                                                                  uu____5790;
+                                                                  uu____5812;
                                                                 FStar_Syntax_Syntax.vars
                                                                   =
-                                                                  uu____5791;_})
+                                                                  uu____5813;_})
                                                   when
-                                                  let uu____5826 =
+                                                  let uu____5848 =
                                                     FStar_Ident.string_of_lid
                                                       e
                                                      in
-                                                  uu____5826 =
+                                                  uu____5848 =
                                                     "FStar.HyperStack.ST.StackInline"
                                                   ->
                                                   [FStar_Extraction_ML_Syntax.StackInline]
-                                              | uu____5830 -> []  in
+                                              | uu____5852 -> []  in
                                             let meta =
                                               FStar_List.append flags
                                                 (FStar_List.append flags'
                                                    flags'')
                                                in
                                             let ml_lb1 =
-                                              let uu___913_5835 = ml_lb  in
+                                              let uu___915_5857 = ml_lb  in
                                               {
                                                 FStar_Extraction_ML_Syntax.mllb_name
                                                   =
-                                                  (uu___913_5835.FStar_Extraction_ML_Syntax.mllb_name);
+                                                  (uu___915_5857.FStar_Extraction_ML_Syntax.mllb_name);
                                                 FStar_Extraction_ML_Syntax.mllb_tysc
                                                   =
-                                                  (uu___913_5835.FStar_Extraction_ML_Syntax.mllb_tysc);
+                                                  (uu___915_5857.FStar_Extraction_ML_Syntax.mllb_tysc);
                                                 FStar_Extraction_ML_Syntax.mllb_add_unit
                                                   =
-                                                  (uu___913_5835.FStar_Extraction_ML_Syntax.mllb_add_unit);
+                                                  (uu___915_5857.FStar_Extraction_ML_Syntax.mllb_add_unit);
                                                 FStar_Extraction_ML_Syntax.mllb_def
                                                   =
-                                                  (uu___913_5835.FStar_Extraction_ML_Syntax.mllb_def);
+                                                  (uu___915_5857.FStar_Extraction_ML_Syntax.mllb_def);
                                                 FStar_Extraction_ML_Syntax.mllb_meta
                                                   = meta;
                                                 FStar_Extraction_ML_Syntax.print_typ
                                                   =
-                                                  (uu___913_5835.FStar_Extraction_ML_Syntax.print_typ)
+                                                  (uu___915_5857.FStar_Extraction_ML_Syntax.print_typ)
                                               }  in
-                                            let uu____5836 =
-                                              let uu____5841 =
+                                            let uu____5858 =
+                                              let uu____5863 =
                                                 FStar_All.pipe_right quals
                                                   (FStar_Util.for_some
-                                                     (fun uu___8_5848  ->
-                                                        match uu___8_5848
+                                                     (fun uu___8_5870  ->
+                                                        match uu___8_5870
                                                         with
                                                         | FStar_Syntax_Syntax.Projector
-                                                            uu____5850 ->
+                                                            uu____5872 ->
                                                             true
-                                                        | uu____5856 -> false))
+                                                        | uu____5878 -> false))
                                                  in
-                                              if uu____5841
+                                              if uu____5863
                                               then
                                                 let mname =
-                                                  let uu____5872 =
+                                                  let uu____5894 =
                                                     mangle_projector_lid
                                                       lb_lid
                                                      in
                                                   FStar_All.pipe_right
-                                                    uu____5872
+                                                    uu____5894
                                                     FStar_Extraction_ML_Syntax.mlpath_of_lident
                                                    in
-                                                let uu____5881 =
-                                                  let uu____5889 =
+                                                let uu____5903 =
+                                                  let uu____5911 =
                                                     FStar_Util.right lbname
                                                      in
-                                                  let uu____5890 =
+                                                  let uu____5912 =
                                                     FStar_Util.must
                                                       ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc
                                                      in
                                                   FStar_Extraction_ML_UEnv.extend_fv'
-                                                    env uu____5889 mname
-                                                    uu____5890
+                                                    env uu____5911 mname
+                                                    uu____5912
                                                     ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit
                                                     false
                                                    in
-                                                match uu____5881 with
-                                                | (env1,uu____5897,uu____5898)
+                                                match uu____5903 with
+                                                | (env1,uu____5919,uu____5920)
                                                     ->
                                                     (env1,
-                                                      (let uu___926_5902 =
+                                                      (let uu___928_5924 =
                                                          ml_lb1  in
                                                        {
                                                          FStar_Extraction_ML_Syntax.mllb_name
@@ -2001,169 +2017,169 @@ let rec (extract_sig :
                                                               mname);
                                                          FStar_Extraction_ML_Syntax.mllb_tysc
                                                            =
-                                                           (uu___926_5902.FStar_Extraction_ML_Syntax.mllb_tysc);
+                                                           (uu___928_5924.FStar_Extraction_ML_Syntax.mllb_tysc);
                                                          FStar_Extraction_ML_Syntax.mllb_add_unit
                                                            =
-                                                           (uu___926_5902.FStar_Extraction_ML_Syntax.mllb_add_unit);
+                                                           (uu___928_5924.FStar_Extraction_ML_Syntax.mllb_add_unit);
                                                          FStar_Extraction_ML_Syntax.mllb_def
                                                            =
-                                                           (uu___926_5902.FStar_Extraction_ML_Syntax.mllb_def);
+                                                           (uu___928_5924.FStar_Extraction_ML_Syntax.mllb_def);
                                                          FStar_Extraction_ML_Syntax.mllb_meta
                                                            =
-                                                           (uu___926_5902.FStar_Extraction_ML_Syntax.mllb_meta);
+                                                           (uu___928_5924.FStar_Extraction_ML_Syntax.mllb_meta);
                                                          FStar_Extraction_ML_Syntax.print_typ
                                                            =
-                                                           (uu___926_5902.FStar_Extraction_ML_Syntax.print_typ)
+                                                           (uu___928_5924.FStar_Extraction_ML_Syntax.print_typ)
                                                        }))
                                               else
-                                                (let uu____5909 =
-                                                   let uu____5917 =
+                                                (let uu____5931 =
+                                                   let uu____5939 =
                                                      FStar_Util.must
                                                        ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc
                                                       in
                                                    FStar_Extraction_ML_UEnv.extend_lb
-                                                     env lbname t uu____5917
+                                                     env lbname t uu____5939
                                                      ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit
                                                      false
                                                     in
-                                                 match uu____5909 with
-                                                 | (env1,uu____5924,uu____5925)
+                                                 match uu____5931 with
+                                                 | (env1,uu____5946,uu____5947)
                                                      -> (env1, ml_lb1))
                                                in
-                                            match uu____5836 with
+                                            match uu____5858 with
                                             | (g1,ml_lb2) ->
                                                 (g1, (ml_lb2 :: ml_lbs))))
                               (g, []) bindings
                               (FStar_Pervasives_Native.snd lbs1)
                              in
-                          (match uu____5674 with
+                          (match uu____5696 with
                            | (g1,ml_lbs') ->
-                               let uu____5955 =
-                                 let uu____5958 =
-                                   let uu____5961 =
-                                     let uu____5962 =
+                               let uu____5977 =
+                                 let uu____5980 =
+                                   let uu____5983 =
+                                     let uu____5984 =
                                        FStar_Extraction_ML_Util.mlloc_of_range
                                          se.FStar_Syntax_Syntax.sigrng
                                         in
                                      FStar_Extraction_ML_Syntax.MLM_Loc
-                                       uu____5962
+                                       uu____5984
                                       in
-                                   [uu____5961;
+                                   [uu____5983;
                                    FStar_Extraction_ML_Syntax.MLM_Let
                                      (flavor, (FStar_List.rev ml_lbs'))]
                                     in
-                                 let uu____5965 = maybe_register_plugin g1 se
+                                 let uu____5987 = maybe_register_plugin g1 se
                                     in
-                                 FStar_List.append uu____5958 uu____5965  in
-                               (g1, uu____5955))
-                      | uu____5970 ->
-                          let uu____5971 =
-                            let uu____5973 =
+                                 FStar_List.append uu____5980 uu____5987  in
+                               (g1, uu____5977))
+                      | uu____5992 ->
+                          let uu____5993 =
+                            let uu____5995 =
                               FStar_Extraction_ML_Code.string_of_mlexpr
                                 g.FStar_Extraction_ML_UEnv.currentModule
                                 ml_let
                                in
                             FStar_Util.format1
                               "Impossible: Translated a let to a non-let: %s"
-                              uu____5973
+                              uu____5995
                              in
-                          failwith uu____5971)))
-       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____5983,t) ->
+                          failwith uu____5993)))
+       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____6005,t) ->
            let quals = se.FStar_Syntax_Syntax.sigquals  in
-           let uu____5988 =
+           let uu____6010 =
              (FStar_All.pipe_right quals
                 (FStar_List.contains FStar_Syntax_Syntax.Assumption))
                &&
-               (let uu____5994 =
+               (let uu____6016 =
                   FStar_TypeChecker_Util.must_erase_for_extraction
                     g.FStar_Extraction_ML_UEnv.env_tcenv t
                    in
-                Prims.op_Negation uu____5994)
+                Prims.op_Negation uu____6016)
               in
-           if uu____5988
+           if uu____6010
            then
              let always_fail1 =
-               let uu___946_6004 = se  in
-               let uu____6005 =
-                 let uu____6006 =
-                   let uu____6013 =
-                     let uu____6014 =
-                       let uu____6017 = always_fail lid t  in [uu____6017]
+               let uu___948_6026 = se  in
+               let uu____6027 =
+                 let uu____6028 =
+                   let uu____6035 =
+                     let uu____6036 =
+                       let uu____6039 = always_fail lid t  in [uu____6039]
                         in
-                     (false, uu____6014)  in
-                   (uu____6013, [])  in
-                 FStar_Syntax_Syntax.Sig_let uu____6006  in
+                     (false, uu____6036)  in
+                   (uu____6035, [])  in
+                 FStar_Syntax_Syntax.Sig_let uu____6028  in
                {
-                 FStar_Syntax_Syntax.sigel = uu____6005;
+                 FStar_Syntax_Syntax.sigel = uu____6027;
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___946_6004.FStar_Syntax_Syntax.sigrng);
+                   (uu___948_6026.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___946_6004.FStar_Syntax_Syntax.sigquals);
+                   (uu___948_6026.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___946_6004.FStar_Syntax_Syntax.sigmeta);
+                   (uu___948_6026.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___946_6004.FStar_Syntax_Syntax.sigattrs)
+                   (uu___948_6026.FStar_Syntax_Syntax.sigattrs)
                }  in
-             let uu____6024 = extract_sig g always_fail1  in
-             (match uu____6024 with
+             let uu____6046 = extract_sig g always_fail1  in
+             (match uu____6046 with
               | (g1,mlm) ->
-                  let uu____6043 =
+                  let uu____6065 =
                     FStar_Util.find_map quals
-                      (fun uu___9_6048  ->
-                         match uu___9_6048 with
+                      (fun uu___9_6070  ->
+                         match uu___9_6070 with
                          | FStar_Syntax_Syntax.Discriminator l ->
                              FStar_Pervasives_Native.Some l
-                         | uu____6052 -> FStar_Pervasives_Native.None)
+                         | uu____6074 -> FStar_Pervasives_Native.None)
                      in
-                  (match uu____6043 with
+                  (match uu____6065 with
                    | FStar_Pervasives_Native.Some l ->
-                       let uu____6060 =
-                         let uu____6063 =
-                           let uu____6064 =
+                       let uu____6082 =
+                         let uu____6085 =
+                           let uu____6086 =
                              FStar_Extraction_ML_Util.mlloc_of_range
                                se.FStar_Syntax_Syntax.sigrng
                               in
-                           FStar_Extraction_ML_Syntax.MLM_Loc uu____6064  in
-                         let uu____6065 =
-                           let uu____6068 =
+                           FStar_Extraction_ML_Syntax.MLM_Loc uu____6086  in
+                         let uu____6087 =
+                           let uu____6090 =
                              FStar_Extraction_ML_Term.ind_discriminator_body
                                g1 lid l
                               in
-                           [uu____6068]  in
-                         uu____6063 :: uu____6065  in
-                       (g1, uu____6060)
-                   | uu____6071 ->
-                       let uu____6074 =
+                           [uu____6090]  in
+                         uu____6085 :: uu____6087  in
+                       (g1, uu____6082)
+                   | uu____6093 ->
+                       let uu____6096 =
                          FStar_Util.find_map quals
-                           (fun uu___10_6080  ->
-                              match uu___10_6080 with
-                              | FStar_Syntax_Syntax.Projector (l,uu____6084)
+                           (fun uu___10_6102  ->
+                              match uu___10_6102 with
+                              | FStar_Syntax_Syntax.Projector (l,uu____6106)
                                   -> FStar_Pervasives_Native.Some l
-                              | uu____6085 -> FStar_Pervasives_Native.None)
+                              | uu____6107 -> FStar_Pervasives_Native.None)
                           in
-                       (match uu____6074 with
-                        | FStar_Pervasives_Native.Some uu____6092 -> (g1, [])
-                        | uu____6095 -> (g1, mlm))))
+                       (match uu____6096 with
+                        | FStar_Pervasives_Native.Some uu____6114 -> (g1, [])
+                        | uu____6117 -> (g1, mlm))))
            else (g, [])
        | FStar_Syntax_Syntax.Sig_main e ->
-           let uu____6105 = FStar_Extraction_ML_Term.term_as_mlexpr g e  in
-           (match uu____6105 with
-            | (ml_main,uu____6119,uu____6120) ->
-                let uu____6121 =
-                  let uu____6124 =
-                    let uu____6125 =
+           let uu____6127 = FStar_Extraction_ML_Term.term_as_mlexpr g e  in
+           (match uu____6127 with
+            | (ml_main,uu____6141,uu____6142) ->
+                let uu____6143 =
+                  let uu____6146 =
+                    let uu____6147 =
                       FStar_Extraction_ML_Util.mlloc_of_range
                         se.FStar_Syntax_Syntax.sigrng
                        in
-                    FStar_Extraction_ML_Syntax.MLM_Loc uu____6125  in
-                  [uu____6124; FStar_Extraction_ML_Syntax.MLM_Top ml_main]
+                    FStar_Extraction_ML_Syntax.MLM_Loc uu____6147  in
+                  [uu____6146; FStar_Extraction_ML_Syntax.MLM_Top ml_main]
                    in
-                (g, uu____6121))
-       | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____6128 ->
+                (g, uu____6143))
+       | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____6150 ->
            failwith "impossible -- removed by tc.fs"
-       | FStar_Syntax_Syntax.Sig_assume uu____6136 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_sub_effect uu____6145 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____6148 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_assume uu____6158 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_sub_effect uu____6167 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____6170 -> (g, [])
        | FStar_Syntax_Syntax.Sig_pragma p ->
            (FStar_Syntax_Util.process_pragma p se.FStar_Syntax_Syntax.sigrng;
             (g, [])))
@@ -2176,74 +2192,74 @@ let (extract' :
   =
   fun g  ->
     fun m  ->
-      let uu____6190 = FStar_Options.restore_cmd_line_options true  in
+      let uu____6212 = FStar_Options.restore_cmd_line_options true  in
       let name =
         FStar_Extraction_ML_Syntax.mlpath_of_lident
           m.FStar_Syntax_Syntax.name
          in
       let g1 =
-        let uu___989_6194 = g  in
-        let uu____6195 =
+        let uu___991_6216 = g  in
+        let uu____6217 =
           FStar_TypeChecker_Env.set_current_module
             g.FStar_Extraction_ML_UEnv.env_tcenv m.FStar_Syntax_Syntax.name
            in
         {
-          FStar_Extraction_ML_UEnv.env_tcenv = uu____6195;
+          FStar_Extraction_ML_UEnv.env_tcenv = uu____6217;
           FStar_Extraction_ML_UEnv.env_bindings =
-            (uu___989_6194.FStar_Extraction_ML_UEnv.env_bindings);
+            (uu___991_6216.FStar_Extraction_ML_UEnv.env_bindings);
           FStar_Extraction_ML_UEnv.env_mlident_map =
-            (uu___989_6194.FStar_Extraction_ML_UEnv.env_mlident_map);
+            (uu___991_6216.FStar_Extraction_ML_UEnv.env_mlident_map);
           FStar_Extraction_ML_UEnv.tydefs =
-            (uu___989_6194.FStar_Extraction_ML_UEnv.tydefs);
+            (uu___991_6216.FStar_Extraction_ML_UEnv.tydefs);
           FStar_Extraction_ML_UEnv.type_names =
-            (uu___989_6194.FStar_Extraction_ML_UEnv.type_names);
+            (uu___991_6216.FStar_Extraction_ML_UEnv.type_names);
           FStar_Extraction_ML_UEnv.currentModule = name
         }  in
-      let uu____6196 =
+      let uu____6218 =
         FStar_Util.fold_map
           (fun g2  ->
              fun se  ->
-               let uu____6215 =
+               let uu____6237 =
                  FStar_Options.debug_module
                    (m.FStar_Syntax_Syntax.name).FStar_Ident.str
                   in
-               if uu____6215
+               if uu____6237
                then
                  let nm =
-                   let uu____6226 =
+                   let uu____6248 =
                      FStar_All.pipe_right
                        (FStar_Syntax_Util.lids_of_sigelt se)
                        (FStar_List.map FStar_Ident.string_of_lid)
                       in
-                   FStar_All.pipe_right uu____6226 (FStar_String.concat ", ")
+                   FStar_All.pipe_right uu____6248 (FStar_String.concat ", ")
                     in
                  (FStar_Util.print1 "+++About to extract {%s}\n" nm;
-                  (let uu____6243 = FStar_Util.format1 "---Extracted {%s}" nm
+                  (let uu____6265 = FStar_Util.format1 "---Extracted {%s}" nm
                       in
-                   FStar_Util.measure_execution_time uu____6243
-                     (fun uu____6253  -> extract_sig g2 se)))
+                   FStar_Util.measure_execution_time uu____6265
+                     (fun uu____6275  -> extract_sig g2 se)))
                else extract_sig g2 se) g1 m.FStar_Syntax_Syntax.declarations
          in
-      match uu____6196 with
+      match uu____6218 with
       | (g2,sigs) ->
           let mlm = FStar_List.flatten sigs  in
           let is_kremlin =
-            let uu____6275 = FStar_Options.codegen ()  in
-            uu____6275 = (FStar_Pervasives_Native.Some FStar_Options.Kremlin)
+            let uu____6297 = FStar_Options.codegen ()  in
+            uu____6297 = (FStar_Pervasives_Native.Some FStar_Options.Kremlin)
              in
           if
             ((m.FStar_Syntax_Syntax.name).FStar_Ident.str <> "Prims") &&
               (is_kremlin ||
                  (Prims.op_Negation m.FStar_Syntax_Syntax.is_interface))
           then
-            ((let uu____6290 =
-                let uu____6292 = FStar_Options.silent ()  in
-                Prims.op_Negation uu____6292  in
-              if uu____6290
+            ((let uu____6312 =
+                let uu____6314 = FStar_Options.silent ()  in
+                Prims.op_Negation uu____6314  in
+              if uu____6312
               then
-                let uu____6295 =
+                let uu____6317 =
                   FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
-                FStar_Util.print1 "Extracted module %s\n" uu____6295
+                FStar_Util.print1 "Extracted module %s\n" uu____6317
               else ());
              (g2,
                (FStar_Pervasives_Native.Some
@@ -2260,42 +2276,42 @@ let (extract :
   =
   fun g  ->
     fun m  ->
-      (let uu____6370 = FStar_Options.restore_cmd_line_options true  in
-       FStar_All.pipe_left (fun a2  -> ()) uu____6370);
-      (let uu____6373 =
-         let uu____6375 =
+      (let uu____6392 = FStar_Options.restore_cmd_line_options true  in
+       FStar_All.pipe_left (fun a2  -> ()) uu____6392);
+      (let uu____6395 =
+         let uu____6397 =
            FStar_Options.should_extract
              (m.FStar_Syntax_Syntax.name).FStar_Ident.str
             in
-         Prims.op_Negation uu____6375  in
-       if uu____6373
+         Prims.op_Negation uu____6397  in
+       if uu____6395
        then
-         let uu____6378 =
-           let uu____6380 =
+         let uu____6400 =
+           let uu____6402 =
              FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
            FStar_Util.format1
              "Extract called on a module %s that should not be extracted"
-             uu____6380
+             uu____6402
             in
-         failwith uu____6378
+         failwith uu____6400
        else ());
-      (let uu____6385 = FStar_Options.interactive ()  in
-       if uu____6385
+      (let uu____6407 = FStar_Options.interactive ()  in
+       if uu____6407
        then (g, FStar_Pervasives_Native.None)
        else
          (let res =
-            let uu____6405 = FStar_Options.debug_any ()  in
-            if uu____6405
+            let uu____6427 = FStar_Options.debug_any ()  in
+            if uu____6427
             then
               let msg =
-                let uu____6416 =
+                let uu____6438 =
                   FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name
                    in
-                FStar_Util.format1 "Extracting module %s\n" uu____6416  in
+                FStar_Util.format1 "Extracting module %s\n" uu____6438  in
               FStar_Util.measure_execution_time msg
-                (fun uu____6426  -> extract' g m)
+                (fun uu____6448  -> extract' g m)
             else extract' g m  in
-          (let uu____6430 = FStar_Options.restore_cmd_line_options true  in
-           FStar_All.pipe_left (fun a3  -> ()) uu____6430);
+          (let uu____6452 = FStar_Options.restore_cmd_line_options true  in
+           FStar_All.pipe_left (fun a3  -> ()) uu____6452);
           res))
   

--- a/src/ocaml-output/FStar_Ident.ml
+++ b/src/ocaml-output/FStar_Ident.ml
@@ -1,7 +1,7 @@
 open Prims
 type ident = {
   idText: Prims.string ;
-  idRange: FStar_Range.range }[@@deriving yojson,show]
+  idRange: FStar_Range.range }[@@deriving yojson,show,yojson,show]
 let (__proj__Mkident__item__idText : ident -> Prims.string) =
   fun projectee  -> match projectee with | { idText; idRange;_} -> idText 
 let (__proj__Mkident__item__idRange : ident -> FStar_Range.range) =
@@ -12,7 +12,7 @@ type lident =
   ns: ident Prims.list ;
   ident: ident ;
   nsstr: Prims.string ;
-  str: Prims.string }[@@deriving yojson,show]
+  str: Prims.string }[@@deriving yojson,show,yojson,show]
 let (__proj__Mklident__item__ns : lident -> ident Prims.list) =
   fun projectee  -> match projectee with | { ns; ident; nsstr; str;_} -> ns 
 let (__proj__Mklident__item__ident : lident -> ident) =

--- a/src/ocaml-output/FStar_Interactive_Ide.ml
+++ b/src/ocaml-output/FStar_Interactive_Ide.ml
@@ -1755,7 +1755,9 @@ let run_push_without_deps :
                FStar_TypeChecker_Env.nbe =
                  (uu___573_4546.FStar_TypeChecker_Env.nbe);
                FStar_TypeChecker_Env.strict_args_tab =
-                 (uu___573_4546.FStar_TypeChecker_Env.strict_args_tab)
+                 (uu___573_4546.FStar_TypeChecker_Env.strict_args_tab);
+               FStar_TypeChecker_Env.erasable_types_tab =
+                 (uu___573_4546.FStar_TypeChecker_Env.erasable_types_tab)
              });
           FStar_Interactive_JsonHelper.repl_stdin =
             (uu___571_4544.FStar_Interactive_JsonHelper.repl_stdin);

--- a/src/ocaml-output/FStar_Interactive_Legacy.ml
+++ b/src/ocaml-output/FStar_Interactive_Legacy.ml
@@ -140,7 +140,9 @@ let (push_with_kind :
               FStar_TypeChecker_Env.nbe =
                 (uu___30_299.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___30_299.FStar_TypeChecker_Env.strict_args_tab)
+                (uu___30_299.FStar_TypeChecker_Env.strict_args_tab);
+              FStar_TypeChecker_Env.erasable_types_tab =
+                (uu___30_299.FStar_TypeChecker_Env.erasable_types_tab)
             }  in
           let res = FStar_TypeChecker_Tc.push_context env1 msg  in
           FStar_Options.push ();

--- a/src/ocaml-output/FStar_Interactive_PushHelper.ml
+++ b/src/ocaml-output/FStar_Interactive_PushHelper.ml
@@ -114,7 +114,9 @@ let (set_check_kind :
         FStar_TypeChecker_Env.dsenv = uu____72;
         FStar_TypeChecker_Env.nbe = (uu___4_71.FStar_TypeChecker_Env.nbe);
         FStar_TypeChecker_Env.strict_args_tab =
-          (uu___4_71.FStar_TypeChecker_Env.strict_args_tab)
+          (uu___4_71.FStar_TypeChecker_Env.strict_args_tab);
+        FStar_TypeChecker_Env.erasable_types_tab =
+          (uu___4_71.FStar_TypeChecker_Env.erasable_types_tab)
       }
   
 let (repl_ld_tasks_of_deps :

--- a/src/ocaml-output/FStar_Parser_Const.ml
+++ b/src/ocaml-output/FStar_Parser_Const.ml
@@ -239,6 +239,8 @@ let (must_erase_for_extraction_attr : FStar_Ident.lident) =
   psconst "must_erase_for_extraction" 
 let (strict_on_arguments_attr : FStar_Ident.lident) =
   p2l ["FStar"; "Pervasives"; "strict_on_arguments"] 
+let (erasable_attr : FStar_Ident.lident) =
+  p2l ["FStar"; "Pervasives"; "erasable"] 
 let (comment_attr : FStar_Ident.lident) =
   p2l ["FStar"; "Pervasives"; "Comment"] 
 let (fail_attr : FStar_Ident.lident) = psconst "expect_failure" 
@@ -254,13 +256,13 @@ let (postprocess_extr_with : FStar_Ident.lident) =
   p2l ["FStar"; "Tactics"; "Effect"; "postprocess_for_extraction_with"] 
 let (gen_reset : ((unit -> Prims.int) * (unit -> unit))) =
   let x = FStar_Util.mk_ref Prims.int_zero  in
-  let gen1 uu____897 = FStar_Util.incr x; FStar_Util.read x  in
-  let reset uu____905 = FStar_Util.write x Prims.int_zero  in (gen1, reset) 
+  let gen1 uu____905 = FStar_Util.incr x; FStar_Util.read x  in
+  let reset uu____913 = FStar_Util.write x Prims.int_zero  in (gen1, reset) 
 let (next_id : unit -> Prims.int) = FStar_Pervasives_Native.fst gen_reset 
 let (sli : FStar_Ident.lident -> Prims.string) =
   fun l  ->
-    let uu____936 = FStar_Options.print_real_names ()  in
-    if uu____936
+    let uu____944 = FStar_Options.print_real_names ()  in
+    if uu____944
     then l.FStar_Ident.str
     else (l.FStar_Ident.ident).FStar_Ident.idText
   
@@ -272,28 +274,28 @@ let (const_to_string : FStar_Const.sconst -> Prims.string) =
     | FStar_Const.Const_bool b -> if b then "true" else "false"
     | FStar_Const.Const_real r -> FStar_String.op_Hat r "R"
     | FStar_Const.Const_float x1 -> FStar_Util.string_of_float x1
-    | FStar_Const.Const_string (s,uu____965) -> FStar_Util.format1 "\"%s\"" s
-    | FStar_Const.Const_bytearray uu____969 -> "<bytearray>"
-    | FStar_Const.Const_int (x1,uu____978) -> x1
+    | FStar_Const.Const_string (s,uu____973) -> FStar_Util.format1 "\"%s\"" s
+    | FStar_Const.Const_bytearray uu____977 -> "<bytearray>"
+    | FStar_Const.Const_int (x1,uu____986) -> x1
     | FStar_Const.Const_char c ->
-        let uu____995 = FStar_String.op_Hat (FStar_Util.string_of_char c) "'"
-           in
-        FStar_String.op_Hat "'" uu____995
+        let uu____1003 =
+          FStar_String.op_Hat (FStar_Util.string_of_char c) "'"  in
+        FStar_String.op_Hat "'" uu____1003
     | FStar_Const.Const_range r -> FStar_Range.string_of_range r
     | FStar_Const.Const_range_of  -> "range_of"
     | FStar_Const.Const_set_range_of  -> "set_range_of"
     | FStar_Const.Const_reify  -> "reify"
     | FStar_Const.Const_reflect l ->
-        let uu____1004 = sli l  in
-        FStar_Util.format1 "[[%s.reflect]]" uu____1004
+        let uu____1012 = sli l  in
+        FStar_Util.format1 "[[%s.reflect]]" uu____1012
   
 let (mk_tuple_lid : Prims.int -> FStar_Range.range -> FStar_Ident.lident) =
   fun n1  ->
     fun r  ->
       let t =
-        let uu____1022 = FStar_Util.string_of_int n1  in
-        FStar_Util.format1 "tuple%s" uu____1022  in
-      let uu____1025 = psnconst t  in FStar_Ident.set_lid_range uu____1025 r
+        let uu____1030 = FStar_Util.string_of_int n1  in
+        FStar_Util.format1 "tuple%s" uu____1030  in
+      let uu____1033 = psnconst t  in FStar_Ident.set_lid_range uu____1033 r
   
 let (lid_tuple2 : FStar_Ident.lident) =
   mk_tuple_lid (Prims.of_int (2)) FStar_Range.dummyRange 
@@ -301,17 +303,17 @@ let (is_tuple_constructor_string : Prims.string -> Prims.bool) =
   fun s  -> FStar_Util.starts_with s "FStar.Pervasives.Native.tuple" 
 let (is_tuple_constructor_lid : FStar_Ident.ident -> Prims.bool) =
   fun lid  ->
-    let uu____1046 = FStar_Ident.text_of_id lid  in
-    is_tuple_constructor_string uu____1046
+    let uu____1054 = FStar_Ident.text_of_id lid  in
+    is_tuple_constructor_string uu____1054
   
 let (mk_tuple_data_lid :
   Prims.int -> FStar_Range.range -> FStar_Ident.lident) =
   fun n1  ->
     fun r  ->
       let t =
-        let uu____1063 = FStar_Util.string_of_int n1  in
-        FStar_Util.format1 "Mktuple%s" uu____1063  in
-      let uu____1066 = psnconst t  in FStar_Ident.set_lid_range uu____1066 r
+        let uu____1071 = FStar_Util.string_of_int n1  in
+        FStar_Util.format1 "Mktuple%s" uu____1071  in
+      let uu____1074 = psnconst t  in FStar_Ident.set_lid_range uu____1074 r
   
 let (lid_Mktuple2 : FStar_Ident.lident) =
   mk_tuple_data_lid (Prims.of_int (2)) FStar_Range.dummyRange 
@@ -320,8 +322,8 @@ let (is_tuple_datacon_string : Prims.string -> Prims.bool) =
 let (is_tuple_data_lid : FStar_Ident.lident -> Prims.int -> Prims.bool) =
   fun f  ->
     fun n1  ->
-      let uu____1094 = mk_tuple_data_lid n1 FStar_Range.dummyRange  in
-      FStar_Ident.lid_equals f uu____1094
+      let uu____1102 = mk_tuple_data_lid n1 FStar_Range.dummyRange  in
+      FStar_Ident.lid_equals f uu____1102
   
 let (is_tuple_data_lid' : FStar_Ident.lident -> Prims.bool) =
   fun f  -> is_tuple_datacon_string f.FStar_Ident.str 
@@ -331,11 +333,11 @@ let (mk_dtuple_lid : Prims.int -> FStar_Range.range -> FStar_Ident.lident) =
   fun n1  ->
     fun r  ->
       let t =
-        let uu____1142 = FStar_Util.string_of_int n1  in
-        FStar_Util.format1 "dtuple%s" uu____1142  in
-      let uu____1145 = let uu____1146 = mod_prefix_dtuple n1  in uu____1146 t
+        let uu____1150 = FStar_Util.string_of_int n1  in
+        FStar_Util.format1 "dtuple%s" uu____1150  in
+      let uu____1153 = let uu____1154 = mod_prefix_dtuple n1  in uu____1154 t
          in
-      FStar_Ident.set_lid_range uu____1145 r
+      FStar_Ident.set_lid_range uu____1153 r
   
 let (is_dtuple_constructor_string : Prims.string -> Prims.bool) =
   fun s  ->
@@ -349,11 +351,11 @@ let (mk_dtuple_data_lid :
   fun n1  ->
     fun r  ->
       let t =
-        let uu____1187 = FStar_Util.string_of_int n1  in
-        FStar_Util.format1 "Mkdtuple%s" uu____1187  in
-      let uu____1190 = let uu____1191 = mod_prefix_dtuple n1  in uu____1191 t
+        let uu____1195 = FStar_Util.string_of_int n1  in
+        FStar_Util.format1 "Mkdtuple%s" uu____1195  in
+      let uu____1198 = let uu____1199 = mod_prefix_dtuple n1  in uu____1199 t
          in
-      FStar_Ident.set_lid_range uu____1190 r
+      FStar_Ident.set_lid_range uu____1198 r
   
 let (is_dtuple_datacon_string : Prims.string -> Prims.bool) =
   fun s  ->
@@ -363,13 +365,13 @@ let (is_dtuple_datacon_string : Prims.string -> Prims.bool) =
 let (is_dtuple_data_lid : FStar_Ident.lident -> Prims.int -> Prims.bool) =
   fun f  ->
     fun n1  ->
-      let uu____1224 = mk_dtuple_data_lid n1 FStar_Range.dummyRange  in
-      FStar_Ident.lid_equals f uu____1224
+      let uu____1232 = mk_dtuple_data_lid n1 FStar_Range.dummyRange  in
+      FStar_Ident.lid_equals f uu____1232
   
 let (is_dtuple_data_lid' : FStar_Ident.lident -> Prims.bool) =
   fun f  ->
-    let uu____1232 = FStar_Ident.text_of_lid f  in
-    is_dtuple_datacon_string uu____1232
+    let uu____1240 = FStar_Ident.text_of_lid f  in
+    is_dtuple_datacon_string uu____1240
   
 let (is_name : FStar_Ident.lident -> Prims.bool) =
   fun lid  ->

--- a/src/ocaml-output/FStar_Pervasives.ml
+++ b/src/ocaml-output/FStar_Pervasives.ml
@@ -48,7 +48,7 @@ type ('Ah,'Aa,'Apre) all_post_h' = unit
 type ('Ah,'Aa) all_post_h = unit
 type ('Ah,'Aa) all_wp_h = unit
 type ('Aheap,'Aa,'Awp,'Apost,'Ah0) all_ite_wp = unit
-type ('Aheap,'Aa,'Ax,'Ap,'Auu___3_731) all_return = 'Ap
+type ('Aheap,'Aa,'Ax,'Ap,'Auu___3_732) all_return = 'Ap
 type ('Aheap,'Ar1,'Aa,'Ab,'Awp1,'Awp2,'Ap,'Ah0) all_bind_wp = 'Awp1
 type ('Aheap,'Aa,'Ap,'Awp_then,'Awp_else,'Apost,'Ah0) all_if_then_else = unit
 type ('Aheap,'Aa,'Awp1,'Awp2) all_stronger = unit
@@ -61,12 +61,12 @@ type ('a,'b) either =
   | Inl of 'a 
   | Inr of 'b 
 let uu___is_Inl : 'a 'b . ('a,'b) either -> Prims.bool =
-  fun projectee  -> match projectee with | Inl v -> true | uu____960 -> false 
+  fun projectee  -> match projectee with | Inl v -> true | uu____961 -> false 
 let __proj__Inl__item__v : 'a 'b . ('a,'b) either -> 'a =
   fun projectee  -> match projectee with | Inl v -> v 
 let uu___is_Inr : 'a 'b . ('a,'b) either -> Prims.bool =
   fun projectee  ->
-    match projectee with | Inr v -> true | uu____1014 -> false
+    match projectee with | Inr v -> true | uu____1015 -> false
   
 let __proj__Inr__item__v : 'a 'b . ('a,'b) either -> 'b =
   fun projectee  -> match projectee with | Inr v -> v 
@@ -120,75 +120,75 @@ type __internal_ocaml_attributes =
   | CMacro 
 let (uu___is_PpxDerivingShow : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | PpxDerivingShow  -> true | uu____1630 -> false
+    match projectee with | PpxDerivingShow  -> true | uu____1631 -> false
   
 let (uu___is_PpxDerivingShowConstant :
   __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | PpxDerivingShowConstant _0 -> true
-    | uu____1643 -> false
+    | uu____1644 -> false
   
 let (__proj__PpxDerivingShowConstant__item___0 :
   __internal_ocaml_attributes -> Prims.string) =
   fun projectee  -> match projectee with | PpxDerivingShowConstant _0 -> _0 
 let (uu___is_PpxDerivingYoJson : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | PpxDerivingYoJson  -> true | uu____1664 -> false
+    match projectee with | PpxDerivingYoJson  -> true | uu____1665 -> false
   
 let (uu___is_CInline : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CInline  -> true | uu____1675 -> false
+    match projectee with | CInline  -> true | uu____1676 -> false
   
 let (uu___is_Substitute : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Substitute  -> true | uu____1686 -> false
+    match projectee with | Substitute  -> true | uu____1687 -> false
   
 let (uu___is_Gc : __internal_ocaml_attributes -> Prims.bool) =
-  fun projectee  -> match projectee with | Gc  -> true | uu____1697 -> false 
+  fun projectee  -> match projectee with | Gc  -> true | uu____1698 -> false 
 let (uu___is_Comment : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Comment _0 -> true | uu____1710 -> false
+    match projectee with | Comment _0 -> true | uu____1711 -> false
   
 let (__proj__Comment__item___0 : __internal_ocaml_attributes -> Prims.string)
   = fun projectee  -> match projectee with | Comment _0 -> _0 
 let (uu___is_CPrologue : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CPrologue _0 -> true | uu____1733 -> false
+    match projectee with | CPrologue _0 -> true | uu____1734 -> false
   
 let (__proj__CPrologue__item___0 :
   __internal_ocaml_attributes -> Prims.string) =
   fun projectee  -> match projectee with | CPrologue _0 -> _0 
 let (uu___is_CEpilogue : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CEpilogue _0 -> true | uu____1756 -> false
+    match projectee with | CEpilogue _0 -> true | uu____1757 -> false
   
 let (__proj__CEpilogue__item___0 :
   __internal_ocaml_attributes -> Prims.string) =
   fun projectee  -> match projectee with | CEpilogue _0 -> _0 
 let (uu___is_CConst : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CConst _0 -> true | uu____1779 -> false
+    match projectee with | CConst _0 -> true | uu____1780 -> false
   
 let (__proj__CConst__item___0 : __internal_ocaml_attributes -> Prims.string)
   = fun projectee  -> match projectee with | CConst _0 -> _0 
 let (uu___is_CCConv : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CCConv _0 -> true | uu____1802 -> false
+    match projectee with | CCConv _0 -> true | uu____1803 -> false
   
 let (__proj__CCConv__item___0 : __internal_ocaml_attributes -> Prims.string)
   = fun projectee  -> match projectee with | CCConv _0 -> _0 
 let (uu___is_CAbstractStruct : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CAbstractStruct  -> true | uu____1823 -> false
+    match projectee with | CAbstractStruct  -> true | uu____1824 -> false
   
 let (uu___is_CIfDef : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CIfDef  -> true | uu____1834 -> false
+    match projectee with | CIfDef  -> true | uu____1835 -> false
   
 let (uu___is_CMacro : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CMacro  -> true | uu____1845 -> false
+    match projectee with | CMacro  -> true | uu____1846 -> false
   
 
 
@@ -219,51 +219,51 @@ type norm_step =
   | UnfoldAttr of Prims.string Prims.list 
 let (uu___is_Simpl : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Simpl  -> true | uu____1907 -> false
+    match projectee with | Simpl  -> true | uu____1908 -> false
   
 let (uu___is_Weak : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Weak  -> true | uu____1918 -> false
+    match projectee with | Weak  -> true | uu____1919 -> false
   
 let (uu___is_HNF : norm_step -> Prims.bool) =
-  fun projectee  -> match projectee with | HNF  -> true | uu____1929 -> false 
+  fun projectee  -> match projectee with | HNF  -> true | uu____1930 -> false 
 let (uu___is_Primops : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Primops  -> true | uu____1940 -> false
+    match projectee with | Primops  -> true | uu____1941 -> false
   
 let (uu___is_Delta : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Delta  -> true | uu____1951 -> false
+    match projectee with | Delta  -> true | uu____1952 -> false
   
 let (uu___is_Zeta : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Zeta  -> true | uu____1962 -> false
+    match projectee with | Zeta  -> true | uu____1963 -> false
   
 let (uu___is_Iota : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Iota  -> true | uu____1973 -> false
+    match projectee with | Iota  -> true | uu____1974 -> false
   
 let (uu___is_NBE : norm_step -> Prims.bool) =
-  fun projectee  -> match projectee with | NBE  -> true | uu____1984 -> false 
+  fun projectee  -> match projectee with | NBE  -> true | uu____1985 -> false 
 let (uu___is_Reify : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Reify  -> true | uu____1995 -> false
+    match projectee with | Reify  -> true | uu____1996 -> false
   
 let (uu___is_UnfoldOnly : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldOnly _0 -> true | uu____2010 -> false
+    match projectee with | UnfoldOnly _0 -> true | uu____2011 -> false
   
 let (__proj__UnfoldOnly__item___0 : norm_step -> Prims.string Prims.list) =
   fun projectee  -> match projectee with | UnfoldOnly _0 -> _0 
 let (uu___is_UnfoldFully : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldFully _0 -> true | uu____2041 -> false
+    match projectee with | UnfoldFully _0 -> true | uu____2042 -> false
   
 let (__proj__UnfoldFully__item___0 : norm_step -> Prims.string Prims.list) =
   fun projectee  -> match projectee with | UnfoldFully _0 -> _0 
 let (uu___is_UnfoldAttr : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldAttr _0 -> true | uu____2072 -> false
+    match projectee with | UnfoldAttr _0 -> true | uu____2073 -> false
   
 let (__proj__UnfoldAttr__item___0 : norm_step -> Prims.string Prims.list) =
   fun projectee  -> match projectee with | UnfoldAttr _0 -> _0 

--- a/src/ocaml-output/FStar_Pervasives.ml
+++ b/src/ocaml-output/FStar_Pervasives.ml
@@ -6,7 +6,7 @@ type 'Aheap st_pre_h = unit
 type ('Aheap,'Aa,'Apre) st_post_h' = unit
 type ('Aheap,'Aa) st_post_h = unit
 type ('Aheap,'Aa) st_wp_h = unit
-type ('Aheap,'Aa,'Ax,'Ap,'Auu___0_113) st_return = 'Ap
+type ('Aheap,'Aa,'Ax,'Ap,'Auu___0_105) st_return = 'Ap
 type ('Aheap,'Ar1,'Aa,'Ab,'Awp1,'Awp2,'Ap,'Ah0) st_bind_wp = 'Awp1
 type ('Aheap,'Aa,'Ap,'Awp_then,'Awp_else,'Apost,'Ah0) st_if_then_else = unit
 type ('Aheap,'Aa,'Awp,'Apost,'Ah0) st_ite_wp = unit
@@ -18,16 +18,16 @@ type 'Aa result =
   | E of Prims.exn 
   | Err of Prims.string 
 let uu___is_V : 'Aa . 'Aa result -> Prims.bool =
-  fun projectee  -> match projectee with | V v -> true | uu____359 -> false 
+  fun projectee  -> match projectee with | V v -> true | uu____351 -> false 
 let __proj__V__item__v : 'Aa . 'Aa result -> 'Aa =
   fun projectee  -> match projectee with | V v -> v 
 let uu___is_E : 'Aa . 'Aa result -> Prims.bool =
-  fun projectee  -> match projectee with | E e -> true | uu____397 -> false 
+  fun projectee  -> match projectee with | E e -> true | uu____389 -> false 
 let __proj__E__item__e : 'Aa . 'Aa result -> Prims.exn =
   fun projectee  -> match projectee with | E e -> e 
 let uu___is_Err : 'Aa . 'Aa result -> Prims.bool =
   fun projectee  ->
-    match projectee with | Err msg -> true | uu____436 -> false
+    match projectee with | Err msg -> true | uu____428 -> false
   
 let __proj__Err__item__msg : 'Aa . 'Aa result -> Prims.string =
   fun projectee  -> match projectee with | Err msg -> msg 
@@ -48,7 +48,7 @@ type ('Ah,'Aa,'Apre) all_post_h' = unit
 type ('Ah,'Aa) all_post_h = unit
 type ('Ah,'Aa) all_wp_h = unit
 type ('Aheap,'Aa,'Awp,'Apost,'Ah0) all_ite_wp = unit
-type ('Aheap,'Aa,'Ax,'Ap,'Auu___3_748) all_return = 'Ap
+type ('Aheap,'Aa,'Ax,'Ap,'Auu___3_731) all_return = 'Ap
 type ('Aheap,'Ar1,'Aa,'Ab,'Awp1,'Awp2,'Ap,'Ah0) all_bind_wp = 'Awp1
 type ('Aheap,'Aa,'Ap,'Awp_then,'Awp_else,'Apost,'Ah0) all_if_then_else = unit
 type ('Aheap,'Aa,'Awp1,'Awp2) all_stronger = unit
@@ -61,12 +61,12 @@ type ('a,'b) either =
   | Inl of 'a 
   | Inr of 'b 
 let uu___is_Inl : 'a 'b . ('a,'b) either -> Prims.bool =
-  fun projectee  -> match projectee with | Inl v -> true | uu____979 -> false 
+  fun projectee  -> match projectee with | Inl v -> true | uu____960 -> false 
 let __proj__Inl__item__v : 'a 'b . ('a,'b) either -> 'a =
   fun projectee  -> match projectee with | Inl v -> v 
 let uu___is_Inr : 'a 'b . ('a,'b) either -> Prims.bool =
   fun projectee  ->
-    match projectee with | Inr v -> true | uu____1033 -> false
+    match projectee with | Inr v -> true | uu____1014 -> false
   
 let __proj__Inr__item__v : 'a 'b . ('a,'b) either -> 'b =
   fun projectee  -> match projectee with | Inr v -> v 
@@ -120,76 +120,77 @@ type __internal_ocaml_attributes =
   | CMacro 
 let (uu___is_PpxDerivingShow : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | PpxDerivingShow  -> true | uu____1651 -> false
+    match projectee with | PpxDerivingShow  -> true | uu____1630 -> false
   
 let (uu___is_PpxDerivingShowConstant :
   __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | PpxDerivingShowConstant _0 -> true
-    | uu____1664 -> false
+    | uu____1643 -> false
   
 let (__proj__PpxDerivingShowConstant__item___0 :
   __internal_ocaml_attributes -> Prims.string) =
   fun projectee  -> match projectee with | PpxDerivingShowConstant _0 -> _0 
 let (uu___is_PpxDerivingYoJson : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | PpxDerivingYoJson  -> true | uu____1685 -> false
+    match projectee with | PpxDerivingYoJson  -> true | uu____1664 -> false
   
 let (uu___is_CInline : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CInline  -> true | uu____1696 -> false
+    match projectee with | CInline  -> true | uu____1675 -> false
   
 let (uu___is_Substitute : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Substitute  -> true | uu____1707 -> false
+    match projectee with | Substitute  -> true | uu____1686 -> false
   
 let (uu___is_Gc : __internal_ocaml_attributes -> Prims.bool) =
-  fun projectee  -> match projectee with | Gc  -> true | uu____1718 -> false 
+  fun projectee  -> match projectee with | Gc  -> true | uu____1697 -> false 
 let (uu___is_Comment : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Comment _0 -> true | uu____1731 -> false
+    match projectee with | Comment _0 -> true | uu____1710 -> false
   
 let (__proj__Comment__item___0 : __internal_ocaml_attributes -> Prims.string)
   = fun projectee  -> match projectee with | Comment _0 -> _0 
 let (uu___is_CPrologue : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CPrologue _0 -> true | uu____1754 -> false
+    match projectee with | CPrologue _0 -> true | uu____1733 -> false
   
 let (__proj__CPrologue__item___0 :
   __internal_ocaml_attributes -> Prims.string) =
   fun projectee  -> match projectee with | CPrologue _0 -> _0 
 let (uu___is_CEpilogue : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CEpilogue _0 -> true | uu____1777 -> false
+    match projectee with | CEpilogue _0 -> true | uu____1756 -> false
   
 let (__proj__CEpilogue__item___0 :
   __internal_ocaml_attributes -> Prims.string) =
   fun projectee  -> match projectee with | CEpilogue _0 -> _0 
 let (uu___is_CConst : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CConst _0 -> true | uu____1800 -> false
+    match projectee with | CConst _0 -> true | uu____1779 -> false
   
 let (__proj__CConst__item___0 : __internal_ocaml_attributes -> Prims.string)
   = fun projectee  -> match projectee with | CConst _0 -> _0 
 let (uu___is_CCConv : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CCConv _0 -> true | uu____1823 -> false
+    match projectee with | CCConv _0 -> true | uu____1802 -> false
   
 let (__proj__CCConv__item___0 : __internal_ocaml_attributes -> Prims.string)
   = fun projectee  -> match projectee with | CCConv _0 -> _0 
 let (uu___is_CAbstractStruct : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CAbstractStruct  -> true | uu____1844 -> false
+    match projectee with | CAbstractStruct  -> true | uu____1823 -> false
   
 let (uu___is_CIfDef : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CIfDef  -> true | uu____1855 -> false
+    match projectee with | CIfDef  -> true | uu____1834 -> false
   
 let (uu___is_CMacro : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CMacro  -> true | uu____1866 -> false
+    match projectee with | CMacro  -> true | uu____1845 -> false
   
+
 
 
 
@@ -218,51 +219,51 @@ type norm_step =
   | UnfoldAttr of Prims.string Prims.list 
 let (uu___is_Simpl : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Simpl  -> true | uu____1931 -> false
+    match projectee with | Simpl  -> true | uu____1907 -> false
   
 let (uu___is_Weak : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Weak  -> true | uu____1942 -> false
+    match projectee with | Weak  -> true | uu____1918 -> false
   
 let (uu___is_HNF : norm_step -> Prims.bool) =
-  fun projectee  -> match projectee with | HNF  -> true | uu____1953 -> false 
+  fun projectee  -> match projectee with | HNF  -> true | uu____1929 -> false 
 let (uu___is_Primops : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Primops  -> true | uu____1964 -> false
+    match projectee with | Primops  -> true | uu____1940 -> false
   
 let (uu___is_Delta : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Delta  -> true | uu____1975 -> false
+    match projectee with | Delta  -> true | uu____1951 -> false
   
 let (uu___is_Zeta : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Zeta  -> true | uu____1986 -> false
+    match projectee with | Zeta  -> true | uu____1962 -> false
   
 let (uu___is_Iota : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Iota  -> true | uu____1997 -> false
+    match projectee with | Iota  -> true | uu____1973 -> false
   
 let (uu___is_NBE : norm_step -> Prims.bool) =
-  fun projectee  -> match projectee with | NBE  -> true | uu____2008 -> false 
+  fun projectee  -> match projectee with | NBE  -> true | uu____1984 -> false 
 let (uu___is_Reify : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Reify  -> true | uu____2019 -> false
+    match projectee with | Reify  -> true | uu____1995 -> false
   
 let (uu___is_UnfoldOnly : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldOnly _0 -> true | uu____2034 -> false
+    match projectee with | UnfoldOnly _0 -> true | uu____2010 -> false
   
 let (__proj__UnfoldOnly__item___0 : norm_step -> Prims.string Prims.list) =
   fun projectee  -> match projectee with | UnfoldOnly _0 -> _0 
 let (uu___is_UnfoldFully : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldFully _0 -> true | uu____2065 -> false
+    match projectee with | UnfoldFully _0 -> true | uu____2041 -> false
   
 let (__proj__UnfoldFully__item___0 : norm_step -> Prims.string Prims.list) =
   fun projectee  -> match projectee with | UnfoldFully _0 -> _0 
 let (uu___is_UnfoldAttr : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldAttr _0 -> true | uu____2096 -> false
+    match projectee with | UnfoldAttr _0 -> true | uu____2072 -> false
   
 let (__proj__UnfoldAttr__item___0 : norm_step -> Prims.string Prims.list) =
   fun projectee  -> match projectee with | UnfoldAttr _0 -> _0 

--- a/src/ocaml-output/FStar_Range.ml
+++ b/src/ocaml-output/FStar_Range.ml
@@ -2,7 +2,7 @@ open Prims
 type file_name = Prims.string[@@deriving yojson,show]
 type pos = {
   line: Prims.int ;
-  col: Prims.int }[@@deriving yojson,show]
+  col: Prims.int }[@@deriving yojson,show,yojson,show]
 let (__proj__Mkpos__item__line : pos -> Prims.int) =
   fun projectee  -> match projectee with | { line; col;_} -> line 
 let (__proj__Mkpos__item__col : pos -> Prims.int) =
@@ -17,7 +17,7 @@ let (pos_geq : pos -> pos -> Prims.bool) =
 type rng = {
   file_name: file_name ;
   start_pos: pos ;
-  end_pos: pos }[@@deriving yojson,show]
+  end_pos: pos }[@@deriving yojson,show,yojson,show]
 let (__proj__Mkrng__item__file_name : rng -> file_name) =
   fun projectee  ->
     match projectee with | { file_name; start_pos; end_pos;_} -> file_name
@@ -32,7 +32,7 @@ let (__proj__Mkrng__item__end_pos : rng -> pos) =
   
 type range = {
   def_range: rng ;
-  use_range: rng }[@@deriving yojson,show]
+  use_range: rng }[@@deriving yojson,show,yojson,show]
 let (__proj__Mkrange__item__def_range : range -> rng) =
   fun projectee  ->
     match projectee with | { def_range; use_range;_} -> def_range

--- a/src/ocaml-output/FStar_Reflection_Data.ml
+++ b/src/ocaml-output/FStar_Reflection_Data.ml
@@ -174,27 +174,27 @@ let (uu___is_Tv_Type : term_view -> Prims.bool) =
 
 let (uu___is_Tv_Refine : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_Refine _0 -> true | uu____690 -> false
+    match projectee with | Tv_Refine _0 -> true | uu____689 -> false
   
 let (__proj__Tv_Refine__item___0 :
   term_view -> (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term)) =
   fun projectee  -> match projectee with | Tv_Refine _0 -> _0 
 let (uu___is_Tv_Const : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_Const _0 -> true | uu____721 -> false
+    match projectee with | Tv_Const _0 -> true | uu____720 -> false
   
 let (__proj__Tv_Const__item___0 : term_view -> vconst) =
   fun projectee  -> match projectee with | Tv_Const _0 -> _0 
 let (uu___is_Tv_Uvar : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_Uvar _0 -> true | uu____744 -> false
+    match projectee with | Tv_Uvar _0 -> true | uu____743 -> false
   
 let (__proj__Tv_Uvar__item___0 :
   term_view -> (FStar_BigInt.t * FStar_Syntax_Syntax.ctx_uvar_and_subst)) =
   fun projectee  -> match projectee with | Tv_Uvar _0 -> _0 
 let (uu___is_Tv_Let : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_Let _0 -> true | uu____784 -> false
+    match projectee with | Tv_Let _0 -> true | uu____783 -> false
   
 let (__proj__Tv_Let__item___0 :
   term_view ->
@@ -203,14 +203,14 @@ let (__proj__Tv_Let__item___0 :
   = fun projectee  -> match projectee with | Tv_Let _0 -> _0 
 let (uu___is_Tv_Match : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_Match _0 -> true | uu____836 -> false
+    match projectee with | Tv_Match _0 -> true | uu____835 -> false
   
 let (__proj__Tv_Match__item___0 :
   term_view -> (FStar_Syntax_Syntax.term * branch Prims.list)) =
   fun projectee  -> match projectee with | Tv_Match _0 -> _0 
 let (uu___is_Tv_AscribedT : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_AscribedT _0 -> true | uu____881 -> false
+    match projectee with | Tv_AscribedT _0 -> true | uu____880 -> false
   
 let (__proj__Tv_AscribedT__item___0 :
   term_view ->
@@ -219,7 +219,7 @@ let (__proj__Tv_AscribedT__item___0 :
   = fun projectee  -> match projectee with | Tv_AscribedT _0 -> _0 
 let (uu___is_Tv_AscribedC : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_AscribedC _0 -> true | uu____932 -> false
+    match projectee with | Tv_AscribedC _0 -> true | uu____931 -> false
   
 let (__proj__Tv_AscribedC__item___0 :
   term_view ->
@@ -228,7 +228,7 @@ let (__proj__Tv_AscribedC__item___0 :
   = fun projectee  -> match projectee with | Tv_AscribedC _0 -> _0 
 let (uu___is_Tv_Unknown : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_Unknown  -> true | uu____974 -> false
+    match projectee with | Tv_Unknown  -> true | uu____973 -> false
   
 type bv_view =
   {
@@ -255,7 +255,7 @@ type comp_view =
   | C_Unknown 
 let (uu___is_C_Total : comp_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | C_Total _0 -> true | uu____1064 -> false
+    match projectee with | C_Total _0 -> true | uu____1063 -> false
   
 let (__proj__C_Total__item___0 :
   comp_view ->
@@ -263,14 +263,14 @@ let (__proj__C_Total__item___0 :
   = fun projectee  -> match projectee with | C_Total _0 -> _0 
 let (uu___is_C_Lemma : comp_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | C_Lemma _0 -> true | uu____1105 -> false
+    match projectee with | C_Lemma _0 -> true | uu____1104 -> false
   
 let (__proj__C_Lemma__item___0 :
   comp_view -> (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term)) =
   fun projectee  -> match projectee with | C_Lemma _0 -> _0 
 let (uu___is_C_Unknown : comp_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | C_Unknown  -> true | uu____1135 -> false
+    match projectee with | C_Unknown  -> true | uu____1134 -> false
   
 type sigelt_view =
   | Sg_Let of (Prims.bool * FStar_Syntax_Syntax.fv *
@@ -282,7 +282,7 @@ type sigelt_view =
   | Unk 
 let (uu___is_Sg_Let : sigelt_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Sg_Let _0 -> true | uu____1208 -> false
+    match projectee with | Sg_Let _0 -> true | uu____1207 -> false
   
 let (__proj__Sg_Let__item___0 :
   sigelt_view ->
@@ -291,7 +291,7 @@ let (__proj__Sg_Let__item___0 :
   = fun projectee  -> match projectee with | Sg_Let _0 -> _0 
 let (uu___is_Sg_Inductive : sigelt_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Sg_Inductive _0 -> true | uu____1282 -> false
+    match projectee with | Sg_Inductive _0 -> true | uu____1281 -> false
   
 let (__proj__Sg_Inductive__item___0 :
   sigelt_view ->
@@ -300,12 +300,12 @@ let (__proj__Sg_Inductive__item___0 :
   = fun projectee  -> match projectee with | Sg_Inductive _0 -> _0 
 let (uu___is_Sg_Constructor : sigelt_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Sg_Constructor _0 -> true | uu____1353 -> false
+    match projectee with | Sg_Constructor _0 -> true | uu____1352 -> false
   
 let (__proj__Sg_Constructor__item___0 : sigelt_view -> (name * typ)) =
   fun projectee  -> match projectee with | Sg_Constructor _0 -> _0 
 let (uu___is_Unk : sigelt_view -> Prims.bool) =
-  fun projectee  -> match projectee with | Unk  -> true | uu____1383 -> false 
+  fun projectee  -> match projectee with | Unk  -> true | uu____1382 -> false 
 type var = FStar_BigInt.t
 type exp =
   | Unit 
@@ -313,17 +313,17 @@ type exp =
   | Mult of (exp * exp) 
 let (uu___is_Unit : exp -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Unit  -> true | uu____1408 -> false
+    match projectee with | Unit  -> true | uu____1407 -> false
   
 let (uu___is_Var : exp -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Var _0 -> true | uu____1420 -> false
+    match projectee with | Var _0 -> true | uu____1419 -> false
   
 let (__proj__Var__item___0 : exp -> var) =
   fun projectee  -> match projectee with | Var _0 -> _0 
 let (uu___is_Mult : exp -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Mult _0 -> true | uu____1443 -> false
+    match projectee with | Mult _0 -> true | uu____1442 -> false
   
 let (__proj__Mult__item___0 : exp -> (exp * exp)) =
   fun projectee  -> match projectee with | Mult _0 -> _0 
@@ -360,42 +360,42 @@ let (fstar_refl_data_lid : Prims.string -> FStar_Ident.lident) =
 let (fstar_refl_data_const : Prims.string -> refl_constant) =
   fun s  ->
     let lid = fstar_refl_data_lid s  in
-    let uu____1593 =
+    let uu____1592 =
       FStar_Syntax_Syntax.lid_as_fv lid FStar_Syntax_Syntax.delta_constant
         (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
        in
-    let uu____1594 = FStar_Syntax_Syntax.tdataconstr lid  in
-    { lid; fv = uu____1593; t = uu____1594 }
+    let uu____1593 = FStar_Syntax_Syntax.tdataconstr lid  in
+    { lid; fv = uu____1592; t = uu____1593 }
   
 let (mk_refl_types_lid_as_term : Prims.string -> FStar_Syntax_Syntax.term) =
   fun s  ->
-    let uu____1603 = fstar_refl_types_lid s  in
-    FStar_Syntax_Syntax.tconst uu____1603
+    let uu____1602 = fstar_refl_types_lid s  in
+    FStar_Syntax_Syntax.tconst uu____1602
   
 let (mk_refl_types_lid_as_fv : Prims.string -> FStar_Syntax_Syntax.fv) =
   fun s  ->
-    let uu____1612 = fstar_refl_types_lid s  in
-    FStar_Syntax_Syntax.fvconst uu____1612
+    let uu____1611 = fstar_refl_types_lid s  in
+    FStar_Syntax_Syntax.fvconst uu____1611
   
 let (mk_refl_syntax_lid_as_term : Prims.string -> FStar_Syntax_Syntax.term) =
   fun s  ->
-    let uu____1621 = fstar_refl_syntax_lid s  in
-    FStar_Syntax_Syntax.tconst uu____1621
+    let uu____1620 = fstar_refl_syntax_lid s  in
+    FStar_Syntax_Syntax.tconst uu____1620
   
 let (mk_refl_syntax_lid_as_fv : Prims.string -> FStar_Syntax_Syntax.fv) =
   fun s  ->
-    let uu____1630 = fstar_refl_syntax_lid s  in
-    FStar_Syntax_Syntax.fvconst uu____1630
+    let uu____1629 = fstar_refl_syntax_lid s  in
+    FStar_Syntax_Syntax.fvconst uu____1629
   
 let (mk_refl_data_lid_as_term : Prims.string -> FStar_Syntax_Syntax.term) =
   fun s  ->
-    let uu____1639 = fstar_refl_data_lid s  in
-    FStar_Syntax_Syntax.tconst uu____1639
+    let uu____1638 = fstar_refl_data_lid s  in
+    FStar_Syntax_Syntax.tconst uu____1638
   
 let (mk_refl_data_lid_as_fv : Prims.string -> FStar_Syntax_Syntax.fv) =
   fun s  ->
-    let uu____1648 = fstar_refl_data_lid s  in
-    FStar_Syntax_Syntax.fvconst uu____1648
+    let uu____1647 = fstar_refl_data_lid s  in
+    FStar_Syntax_Syntax.fvconst uu____1647
   
 let (mk_inspect_pack_pair : Prims.string -> (refl_constant * refl_constant))
   =
@@ -413,11 +413,11 @@ let (mk_inspect_pack_pair : Prims.string -> (refl_constant * refl_constant))
         FStar_Pervasives_Native.None
        in
     let inspect =
-      let uu____1670 = FStar_Syntax_Syntax.fv_to_tm inspect_fv  in
-      { lid = inspect_lid; fv = inspect_fv; t = uu____1670 }  in
+      let uu____1669 = FStar_Syntax_Syntax.fv_to_tm inspect_fv  in
+      { lid = inspect_lid; fv = inspect_fv; t = uu____1669 }  in
     let pack =
-      let uu____1672 = FStar_Syntax_Syntax.fv_to_tm pack_fv  in
-      { lid = pack_lid; fv = pack_fv; t = uu____1672 }  in
+      let uu____1671 = FStar_Syntax_Syntax.fv_to_tm pack_fv  in
+      { lid = pack_lid; fv = pack_fv; t = uu____1671 }  in
     (inspect, pack)
   
 let (uu___71 : (refl_constant * refl_constant)) = mk_inspect_pack_pair "_ln" 
@@ -548,28 +548,28 @@ let (fstar_refl_exp_fv : FStar_Syntax_Syntax.fv) =
 let (ref_Mk_bv : refl_constant) =
   let lid = fstar_refl_data_lid "Mkbv_view"  in
   let attr =
-    let uu____1821 =
-      let uu____1828 = fstar_refl_data_lid "bv_view"  in
-      let uu____1830 =
-        let uu____1833 =
+    let uu____1820 =
+      let uu____1827 = fstar_refl_data_lid "bv_view"  in
+      let uu____1829 =
+        let uu____1832 =
           FStar_Ident.mk_ident ("bv_ppname", FStar_Range.dummyRange)  in
-        let uu____1836 =
-          let uu____1839 =
+        let uu____1835 =
+          let uu____1838 =
             FStar_Ident.mk_ident ("bv_index", FStar_Range.dummyRange)  in
-          let uu____1842 =
-            let uu____1845 =
+          let uu____1841 =
+            let uu____1844 =
               FStar_Ident.mk_ident ("bv_sort", FStar_Range.dummyRange)  in
-            [uu____1845]  in
-          uu____1839 :: uu____1842  in
-        uu____1833 :: uu____1836  in
-      (uu____1828, uu____1830)  in
-    FStar_Syntax_Syntax.Record_ctor uu____1821  in
+            [uu____1844]  in
+          uu____1838 :: uu____1841  in
+        uu____1832 :: uu____1835  in
+      (uu____1827, uu____1829)  in
+    FStar_Syntax_Syntax.Record_ctor uu____1820  in
   let fv =
     FStar_Syntax_Syntax.lid_as_fv lid FStar_Syntax_Syntax.delta_constant
       (FStar_Pervasives_Native.Some attr)
      in
-  let uu____1851 = FStar_Syntax_Syntax.fv_to_tm fv  in
-  { lid; fv; t = uu____1851 } 
+  let uu____1850 = FStar_Syntax_Syntax.fv_to_tm fv  in
+  { lid; fv; t = uu____1850 } 
 let (ref_Q_Explicit : refl_constant) = fstar_refl_data_const "Q_Explicit" 
 let (ref_Q_Implicit : refl_constant) = fstar_refl_data_const "Q_Implicit" 
 let (ref_Q_Meta : refl_constant) = fstar_refl_data_const "Q_Meta" 
@@ -613,11 +613,11 @@ let (ref_E_Unit : refl_constant) = fstar_refl_data_const "Unit"
 let (ref_E_Var : refl_constant) = fstar_refl_data_const "Var" 
 let (ref_E_Mult : refl_constant) = fstar_refl_data_const "Mult" 
 let (t_exp : FStar_Syntax_Syntax.term) =
-  let uu____1935 =
+  let uu____1934 =
     FStar_Ident.lid_of_path ["FStar"; "Reflection"; "Data"; "exp"]
       FStar_Range.dummyRange
      in
-  FStar_Syntax_Syntax.tconst uu____1935 
+  FStar_Syntax_Syntax.tconst uu____1934 
 let (ord_Lt_lid : FStar_Ident.lident) =
   FStar_Ident.lid_of_path ["FStar"; "Order"; "Lt"] FStar_Range.dummyRange 
 let (ord_Eq_lid : FStar_Ident.lident) =

--- a/src/ocaml-output/FStar_SMTEncoding_Encode.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Encode.ml
@@ -1935,7 +1935,10 @@ let (encode_free_var :
                                      FStar_TypeChecker_Env.nbe =
                                        (uu___311_7435.FStar_TypeChecker_Env.nbe);
                                      FStar_TypeChecker_Env.strict_args_tab =
-                                       (uu___311_7435.FStar_TypeChecker_Env.strict_args_tab)
+                                       (uu___311_7435.FStar_TypeChecker_Env.strict_args_tab);
+                                     FStar_TypeChecker_Env.erasable_types_tab
+                                       =
+                                       (uu___311_7435.FStar_TypeChecker_Env.erasable_types_tab)
                                    }) comp FStar_Syntax_Syntax.U_unknown
                                  in
                               FStar_Syntax_Syntax.mk_Total uu____7432
@@ -2942,7 +2945,9 @@ let (encode_top_level_let :
                   FStar_TypeChecker_Env.nbe =
                     (uu___523_9449.FStar_TypeChecker_Env.nbe);
                   FStar_TypeChecker_Env.strict_args_tab =
-                    (uu___523_9449.FStar_TypeChecker_Env.strict_args_tab)
+                    (uu___523_9449.FStar_TypeChecker_Env.strict_args_tab);
+                  FStar_TypeChecker_Env.erasable_types_tab =
+                    (uu___523_9449.FStar_TypeChecker_Env.erasable_types_tab)
                 }  in
               let subst_comp1 formals actuals comp =
                 let subst1 =

--- a/src/ocaml-output/FStar_SMTEncoding_EncodeTerm.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_EncodeTerm.ml
@@ -1639,7 +1639,9 @@ and (encode_term :
                               FStar_TypeChecker_Env.nbe =
                                 (uu___725_5340.FStar_TypeChecker_Env.nbe);
                               FStar_TypeChecker_Env.strict_args_tab =
-                                (uu___725_5340.FStar_TypeChecker_Env.strict_args_tab)
+                                (uu___725_5340.FStar_TypeChecker_Env.strict_args_tab);
+                              FStar_TypeChecker_Env.erasable_types_tab =
+                                (uu___725_5340.FStar_TypeChecker_Env.erasable_types_tab)
                             }) res
                           in
                        (match uu____5331 with

--- a/src/ocaml-output/FStar_Syntax_Syntax.ml
+++ b/src/ocaml-output/FStar_Syntax_Syntax.ml
@@ -1,7 +1,7 @@
 open Prims
 type 'a withinfo_t = {
   v: 'a ;
-  p: FStar_Range.range }[@@deriving yojson,show]
+  p: FStar_Range.range }[@@deriving yojson,show,yojson,show]
 let __proj__Mkwithinfo_t__item__v : 'a . 'a withinfo_t -> 'a =
   fun projectee  -> match projectee with | { v = v1; p;_} -> v1 
 let __proj__Mkwithinfo_t__item__p : 'a . 'a withinfo_t -> FStar_Range.range =
@@ -14,7 +14,7 @@ type pragma =
   | PushOptions of Prims.string FStar_Pervasives_Native.option 
   | PopOptions 
   | RestartSolver 
-  | LightOff [@@deriving yojson,show]
+  | LightOff [@@deriving yojson,show,yojson,show]
 let (uu___is_SetOptions : pragma -> Prims.bool) =
   fun projectee  ->
     match projectee with | SetOptions _0 -> true | uu____175 -> false
@@ -77,7 +77,7 @@ let (__proj__ET_app__item___0 :
   fun projectee  -> match projectee with | ET_app _0 -> _0 
 type version = {
   major: Prims.int ;
-  minor: Prims.int }[@@deriving yojson,show]
+  minor: Prims.int }[@@deriving yojson,show,yojson,show]
 let (__proj__Mkversion__item__major : version -> Prims.int) =
   fun projectee  -> match projectee with | { major; minor;_} -> major 
 let (__proj__Mkversion__item__minor : version -> Prims.int) =
@@ -90,7 +90,7 @@ type universe =
   | U_name of FStar_Ident.ident 
   | U_unif of (universe FStar_Pervasives_Native.option FStar_Unionfind.p_uvar
   * version) 
-  | U_unknown [@@deriving yojson,show]
+  | U_unknown [@@deriving yojson,show,yojson,show]
 let (uu___is_U_zero : universe -> Prims.bool) =
   fun projectee  ->
     match projectee with | U_zero  -> true | uu____485 -> false
@@ -141,7 +141,7 @@ type universes = universe Prims.list[@@deriving yojson,show]
 type monad_name = FStar_Ident.lident[@@deriving yojson,show]
 type quote_kind =
   | Quote_static 
-  | Quote_dynamic [@@deriving yojson,show]
+  | Quote_dynamic [@@deriving yojson,show,yojson,show]
 let (uu___is_Quote_static : quote_kind -> Prims.bool) =
   fun projectee  ->
     match projectee with | Quote_static  -> true | uu____658 -> false
@@ -152,7 +152,7 @@ let (uu___is_Quote_dynamic : quote_kind -> Prims.bool) =
   
 type maybe_set_use_range =
   | NoUseRange 
-  | SomeUseRange of FStar_Range.range [@@deriving yojson,show]
+  | SomeUseRange of FStar_Range.range [@@deriving yojson,show,yojson,show]
 let (uu___is_NoUseRange : maybe_set_use_range -> Prims.bool) =
   fun projectee  ->
     match projectee with | NoUseRange  -> true | uu____685 -> false
@@ -167,7 +167,7 @@ let (__proj__SomeUseRange__item___0 :
 type delta_depth =
   | Delta_constant_at_level of Prims.int 
   | Delta_equational_at_level of Prims.int 
-  | Delta_abstract of delta_depth [@@deriving yojson,show]
+  | Delta_abstract of delta_depth [@@deriving yojson,show,yojson,show]
 let (uu___is_Delta_constant_at_level : delta_depth -> Prims.bool) =
   fun projectee  ->
     match projectee with
@@ -194,7 +194,7 @@ let (__proj__Delta_abstract__item___0 : delta_depth -> delta_depth) =
 type should_check_uvar =
   | Allow_unresolved 
   | Allow_untyped 
-  | Strict [@@deriving yojson,show]
+  | Strict [@@deriving yojson,show,yojson,show]
 let (uu___is_Allow_unresolved : should_check_uvar -> Prims.bool) =
   fun projectee  ->
     match projectee with | Allow_unresolved  -> true | uu____797 -> false

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -1522,7 +1522,9 @@ let (__tc :
                     FStar_TypeChecker_Env.nbe =
                       (uu___484_3058.FStar_TypeChecker_Env.nbe);
                     FStar_TypeChecker_Env.strict_args_tab =
-                      (uu___484_3058.FStar_TypeChecker_Env.strict_args_tab)
+                      (uu___484_3058.FStar_TypeChecker_Env.strict_args_tab);
+                    FStar_TypeChecker_Env.erasable_types_tab =
+                      (uu___484_3058.FStar_TypeChecker_Env.erasable_types_tab)
                   }  in
                 try
                   (fun uu___488_3070  ->
@@ -1657,7 +1659,9 @@ let (__tc_ghost :
                     FStar_TypeChecker_Env.nbe =
                       (uu___505_3194.FStar_TypeChecker_Env.nbe);
                     FStar_TypeChecker_Env.strict_args_tab =
-                      (uu___505_3194.FStar_TypeChecker_Env.strict_args_tab)
+                      (uu___505_3194.FStar_TypeChecker_Env.strict_args_tab);
+                    FStar_TypeChecker_Env.erasable_types_tab =
+                      (uu___505_3194.FStar_TypeChecker_Env.erasable_types_tab)
                   }  in
                 try
                   (fun uu___509_3209  ->
@@ -1796,7 +1800,9 @@ let (__tc_lax :
                     FStar_TypeChecker_Env.nbe =
                       (uu___530_3345.FStar_TypeChecker_Env.nbe);
                     FStar_TypeChecker_Env.strict_args_tab =
-                      (uu___530_3345.FStar_TypeChecker_Env.strict_args_tab)
+                      (uu___530_3345.FStar_TypeChecker_Env.strict_args_tab);
+                    FStar_TypeChecker_Env.erasable_types_tab =
+                      (uu___530_3345.FStar_TypeChecker_Env.erasable_types_tab)
                   }  in
                 let e2 =
                   let uu___533_3348 = e1  in
@@ -1887,7 +1893,9 @@ let (__tc_lax :
                     FStar_TypeChecker_Env.nbe =
                       (uu___533_3348.FStar_TypeChecker_Env.nbe);
                     FStar_TypeChecker_Env.strict_args_tab =
-                      (uu___533_3348.FStar_TypeChecker_Env.strict_args_tab)
+                      (uu___533_3348.FStar_TypeChecker_Env.strict_args_tab);
+                    FStar_TypeChecker_Env.erasable_types_tab =
+                      (uu___533_3348.FStar_TypeChecker_Env.erasable_types_tab)
                   }  in
                 try
                   (fun uu___537_3360  ->
@@ -3611,7 +3619,10 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> unit tac) =
                                                                     (uu___1011_7283.FStar_TypeChecker_Env.nbe);
                                                                     FStar_TypeChecker_Env.strict_args_tab
                                                                     =
-                                                                    (uu___1011_7283.FStar_TypeChecker_Env.strict_args_tab)
+                                                                    (uu___1011_7283.FStar_TypeChecker_Env.strict_args_tab);
+                                                                    FStar_TypeChecker_Env.erasable_types_tab
+                                                                    =
+                                                                    (uu___1011_7283.FStar_TypeChecker_Env.erasable_types_tab)
                                                                     }  in
                                                                     let g_typ
                                                                     =
@@ -4733,7 +4744,9 @@ let (pointwise_rec :
                      FStar_TypeChecker_Env.nbe =
                        (uu___1409_9935.FStar_TypeChecker_Env.nbe);
                      FStar_TypeChecker_Env.strict_args_tab =
-                       (uu___1409_9935.FStar_TypeChecker_Env.strict_args_tab)
+                       (uu___1409_9935.FStar_TypeChecker_Env.strict_args_tab);
+                     FStar_TypeChecker_Env.erasable_types_tab =
+                       (uu___1409_9935.FStar_TypeChecker_Env.erasable_types_tab)
                    }) t
                  in
               match uu____9926 with
@@ -5106,7 +5119,9 @@ let (rewrite_rec :
                                    FStar_TypeChecker_Env.nbe =
                                      (uu___1516_10917.FStar_TypeChecker_Env.nbe);
                                    FStar_TypeChecker_Env.strict_args_tab =
-                                     (uu___1516_10917.FStar_TypeChecker_Env.strict_args_tab)
+                                     (uu___1516_10917.FStar_TypeChecker_Env.strict_args_tab);
+                                   FStar_TypeChecker_Env.erasable_types_tab =
+                                     (uu___1516_10917.FStar_TypeChecker_Env.erasable_types_tab)
                                  }) t1
                                in
                             match uu____10908 with
@@ -5586,7 +5601,9 @@ let (join_goals :
                                   FStar_TypeChecker_Env.nbe =
                                     (uu___1647_11818.FStar_TypeChecker_Env.nbe);
                                   FStar_TypeChecker_Env.strict_args_tab =
-                                    (uu___1647_11818.FStar_TypeChecker_Env.strict_args_tab)
+                                    (uu___1647_11818.FStar_TypeChecker_Env.strict_args_tab);
+                                  FStar_TypeChecker_Env.erasable_types_tab =
+                                    (uu___1647_11818.FStar_TypeChecker_Env.erasable_types_tab)
                                 }  in
                               let uu____11823 =
                                 mk_irrelevant_goal "joined" nenv ng
@@ -5885,7 +5902,9 @@ let (unshelve : FStar_Syntax_Syntax.term -> unit tac) =
                    FStar_TypeChecker_Env.nbe =
                      (uu___1727_12248.FStar_TypeChecker_Env.nbe);
                    FStar_TypeChecker_Env.strict_args_tab =
-                     (uu___1727_12248.FStar_TypeChecker_Env.strict_args_tab)
+                     (uu___1727_12248.FStar_TypeChecker_Env.strict_args_tab);
+                   FStar_TypeChecker_Env.erasable_types_tab =
+                     (uu___1727_12248.FStar_TypeChecker_Env.erasable_types_tab)
                  }  in
                let g =
                  FStar_Tactics_Types.mk_goal env1 ctx_uvar opts false ""  in
@@ -6118,41 +6137,61 @@ let (t_destruct :
                                             | FStar_Syntax_Syntax.Sig_inductive_typ
                                                 (_lid,t_us,t_ps,t_ty,mut,c_lids)
                                                 ->
-                                                failwhen
-                                                  ((FStar_List.length a_us)
-                                                     <>
-                                                     (FStar_List.length t_us))
-                                                  "t_us don't match?"
-                                                  (fun uu____13014  ->
-                                                     let uu____13015 =
-                                                       FStar_Syntax_Subst.open_term
-                                                         t_ps t_ty
-                                                        in
-                                                     match uu____13015 with
-                                                     | (t_ps1,t_ty1) ->
-                                                         let uu____13030 =
-                                                           mapM
-                                                             (fun c_lid  ->
-                                                                let uu____13058
-                                                                  =
-                                                                  let uu____13061
+                                                let erasable1 =
+                                                  FStar_Syntax_Util.has_attribute
+                                                    se.FStar_Syntax_Syntax.sigattrs
+                                                    FStar_Parser_Const.erasable_attr
+                                                   in
+                                                let uu____13004 =
+                                                  erasable1 &&
+                                                    (let uu____13007 =
+                                                       is_irrelevant g  in
+                                                     Prims.op_Negation
+                                                       uu____13007)
+                                                   in
+                                                failwhen uu____13004
+                                                  "cannot destruct erasable type to solve proof-relevant goal"
+                                                  (fun uu____13017  ->
+                                                     failwhen
+                                                       ((FStar_List.length
+                                                           a_us)
+                                                          <>
+                                                          (FStar_List.length
+                                                             t_us))
+                                                       "t_us don't match?"
+                                                       (fun uu____13030  ->
+                                                          let uu____13031 =
+                                                            FStar_Syntax_Subst.open_term
+                                                              t_ps t_ty
+                                                             in
+                                                          match uu____13031
+                                                          with
+                                                          | (t_ps1,t_ty1) ->
+                                                              let uu____13046
+                                                                =
+                                                                mapM
+                                                                  (fun c_lid 
+                                                                    ->
+                                                                    let uu____13074
+                                                                    =
+                                                                    let uu____13077
                                                                     =
                                                                     FStar_Tactics_Types.goal_env
                                                                     g  in
-                                                                  FStar_TypeChecker_Env.lookup_sigelt
-                                                                    uu____13061
-                                                                    c_lid
-                                                                   in
-                                                                match uu____13058
-                                                                with
-                                                                | FStar_Pervasives_Native.None
+                                                                    FStar_TypeChecker_Env.lookup_sigelt
+                                                                    uu____13077
+                                                                    c_lid  in
+                                                                    match uu____13074
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives_Native.None
                                                                      ->
                                                                     fail
                                                                     "ctor not found?"
-                                                                | FStar_Pervasives_Native.Some
+                                                                    | 
+                                                                    FStar_Pervasives_Native.Some
                                                                     se1 ->
-                                                                    (
-                                                                    match 
+                                                                    (match 
                                                                     se1.FStar_Syntax_Syntax.sigel
                                                                     with
                                                                     | 
@@ -6173,7 +6212,7 @@ let (t_destruct :
                                                                     c_us))
                                                                     "t_us don't match?"
                                                                     (fun
-                                                                    uu____13135
+                                                                    uu____13151
                                                                      ->
                                                                     let s =
                                                                     FStar_TypeChecker_Env.mk_univ_subst
@@ -6184,50 +6223,50 @@ let (t_destruct :
                                                                     FStar_Syntax_Subst.subst
                                                                     s c_ty
                                                                      in
-                                                                    let uu____13140
+                                                                    let uu____13156
                                                                     =
                                                                     FStar_TypeChecker_Env.inst_tscheme
                                                                     (c_us,
                                                                     c_ty1)
                                                                      in
-                                                                    match uu____13140
+                                                                    match uu____13156
                                                                     with
                                                                     | 
                                                                     (c_us1,c_ty2)
                                                                     ->
-                                                                    let uu____13163
+                                                                    let uu____13179
                                                                     =
                                                                     FStar_Syntax_Util.arrow_formals_comp
                                                                     c_ty2  in
-                                                                    (match uu____13163
+                                                                    (match uu____13179
                                                                     with
                                                                     | 
                                                                     (bs,comp)
                                                                     ->
-                                                                    let uu____13206
+                                                                    let uu____13222
                                                                     =
                                                                     FStar_List.splitAt
                                                                     nparam bs
                                                                      in
-                                                                    (match uu____13206
+                                                                    (match uu____13222
                                                                     with
                                                                     | 
                                                                     (d_ps,bs1)
                                                                     ->
-                                                                    let uu____13279
+                                                                    let uu____13295
                                                                     =
-                                                                    let uu____13281
+                                                                    let uu____13297
                                                                     =
                                                                     FStar_Syntax_Util.is_total_comp
                                                                     comp  in
                                                                     Prims.op_Negation
-                                                                    uu____13281
+                                                                    uu____13297
                                                                      in
                                                                     failwhen
-                                                                    uu____13279
+                                                                    uu____13295
                                                                     "not total?"
                                                                     (fun
-                                                                    uu____13300
+                                                                    uu____13316
                                                                      ->
                                                                     let mk_pat
                                                                     p =
@@ -6239,25 +6278,25 @@ let (t_destruct :
                                                                     (s_tm1.FStar_Syntax_Syntax.pos)
                                                                     }  in
                                                                     let is_imp
-                                                                    uu___5_13317
+                                                                    uu___5_13333
                                                                     =
-                                                                    match uu___5_13317
+                                                                    match uu___5_13333
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.Some
                                                                     (FStar_Syntax_Syntax.Implicit
-                                                                    uu____13321)
+                                                                    uu____13337)
                                                                     -> true
                                                                     | 
-                                                                    uu____13324
+                                                                    uu____13340
                                                                     -> false
                                                                      in
-                                                                    let uu____13328
+                                                                    let uu____13344
                                                                     =
                                                                     FStar_List.splitAt
                                                                     nparam
                                                                     args  in
-                                                                    match uu____13328
+                                                                    match uu____13344
                                                                     with
                                                                     | 
                                                                     (a_ps,a_is)
@@ -6269,7 +6308,7 @@ let (t_destruct :
                                                                     d_ps))
                                                                     "params not match?"
                                                                     (fun
-                                                                    uu____13462
+                                                                    uu____13479
                                                                      ->
                                                                     let d_ps_a_ps
                                                                     =
@@ -6280,13 +6319,13 @@ let (t_destruct :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____13524
+                                                                    uu____13541
                                                                      ->
-                                                                    match uu____13524
+                                                                    match uu____13541
                                                                     with
                                                                     | 
-                                                                    ((bv,uu____13544),
-                                                                    (t,uu____13546))
+                                                                    ((bv,uu____13561),
+                                                                    (t,uu____13563))
                                                                     ->
                                                                     FStar_Syntax_Syntax.NT
                                                                     (bv, t))
@@ -6300,13 +6339,13 @@ let (t_destruct :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____13616
+                                                                    uu____13633
                                                                      ->
-                                                                    match uu____13616
+                                                                    match uu____13633
                                                                     with
                                                                     | 
-                                                                    ((bv,uu____13643),
-                                                                    (t,uu____13645))
+                                                                    ((bv,uu____13660),
+                                                                    (t,uu____13662))
                                                                     ->
                                                                     ((mk_pat
                                                                     (FStar_Syntax_Syntax.Pat_dot_term
@@ -6318,9 +6357,9 @@ let (t_destruct :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____13704
+                                                                    uu____13721
                                                                      ->
-                                                                    match uu____13704
+                                                                    match uu____13721
                                                                     with
                                                                     | 
                                                                     (bv,aq)
@@ -6353,155 +6392,158 @@ let (t_destruct :
                                                                     env.FStar_TypeChecker_Env.universe_of
                                                                     env s_ty
                                                                      in
-                                                                    let uu____13759
+                                                                    let uu____13776
                                                                     =
                                                                     FStar_TypeChecker_TcTerm.tc_pat
-                                                                    (let uu___1891_13776
+                                                                    (let uu___1893_13796
                                                                     = env  in
                                                                     {
                                                                     FStar_TypeChecker_Env.solver
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.solver);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.solver);
                                                                     FStar_TypeChecker_Env.range
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.range);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.range);
                                                                     FStar_TypeChecker_Env.curmodule
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.curmodule);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.curmodule);
                                                                     FStar_TypeChecker_Env.gamma
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.gamma);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.gamma);
                                                                     FStar_TypeChecker_Env.gamma_sig
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.gamma_sig);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.gamma_sig);
                                                                     FStar_TypeChecker_Env.gamma_cache
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.gamma_cache);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.gamma_cache);
                                                                     FStar_TypeChecker_Env.modules
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.modules);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.modules);
                                                                     FStar_TypeChecker_Env.expected_typ
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.expected_typ);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.expected_typ);
                                                                     FStar_TypeChecker_Env.sigtab
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.sigtab);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.sigtab);
                                                                     FStar_TypeChecker_Env.attrtab
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.attrtab);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.attrtab);
                                                                     FStar_TypeChecker_Env.is_pattern
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.is_pattern);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.is_pattern);
                                                                     FStar_TypeChecker_Env.instantiate_imp
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.instantiate_imp);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.instantiate_imp);
                                                                     FStar_TypeChecker_Env.effects
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.effects);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.effects);
                                                                     FStar_TypeChecker_Env.generalize
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.generalize);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.generalize);
                                                                     FStar_TypeChecker_Env.letrecs
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.letrecs);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.letrecs);
                                                                     FStar_TypeChecker_Env.top_level
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.top_level);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.top_level);
                                                                     FStar_TypeChecker_Env.check_uvars
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.check_uvars);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.check_uvars);
                                                                     FStar_TypeChecker_Env.use_eq
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.use_eq);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.use_eq);
                                                                     FStar_TypeChecker_Env.is_iface
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.is_iface);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.is_iface);
                                                                     FStar_TypeChecker_Env.admit
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.admit);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.admit);
                                                                     FStar_TypeChecker_Env.lax
                                                                     = true;
                                                                     FStar_TypeChecker_Env.lax_universes
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.lax_universes);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.lax_universes);
                                                                     FStar_TypeChecker_Env.phase1
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.phase1);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.phase1);
                                                                     FStar_TypeChecker_Env.failhard
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.failhard);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.failhard);
                                                                     FStar_TypeChecker_Env.nosynth
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.nosynth);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.nosynth);
                                                                     FStar_TypeChecker_Env.uvar_subtyping
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.uvar_subtyping);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.uvar_subtyping);
                                                                     FStar_TypeChecker_Env.tc_term
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.tc_term);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.tc_term);
                                                                     FStar_TypeChecker_Env.type_of
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.type_of);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.type_of);
                                                                     FStar_TypeChecker_Env.universe_of
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.universe_of);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.universe_of);
                                                                     FStar_TypeChecker_Env.check_type_of
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.check_type_of);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.check_type_of);
                                                                     FStar_TypeChecker_Env.use_bv_sorts
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.use_bv_sorts);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.use_bv_sorts);
                                                                     FStar_TypeChecker_Env.qtbl_name_and_index
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                                     FStar_TypeChecker_Env.normalized_eff_names
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.normalized_eff_names);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.normalized_eff_names);
                                                                     FStar_TypeChecker_Env.fv_delta_depths
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.fv_delta_depths);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.fv_delta_depths);
                                                                     FStar_TypeChecker_Env.proof_ns
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.proof_ns);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.proof_ns);
                                                                     FStar_TypeChecker_Env.synth_hook
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.synth_hook);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.synth_hook);
                                                                     FStar_TypeChecker_Env.splice
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.splice);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.splice);
                                                                     FStar_TypeChecker_Env.postprocess
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.postprocess);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.postprocess);
                                                                     FStar_TypeChecker_Env.is_native_tactic
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.is_native_tactic);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.is_native_tactic);
                                                                     FStar_TypeChecker_Env.identifier_info
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.identifier_info);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.identifier_info);
                                                                     FStar_TypeChecker_Env.tc_hooks
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.tc_hooks);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.tc_hooks);
                                                                     FStar_TypeChecker_Env.dsenv
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.dsenv);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.dsenv);
                                                                     FStar_TypeChecker_Env.nbe
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.nbe);
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.nbe);
                                                                     FStar_TypeChecker_Env.strict_args_tab
                                                                     =
-                                                                    (uu___1891_13776.FStar_TypeChecker_Env.strict_args_tab)
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.strict_args_tab);
+                                                                    FStar_TypeChecker_Env.erasable_types_tab
+                                                                    =
+                                                                    (uu___1893_13796.FStar_TypeChecker_Env.erasable_types_tab)
                                                                     }) s_ty
                                                                     pat  in
-                                                                    match uu____13759
+                                                                    match uu____13776
                                                                     with
                                                                     | 
-                                                                    (uu____13790,uu____13791,uu____13792,pat_t,uu____13794,_guard_pat)
+                                                                    (uu____13810,uu____13811,uu____13812,pat_t,uu____13814,_guard_pat,_erasable)
                                                                     ->
                                                                     let eq_b
                                                                     =
-                                                                    let uu____13801
+                                                                    let uu____13824
                                                                     =
-                                                                    let uu____13802
+                                                                    let uu____13825
                                                                     =
                                                                     FStar_Syntax_Util.mk_eq2
                                                                     equ s_ty
@@ -6509,52 +6551,52 @@ let (t_destruct :
                                                                     pat_t  in
                                                                     FStar_Syntax_Util.mk_squash
                                                                     equ
-                                                                    uu____13802
+                                                                    uu____13825
                                                                      in
                                                                     FStar_Syntax_Syntax.gen_bv
                                                                     "breq"
                                                                     FStar_Pervasives_Native.None
-                                                                    uu____13801
+                                                                    uu____13824
                                                                      in
                                                                     let cod1
                                                                     =
-                                                                    let uu____13807
+                                                                    let uu____13830
                                                                     =
-                                                                    let uu____13816
+                                                                    let uu____13839
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_binder
                                                                     eq_b  in
-                                                                    [uu____13816]
+                                                                    [uu____13839]
                                                                      in
-                                                                    let uu____13835
+                                                                    let uu____13858
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     cod  in
                                                                     FStar_Syntax_Util.arrow
-                                                                    uu____13807
-                                                                    uu____13835
+                                                                    uu____13830
+                                                                    uu____13858
                                                                      in
                                                                     let nty =
-                                                                    let uu____13841
+                                                                    let uu____13864
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     cod1  in
                                                                     FStar_Syntax_Util.arrow
                                                                     bs2
-                                                                    uu____13841
+                                                                    uu____13864
                                                                      in
-                                                                    let uu____13844
+                                                                    let uu____13867
                                                                     =
                                                                     new_uvar
                                                                     "destruct branch"
                                                                     env nty
                                                                      in
                                                                     bind
-                                                                    uu____13844
+                                                                    uu____13867
                                                                     (fun
-                                                                    uu____13874
+                                                                    uu____13897
                                                                      ->
-                                                                    match uu____13874
+                                                                    match uu____13897
                                                                     with
                                                                     | 
                                                                     (uvt,uv)
@@ -6572,60 +6614,63 @@ let (t_destruct :
                                                                      in
                                                                     let brt1
                                                                     =
-                                                                    let uu____13901
+                                                                    let uu____13924
                                                                     =
-                                                                    let uu____13912
+                                                                    let uu____13935
                                                                     =
                                                                     FStar_Syntax_Syntax.as_arg
                                                                     FStar_Syntax_Util.exp_unit
                                                                      in
-                                                                    [uu____13912]
+                                                                    [uu____13935]
                                                                      in
                                                                     FStar_Syntax_Util.mk_app
                                                                     brt
-                                                                    uu____13901
+                                                                    uu____13924
                                                                      in
                                                                     let br =
                                                                     FStar_Syntax_Subst.close_branch
                                                                     (pat,
                                                                     FStar_Pervasives_Native.None,
                                                                     brt1)  in
-                                                                    let uu____13948
+                                                                    let uu____13971
                                                                     =
-                                                                    let uu____13959
+                                                                    let uu____13982
                                                                     =
-                                                                    let uu____13964
+                                                                    let uu____13987
                                                                     =
                                                                     FStar_BigInt.of_int_fs
                                                                     (FStar_List.length
                                                                     bs2)  in
                                                                     (fv1,
-                                                                    uu____13964)
+                                                                    uu____13987)
                                                                      in
                                                                     (g', br,
-                                                                    uu____13959)
+                                                                    uu____13982)
                                                                      in
                                                                     ret
-                                                                    uu____13948))))))
+                                                                    uu____13971))))))
                                                                     | 
-                                                                    uu____13985
+                                                                    uu____14008
                                                                     ->
                                                                     fail
                                                                     "impossible: not a ctor"))
-                                                             c_lids
-                                                            in
-                                                         bind uu____13030
-                                                           (fun goal_brs  ->
-                                                              let uu____14035
-                                                                =
-                                                                FStar_List.unzip3
-                                                                  goal_brs
+                                                                  c_lids
                                                                  in
-                                                              match uu____14035
-                                                              with
-                                                              | (goals,brs,infos)
-                                                                  ->
-                                                                  let w =
+                                                              bind
+                                                                uu____13046
+                                                                (fun goal_brs
+                                                                    ->
+                                                                   let uu____14058
+                                                                    =
+                                                                    FStar_List.unzip3
+                                                                    goal_brs
+                                                                     in
+                                                                   match uu____14058
+                                                                   with
+                                                                   | 
+                                                                   (goals,brs,infos)
+                                                                    ->
+                                                                    let w =
                                                                     FStar_Syntax_Syntax.mk
                                                                     (FStar_Syntax_Syntax.Tm_match
                                                                     (s_tm1,
@@ -6633,27 +6678,26 @@ let (t_destruct :
                                                                     FStar_Pervasives_Native.None
                                                                     s_tm1.FStar_Syntax_Syntax.pos
                                                                      in
-                                                                  let uu____14108
+                                                                    let uu____14131
                                                                     =
                                                                     solve' g
                                                                     w  in
-                                                                  bind
-                                                                    uu____14108
-                                                                    (
-                                                                    fun
-                                                                    uu____14119
+                                                                    bind
+                                                                    uu____14131
+                                                                    (fun
+                                                                    uu____14142
                                                                      ->
-                                                                    let uu____14120
+                                                                    let uu____14143
                                                                     =
                                                                     add_goals
                                                                     goals  in
                                                                     bind
-                                                                    uu____14120
+                                                                    uu____14143
                                                                     (fun
-                                                                    uu____14130
+                                                                    uu____14153
                                                                      ->
-                                                                    ret infos))))
-                                            | uu____14137 ->
+                                                                    ret infos)))))
+                                            | uu____14160 ->
                                                 fail "not an inductive type"))))))
        in
     FStar_All.pipe_left (wrap_err "destruct") uu____12761
@@ -6663,24 +6707,24 @@ let rec last : 'a . 'a Prims.list -> 'a =
     match l with
     | [] -> failwith "last: empty list"
     | x::[] -> x
-    | uu____14186::xs -> last xs
+    | uu____14209::xs -> last xs
   
 let rec init : 'a . 'a Prims.list -> 'a Prims.list =
   fun l  ->
     match l with
     | [] -> failwith "init: empty list"
     | x::[] -> []
-    | x::xs -> let uu____14216 = init xs  in x :: uu____14216
+    | x::xs -> let uu____14239 = init xs  in x :: uu____14239
   
 let rec (inspect :
   FStar_Syntax_Syntax.term -> FStar_Reflection_Data.term_view tac) =
   fun t  ->
-    let uu____14229 =
+    let uu____14252 =
       let t1 = FStar_Syntax_Util.unascribe t  in
       let t2 = FStar_Syntax_Util.un_uinst t1  in
       let t3 = FStar_Syntax_Util.unlazy_emb t2  in
       match t3.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_meta (t4,uu____14238) -> inspect t4
+      | FStar_Syntax_Syntax.Tm_meta (t4,uu____14261) -> inspect t4
       | FStar_Syntax_Syntax.Tm_name bv ->
           FStar_All.pipe_left ret (FStar_Reflection_Data.Tv_Var bv)
       | FStar_Syntax_Syntax.Tm_bvar bv ->
@@ -6690,93 +6734,93 @@ let rec (inspect :
       | FStar_Syntax_Syntax.Tm_app (hd1,[]) ->
           failwith "empty arguments on Tm_app"
       | FStar_Syntax_Syntax.Tm_app (hd1,args) ->
-          let uu____14304 = last args  in
-          (match uu____14304 with
+          let uu____14327 = last args  in
+          (match uu____14327 with
            | (a,q) ->
                let q' = FStar_Reflection_Basic.inspect_aqual q  in
-               let uu____14334 =
-                 let uu____14335 =
-                   let uu____14340 =
-                     let uu____14341 =
-                       let uu____14346 = init args  in
-                       FStar_Syntax_Syntax.mk_Tm_app hd1 uu____14346  in
-                     uu____14341 FStar_Pervasives_Native.None
+               let uu____14357 =
+                 let uu____14358 =
+                   let uu____14363 =
+                     let uu____14364 =
+                       let uu____14369 = init args  in
+                       FStar_Syntax_Syntax.mk_Tm_app hd1 uu____14369  in
+                     uu____14364 FStar_Pervasives_Native.None
                        t3.FStar_Syntax_Syntax.pos
                       in
-                   (uu____14340, (a, q'))  in
-                 FStar_Reflection_Data.Tv_App uu____14335  in
-               FStar_All.pipe_left ret uu____14334)
-      | FStar_Syntax_Syntax.Tm_abs ([],uu____14357,uu____14358) ->
+                   (uu____14363, (a, q'))  in
+                 FStar_Reflection_Data.Tv_App uu____14358  in
+               FStar_All.pipe_left ret uu____14357)
+      | FStar_Syntax_Syntax.Tm_abs ([],uu____14380,uu____14381) ->
           failwith "empty arguments on Tm_abs"
       | FStar_Syntax_Syntax.Tm_abs (bs,t4,k) ->
-          let uu____14411 = FStar_Syntax_Subst.open_term bs t4  in
-          (match uu____14411 with
+          let uu____14434 = FStar_Syntax_Subst.open_term bs t4  in
+          (match uu____14434 with
            | (bs1,t5) ->
                (match bs1 with
                 | [] -> failwith "impossible"
                 | b::bs2 ->
-                    let uu____14453 =
-                      let uu____14454 =
-                        let uu____14459 = FStar_Syntax_Util.abs bs2 t5 k  in
-                        (b, uu____14459)  in
-                      FStar_Reflection_Data.Tv_Abs uu____14454  in
-                    FStar_All.pipe_left ret uu____14453))
-      | FStar_Syntax_Syntax.Tm_type uu____14462 ->
+                    let uu____14476 =
+                      let uu____14477 =
+                        let uu____14482 = FStar_Syntax_Util.abs bs2 t5 k  in
+                        (b, uu____14482)  in
+                      FStar_Reflection_Data.Tv_Abs uu____14477  in
+                    FStar_All.pipe_left ret uu____14476))
+      | FStar_Syntax_Syntax.Tm_type uu____14485 ->
           FStar_All.pipe_left ret (FStar_Reflection_Data.Tv_Type ())
       | FStar_Syntax_Syntax.Tm_arrow ([],k) ->
           failwith "empty binders on arrow"
-      | FStar_Syntax_Syntax.Tm_arrow uu____14487 ->
-          let uu____14502 = FStar_Syntax_Util.arrow_one t3  in
-          (match uu____14502 with
+      | FStar_Syntax_Syntax.Tm_arrow uu____14510 ->
+          let uu____14525 = FStar_Syntax_Util.arrow_one t3  in
+          (match uu____14525 with
            | FStar_Pervasives_Native.Some (b,c) ->
                FStar_All.pipe_left ret
                  (FStar_Reflection_Data.Tv_Arrow (b, c))
            | FStar_Pervasives_Native.None  -> failwith "impossible")
       | FStar_Syntax_Syntax.Tm_refine (bv,t4) ->
           let b = FStar_Syntax_Syntax.mk_binder bv  in
-          let uu____14533 = FStar_Syntax_Subst.open_term [b] t4  in
-          (match uu____14533 with
+          let uu____14556 = FStar_Syntax_Subst.open_term [b] t4  in
+          (match uu____14556 with
            | (b',t5) ->
                let b1 =
                  match b' with
                  | b'1::[] -> b'1
-                 | uu____14586 -> failwith "impossible"  in
+                 | uu____14609 -> failwith "impossible"  in
                FStar_All.pipe_left ret
                  (FStar_Reflection_Data.Tv_Refine
                     ((FStar_Pervasives_Native.fst b1), t5)))
       | FStar_Syntax_Syntax.Tm_constant c ->
-          let uu____14599 =
-            let uu____14600 = FStar_Reflection_Basic.inspect_const c  in
-            FStar_Reflection_Data.Tv_Const uu____14600  in
-          FStar_All.pipe_left ret uu____14599
+          let uu____14622 =
+            let uu____14623 = FStar_Reflection_Basic.inspect_const c  in
+            FStar_Reflection_Data.Tv_Const uu____14623  in
+          FStar_All.pipe_left ret uu____14622
       | FStar_Syntax_Syntax.Tm_uvar (ctx_u,s) ->
-          let uu____14621 =
-            let uu____14622 =
-              let uu____14627 =
-                let uu____14628 =
+          let uu____14644 =
+            let uu____14645 =
+              let uu____14650 =
+                let uu____14651 =
                   FStar_Syntax_Unionfind.uvar_id
                     ctx_u.FStar_Syntax_Syntax.ctx_uvar_head
                    in
-                FStar_BigInt.of_int_fs uu____14628  in
-              (uu____14627, (ctx_u, s))  in
-            FStar_Reflection_Data.Tv_Uvar uu____14622  in
-          FStar_All.pipe_left ret uu____14621
+                FStar_BigInt.of_int_fs uu____14651  in
+              (uu____14650, (ctx_u, s))  in
+            FStar_Reflection_Data.Tv_Uvar uu____14645  in
+          FStar_All.pipe_left ret uu____14644
       | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),t21) ->
           if lb.FStar_Syntax_Syntax.lbunivs <> []
           then FStar_All.pipe_left ret FStar_Reflection_Data.Tv_Unknown
           else
             (match lb.FStar_Syntax_Syntax.lbname with
-             | FStar_Util.Inr uu____14668 ->
+             | FStar_Util.Inr uu____14691 ->
                  FStar_All.pipe_left ret FStar_Reflection_Data.Tv_Unknown
              | FStar_Util.Inl bv ->
                  let b = FStar_Syntax_Syntax.mk_binder bv  in
-                 let uu____14673 = FStar_Syntax_Subst.open_term [b] t21  in
-                 (match uu____14673 with
+                 let uu____14696 = FStar_Syntax_Subst.open_term [b] t21  in
+                 (match uu____14696 with
                   | (bs,t22) ->
                       let b1 =
                         match bs with
                         | b1::[] -> b1
-                        | uu____14726 ->
+                        | uu____14749 ->
                             failwith
                               "impossible: open_term returned different amount of binders"
                          in
@@ -6789,42 +6833,42 @@ let rec (inspect :
           then FStar_All.pipe_left ret FStar_Reflection_Data.Tv_Unknown
           else
             (match lb.FStar_Syntax_Syntax.lbname with
-             | FStar_Util.Inr uu____14768 ->
+             | FStar_Util.Inr uu____14791 ->
                  FStar_All.pipe_left ret FStar_Reflection_Data.Tv_Unknown
              | FStar_Util.Inl bv ->
-                 let uu____14772 = FStar_Syntax_Subst.open_let_rec [lb] t21
+                 let uu____14795 = FStar_Syntax_Subst.open_let_rec [lb] t21
                     in
-                 (match uu____14772 with
+                 (match uu____14795 with
                   | (lbs,t22) ->
                       (match lbs with
                        | lb1::[] ->
                            (match lb1.FStar_Syntax_Syntax.lbname with
-                            | FStar_Util.Inr uu____14792 ->
+                            | FStar_Util.Inr uu____14815 ->
                                 ret FStar_Reflection_Data.Tv_Unknown
                             | FStar_Util.Inl bv1 ->
                                 FStar_All.pipe_left ret
                                   (FStar_Reflection_Data.Tv_Let
                                      (true, bv1,
                                        (lb1.FStar_Syntax_Syntax.lbdef), t22)))
-                       | uu____14798 ->
+                       | uu____14821 ->
                            failwith
                              "impossible: open_term returned different amount of binders")))
       | FStar_Syntax_Syntax.Tm_match (t4,brs) ->
           let rec inspect_pat p =
             match p.FStar_Syntax_Syntax.v with
             | FStar_Syntax_Syntax.Pat_constant c ->
-                let uu____14853 = FStar_Reflection_Basic.inspect_const c  in
-                FStar_Reflection_Data.Pat_Constant uu____14853
+                let uu____14876 = FStar_Reflection_Basic.inspect_const c  in
+                FStar_Reflection_Data.Pat_Constant uu____14876
             | FStar_Syntax_Syntax.Pat_cons (fv,ps) ->
-                let uu____14874 =
-                  let uu____14881 =
+                let uu____14897 =
+                  let uu____14904 =
                     FStar_List.map
-                      (fun uu____14894  ->
-                         match uu____14894 with
-                         | (p1,uu____14903) -> inspect_pat p1) ps
+                      (fun uu____14917  ->
+                         match uu____14917 with
+                         | (p1,uu____14926) -> inspect_pat p1) ps
                      in
-                  (fv, uu____14881)  in
-                FStar_Reflection_Data.Pat_Cons uu____14874
+                  (fv, uu____14904)  in
+                FStar_Reflection_Data.Pat_Cons uu____14897
             | FStar_Syntax_Syntax.Pat_var bv ->
                 FStar_Reflection_Data.Pat_Var bv
             | FStar_Syntax_Syntax.Pat_wild bv ->
@@ -6835,109 +6879,109 @@ let rec (inspect :
           let brs1 = FStar_List.map FStar_Syntax_Subst.open_branch brs  in
           let brs2 =
             FStar_List.map
-              (fun uu___6_14999  ->
-                 match uu___6_14999 with
-                 | (pat,uu____15021,t5) ->
-                     let uu____15039 = inspect_pat pat  in (uu____15039, t5))
+              (fun uu___6_15022  ->
+                 match uu___6_15022 with
+                 | (pat,uu____15044,t5) ->
+                     let uu____15062 = inspect_pat pat  in (uu____15062, t5))
               brs1
              in
           FStar_All.pipe_left ret (FStar_Reflection_Data.Tv_Match (t4, brs2))
       | FStar_Syntax_Syntax.Tm_unknown  ->
           FStar_All.pipe_left ret FStar_Reflection_Data.Tv_Unknown
-      | uu____15048 ->
-          ((let uu____15050 =
-              let uu____15056 =
-                let uu____15058 = FStar_Syntax_Print.tag_of_term t3  in
-                let uu____15060 = FStar_Syntax_Print.term_to_string t3  in
+      | uu____15071 ->
+          ((let uu____15073 =
+              let uu____15079 =
+                let uu____15081 = FStar_Syntax_Print.tag_of_term t3  in
+                let uu____15083 = FStar_Syntax_Print.term_to_string t3  in
                 FStar_Util.format2
                   "inspect: outside of expected syntax (%s, %s)\n"
-                  uu____15058 uu____15060
+                  uu____15081 uu____15083
                  in
-              (FStar_Errors.Warning_CantInspect, uu____15056)  in
-            FStar_Errors.log_issue t3.FStar_Syntax_Syntax.pos uu____15050);
+              (FStar_Errors.Warning_CantInspect, uu____15079)  in
+            FStar_Errors.log_issue t3.FStar_Syntax_Syntax.pos uu____15073);
            FStar_All.pipe_left ret FStar_Reflection_Data.Tv_Unknown)
        in
-    wrap_err "inspect" uu____14229
+    wrap_err "inspect" uu____14252
   
 let (pack : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term tac)
   =
   fun tv  ->
     match tv with
     | FStar_Reflection_Data.Tv_Var bv ->
-        let uu____15078 = FStar_Syntax_Syntax.bv_to_name bv  in
-        FStar_All.pipe_left ret uu____15078
+        let uu____15101 = FStar_Syntax_Syntax.bv_to_name bv  in
+        FStar_All.pipe_left ret uu____15101
     | FStar_Reflection_Data.Tv_BVar bv ->
-        let uu____15082 = FStar_Syntax_Syntax.bv_to_tm bv  in
-        FStar_All.pipe_left ret uu____15082
+        let uu____15105 = FStar_Syntax_Syntax.bv_to_tm bv  in
+        FStar_All.pipe_left ret uu____15105
     | FStar_Reflection_Data.Tv_FVar fv ->
-        let uu____15086 = FStar_Syntax_Syntax.fv_to_tm fv  in
-        FStar_All.pipe_left ret uu____15086
+        let uu____15109 = FStar_Syntax_Syntax.fv_to_tm fv  in
+        FStar_All.pipe_left ret uu____15109
     | FStar_Reflection_Data.Tv_App (l,(r,q)) ->
         let q' = FStar_Reflection_Basic.pack_aqual q  in
-        let uu____15093 = FStar_Syntax_Util.mk_app l [(r, q')]  in
-        FStar_All.pipe_left ret uu____15093
+        let uu____15116 = FStar_Syntax_Util.mk_app l [(r, q')]  in
+        FStar_All.pipe_left ret uu____15116
     | FStar_Reflection_Data.Tv_Abs (b,t) ->
-        let uu____15118 =
+        let uu____15141 =
           FStar_Syntax_Util.abs [b] t FStar_Pervasives_Native.None  in
-        FStar_All.pipe_left ret uu____15118
+        FStar_All.pipe_left ret uu____15141
     | FStar_Reflection_Data.Tv_Arrow (b,c) ->
-        let uu____15135 = FStar_Syntax_Util.arrow [b] c  in
-        FStar_All.pipe_left ret uu____15135
+        let uu____15158 = FStar_Syntax_Util.arrow [b] c  in
+        FStar_All.pipe_left ret uu____15158
     | FStar_Reflection_Data.Tv_Type () ->
         FStar_All.pipe_left ret FStar_Syntax_Util.ktype
     | FStar_Reflection_Data.Tv_Refine (bv,t) ->
-        let uu____15154 = FStar_Syntax_Util.refine bv t  in
-        FStar_All.pipe_left ret uu____15154
+        let uu____15177 = FStar_Syntax_Util.refine bv t  in
+        FStar_All.pipe_left ret uu____15177
     | FStar_Reflection_Data.Tv_Const c ->
-        let uu____15158 =
-          let uu____15159 =
-            let uu____15166 =
-              let uu____15167 = FStar_Reflection_Basic.pack_const c  in
-              FStar_Syntax_Syntax.Tm_constant uu____15167  in
-            FStar_Syntax_Syntax.mk uu____15166  in
-          uu____15159 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
-        FStar_All.pipe_left ret uu____15158
+        let uu____15181 =
+          let uu____15182 =
+            let uu____15189 =
+              let uu____15190 = FStar_Reflection_Basic.pack_const c  in
+              FStar_Syntax_Syntax.Tm_constant uu____15190  in
+            FStar_Syntax_Syntax.mk uu____15189  in
+          uu____15182 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
+        FStar_All.pipe_left ret uu____15181
     | FStar_Reflection_Data.Tv_Uvar (_u,ctx_u_s) ->
-        let uu____15172 =
+        let uu____15195 =
           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_uvar ctx_u_s)
             FStar_Pervasives_Native.None FStar_Range.dummyRange
            in
-        FStar_All.pipe_left ret uu____15172
+        FStar_All.pipe_left ret uu____15195
     | FStar_Reflection_Data.Tv_Let (false ,bv,t1,t2) ->
         let lb =
           FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl bv) []
             bv.FStar_Syntax_Syntax.sort FStar_Parser_Const.effect_Tot_lid t1
             [] FStar_Range.dummyRange
            in
-        let uu____15183 =
-          let uu____15184 =
-            let uu____15191 =
-              let uu____15192 =
-                let uu____15206 =
-                  let uu____15209 =
-                    let uu____15210 = FStar_Syntax_Syntax.mk_binder bv  in
-                    [uu____15210]  in
-                  FStar_Syntax_Subst.close uu____15209 t2  in
-                ((false, [lb]), uu____15206)  in
-              FStar_Syntax_Syntax.Tm_let uu____15192  in
-            FStar_Syntax_Syntax.mk uu____15191  in
-          uu____15184 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
-        FStar_All.pipe_left ret uu____15183
+        let uu____15206 =
+          let uu____15207 =
+            let uu____15214 =
+              let uu____15215 =
+                let uu____15229 =
+                  let uu____15232 =
+                    let uu____15233 = FStar_Syntax_Syntax.mk_binder bv  in
+                    [uu____15233]  in
+                  FStar_Syntax_Subst.close uu____15232 t2  in
+                ((false, [lb]), uu____15229)  in
+              FStar_Syntax_Syntax.Tm_let uu____15215  in
+            FStar_Syntax_Syntax.mk uu____15214  in
+          uu____15207 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
+        FStar_All.pipe_left ret uu____15206
     | FStar_Reflection_Data.Tv_Let (true ,bv,t1,t2) ->
         let lb =
           FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl bv) []
             bv.FStar_Syntax_Syntax.sort FStar_Parser_Const.effect_Tot_lid t1
             [] FStar_Range.dummyRange
            in
-        let uu____15252 = FStar_Syntax_Subst.close_let_rec [lb] t2  in
-        (match uu____15252 with
+        let uu____15275 = FStar_Syntax_Subst.close_let_rec [lb] t2  in
+        (match uu____15275 with
          | (lbs,body) ->
-             let uu____15267 =
+             let uu____15290 =
                FStar_Syntax_Syntax.mk
                  (FStar_Syntax_Syntax.Tm_let ((true, lbs), body))
                  FStar_Pervasives_Native.None FStar_Range.dummyRange
                 in
-             FStar_All.pipe_left ret uu____15267)
+             FStar_All.pipe_left ret uu____15290)
     | FStar_Reflection_Data.Tv_Match (t,brs) ->
         let wrap v1 =
           {
@@ -6947,22 +6991,22 @@ let (pack : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term tac)
         let rec pack_pat p =
           match p with
           | FStar_Reflection_Data.Pat_Constant c ->
-              let uu____15304 =
-                let uu____15305 = FStar_Reflection_Basic.pack_const c  in
-                FStar_Syntax_Syntax.Pat_constant uu____15305  in
-              FStar_All.pipe_left wrap uu____15304
+              let uu____15327 =
+                let uu____15328 = FStar_Reflection_Basic.pack_const c  in
+                FStar_Syntax_Syntax.Pat_constant uu____15328  in
+              FStar_All.pipe_left wrap uu____15327
           | FStar_Reflection_Data.Pat_Cons (fv,ps) ->
-              let uu____15312 =
-                let uu____15313 =
-                  let uu____15327 =
+              let uu____15335 =
+                let uu____15336 =
+                  let uu____15350 =
                     FStar_List.map
                       (fun p1  ->
-                         let uu____15345 = pack_pat p1  in
-                         (uu____15345, false)) ps
+                         let uu____15368 = pack_pat p1  in
+                         (uu____15368, false)) ps
                      in
-                  (fv, uu____15327)  in
-                FStar_Syntax_Syntax.Pat_cons uu____15313  in
-              FStar_All.pipe_left wrap uu____15312
+                  (fv, uu____15350)  in
+                FStar_Syntax_Syntax.Pat_cons uu____15336  in
+              FStar_All.pipe_left wrap uu____15335
           | FStar_Reflection_Data.Pat_Var bv ->
               FStar_All.pipe_left wrap (FStar_Syntax_Syntax.Pat_var bv)
           | FStar_Reflection_Data.Pat_Wild bv ->
@@ -6973,59 +7017,59 @@ let (pack : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term tac)
            in
         let brs1 =
           FStar_List.map
-            (fun uu___7_15394  ->
-               match uu___7_15394 with
+            (fun uu___7_15417  ->
+               match uu___7_15417 with
                | (pat,t1) ->
-                   let uu____15411 = pack_pat pat  in
-                   (uu____15411, FStar_Pervasives_Native.None, t1)) brs
+                   let uu____15434 = pack_pat pat  in
+                   (uu____15434, FStar_Pervasives_Native.None, t1)) brs
            in
         let brs2 = FStar_List.map FStar_Syntax_Subst.close_branch brs1  in
-        let uu____15459 =
+        let uu____15482 =
           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_match (t, brs2))
             FStar_Pervasives_Native.None FStar_Range.dummyRange
            in
-        FStar_All.pipe_left ret uu____15459
+        FStar_All.pipe_left ret uu____15482
     | FStar_Reflection_Data.Tv_AscribedT (e,t,tacopt) ->
-        let uu____15487 =
+        let uu____15510 =
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_ascribed
                (e, ((FStar_Util.Inl t), tacopt),
                  FStar_Pervasives_Native.None)) FStar_Pervasives_Native.None
             FStar_Range.dummyRange
            in
-        FStar_All.pipe_left ret uu____15487
+        FStar_All.pipe_left ret uu____15510
     | FStar_Reflection_Data.Tv_AscribedC (e,c,tacopt) ->
-        let uu____15533 =
+        let uu____15556 =
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_ascribed
                (e, ((FStar_Util.Inr c), tacopt),
                  FStar_Pervasives_Native.None)) FStar_Pervasives_Native.None
             FStar_Range.dummyRange
            in
-        FStar_All.pipe_left ret uu____15533
+        FStar_All.pipe_left ret uu____15556
     | FStar_Reflection_Data.Tv_Unknown  ->
-        let uu____15572 =
+        let uu____15595 =
           FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
             FStar_Pervasives_Native.None FStar_Range.dummyRange
            in
-        FStar_All.pipe_left ret uu____15572
+        FStar_All.pipe_left ret uu____15595
   
 let (lget :
   FStar_Reflection_Data.typ -> Prims.string -> FStar_Syntax_Syntax.term tac)
   =
   fun ty  ->
     fun k  ->
-      let uu____15592 =
+      let uu____15615 =
         bind get
           (fun ps  ->
-             let uu____15598 =
+             let uu____15621 =
                FStar_Util.psmap_try_find ps.FStar_Tactics_Types.local_state k
                 in
-             match uu____15598 with
+             match uu____15621 with
              | FStar_Pervasives_Native.None  -> fail "not found"
              | FStar_Pervasives_Native.Some t -> unquote ty t)
          in
-      FStar_All.pipe_left (wrap_err "lget") uu____15592
+      FStar_All.pipe_left (wrap_err "lget") uu____15615
   
 let (lset :
   FStar_Reflection_Data.typ ->
@@ -7034,45 +7078,45 @@ let (lset :
   fun _ty  ->
     fun k  ->
       fun t  ->
-        let uu____15632 =
+        let uu____15655 =
           bind get
             (fun ps  ->
                let ps1 =
-                 let uu___2189_15639 = ps  in
-                 let uu____15640 =
+                 let uu___2192_15662 = ps  in
+                 let uu____15663 =
                    FStar_Util.psmap_add ps.FStar_Tactics_Types.local_state k
                      t
                     in
                  {
                    FStar_Tactics_Types.main_context =
-                     (uu___2189_15639.FStar_Tactics_Types.main_context);
+                     (uu___2192_15662.FStar_Tactics_Types.main_context);
                    FStar_Tactics_Types.main_goal =
-                     (uu___2189_15639.FStar_Tactics_Types.main_goal);
+                     (uu___2192_15662.FStar_Tactics_Types.main_goal);
                    FStar_Tactics_Types.all_implicits =
-                     (uu___2189_15639.FStar_Tactics_Types.all_implicits);
+                     (uu___2192_15662.FStar_Tactics_Types.all_implicits);
                    FStar_Tactics_Types.goals =
-                     (uu___2189_15639.FStar_Tactics_Types.goals);
+                     (uu___2192_15662.FStar_Tactics_Types.goals);
                    FStar_Tactics_Types.smt_goals =
-                     (uu___2189_15639.FStar_Tactics_Types.smt_goals);
+                     (uu___2192_15662.FStar_Tactics_Types.smt_goals);
                    FStar_Tactics_Types.depth =
-                     (uu___2189_15639.FStar_Tactics_Types.depth);
+                     (uu___2192_15662.FStar_Tactics_Types.depth);
                    FStar_Tactics_Types.__dump =
-                     (uu___2189_15639.FStar_Tactics_Types.__dump);
+                     (uu___2192_15662.FStar_Tactics_Types.__dump);
                    FStar_Tactics_Types.psc =
-                     (uu___2189_15639.FStar_Tactics_Types.psc);
+                     (uu___2192_15662.FStar_Tactics_Types.psc);
                    FStar_Tactics_Types.entry_range =
-                     (uu___2189_15639.FStar_Tactics_Types.entry_range);
+                     (uu___2192_15662.FStar_Tactics_Types.entry_range);
                    FStar_Tactics_Types.guard_policy =
-                     (uu___2189_15639.FStar_Tactics_Types.guard_policy);
+                     (uu___2192_15662.FStar_Tactics_Types.guard_policy);
                    FStar_Tactics_Types.freshness =
-                     (uu___2189_15639.FStar_Tactics_Types.freshness);
+                     (uu___2192_15662.FStar_Tactics_Types.freshness);
                    FStar_Tactics_Types.tac_verb_dbg =
-                     (uu___2189_15639.FStar_Tactics_Types.tac_verb_dbg);
-                   FStar_Tactics_Types.local_state = uu____15640
+                     (uu___2192_15662.FStar_Tactics_Types.tac_verb_dbg);
+                   FStar_Tactics_Types.local_state = uu____15663
                  }  in
                set ps1)
            in
-        FStar_All.pipe_left (wrap_err "lset") uu____15632
+        FStar_All.pipe_left (wrap_err "lset") uu____15655
   
 let (goal_of_goal_ty :
   env ->
@@ -7081,18 +7125,18 @@ let (goal_of_goal_ty :
   =
   fun env  ->
     fun typ  ->
-      let uu____15667 =
+      let uu____15690 =
         FStar_TypeChecker_Util.new_implicit_var "proofstate_of_goal_ty"
           typ.FStar_Syntax_Syntax.pos env typ
          in
-      match uu____15667 with
+      match uu____15690 with
       | (u,ctx_uvars,g_u) ->
-          let uu____15700 = FStar_List.hd ctx_uvars  in
-          (match uu____15700 with
-           | (ctx_uvar,uu____15714) ->
+          let uu____15723 = FStar_List.hd ctx_uvars  in
+          (match uu____15723 with
+           | (ctx_uvar,uu____15737) ->
                let g =
-                 let uu____15716 = FStar_Options.peek ()  in
-                 FStar_Tactics_Types.mk_goal env ctx_uvar uu____15716 false
+                 let uu____15739 = FStar_Options.peek ()  in
+                 FStar_Tactics_Types.mk_goal env ctx_uvar uu____15739 false
                    ""
                   in
                (g, g_u))
@@ -7106,15 +7150,15 @@ let (proofstate_of_goal_ty :
   fun rng  ->
     fun env  ->
       fun typ  ->
-        let uu____15739 = goal_of_goal_ty env typ  in
-        match uu____15739 with
+        let uu____15762 = goal_of_goal_ty env typ  in
+        match uu____15762 with
         | (g,g_u) ->
             let ps =
-              let uu____15751 =
+              let uu____15774 =
                 FStar_TypeChecker_Env.debug env
                   (FStar_Options.Other "TacVerbose")
                  in
-              let uu____15754 = FStar_Util.psmap_empty ()  in
+              let uu____15777 = FStar_Util.psmap_empty ()  in
               {
                 FStar_Tactics_Types.main_context = env;
                 FStar_Tactics_Types.main_goal = g;
@@ -7128,9 +7172,9 @@ let (proofstate_of_goal_ty :
                 FStar_Tactics_Types.entry_range = rng;
                 FStar_Tactics_Types.guard_policy = FStar_Tactics_Types.SMT;
                 FStar_Tactics_Types.freshness = Prims.int_zero;
-                FStar_Tactics_Types.tac_verb_dbg = uu____15751;
-                FStar_Tactics_Types.local_state = uu____15754
+                FStar_Tactics_Types.tac_verb_dbg = uu____15774;
+                FStar_Tactics_Types.local_state = uu____15777
               }  in
-            let uu____15759 = FStar_Tactics_Types.goal_witness g  in
-            (ps, uu____15759)
+            let uu____15782 = FStar_Tactics_Types.goal_witness g  in
+            (ps, uu____15782)
   

--- a/src/ocaml-output/FStar_Tactics_Interpreter.ml
+++ b/src/ocaml-output/FStar_Tactics_Interpreter.ml
@@ -1850,7 +1850,9 @@ let (run_tactic_on_typ :
                            FStar_TypeChecker_Env.nbe =
                              (uu___199_2399.FStar_TypeChecker_Env.nbe);
                            FStar_TypeChecker_Env.strict_args_tab =
-                             (uu___199_2399.FStar_TypeChecker_Env.strict_args_tab)
+                             (uu___199_2399.FStar_TypeChecker_Env.strict_args_tab);
+                           FStar_TypeChecker_Env.erasable_types_tab =
+                             (uu___199_2399.FStar_TypeChecker_Env.erasable_types_tab)
                          }  in
                        let env3 =
                          let uu___202_2402 = env2  in
@@ -1941,7 +1943,9 @@ let (run_tactic_on_typ :
                            FStar_TypeChecker_Env.nbe =
                              (uu___202_2402.FStar_TypeChecker_Env.nbe);
                            FStar_TypeChecker_Env.strict_args_tab =
-                             (uu___202_2402.FStar_TypeChecker_Env.strict_args_tab)
+                             (uu___202_2402.FStar_TypeChecker_Env.strict_args_tab);
+                           FStar_TypeChecker_Env.erasable_types_tab =
+                             (uu___202_2402.FStar_TypeChecker_Env.erasable_types_tab)
                          }  in
                        let env4 =
                          let uu___205_2405 = env3  in
@@ -2032,7 +2036,9 @@ let (run_tactic_on_typ :
                            FStar_TypeChecker_Env.nbe =
                              (uu___205_2405.FStar_TypeChecker_Env.nbe);
                            FStar_TypeChecker_Env.strict_args_tab =
-                             (uu___205_2405.FStar_TypeChecker_Env.strict_args_tab)
+                             (uu___205_2405.FStar_TypeChecker_Env.strict_args_tab);
+                           FStar_TypeChecker_Env.erasable_types_tab =
+                             (uu___205_2405.FStar_TypeChecker_Env.erasable_types_tab)
                          }  in
                        let rng =
                          let uu____2408 = FStar_Range.use_range rng_goal  in

--- a/src/ocaml-output/FStar_Tactics_Types.ml
+++ b/src/ocaml-output/FStar_Tactics_Types.ml
@@ -121,7 +121,9 @@ let (goal_env : goal -> FStar_TypeChecker_Env.env) =
       FStar_TypeChecker_Env.dsenv = (uu___17_119.FStar_TypeChecker_Env.dsenv);
       FStar_TypeChecker_Env.nbe = (uu___17_119.FStar_TypeChecker_Env.nbe);
       FStar_TypeChecker_Env.strict_args_tab =
-        (uu___17_119.FStar_TypeChecker_Env.strict_args_tab)
+        (uu___17_119.FStar_TypeChecker_Env.strict_args_tab);
+      FStar_TypeChecker_Env.erasable_types_tab =
+        (uu___17_119.FStar_TypeChecker_Env.erasable_types_tab)
     }
   
 let (goal_witness : goal -> FStar_Syntax_Syntax.term) =

--- a/src/ocaml-output/FStar_Tests_Pars.ml
+++ b/src/ocaml-output/FStar_Tests_Pars.ml
@@ -185,7 +185,9 @@ let (init_once : unit -> unit) =
              FStar_TypeChecker_Env.nbe =
                (uu___46_235.FStar_TypeChecker_Env.nbe);
              FStar_TypeChecker_Env.strict_args_tab =
-               (uu___46_235.FStar_TypeChecker_Env.strict_args_tab)
+               (uu___46_235.FStar_TypeChecker_Env.strict_args_tab);
+             FStar_TypeChecker_Env.erasable_types_tab =
+               (uu___46_235.FStar_TypeChecker_Env.erasable_types_tab)
            }  in
          let uu____236 =
            FStar_TypeChecker_Tc.check_module env1 prims_mod false  in
@@ -280,7 +282,9 @@ let (init_once : unit -> unit) =
                   FStar_TypeChecker_Env.nbe =
                     (uu___52_245.FStar_TypeChecker_Env.nbe);
                   FStar_TypeChecker_Env.strict_args_tab =
-                    (uu___52_245.FStar_TypeChecker_Env.strict_args_tab)
+                    (uu___52_245.FStar_TypeChecker_Env.strict_args_tab);
+                  FStar_TypeChecker_Env.erasable_types_tab =
+                    (uu___52_245.FStar_TypeChecker_Env.erasable_types_tab)
                 }  in
               let env4 =
                 FStar_TypeChecker_Env.set_current_module env3 test_lid  in
@@ -433,7 +437,9 @@ let (tc' :
           (uu___83_378.FStar_TypeChecker_Env.dsenv);
         FStar_TypeChecker_Env.nbe = (uu___83_378.FStar_TypeChecker_Env.nbe);
         FStar_TypeChecker_Env.strict_args_tab =
-          (uu___83_378.FStar_TypeChecker_Env.strict_args_tab)
+          (uu___83_378.FStar_TypeChecker_Env.strict_args_tab);
+        FStar_TypeChecker_Env.erasable_types_tab =
+          (uu___83_378.FStar_TypeChecker_Env.erasable_types_tab)
       }  in
     let uu____380 = FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term tcenv1 tm
        in
@@ -540,7 +546,9 @@ let (tc_nbe_term : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
           (uu___103_441.FStar_TypeChecker_Env.dsenv);
         FStar_TypeChecker_Env.nbe = (uu___103_441.FStar_TypeChecker_Env.nbe);
         FStar_TypeChecker_Env.strict_args_tab =
-          (uu___103_441.FStar_TypeChecker_Env.strict_args_tab)
+          (uu___103_441.FStar_TypeChecker_Env.strict_args_tab);
+        FStar_TypeChecker_Env.erasable_types_tab =
+          (uu___103_441.FStar_TypeChecker_Env.erasable_types_tab)
       }  in
     let uu____443 = FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term tcenv1 tm
        in

--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -3367,11 +3367,8 @@ let rec (non_informative : env -> FStar_Syntax_Syntax.typ -> Prims.bool) =
       | FStar_Syntax_Syntax.Tm_uinst (t1,uu____19779) ->
           non_informative env t1
       | FStar_Syntax_Syntax.Tm_arrow (uu____19784,c) ->
-          ((FStar_Syntax_Util.is_pure_or_ghost_comp c) &&
-             (non_informative env (FStar_Syntax_Util.comp_result c)))
-            ||
-            (FStar_Syntax_Util.is_ghost_effect
-               (FStar_Syntax_Util.comp_effect_name c))
+          (FStar_Syntax_Util.is_pure_or_ghost_comp c) &&
+            (non_informative env (FStar_Syntax_Util.comp_result c))
       | uu____19806 -> false
   
 let (fv_has_strict_args :

--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -3345,45 +3345,34 @@ let (type_is_erasable : env -> FStar_Syntax_Syntax.fv -> Prims.bool) =
             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
             FStar_Parser_Const.erasable_attr
            in
-        match uu____19710 with
-        | (ex,erasable1) ->
-            let uu____19729 =
-              fv_exists_and_has_attr env
-                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                FStar_Parser_Const.must_erase_for_extraction_attr
-               in
-            (match uu____19729 with
-             | (ex',must_erase_for_extraction_attr1) ->
-                 ((ex || ex'),
-                   (erasable1 || must_erase_for_extraction_attr1)))
-         in
+        match uu____19710 with | (ex,erasable1) -> (ex, erasable1)  in
       cache_in_fv_tab env.erasable_types_tab fv f
   
 let rec (non_informative : env -> FStar_Syntax_Syntax.typ -> Prims.bool) =
   fun env  ->
     fun t  ->
-      let uu____19763 =
-        let uu____19764 = FStar_Syntax_Util.unrefine t  in
-        uu____19764.FStar_Syntax_Syntax.n  in
-      match uu____19763 with
-      | FStar_Syntax_Syntax.Tm_type uu____19768 -> true
+      let uu____19744 =
+        let uu____19745 = FStar_Syntax_Util.unrefine t  in
+        uu____19745.FStar_Syntax_Syntax.n  in
+      match uu____19744 with
+      | FStar_Syntax_Syntax.Tm_type uu____19749 -> true
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           (((FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.unit_lid) ||
               (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid))
              ||
              (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.erased_lid))
             || (type_is_erasable env fv)
-      | FStar_Syntax_Syntax.Tm_app (head1,uu____19772) ->
+      | FStar_Syntax_Syntax.Tm_app (head1,uu____19753) ->
           non_informative env head1
-      | FStar_Syntax_Syntax.Tm_uinst (t1,uu____19798) ->
+      | FStar_Syntax_Syntax.Tm_uinst (t1,uu____19779) ->
           non_informative env t1
-      | FStar_Syntax_Syntax.Tm_arrow (uu____19803,c) ->
+      | FStar_Syntax_Syntax.Tm_arrow (uu____19784,c) ->
           ((FStar_Syntax_Util.is_pure_or_ghost_comp c) &&
              (non_informative env (FStar_Syntax_Util.comp_result c)))
             ||
             (FStar_Syntax_Util.is_ghost_effect
                (FStar_Syntax_Util.comp_effect_name c))
-      | uu____19825 -> false
+      | uu____19806 -> false
   
 let (fv_has_strict_args :
   env ->
@@ -3392,10 +3381,10 @@ let (fv_has_strict_args :
   =
   fun env  ->
     fun fv  ->
-      let f uu____19858 =
+      let f uu____19839 =
         let attrs =
-          let uu____19864 = FStar_Syntax_Syntax.lid_of_fv fv  in
-          lookup_attrs_of_lid env uu____19864  in
+          let uu____19845 = FStar_Syntax_Syntax.lid_of_fv fv  in
+          lookup_attrs_of_lid env uu____19845  in
         match attrs with
         | FStar_Pervasives_Native.None  ->
             (false, FStar_Pervasives_Native.None)
@@ -3403,11 +3392,11 @@ let (fv_has_strict_args :
             let res =
               FStar_Util.find_map attrs1
                 (fun x  ->
-                   let uu____19904 =
+                   let uu____19885 =
                      FStar_ToSyntax_ToSyntax.parse_attr_with_list false x
                        FStar_Parser_Const.strict_on_arguments_attr
                       in
-                   FStar_Pervasives_Native.fst uu____19904)
+                   FStar_Pervasives_Native.fst uu____19885)
                in
             (true, res)
          in
@@ -3420,31 +3409,31 @@ let (try_lookup_effect_lid :
   =
   fun env  ->
     fun ftv  ->
-      let uu____19949 = lookup_qname env ftv  in
-      match uu____19949 with
+      let uu____19930 = lookup_qname env ftv  in
+      match uu____19930 with
       | FStar_Pervasives_Native.Some
-          (FStar_Util.Inr (se,FStar_Pervasives_Native.None ),uu____19953) ->
-          let uu____19998 =
+          (FStar_Util.Inr (se,FStar_Pervasives_Native.None ),uu____19934) ->
+          let uu____19979 =
             effect_signature FStar_Pervasives_Native.None se env.range  in
-          (match uu____19998 with
+          (match uu____19979 with
            | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-           | FStar_Pervasives_Native.Some ((uu____20019,t),r) ->
-               let uu____20034 =
-                 let uu____20035 = FStar_Ident.range_of_lid ftv  in
-                 FStar_Syntax_Subst.set_use_range uu____20035 t  in
-               FStar_Pervasives_Native.Some uu____20034)
-      | uu____20036 -> FStar_Pervasives_Native.None
+           | FStar_Pervasives_Native.Some ((uu____20000,t),r) ->
+               let uu____20015 =
+                 let uu____20016 = FStar_Ident.range_of_lid ftv  in
+                 FStar_Syntax_Subst.set_use_range uu____20016 t  in
+               FStar_Pervasives_Native.Some uu____20015)
+      | uu____20017 -> FStar_Pervasives_Native.None
   
 let (lookup_effect_lid :
   env -> FStar_Ident.lident -> FStar_Syntax_Syntax.term) =
   fun env  ->
     fun ftv  ->
-      let uu____20048 = try_lookup_effect_lid env ftv  in
-      match uu____20048 with
+      let uu____20029 = try_lookup_effect_lid env ftv  in
+      match uu____20029 with
       | FStar_Pervasives_Native.None  ->
-          let uu____20051 = name_not_found ftv  in
-          let uu____20057 = FStar_Ident.range_of_lid ftv  in
-          FStar_Errors.raise_error uu____20051 uu____20057
+          let uu____20032 = name_not_found ftv  in
+          let uu____20038 = FStar_Ident.range_of_lid ftv  in
+          FStar_Errors.raise_error uu____20032 uu____20038
       | FStar_Pervasives_Native.Some k -> k
   
 let (lookup_effect_abbrev :
@@ -3457,37 +3446,37 @@ let (lookup_effect_abbrev :
   fun env  ->
     fun univ_insts  ->
       fun lid0  ->
-        let uu____20081 = lookup_qname env lid0  in
-        match uu____20081 with
+        let uu____20062 = lookup_qname env lid0  in
+        match uu____20062 with
         | FStar_Pervasives_Native.Some
             (FStar_Util.Inr
              ({
                 FStar_Syntax_Syntax.sigel =
                   FStar_Syntax_Syntax.Sig_effect_abbrev
-                  (lid,univs1,binders,c,uu____20092);
-                FStar_Syntax_Syntax.sigrng = uu____20093;
+                  (lid,univs1,binders,c,uu____20073);
+                FStar_Syntax_Syntax.sigrng = uu____20074;
                 FStar_Syntax_Syntax.sigquals = quals;
-                FStar_Syntax_Syntax.sigmeta = uu____20095;
-                FStar_Syntax_Syntax.sigattrs = uu____20096;_},FStar_Pervasives_Native.None
-              ),uu____20097)
+                FStar_Syntax_Syntax.sigmeta = uu____20076;
+                FStar_Syntax_Syntax.sigattrs = uu____20077;_},FStar_Pervasives_Native.None
+              ),uu____20078)
             ->
             let lid1 =
-              let uu____20151 =
-                let uu____20152 = FStar_Ident.range_of_lid lid  in
-                let uu____20153 =
-                  let uu____20154 = FStar_Ident.range_of_lid lid0  in
-                  FStar_Range.use_range uu____20154  in
-                FStar_Range.set_use_range uu____20152 uu____20153  in
-              FStar_Ident.set_lid_range lid uu____20151  in
-            let uu____20155 =
+              let uu____20132 =
+                let uu____20133 = FStar_Ident.range_of_lid lid  in
+                let uu____20134 =
+                  let uu____20135 = FStar_Ident.range_of_lid lid0  in
+                  FStar_Range.use_range uu____20135  in
+                FStar_Range.set_use_range uu____20133 uu____20134  in
+              FStar_Ident.set_lid_range lid uu____20132  in
+            let uu____20136 =
               FStar_All.pipe_right quals
                 (FStar_Util.for_some
-                   (fun uu___6_20161  ->
-                      match uu___6_20161 with
+                   (fun uu___6_20142  ->
+                      match uu___6_20142 with
                       | FStar_Syntax_Syntax.Irreducible  -> true
-                      | uu____20164 -> false))
+                      | uu____20145 -> false))
                in
-            if uu____20155
+            if uu____20136
             then FStar_Pervasives_Native.None
             else
               (let insts =
@@ -3496,212 +3485,212 @@ let (lookup_effect_abbrev :
                      (FStar_List.length univs1)
                  then univ_insts
                  else
-                   (let uu____20183 =
-                      let uu____20185 =
-                        let uu____20187 = get_range env  in
-                        FStar_Range.string_of_range uu____20187  in
-                      let uu____20188 = FStar_Syntax_Print.lid_to_string lid1
+                   (let uu____20164 =
+                      let uu____20166 =
+                        let uu____20168 = get_range env  in
+                        FStar_Range.string_of_range uu____20168  in
+                      let uu____20169 = FStar_Syntax_Print.lid_to_string lid1
                          in
-                      let uu____20190 =
+                      let uu____20171 =
                         FStar_All.pipe_right (FStar_List.length univ_insts)
                           FStar_Util.string_of_int
                          in
                       FStar_Util.format3
                         "(%s) Unexpected instantiation of effect %s with %s universes"
-                        uu____20185 uu____20188 uu____20190
+                        uu____20166 uu____20169 uu____20171
                        in
-                    failwith uu____20183)
+                    failwith uu____20164)
                   in
                match (binders, univs1) with
-               | ([],uu____20211) ->
+               | ([],uu____20192) ->
                    failwith
                      "Unexpected effect abbreviation with no arguments"
-               | (uu____20237,uu____20238::uu____20239::uu____20240) ->
-                   let uu____20261 =
-                     let uu____20263 = FStar_Syntax_Print.lid_to_string lid1
+               | (uu____20218,uu____20219::uu____20220::uu____20221) ->
+                   let uu____20242 =
+                     let uu____20244 = FStar_Syntax_Print.lid_to_string lid1
                         in
-                     let uu____20265 =
+                     let uu____20246 =
                        FStar_All.pipe_left FStar_Util.string_of_int
                          (FStar_List.length univs1)
                         in
                      FStar_Util.format2
                        "Unexpected effect abbreviation %s; polymorphic in %s universes"
-                       uu____20263 uu____20265
+                       uu____20244 uu____20246
                       in
-                   failwith uu____20261
-               | uu____20276 ->
-                   let uu____20291 =
-                     let uu____20296 =
-                       let uu____20297 = FStar_Syntax_Util.arrow binders c
+                   failwith uu____20242
+               | uu____20257 ->
+                   let uu____20272 =
+                     let uu____20277 =
+                       let uu____20278 = FStar_Syntax_Util.arrow binders c
                           in
-                       (univs1, uu____20297)  in
-                     inst_tscheme_with uu____20296 insts  in
-                   (match uu____20291 with
-                    | (uu____20310,t) ->
+                       (univs1, uu____20278)  in
+                     inst_tscheme_with uu____20277 insts  in
+                   (match uu____20272 with
+                    | (uu____20291,t) ->
                         let t1 =
-                          let uu____20313 = FStar_Ident.range_of_lid lid1  in
-                          FStar_Syntax_Subst.set_use_range uu____20313 t  in
-                        let uu____20314 =
-                          let uu____20315 = FStar_Syntax_Subst.compress t1
+                          let uu____20294 = FStar_Ident.range_of_lid lid1  in
+                          FStar_Syntax_Subst.set_use_range uu____20294 t  in
+                        let uu____20295 =
+                          let uu____20296 = FStar_Syntax_Subst.compress t1
                              in
-                          uu____20315.FStar_Syntax_Syntax.n  in
-                        (match uu____20314 with
+                          uu____20296.FStar_Syntax_Syntax.n  in
+                        (match uu____20295 with
                          | FStar_Syntax_Syntax.Tm_arrow (binders1,c1) ->
                              FStar_Pervasives_Native.Some (binders1, c1)
-                         | uu____20350 -> failwith "Impossible")))
-        | uu____20358 -> FStar_Pervasives_Native.None
+                         | uu____20331 -> failwith "Impossible")))
+        | uu____20339 -> FStar_Pervasives_Native.None
   
 let (norm_eff_name : env -> FStar_Ident.lident -> FStar_Ident.lident) =
   fun env  ->
     fun l  ->
       let rec find1 l1 =
-        let uu____20382 =
+        let uu____20363 =
           lookup_effect_abbrev env [FStar_Syntax_Syntax.U_unknown] l1  in
-        match uu____20382 with
+        match uu____20363 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-        | FStar_Pervasives_Native.Some (uu____20395,c) ->
+        | FStar_Pervasives_Native.Some (uu____20376,c) ->
             let l2 = FStar_Syntax_Util.comp_effect_name c  in
-            let uu____20402 = find1 l2  in
-            (match uu____20402 with
+            let uu____20383 = find1 l2  in
+            (match uu____20383 with
              | FStar_Pervasives_Native.None  ->
                  FStar_Pervasives_Native.Some l2
              | FStar_Pervasives_Native.Some l' ->
                  FStar_Pervasives_Native.Some l')
          in
       let res =
-        let uu____20409 =
+        let uu____20390 =
           FStar_Util.smap_try_find env.normalized_eff_names l.FStar_Ident.str
            in
-        match uu____20409 with
+        match uu____20390 with
         | FStar_Pervasives_Native.Some l1 -> l1
         | FStar_Pervasives_Native.None  ->
-            let uu____20413 = find1 l  in
-            (match uu____20413 with
+            let uu____20394 = find1 l  in
+            (match uu____20394 with
              | FStar_Pervasives_Native.None  -> l
              | FStar_Pervasives_Native.Some m ->
                  (FStar_Util.smap_add env.normalized_eff_names
                     l.FStar_Ident.str m;
                   m))
          in
-      let uu____20418 = FStar_Ident.range_of_lid l  in
-      FStar_Ident.set_lid_range res uu____20418
+      let uu____20399 = FStar_Ident.range_of_lid l  in
+      FStar_Ident.set_lid_range res uu____20399
   
 let (lookup_effect_quals :
   env -> FStar_Ident.lident -> FStar_Syntax_Syntax.qualifier Prims.list) =
   fun env  ->
     fun l  ->
       let l1 = norm_eff_name env l  in
-      let uu____20433 = lookup_qname env l1  in
-      match uu____20433 with
+      let uu____20414 = lookup_qname env l1  in
+      match uu____20414 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_new_effect
-                uu____20436;
-              FStar_Syntax_Syntax.sigrng = uu____20437;
+                uu____20417;
+              FStar_Syntax_Syntax.sigrng = uu____20418;
               FStar_Syntax_Syntax.sigquals = q;
-              FStar_Syntax_Syntax.sigmeta = uu____20439;
-              FStar_Syntax_Syntax.sigattrs = uu____20440;_},uu____20441),uu____20442)
+              FStar_Syntax_Syntax.sigmeta = uu____20420;
+              FStar_Syntax_Syntax.sigattrs = uu____20421;_},uu____20422),uu____20423)
           -> q
-      | uu____20493 -> []
+      | uu____20474 -> []
   
 let (lookup_projector :
   env -> FStar_Ident.lident -> Prims.int -> FStar_Ident.lident) =
   fun env  ->
     fun lid  ->
       fun i  ->
-        let fail1 uu____20517 =
-          let uu____20518 =
-            let uu____20520 = FStar_Util.string_of_int i  in
-            let uu____20522 = FStar_Syntax_Print.lid_to_string lid  in
+        let fail1 uu____20498 =
+          let uu____20499 =
+            let uu____20501 = FStar_Util.string_of_int i  in
+            let uu____20503 = FStar_Syntax_Print.lid_to_string lid  in
             FStar_Util.format2
               "Impossible: projecting field #%s from constructor %s is undefined"
-              uu____20520 uu____20522
+              uu____20501 uu____20503
              in
-          failwith uu____20518  in
-        let uu____20525 = lookup_datacon env lid  in
-        match uu____20525 with
-        | (uu____20530,t) ->
-            let uu____20532 =
-              let uu____20533 = FStar_Syntax_Subst.compress t  in
-              uu____20533.FStar_Syntax_Syntax.n  in
-            (match uu____20532 with
-             | FStar_Syntax_Syntax.Tm_arrow (binders,uu____20537) ->
+          failwith uu____20499  in
+        let uu____20506 = lookup_datacon env lid  in
+        match uu____20506 with
+        | (uu____20511,t) ->
+            let uu____20513 =
+              let uu____20514 = FStar_Syntax_Subst.compress t  in
+              uu____20514.FStar_Syntax_Syntax.n  in
+            (match uu____20513 with
+             | FStar_Syntax_Syntax.Tm_arrow (binders,uu____20518) ->
                  if
                    (i < Prims.int_zero) || (i >= (FStar_List.length binders))
                  then fail1 ()
                  else
                    (let b = FStar_List.nth binders i  in
-                    let uu____20581 =
+                    let uu____20562 =
                       FStar_Syntax_Util.mk_field_projector_name lid
                         (FStar_Pervasives_Native.fst b) i
                        in
-                    FStar_All.pipe_right uu____20581
+                    FStar_All.pipe_right uu____20562
                       FStar_Pervasives_Native.fst)
-             | uu____20592 -> fail1 ())
+             | uu____20573 -> fail1 ())
   
 let (is_projector : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun l  ->
-      let uu____20606 = lookup_qname env l  in
-      match uu____20606 with
+      let uu____20587 = lookup_qname env l  in
+      match uu____20587 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ
-                (uu____20608,uu____20609,uu____20610);
-              FStar_Syntax_Syntax.sigrng = uu____20611;
+                (uu____20589,uu____20590,uu____20591);
+              FStar_Syntax_Syntax.sigrng = uu____20592;
               FStar_Syntax_Syntax.sigquals = quals;
-              FStar_Syntax_Syntax.sigmeta = uu____20613;
-              FStar_Syntax_Syntax.sigattrs = uu____20614;_},uu____20615),uu____20616)
+              FStar_Syntax_Syntax.sigmeta = uu____20594;
+              FStar_Syntax_Syntax.sigattrs = uu____20595;_},uu____20596),uu____20597)
           ->
           FStar_Util.for_some
-            (fun uu___7_20669  ->
-               match uu___7_20669 with
-               | FStar_Syntax_Syntax.Projector uu____20671 -> true
-               | uu____20677 -> false) quals
-      | uu____20679 -> false
+            (fun uu___7_20650  ->
+               match uu___7_20650 with
+               | FStar_Syntax_Syntax.Projector uu____20652 -> true
+               | uu____20658 -> false) quals
+      | uu____20660 -> false
   
 let (is_datacon : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun lid  ->
-      let uu____20693 = lookup_qname env lid  in
-      match uu____20693 with
+      let uu____20674 = lookup_qname env lid  in
+      match uu____20674 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-                (uu____20695,uu____20696,uu____20697,uu____20698,uu____20699,uu____20700);
-              FStar_Syntax_Syntax.sigrng = uu____20701;
-              FStar_Syntax_Syntax.sigquals = uu____20702;
-              FStar_Syntax_Syntax.sigmeta = uu____20703;
-              FStar_Syntax_Syntax.sigattrs = uu____20704;_},uu____20705),uu____20706)
+                (uu____20676,uu____20677,uu____20678,uu____20679,uu____20680,uu____20681);
+              FStar_Syntax_Syntax.sigrng = uu____20682;
+              FStar_Syntax_Syntax.sigquals = uu____20683;
+              FStar_Syntax_Syntax.sigmeta = uu____20684;
+              FStar_Syntax_Syntax.sigattrs = uu____20685;_},uu____20686),uu____20687)
           -> true
-      | uu____20764 -> false
+      | uu____20745 -> false
   
 let (is_record : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun lid  ->
-      let uu____20778 = lookup_qname env lid  in
-      match uu____20778 with
+      let uu____20759 = lookup_qname env lid  in
+      match uu____20759 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel =
                 FStar_Syntax_Syntax.Sig_inductive_typ
-                (uu____20780,uu____20781,uu____20782,uu____20783,uu____20784,uu____20785);
-              FStar_Syntax_Syntax.sigrng = uu____20786;
+                (uu____20761,uu____20762,uu____20763,uu____20764,uu____20765,uu____20766);
+              FStar_Syntax_Syntax.sigrng = uu____20767;
               FStar_Syntax_Syntax.sigquals = quals;
-              FStar_Syntax_Syntax.sigmeta = uu____20788;
-              FStar_Syntax_Syntax.sigattrs = uu____20789;_},uu____20790),uu____20791)
+              FStar_Syntax_Syntax.sigmeta = uu____20769;
+              FStar_Syntax_Syntax.sigattrs = uu____20770;_},uu____20771),uu____20772)
           ->
           FStar_Util.for_some
-            (fun uu___8_20852  ->
-               match uu___8_20852 with
-               | FStar_Syntax_Syntax.RecordType uu____20854 -> true
-               | FStar_Syntax_Syntax.RecordConstructor uu____20864 -> true
-               | uu____20874 -> false) quals
-      | uu____20876 -> false
+            (fun uu___8_20833  ->
+               match uu___8_20833 with
+               | FStar_Syntax_Syntax.RecordType uu____20835 -> true
+               | FStar_Syntax_Syntax.RecordConstructor uu____20845 -> true
+               | uu____20855 -> false) quals
+      | uu____20857 -> false
   
 let (qninfo_is_action : qninfo -> Prims.bool) =
   fun qninfo  ->
@@ -3710,24 +3699,24 @@ let (qninfo_is_action : qninfo -> Prims.bool) =
         (FStar_Util.Inr
          ({
             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
-              (uu____20886,uu____20887);
-            FStar_Syntax_Syntax.sigrng = uu____20888;
+              (uu____20867,uu____20868);
+            FStar_Syntax_Syntax.sigrng = uu____20869;
             FStar_Syntax_Syntax.sigquals = quals;
-            FStar_Syntax_Syntax.sigmeta = uu____20890;
-            FStar_Syntax_Syntax.sigattrs = uu____20891;_},uu____20892),uu____20893)
+            FStar_Syntax_Syntax.sigmeta = uu____20871;
+            FStar_Syntax_Syntax.sigattrs = uu____20872;_},uu____20873),uu____20874)
         ->
         FStar_Util.for_some
-          (fun uu___9_20950  ->
-             match uu___9_20950 with
-             | FStar_Syntax_Syntax.Action uu____20952 -> true
-             | uu____20954 -> false) quals
-    | uu____20956 -> false
+          (fun uu___9_20931  ->
+             match uu___9_20931 with
+             | FStar_Syntax_Syntax.Action uu____20933 -> true
+             | uu____20935 -> false) quals
+    | uu____20937 -> false
   
 let (is_action : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun lid  ->
-      let uu____20970 = lookup_qname env lid  in
-      FStar_All.pipe_left qninfo_is_action uu____20970
+      let uu____20951 = lookup_qname env lid  in
+      FStar_All.pipe_left qninfo_is_action uu____20951
   
 let (is_interpreted : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   let interpreted_symbols =
@@ -3748,51 +3737,51 @@ let (is_interpreted : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
     FStar_Parser_Const.op_Negation]  in
   fun env  ->
     fun head1  ->
-      let uu____20987 =
-        let uu____20988 = FStar_Syntax_Util.un_uinst head1  in
-        uu____20988.FStar_Syntax_Syntax.n  in
-      match uu____20987 with
+      let uu____20968 =
+        let uu____20969 = FStar_Syntax_Util.un_uinst head1  in
+        uu____20969.FStar_Syntax_Syntax.n  in
+      match uu____20968 with
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           (match fv.FStar_Syntax_Syntax.fv_delta with
-           | FStar_Syntax_Syntax.Delta_equational_at_level uu____20994 ->
+           | FStar_Syntax_Syntax.Delta_equational_at_level uu____20975 ->
                true
-           | uu____20997 -> false)
-      | uu____20999 -> false
+           | uu____20978 -> false)
+      | uu____20980 -> false
   
 let (is_irreducible : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun l  ->
-      let uu____21013 = lookup_qname env l  in
-      match uu____21013 with
+      let uu____20994 = lookup_qname env l  in
+      match uu____20994 with
       | FStar_Pervasives_Native.Some
-          (FStar_Util.Inr (se,uu____21016),uu____21017) ->
+          (FStar_Util.Inr (se,uu____20997),uu____20998) ->
           FStar_Util.for_some
-            (fun uu___10_21065  ->
-               match uu___10_21065 with
+            (fun uu___10_21046  ->
+               match uu___10_21046 with
                | FStar_Syntax_Syntax.Irreducible  -> true
-               | uu____21068 -> false) se.FStar_Syntax_Syntax.sigquals
-      | uu____21070 -> false
+               | uu____21049 -> false) se.FStar_Syntax_Syntax.sigquals
+      | uu____21051 -> false
   
 let (is_type_constructor : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun lid  ->
       let mapper x =
         match FStar_Pervasives_Native.fst x with
-        | FStar_Util.Inl uu____21146 -> FStar_Pervasives_Native.Some false
-        | FStar_Util.Inr (se,uu____21164) ->
+        | FStar_Util.Inl uu____21127 -> FStar_Pervasives_Native.Some false
+        | FStar_Util.Inr (se,uu____21145) ->
             (match se.FStar_Syntax_Syntax.sigel with
-             | FStar_Syntax_Syntax.Sig_declare_typ uu____21182 ->
+             | FStar_Syntax_Syntax.Sig_declare_typ uu____21163 ->
                  FStar_Pervasives_Native.Some
                    (FStar_List.contains FStar_Syntax_Syntax.New
                       se.FStar_Syntax_Syntax.sigquals)
-             | FStar_Syntax_Syntax.Sig_inductive_typ uu____21190 ->
+             | FStar_Syntax_Syntax.Sig_inductive_typ uu____21171 ->
                  FStar_Pervasives_Native.Some true
-             | uu____21209 -> FStar_Pervasives_Native.Some false)
+             | uu____21190 -> FStar_Pervasives_Native.Some false)
          in
-      let uu____21212 =
-        let uu____21216 = lookup_qname env lid  in
-        FStar_Util.bind_opt uu____21216 mapper  in
-      match uu____21212 with
+      let uu____21193 =
+        let uu____21197 = lookup_qname env lid  in
+        FStar_Util.bind_opt uu____21197 mapper  in
+      match uu____21193 with
       | FStar_Pervasives_Native.Some b -> b
       | FStar_Pervasives_Native.None  -> false
   
@@ -3800,20 +3789,20 @@ let (num_inductive_ty_params :
   env -> FStar_Ident.lident -> Prims.int FStar_Pervasives_Native.option) =
   fun env  ->
     fun lid  ->
-      let uu____21276 = lookup_qname env lid  in
-      match uu____21276 with
+      let uu____21257 = lookup_qname env lid  in
+      match uu____21257 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel =
                 FStar_Syntax_Syntax.Sig_inductive_typ
-                (uu____21280,uu____21281,tps,uu____21283,uu____21284,uu____21285);
-              FStar_Syntax_Syntax.sigrng = uu____21286;
-              FStar_Syntax_Syntax.sigquals = uu____21287;
-              FStar_Syntax_Syntax.sigmeta = uu____21288;
-              FStar_Syntax_Syntax.sigattrs = uu____21289;_},uu____21290),uu____21291)
+                (uu____21261,uu____21262,tps,uu____21264,uu____21265,uu____21266);
+              FStar_Syntax_Syntax.sigrng = uu____21267;
+              FStar_Syntax_Syntax.sigquals = uu____21268;
+              FStar_Syntax_Syntax.sigmeta = uu____21269;
+              FStar_Syntax_Syntax.sigattrs = uu____21270;_},uu____21271),uu____21272)
           -> FStar_Pervasives_Native.Some (FStar_List.length tps)
-      | uu____21357 -> FStar_Pervasives_Native.None
+      | uu____21338 -> FStar_Pervasives_Native.None
   
 let (effect_decl_opt :
   env ->
@@ -3825,29 +3814,29 @@ let (effect_decl_opt :
     fun l  ->
       FStar_All.pipe_right (env.effects).decls
         (FStar_Util.find_opt
-           (fun uu____21403  ->
-              match uu____21403 with
-              | (d,uu____21412) ->
+           (fun uu____21384  ->
+              match uu____21384 with
+              | (d,uu____21393) ->
                   FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname l))
   
 let (get_effect_decl :
   env -> FStar_Ident.lident -> FStar_Syntax_Syntax.eff_decl) =
   fun env  ->
     fun l  ->
-      let uu____21428 = effect_decl_opt env l  in
-      match uu____21428 with
+      let uu____21409 = effect_decl_opt env l  in
+      match uu____21409 with
       | FStar_Pervasives_Native.None  ->
-          let uu____21443 = name_not_found l  in
-          let uu____21449 = FStar_Ident.range_of_lid l  in
-          FStar_Errors.raise_error uu____21443 uu____21449
+          let uu____21424 = name_not_found l  in
+          let uu____21430 = FStar_Ident.range_of_lid l  in
+          FStar_Errors.raise_error uu____21424 uu____21430
       | FStar_Pervasives_Native.Some md -> FStar_Pervasives_Native.fst md
   
 let (identity_mlift : mlift) =
   {
-    mlift_wp = (fun uu____21472  -> fun t  -> fun wp  -> wp);
+    mlift_wp = (fun uu____21453  -> fun t  -> fun wp  -> wp);
     mlift_term =
       (FStar_Pervasives_Native.Some
-         (fun uu____21491  ->
+         (fun uu____21472  ->
             fun t  -> fun wp  -> fun e  -> FStar_Util.return_all e))
   } 
 let (join :
@@ -3858,11 +3847,11 @@ let (join :
   fun env  ->
     fun l1  ->
       fun l2  ->
-        let uu____21523 = FStar_Ident.lid_equals l1 l2  in
-        if uu____21523
+        let uu____21504 = FStar_Ident.lid_equals l1 l2  in
+        if uu____21504
         then (l1, identity_mlift, identity_mlift)
         else
-          (let uu____21534 =
+          (let uu____21515 =
              ((FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_GTot_lid)
                 &&
                 (FStar_Ident.lid_equals l2 FStar_Parser_Const.effect_Tot_lid))
@@ -3872,37 +3861,37 @@ let (join :
                   (FStar_Ident.lid_equals l1
                      FStar_Parser_Const.effect_Tot_lid))
               in
-           if uu____21534
+           if uu____21515
            then
              (FStar_Parser_Const.effect_GTot_lid, identity_mlift,
                identity_mlift)
            else
-             (let uu____21545 =
+             (let uu____21526 =
                 FStar_All.pipe_right (env.effects).joins
                   (FStar_Util.find_opt
-                     (fun uu____21598  ->
-                        match uu____21598 with
-                        | (m1,m2,uu____21612,uu____21613,uu____21614) ->
+                     (fun uu____21579  ->
+                        match uu____21579 with
+                        | (m1,m2,uu____21593,uu____21594,uu____21595) ->
                             (FStar_Ident.lid_equals l1 m1) &&
                               (FStar_Ident.lid_equals l2 m2)))
                  in
-              match uu____21545 with
+              match uu____21526 with
               | FStar_Pervasives_Native.None  ->
-                  let uu____21631 =
-                    let uu____21637 =
-                      let uu____21639 = FStar_Syntax_Print.lid_to_string l1
+                  let uu____21612 =
+                    let uu____21618 =
+                      let uu____21620 = FStar_Syntax_Print.lid_to_string l1
                          in
-                      let uu____21641 = FStar_Syntax_Print.lid_to_string l2
+                      let uu____21622 = FStar_Syntax_Print.lid_to_string l2
                          in
                       FStar_Util.format2
-                        "Effects %s and %s cannot be composed" uu____21639
-                        uu____21641
+                        "Effects %s and %s cannot be composed" uu____21620
+                        uu____21622
                        in
-                    (FStar_Errors.Fatal_EffectsCannotBeComposed, uu____21637)
+                    (FStar_Errors.Fatal_EffectsCannotBeComposed, uu____21618)
                      in
-                  FStar_Errors.raise_error uu____21631 env.range
+                  FStar_Errors.raise_error uu____21612 env.range
               | FStar_Pervasives_Native.Some
-                  (uu____21651,uu____21652,m3,j1,j2) -> (m3, j1, j2)))
+                  (uu____21632,uu____21633,m3,j1,j2) -> (m3, j1, j2)))
   
 let (monad_leq :
   env ->
@@ -3912,12 +3901,12 @@ let (monad_leq :
   fun env  ->
     fun l1  ->
       fun l2  ->
-        let uu____21686 =
+        let uu____21667 =
           (FStar_Ident.lid_equals l1 l2) ||
             ((FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_Tot_lid) &&
                (FStar_Ident.lid_equals l2 FStar_Parser_Const.effect_GTot_lid))
            in
-        if uu____21686
+        if uu____21667
         then
           FStar_Pervasives_Native.Some
             { msource = l1; mtarget = l2; mlift = identity_mlift }
@@ -3929,44 +3918,44 @@ let (monad_leq :
                     (FStar_Ident.lid_equals l2 e.mtarget)))
   
 let wp_sig_aux :
-  'Auu____21706 .
-    (FStar_Syntax_Syntax.eff_decl * 'Auu____21706) Prims.list ->
+  'Auu____21687 .
+    (FStar_Syntax_Syntax.eff_decl * 'Auu____21687) Prims.list ->
       FStar_Ident.lident ->
         (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term'
           FStar_Syntax_Syntax.syntax)
   =
   fun decls  ->
     fun m  ->
-      let uu____21735 =
+      let uu____21716 =
         FStar_All.pipe_right decls
           (FStar_Util.find_opt
-             (fun uu____21761  ->
-                match uu____21761 with
-                | (d,uu____21768) ->
+             (fun uu____21742  ->
+                match uu____21742 with
+                | (d,uu____21749) ->
                     FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname m))
          in
-      match uu____21735 with
+      match uu____21716 with
       | FStar_Pervasives_Native.None  ->
-          let uu____21779 =
+          let uu____21760 =
             FStar_Util.format1
               "Impossible: declaration for monad %s not found"
               m.FStar_Ident.str
              in
-          failwith uu____21779
+          failwith uu____21760
       | FStar_Pervasives_Native.Some (md,_q) ->
-          let uu____21794 = inst_tscheme md.FStar_Syntax_Syntax.signature  in
-          (match uu____21794 with
-           | (uu____21805,s) ->
+          let uu____21775 = inst_tscheme md.FStar_Syntax_Syntax.signature  in
+          (match uu____21775 with
+           | (uu____21786,s) ->
                let s1 = FStar_Syntax_Subst.compress s  in
                (match ((md.FStar_Syntax_Syntax.binders),
                         (s1.FStar_Syntax_Syntax.n))
                 with
                 | ([],FStar_Syntax_Syntax.Tm_arrow
-                   ((a,uu____21823)::(wp,uu____21825)::[],c)) when
+                   ((a,uu____21804)::(wp,uu____21806)::[],c)) when
                     FStar_Syntax_Syntax.is_teff
                       (FStar_Syntax_Util.comp_result c)
                     -> (a, (wp.FStar_Syntax_Syntax.sort))
-                | uu____21881 -> failwith "Impossible"))
+                | uu____21862 -> failwith "Impossible"))
   
 let (wp_signature :
   env ->
@@ -3984,7 +3973,7 @@ let (comp_to_comp_typ :
         | FStar_Syntax_Syntax.GTotal (t,FStar_Pervasives_Native.None ) ->
             let u = env.universe_of env t  in
             FStar_Syntax_Syntax.mk_GTotal' t (FStar_Pervasives_Native.Some u)
-        | uu____21946 -> c  in
+        | uu____21927 -> c  in
       FStar_Syntax_Util.comp_to_comp_typ c1
   
 let rec (unfold_effect_abbrev :
@@ -3992,85 +3981,85 @@ let rec (unfold_effect_abbrev :
   fun env  ->
     fun comp  ->
       let c = comp_to_comp_typ env comp  in
-      let uu____21959 =
+      let uu____21940 =
         lookup_effect_abbrev env c.FStar_Syntax_Syntax.comp_univs
           c.FStar_Syntax_Syntax.effect_name
          in
-      match uu____21959 with
+      match uu____21940 with
       | FStar_Pervasives_Native.None  -> c
       | FStar_Pervasives_Native.Some (binders,cdef) ->
-          let uu____21976 = FStar_Syntax_Subst.open_comp binders cdef  in
-          (match uu____21976 with
+          let uu____21957 = FStar_Syntax_Subst.open_comp binders cdef  in
+          (match uu____21957 with
            | (binders1,cdef1) ->
                (if
                   (FStar_List.length binders1) <>
                     ((FStar_List.length c.FStar_Syntax_Syntax.effect_args) +
                        Prims.int_one)
                 then
-                  (let uu____22001 =
-                     let uu____22007 =
-                       let uu____22009 =
+                  (let uu____21982 =
+                     let uu____21988 =
+                       let uu____21990 =
                          FStar_Util.string_of_int
                            (FStar_List.length binders1)
                           in
-                       let uu____22017 =
+                       let uu____21998 =
                          FStar_Util.string_of_int
                            ((FStar_List.length
                                c.FStar_Syntax_Syntax.effect_args)
                               + Prims.int_one)
                           in
-                       let uu____22028 =
-                         let uu____22030 = FStar_Syntax_Syntax.mk_Comp c  in
-                         FStar_Syntax_Print.comp_to_string uu____22030  in
+                       let uu____22009 =
+                         let uu____22011 = FStar_Syntax_Syntax.mk_Comp c  in
+                         FStar_Syntax_Print.comp_to_string uu____22011  in
                        FStar_Util.format3
                          "Effect constructor is not fully applied; expected %s args, got %s args, i.e., %s"
-                         uu____22009 uu____22017 uu____22028
+                         uu____21990 uu____21998 uu____22009
                         in
                      (FStar_Errors.Fatal_ConstructorArgLengthMismatch,
-                       uu____22007)
+                       uu____21988)
                       in
-                   FStar_Errors.raise_error uu____22001
+                   FStar_Errors.raise_error uu____21982
                      comp.FStar_Syntax_Syntax.pos)
                 else ();
                 (let inst1 =
-                   let uu____22038 =
-                     let uu____22049 =
+                   let uu____22019 =
+                     let uu____22030 =
                        FStar_Syntax_Syntax.as_arg
                          c.FStar_Syntax_Syntax.result_typ
                         in
-                     uu____22049 :: (c.FStar_Syntax_Syntax.effect_args)  in
+                     uu____22030 :: (c.FStar_Syntax_Syntax.effect_args)  in
                    FStar_List.map2
-                     (fun uu____22086  ->
-                        fun uu____22087  ->
-                          match (uu____22086, uu____22087) with
-                          | ((x,uu____22117),(t,uu____22119)) ->
+                     (fun uu____22067  ->
+                        fun uu____22068  ->
+                          match (uu____22067, uu____22068) with
+                          | ((x,uu____22098),(t,uu____22100)) ->
                               FStar_Syntax_Syntax.NT (x, t)) binders1
-                     uu____22038
+                     uu____22019
                     in
                  let c1 = FStar_Syntax_Subst.subst_comp inst1 cdef1  in
                  let c2 =
-                   let uu____22150 =
-                     let uu___1582_22151 = comp_to_comp_typ env c1  in
+                   let uu____22131 =
+                     let uu___1579_22132 = comp_to_comp_typ env c1  in
                      {
                        FStar_Syntax_Syntax.comp_univs =
-                         (uu___1582_22151.FStar_Syntax_Syntax.comp_univs);
+                         (uu___1579_22132.FStar_Syntax_Syntax.comp_univs);
                        FStar_Syntax_Syntax.effect_name =
-                         (uu___1582_22151.FStar_Syntax_Syntax.effect_name);
+                         (uu___1579_22132.FStar_Syntax_Syntax.effect_name);
                        FStar_Syntax_Syntax.result_typ =
-                         (uu___1582_22151.FStar_Syntax_Syntax.result_typ);
+                         (uu___1579_22132.FStar_Syntax_Syntax.result_typ);
                        FStar_Syntax_Syntax.effect_args =
-                         (uu___1582_22151.FStar_Syntax_Syntax.effect_args);
+                         (uu___1579_22132.FStar_Syntax_Syntax.effect_args);
                        FStar_Syntax_Syntax.flags =
                          (c.FStar_Syntax_Syntax.flags)
                      }  in
-                   FStar_All.pipe_right uu____22150
+                   FStar_All.pipe_right uu____22131
                      FStar_Syntax_Syntax.mk_Comp
                     in
                  unfold_effect_abbrev env c2)))
   
 let effect_repr_aux :
-  'Auu____22163 .
-    'Auu____22163 ->
+  'Auu____22144 .
+    'Auu____22144 ->
       env ->
         FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
           FStar_Syntax_Syntax.universe ->
@@ -4083,55 +4072,55 @@ let effect_repr_aux :
         fun u_c  ->
           let effect_name =
             norm_eff_name env (FStar_Syntax_Util.comp_effect_name c)  in
-          let uu____22193 = effect_decl_opt env effect_name  in
-          match uu____22193 with
+          let uu____22174 = effect_decl_opt env effect_name  in
+          match uu____22174 with
           | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
           | FStar_Pervasives_Native.Some (ed,qualifiers) ->
               (match (FStar_Pervasives_Native.snd ed.FStar_Syntax_Syntax.repr).FStar_Syntax_Syntax.n
                with
                | FStar_Syntax_Syntax.Tm_unknown  ->
                    FStar_Pervasives_Native.None
-               | uu____22236 ->
+               | uu____22217 ->
                    let c1 = unfold_effect_abbrev env c  in
                    let res_typ = c1.FStar_Syntax_Syntax.result_typ  in
                    let wp =
                      match c1.FStar_Syntax_Syntax.effect_args with
-                     | hd1::uu____22259 -> hd1
+                     | hd1::uu____22240 -> hd1
                      | [] ->
                          let name = FStar_Ident.string_of_lid effect_name  in
                          let message =
-                           let uu____22298 =
+                           let uu____22279 =
                              FStar_Util.format1
                                "Not enough arguments for effect %s. " name
                               in
-                           Prims.op_Hat uu____22298
+                           Prims.op_Hat uu____22279
                              (Prims.op_Hat
                                 "This usually happens when you use a partially applied DM4F effect, "
                                 "like [TAC int] instead of [Tac int].")
                             in
-                         let uu____22303 = get_range env  in
+                         let uu____22284 = get_range env  in
                          FStar_Errors.raise_error
                            (FStar_Errors.Fatal_NotEnoughArgumentsForEffect,
-                             message) uu____22303
+                             message) uu____22284
                       in
                    let repr =
                      inst_effect_fun_with [u_c] env ed
                        ed.FStar_Syntax_Syntax.repr
                       in
-                   let uu____22314 =
-                     let uu____22317 = get_range env  in
-                     let uu____22318 =
-                       let uu____22325 =
-                         let uu____22326 =
-                           let uu____22343 =
-                             let uu____22354 =
+                   let uu____22295 =
+                     let uu____22298 = get_range env  in
+                     let uu____22299 =
+                       let uu____22306 =
+                         let uu____22307 =
+                           let uu____22324 =
+                             let uu____22335 =
                                FStar_Syntax_Syntax.as_arg res_typ  in
-                             [uu____22354; wp]  in
-                           (repr, uu____22343)  in
-                         FStar_Syntax_Syntax.Tm_app uu____22326  in
-                       FStar_Syntax_Syntax.mk uu____22325  in
-                     uu____22318 FStar_Pervasives_Native.None uu____22317  in
-                   FStar_Pervasives_Native.Some uu____22314)
+                             [uu____22335; wp]  in
+                           (repr, uu____22324)  in
+                         FStar_Syntax_Syntax.Tm_app uu____22307  in
+                       FStar_Syntax_Syntax.mk uu____22306  in
+                     uu____22299 FStar_Pervasives_Native.None uu____22298  in
+                   FStar_Pervasives_Native.Some uu____22295)
   
 let (effect_repr :
   env ->
@@ -4171,18 +4160,18 @@ let (is_reifiable_comp : env -> FStar_Syntax_Syntax.comp -> Prims.bool) =
       match c.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Comp ct ->
           is_reifiable_effect env ct.FStar_Syntax_Syntax.effect_name
-      | uu____22498 -> false
+      | uu____22479 -> false
   
 let (is_reifiable_function : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun env  ->
     fun t  ->
-      let uu____22513 =
-        let uu____22514 = FStar_Syntax_Subst.compress t  in
-        uu____22514.FStar_Syntax_Syntax.n  in
-      match uu____22513 with
-      | FStar_Syntax_Syntax.Tm_arrow (uu____22518,c) ->
+      let uu____22494 =
+        let uu____22495 = FStar_Syntax_Subst.compress t  in
+        uu____22495.FStar_Syntax_Syntax.n  in
+      match uu____22494 with
+      | FStar_Syntax_Syntax.Tm_arrow (uu____22499,c) ->
           is_reifiable_comp env c
-      | uu____22540 -> false
+      | uu____22521 -> false
   
 let (reify_comp :
   env ->
@@ -4193,22 +4182,22 @@ let (reify_comp :
     fun c  ->
       fun u_c  ->
         let l = FStar_Syntax_Util.comp_effect_name c  in
-        (let uu____22560 =
-           let uu____22562 = is_reifiable_effect env l  in
-           Prims.op_Negation uu____22562  in
-         if uu____22560
+        (let uu____22541 =
+           let uu____22543 = is_reifiable_effect env l  in
+           Prims.op_Negation uu____22543  in
+         if uu____22541
          then
-           let uu____22565 =
-             let uu____22571 =
-               let uu____22573 = FStar_Ident.string_of_lid l  in
-               FStar_Util.format1 "Effect %s cannot be reified" uu____22573
+           let uu____22546 =
+             let uu____22552 =
+               let uu____22554 = FStar_Ident.string_of_lid l  in
+               FStar_Util.format1 "Effect %s cannot be reified" uu____22554
                 in
-             (FStar_Errors.Fatal_EffectCannotBeReified, uu____22571)  in
-           let uu____22577 = get_range env  in
-           FStar_Errors.raise_error uu____22565 uu____22577
+             (FStar_Errors.Fatal_EffectCannotBeReified, uu____22552)  in
+           let uu____22558 = get_range env  in
+           FStar_Errors.raise_error uu____22546 uu____22558
          else ());
-        (let uu____22580 = effect_repr_aux true env c u_c  in
-         match uu____22580 with
+        (let uu____22561 = effect_repr_aux true env c u_c  in
+         match uu____22561 with
          | FStar_Pervasives_Native.None  ->
              failwith "internal error: reifiable effect has no repr?"
          | FStar_Pervasives_Native.Some tm -> tm)
@@ -4218,53 +4207,53 @@ let (push_sigelt : env -> FStar_Syntax_Syntax.sigelt -> env) =
     fun s  ->
       let sb = ((FStar_Syntax_Util.lids_of_sigelt s), s)  in
       let env1 =
-        let uu___1647_22616 = env  in
+        let uu___1644_22597 = env  in
         {
-          solver = (uu___1647_22616.solver);
-          range = (uu___1647_22616.range);
-          curmodule = (uu___1647_22616.curmodule);
-          gamma = (uu___1647_22616.gamma);
+          solver = (uu___1644_22597.solver);
+          range = (uu___1644_22597.range);
+          curmodule = (uu___1644_22597.curmodule);
+          gamma = (uu___1644_22597.gamma);
           gamma_sig = (sb :: (env.gamma_sig));
-          gamma_cache = (uu___1647_22616.gamma_cache);
-          modules = (uu___1647_22616.modules);
-          expected_typ = (uu___1647_22616.expected_typ);
-          sigtab = (uu___1647_22616.sigtab);
-          attrtab = (uu___1647_22616.attrtab);
-          is_pattern = (uu___1647_22616.is_pattern);
-          instantiate_imp = (uu___1647_22616.instantiate_imp);
-          effects = (uu___1647_22616.effects);
-          generalize = (uu___1647_22616.generalize);
-          letrecs = (uu___1647_22616.letrecs);
-          top_level = (uu___1647_22616.top_level);
-          check_uvars = (uu___1647_22616.check_uvars);
-          use_eq = (uu___1647_22616.use_eq);
-          is_iface = (uu___1647_22616.is_iface);
-          admit = (uu___1647_22616.admit);
-          lax = (uu___1647_22616.lax);
-          lax_universes = (uu___1647_22616.lax_universes);
-          phase1 = (uu___1647_22616.phase1);
-          failhard = (uu___1647_22616.failhard);
-          nosynth = (uu___1647_22616.nosynth);
-          uvar_subtyping = (uu___1647_22616.uvar_subtyping);
-          tc_term = (uu___1647_22616.tc_term);
-          type_of = (uu___1647_22616.type_of);
-          universe_of = (uu___1647_22616.universe_of);
-          check_type_of = (uu___1647_22616.check_type_of);
-          use_bv_sorts = (uu___1647_22616.use_bv_sorts);
-          qtbl_name_and_index = (uu___1647_22616.qtbl_name_and_index);
-          normalized_eff_names = (uu___1647_22616.normalized_eff_names);
-          fv_delta_depths = (uu___1647_22616.fv_delta_depths);
-          proof_ns = (uu___1647_22616.proof_ns);
-          synth_hook = (uu___1647_22616.synth_hook);
-          splice = (uu___1647_22616.splice);
-          postprocess = (uu___1647_22616.postprocess);
-          is_native_tactic = (uu___1647_22616.is_native_tactic);
-          identifier_info = (uu___1647_22616.identifier_info);
-          tc_hooks = (uu___1647_22616.tc_hooks);
-          dsenv = (uu___1647_22616.dsenv);
-          nbe = (uu___1647_22616.nbe);
-          strict_args_tab = (uu___1647_22616.strict_args_tab);
-          erasable_types_tab = (uu___1647_22616.erasable_types_tab)
+          gamma_cache = (uu___1644_22597.gamma_cache);
+          modules = (uu___1644_22597.modules);
+          expected_typ = (uu___1644_22597.expected_typ);
+          sigtab = (uu___1644_22597.sigtab);
+          attrtab = (uu___1644_22597.attrtab);
+          is_pattern = (uu___1644_22597.is_pattern);
+          instantiate_imp = (uu___1644_22597.instantiate_imp);
+          effects = (uu___1644_22597.effects);
+          generalize = (uu___1644_22597.generalize);
+          letrecs = (uu___1644_22597.letrecs);
+          top_level = (uu___1644_22597.top_level);
+          check_uvars = (uu___1644_22597.check_uvars);
+          use_eq = (uu___1644_22597.use_eq);
+          is_iface = (uu___1644_22597.is_iface);
+          admit = (uu___1644_22597.admit);
+          lax = (uu___1644_22597.lax);
+          lax_universes = (uu___1644_22597.lax_universes);
+          phase1 = (uu___1644_22597.phase1);
+          failhard = (uu___1644_22597.failhard);
+          nosynth = (uu___1644_22597.nosynth);
+          uvar_subtyping = (uu___1644_22597.uvar_subtyping);
+          tc_term = (uu___1644_22597.tc_term);
+          type_of = (uu___1644_22597.type_of);
+          universe_of = (uu___1644_22597.universe_of);
+          check_type_of = (uu___1644_22597.check_type_of);
+          use_bv_sorts = (uu___1644_22597.use_bv_sorts);
+          qtbl_name_and_index = (uu___1644_22597.qtbl_name_and_index);
+          normalized_eff_names = (uu___1644_22597.normalized_eff_names);
+          fv_delta_depths = (uu___1644_22597.fv_delta_depths);
+          proof_ns = (uu___1644_22597.proof_ns);
+          synth_hook = (uu___1644_22597.synth_hook);
+          splice = (uu___1644_22597.splice);
+          postprocess = (uu___1644_22597.postprocess);
+          is_native_tactic = (uu___1644_22597.is_native_tactic);
+          identifier_info = (uu___1644_22597.identifier_info);
+          tc_hooks = (uu___1644_22597.tc_hooks);
+          dsenv = (uu___1644_22597.dsenv);
+          nbe = (uu___1644_22597.nbe);
+          strict_args_tab = (uu___1644_22597.strict_args_tab);
+          erasable_types_tab = (uu___1644_22597.erasable_types_tab)
         }  in
       add_sigelt env1 s;
       (env1.tc_hooks).tc_push_in_gamma_hook env1 (FStar_Util.Inr sb);
@@ -4276,63 +4265,63 @@ let (push_new_effect :
       -> env)
   =
   fun env  ->
-    fun uu____22635  ->
-      match uu____22635 with
+    fun uu____22616  ->
+      match uu____22616 with
       | (ed,quals) ->
           let effects =
-            let uu___1656_22649 = env.effects  in
+            let uu___1653_22630 = env.effects  in
             {
               decls = ((ed, quals) :: ((env.effects).decls));
-              order = (uu___1656_22649.order);
-              joins = (uu___1656_22649.joins)
+              order = (uu___1653_22630.order);
+              joins = (uu___1653_22630.joins)
             }  in
-          let uu___1659_22658 = env  in
+          let uu___1656_22639 = env  in
           {
-            solver = (uu___1659_22658.solver);
-            range = (uu___1659_22658.range);
-            curmodule = (uu___1659_22658.curmodule);
-            gamma = (uu___1659_22658.gamma);
-            gamma_sig = (uu___1659_22658.gamma_sig);
-            gamma_cache = (uu___1659_22658.gamma_cache);
-            modules = (uu___1659_22658.modules);
-            expected_typ = (uu___1659_22658.expected_typ);
-            sigtab = (uu___1659_22658.sigtab);
-            attrtab = (uu___1659_22658.attrtab);
-            is_pattern = (uu___1659_22658.is_pattern);
-            instantiate_imp = (uu___1659_22658.instantiate_imp);
+            solver = (uu___1656_22639.solver);
+            range = (uu___1656_22639.range);
+            curmodule = (uu___1656_22639.curmodule);
+            gamma = (uu___1656_22639.gamma);
+            gamma_sig = (uu___1656_22639.gamma_sig);
+            gamma_cache = (uu___1656_22639.gamma_cache);
+            modules = (uu___1656_22639.modules);
+            expected_typ = (uu___1656_22639.expected_typ);
+            sigtab = (uu___1656_22639.sigtab);
+            attrtab = (uu___1656_22639.attrtab);
+            is_pattern = (uu___1656_22639.is_pattern);
+            instantiate_imp = (uu___1656_22639.instantiate_imp);
             effects;
-            generalize = (uu___1659_22658.generalize);
-            letrecs = (uu___1659_22658.letrecs);
-            top_level = (uu___1659_22658.top_level);
-            check_uvars = (uu___1659_22658.check_uvars);
-            use_eq = (uu___1659_22658.use_eq);
-            is_iface = (uu___1659_22658.is_iface);
-            admit = (uu___1659_22658.admit);
-            lax = (uu___1659_22658.lax);
-            lax_universes = (uu___1659_22658.lax_universes);
-            phase1 = (uu___1659_22658.phase1);
-            failhard = (uu___1659_22658.failhard);
-            nosynth = (uu___1659_22658.nosynth);
-            uvar_subtyping = (uu___1659_22658.uvar_subtyping);
-            tc_term = (uu___1659_22658.tc_term);
-            type_of = (uu___1659_22658.type_of);
-            universe_of = (uu___1659_22658.universe_of);
-            check_type_of = (uu___1659_22658.check_type_of);
-            use_bv_sorts = (uu___1659_22658.use_bv_sorts);
-            qtbl_name_and_index = (uu___1659_22658.qtbl_name_and_index);
-            normalized_eff_names = (uu___1659_22658.normalized_eff_names);
-            fv_delta_depths = (uu___1659_22658.fv_delta_depths);
-            proof_ns = (uu___1659_22658.proof_ns);
-            synth_hook = (uu___1659_22658.synth_hook);
-            splice = (uu___1659_22658.splice);
-            postprocess = (uu___1659_22658.postprocess);
-            is_native_tactic = (uu___1659_22658.is_native_tactic);
-            identifier_info = (uu___1659_22658.identifier_info);
-            tc_hooks = (uu___1659_22658.tc_hooks);
-            dsenv = (uu___1659_22658.dsenv);
-            nbe = (uu___1659_22658.nbe);
-            strict_args_tab = (uu___1659_22658.strict_args_tab);
-            erasable_types_tab = (uu___1659_22658.erasable_types_tab)
+            generalize = (uu___1656_22639.generalize);
+            letrecs = (uu___1656_22639.letrecs);
+            top_level = (uu___1656_22639.top_level);
+            check_uvars = (uu___1656_22639.check_uvars);
+            use_eq = (uu___1656_22639.use_eq);
+            is_iface = (uu___1656_22639.is_iface);
+            admit = (uu___1656_22639.admit);
+            lax = (uu___1656_22639.lax);
+            lax_universes = (uu___1656_22639.lax_universes);
+            phase1 = (uu___1656_22639.phase1);
+            failhard = (uu___1656_22639.failhard);
+            nosynth = (uu___1656_22639.nosynth);
+            uvar_subtyping = (uu___1656_22639.uvar_subtyping);
+            tc_term = (uu___1656_22639.tc_term);
+            type_of = (uu___1656_22639.type_of);
+            universe_of = (uu___1656_22639.universe_of);
+            check_type_of = (uu___1656_22639.check_type_of);
+            use_bv_sorts = (uu___1656_22639.use_bv_sorts);
+            qtbl_name_and_index = (uu___1656_22639.qtbl_name_and_index);
+            normalized_eff_names = (uu___1656_22639.normalized_eff_names);
+            fv_delta_depths = (uu___1656_22639.fv_delta_depths);
+            proof_ns = (uu___1656_22639.proof_ns);
+            synth_hook = (uu___1656_22639.synth_hook);
+            splice = (uu___1656_22639.splice);
+            postprocess = (uu___1656_22639.postprocess);
+            is_native_tactic = (uu___1656_22639.is_native_tactic);
+            identifier_info = (uu___1656_22639.identifier_info);
+            tc_hooks = (uu___1656_22639.tc_hooks);
+            dsenv = (uu___1656_22639.dsenv);
+            nbe = (uu___1656_22639.nbe);
+            strict_args_tab = (uu___1656_22639.strict_args_tab);
+            erasable_types_tab = (uu___1656_22639.erasable_types_tab)
           }
   
 let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
@@ -4341,8 +4330,8 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
       let compose_edges e1 e2 =
         let composed_lift =
           let mlift_wp u r wp1 =
-            let uu____22698 = (e1.mlift).mlift_wp u r wp1  in
-            (e2.mlift).mlift_wp u r uu____22698  in
+            let uu____22679 = (e1.mlift).mlift_wp u r wp1  in
+            (e2.mlift).mlift_wp u r uu____22679  in
           let mlift_term =
             match (((e1.mlift).mlift_term), ((e2.mlift).mlift_term)) with
             | (FStar_Pervasives_Native.Some l1,FStar_Pervasives_Native.Some
@@ -4352,10 +4341,10 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
                       fun t  ->
                         fun wp  ->
                           fun e  ->
-                            let uu____22856 = (e1.mlift).mlift_wp u t wp  in
-                            let uu____22857 = l1 u t wp e  in
-                            l2 u t uu____22856 uu____22857))
-            | uu____22858 -> FStar_Pervasives_Native.None  in
+                            let uu____22837 = (e1.mlift).mlift_wp u t wp  in
+                            let uu____22838 = l1 u t wp e  in
+                            l2 u t uu____22837 uu____22838))
+            | uu____22839 -> FStar_Pervasives_Native.None  in
           { mlift_wp; mlift_term }  in
         {
           msource = (e1.msource);
@@ -4363,22 +4352,22 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
           mlift = composed_lift
         }  in
       let mk_mlift_wp lift_t u r wp1 =
-        let uu____22930 = inst_tscheme_with lift_t [u]  in
-        match uu____22930 with
-        | (uu____22937,lift_t1) ->
-            let uu____22939 =
-              let uu____22946 =
-                let uu____22947 =
-                  let uu____22964 =
-                    let uu____22975 = FStar_Syntax_Syntax.as_arg r  in
-                    let uu____22984 =
-                      let uu____22995 = FStar_Syntax_Syntax.as_arg wp1  in
-                      [uu____22995]  in
-                    uu____22975 :: uu____22984  in
-                  (lift_t1, uu____22964)  in
-                FStar_Syntax_Syntax.Tm_app uu____22947  in
-              FStar_Syntax_Syntax.mk uu____22946  in
-            uu____22939 FStar_Pervasives_Native.None
+        let uu____22911 = inst_tscheme_with lift_t [u]  in
+        match uu____22911 with
+        | (uu____22918,lift_t1) ->
+            let uu____22920 =
+              let uu____22927 =
+                let uu____22928 =
+                  let uu____22945 =
+                    let uu____22956 = FStar_Syntax_Syntax.as_arg r  in
+                    let uu____22965 =
+                      let uu____22976 = FStar_Syntax_Syntax.as_arg wp1  in
+                      [uu____22976]  in
+                    uu____22956 :: uu____22965  in
+                  (lift_t1, uu____22945)  in
+                FStar_Syntax_Syntax.Tm_app uu____22928  in
+              FStar_Syntax_Syntax.mk uu____22927  in
+            uu____22920 FStar_Pervasives_Native.None
               wp1.FStar_Syntax_Syntax.pos
          in
       let sub_mlift_wp =
@@ -4388,25 +4377,25 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
             failwith "sub effect should've been elaborated at this stage"
          in
       let mk_mlift_term lift_t u r wp1 e =
-        let uu____23105 = inst_tscheme_with lift_t [u]  in
-        match uu____23105 with
-        | (uu____23112,lift_t1) ->
-            let uu____23114 =
-              let uu____23121 =
-                let uu____23122 =
-                  let uu____23139 =
-                    let uu____23150 = FStar_Syntax_Syntax.as_arg r  in
-                    let uu____23159 =
-                      let uu____23170 = FStar_Syntax_Syntax.as_arg wp1  in
-                      let uu____23179 =
-                        let uu____23190 = FStar_Syntax_Syntax.as_arg e  in
-                        [uu____23190]  in
-                      uu____23170 :: uu____23179  in
-                    uu____23150 :: uu____23159  in
-                  (lift_t1, uu____23139)  in
-                FStar_Syntax_Syntax.Tm_app uu____23122  in
-              FStar_Syntax_Syntax.mk uu____23121  in
-            uu____23114 FStar_Pervasives_Native.None
+        let uu____23086 = inst_tscheme_with lift_t [u]  in
+        match uu____23086 with
+        | (uu____23093,lift_t1) ->
+            let uu____23095 =
+              let uu____23102 =
+                let uu____23103 =
+                  let uu____23120 =
+                    let uu____23131 = FStar_Syntax_Syntax.as_arg r  in
+                    let uu____23140 =
+                      let uu____23151 = FStar_Syntax_Syntax.as_arg wp1  in
+                      let uu____23160 =
+                        let uu____23171 = FStar_Syntax_Syntax.as_arg e  in
+                        [uu____23171]  in
+                      uu____23151 :: uu____23160  in
+                    uu____23131 :: uu____23140  in
+                  (lift_t1, uu____23120)  in
+                FStar_Syntax_Syntax.Tm_app uu____23103  in
+              FStar_Syntax_Syntax.mk uu____23102  in
+            uu____23095 FStar_Pervasives_Native.None
               e.FStar_Syntax_Syntax.pos
          in
       let sub_mlift_term =
@@ -4425,45 +4414,45 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
         }  in
       let print_mlift l =
         let bogus_term s =
-          let uu____23292 =
-            let uu____23293 =
+          let uu____23273 =
+            let uu____23274 =
               FStar_Ident.lid_of_path [s] FStar_Range.dummyRange  in
-            FStar_Syntax_Syntax.lid_as_fv uu____23293
+            FStar_Syntax_Syntax.lid_as_fv uu____23274
               FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
              in
-          FStar_Syntax_Syntax.fv_to_tm uu____23292  in
+          FStar_Syntax_Syntax.fv_to_tm uu____23273  in
         let arg = bogus_term "ARG"  in
         let wp = bogus_term "WP"  in
         let e = bogus_term "COMP"  in
-        let uu____23302 =
-          let uu____23304 = l.mlift_wp FStar_Syntax_Syntax.U_zero arg wp  in
-          FStar_Syntax_Print.term_to_string uu____23304  in
-        let uu____23305 =
-          let uu____23307 =
+        let uu____23283 =
+          let uu____23285 = l.mlift_wp FStar_Syntax_Syntax.U_zero arg wp  in
+          FStar_Syntax_Print.term_to_string uu____23285  in
+        let uu____23286 =
+          let uu____23288 =
             FStar_Util.map_opt l.mlift_term
               (fun l1  ->
-                 let uu____23335 = l1 FStar_Syntax_Syntax.U_zero arg wp e  in
-                 FStar_Syntax_Print.term_to_string uu____23335)
+                 let uu____23316 = l1 FStar_Syntax_Syntax.U_zero arg wp e  in
+                 FStar_Syntax_Print.term_to_string uu____23316)
              in
-          FStar_Util.dflt "none" uu____23307  in
-        FStar_Util.format2 "{ wp : %s ; term : %s }" uu____23302 uu____23305
+          FStar_Util.dflt "none" uu____23288  in
+        FStar_Util.format2 "{ wp : %s ; term : %s }" uu____23283 uu____23286
          in
       let order = edge :: ((env.effects).order)  in
       let ms =
         FStar_All.pipe_right (env.effects).decls
           (FStar_List.map
-             (fun uu____23364  ->
-                match uu____23364 with
-                | (e,uu____23372) -> e.FStar_Syntax_Syntax.mname))
+             (fun uu____23345  ->
+                match uu____23345 with
+                | (e,uu____23353) -> e.FStar_Syntax_Syntax.mname))
          in
-      let find_edge order1 uu____23395 =
-        match uu____23395 with
+      let find_edge order1 uu____23376 =
+        match uu____23376 with
         | (i,j) ->
-            let uu____23406 = FStar_Ident.lid_equals i j  in
-            if uu____23406
+            let uu____23387 = FStar_Ident.lid_equals i j  in
+            if uu____23387
             then
               FStar_All.pipe_right (id_edge i)
-                (fun _23413  -> FStar_Pervasives_Native.Some _23413)
+                (fun _23394  -> FStar_Pervasives_Native.Some _23394)
             else
               FStar_All.pipe_right order1
                 (FStar_Util.find_opt
@@ -4473,37 +4462,37 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
          in
       let order1 =
         let fold_fun order1 k =
-          let uu____23442 =
+          let uu____23423 =
             FStar_All.pipe_right ms
               (FStar_List.collect
                  (fun i  ->
-                    let uu____23452 = FStar_Ident.lid_equals i k  in
-                    if uu____23452
+                    let uu____23433 = FStar_Ident.lid_equals i k  in
+                    if uu____23433
                     then []
                     else
                       FStar_All.pipe_right ms
                         (FStar_List.collect
                            (fun j  ->
-                              let uu____23466 = FStar_Ident.lid_equals j k
+                              let uu____23447 = FStar_Ident.lid_equals j k
                                  in
-                              if uu____23466
+                              if uu____23447
                               then []
                               else
-                                (let uu____23473 =
-                                   let uu____23482 = find_edge order1 (i, k)
+                                (let uu____23454 =
+                                   let uu____23463 = find_edge order1 (i, k)
                                       in
-                                   let uu____23485 = find_edge order1 (k, j)
+                                   let uu____23466 = find_edge order1 (k, j)
                                       in
-                                   (uu____23482, uu____23485)  in
-                                 match uu____23473 with
+                                   (uu____23463, uu____23466)  in
+                                 match uu____23454 with
                                  | (FStar_Pervasives_Native.Some
                                     e1,FStar_Pervasives_Native.Some e2) ->
-                                     let uu____23500 = compose_edges e1 e2
+                                     let uu____23481 = compose_edges e1 e2
                                         in
-                                     [uu____23500]
-                                 | uu____23501 -> [])))))
+                                     [uu____23481]
+                                 | uu____23482 -> [])))))
              in
-          FStar_List.append order1 uu____23442  in
+          FStar_List.append order1 uu____23423  in
         FStar_All.pipe_right ms (FStar_List.fold_left fold_fun order)  in
       let order2 =
         FStar_Util.remove_dups
@@ -4515,28 +4504,28 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
       FStar_All.pipe_right order2
         (FStar_List.iter
            (fun edge1  ->
-              let uu____23531 =
+              let uu____23512 =
                 (FStar_Ident.lid_equals edge1.msource
                    FStar_Parser_Const.effect_DIV_lid)
                   &&
-                  (let uu____23534 = lookup_effect_quals env edge1.mtarget
+                  (let uu____23515 = lookup_effect_quals env edge1.mtarget
                       in
-                   FStar_All.pipe_right uu____23534
+                   FStar_All.pipe_right uu____23515
                      (FStar_List.contains FStar_Syntax_Syntax.TotalEffect))
                  in
-              if uu____23531
+              if uu____23512
               then
-                let uu____23541 =
-                  let uu____23547 =
+                let uu____23522 =
+                  let uu____23528 =
                     FStar_Util.format1
                       "Divergent computations cannot be included in an effect %s marked 'total'"
                       (edge1.mtarget).FStar_Ident.str
                      in
                   (FStar_Errors.Fatal_DivergentComputationCannotBeIncludedInTotal,
-                    uu____23547)
+                    uu____23528)
                    in
-                let uu____23551 = get_range env  in
-                FStar_Errors.raise_error uu____23541 uu____23551
+                let uu____23532 = get_range env  in
+                FStar_Errors.raise_error uu____23522 uu____23532
               else ()));
       (let joins =
          FStar_All.pipe_right ms
@@ -4546,8 +4535,8 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
                    (FStar_List.collect
                       (fun j  ->
                          let join_opt =
-                           let uu____23629 = FStar_Ident.lid_equals i j  in
-                           if uu____23629
+                           let uu____23610 = FStar_Ident.lid_equals i j  in
+                           if uu____23610
                            then
                              FStar_Pervasives_Native.Some
                                (i, (id_edge i), (id_edge i))
@@ -4556,13 +4545,13 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
                                (FStar_List.fold_left
                                   (fun bopt  ->
                                      fun k  ->
-                                       let uu____23681 =
-                                         let uu____23690 =
+                                       let uu____23662 =
+                                         let uu____23671 =
                                            find_edge order2 (i, k)  in
-                                         let uu____23693 =
+                                         let uu____23674 =
                                            find_edge order2 (j, k)  in
-                                         (uu____23690, uu____23693)  in
-                                       match uu____23681 with
+                                         (uu____23671, uu____23674)  in
+                                       match uu____23662 with
                                        | (FStar_Pervasives_Native.Some
                                           ik,FStar_Pervasives_Native.Some jk)
                                            ->
@@ -4572,34 +4561,34 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
                                                 FStar_Pervasives_Native.Some
                                                   (k, ik, jk)
                                             | FStar_Pervasives_Native.Some
-                                                (ub,uu____23735,uu____23736)
+                                                (ub,uu____23716,uu____23717)
                                                 ->
-                                                let uu____23743 =
-                                                  let uu____23750 =
-                                                    let uu____23752 =
+                                                let uu____23724 =
+                                                  let uu____23731 =
+                                                    let uu____23733 =
                                                       find_edge order2
                                                         (k, ub)
                                                        in
                                                     FStar_Util.is_some
-                                                      uu____23752
+                                                      uu____23733
                                                      in
-                                                  let uu____23755 =
-                                                    let uu____23757 =
+                                                  let uu____23736 =
+                                                    let uu____23738 =
                                                       find_edge order2
                                                         (ub, k)
                                                        in
                                                     FStar_Util.is_some
-                                                      uu____23757
+                                                      uu____23738
                                                      in
-                                                  (uu____23750, uu____23755)
+                                                  (uu____23731, uu____23736)
                                                    in
-                                                (match uu____23743 with
+                                                (match uu____23724 with
                                                  | (true ,true ) ->
-                                                     let uu____23774 =
+                                                     let uu____23755 =
                                                        FStar_Ident.lid_equals
                                                          k ub
                                                         in
-                                                     if uu____23774
+                                                     if uu____23755
                                                      then
                                                        (FStar_Errors.log_issue
                                                           FStar_Range.dummyRange
@@ -4614,7 +4603,7 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
                                                      FStar_Pervasives_Native.Some
                                                        (k, ik, jk)
                                                  | (false ,true ) -> bopt))
-                                       | uu____23817 -> bopt)
+                                       | uu____23798 -> bopt)
                                   FStar_Pervasives_Native.None)
                             in
                          match join_opt with
@@ -4623,107 +4612,107 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
                              [(i, j, k, (e1.mlift), (e2.mlift))]))))
           in
        let effects =
-         let uu___1786_23890 = env.effects  in
-         { decls = (uu___1786_23890.decls); order = order2; joins }  in
-       let uu___1789_23891 = env  in
+         let uu___1783_23871 = env.effects  in
+         { decls = (uu___1783_23871.decls); order = order2; joins }  in
+       let uu___1786_23872 = env  in
        {
-         solver = (uu___1789_23891.solver);
-         range = (uu___1789_23891.range);
-         curmodule = (uu___1789_23891.curmodule);
-         gamma = (uu___1789_23891.gamma);
-         gamma_sig = (uu___1789_23891.gamma_sig);
-         gamma_cache = (uu___1789_23891.gamma_cache);
-         modules = (uu___1789_23891.modules);
-         expected_typ = (uu___1789_23891.expected_typ);
-         sigtab = (uu___1789_23891.sigtab);
-         attrtab = (uu___1789_23891.attrtab);
-         is_pattern = (uu___1789_23891.is_pattern);
-         instantiate_imp = (uu___1789_23891.instantiate_imp);
+         solver = (uu___1786_23872.solver);
+         range = (uu___1786_23872.range);
+         curmodule = (uu___1786_23872.curmodule);
+         gamma = (uu___1786_23872.gamma);
+         gamma_sig = (uu___1786_23872.gamma_sig);
+         gamma_cache = (uu___1786_23872.gamma_cache);
+         modules = (uu___1786_23872.modules);
+         expected_typ = (uu___1786_23872.expected_typ);
+         sigtab = (uu___1786_23872.sigtab);
+         attrtab = (uu___1786_23872.attrtab);
+         is_pattern = (uu___1786_23872.is_pattern);
+         instantiate_imp = (uu___1786_23872.instantiate_imp);
          effects;
-         generalize = (uu___1789_23891.generalize);
-         letrecs = (uu___1789_23891.letrecs);
-         top_level = (uu___1789_23891.top_level);
-         check_uvars = (uu___1789_23891.check_uvars);
-         use_eq = (uu___1789_23891.use_eq);
-         is_iface = (uu___1789_23891.is_iface);
-         admit = (uu___1789_23891.admit);
-         lax = (uu___1789_23891.lax);
-         lax_universes = (uu___1789_23891.lax_universes);
-         phase1 = (uu___1789_23891.phase1);
-         failhard = (uu___1789_23891.failhard);
-         nosynth = (uu___1789_23891.nosynth);
-         uvar_subtyping = (uu___1789_23891.uvar_subtyping);
-         tc_term = (uu___1789_23891.tc_term);
-         type_of = (uu___1789_23891.type_of);
-         universe_of = (uu___1789_23891.universe_of);
-         check_type_of = (uu___1789_23891.check_type_of);
-         use_bv_sorts = (uu___1789_23891.use_bv_sorts);
-         qtbl_name_and_index = (uu___1789_23891.qtbl_name_and_index);
-         normalized_eff_names = (uu___1789_23891.normalized_eff_names);
-         fv_delta_depths = (uu___1789_23891.fv_delta_depths);
-         proof_ns = (uu___1789_23891.proof_ns);
-         synth_hook = (uu___1789_23891.synth_hook);
-         splice = (uu___1789_23891.splice);
-         postprocess = (uu___1789_23891.postprocess);
-         is_native_tactic = (uu___1789_23891.is_native_tactic);
-         identifier_info = (uu___1789_23891.identifier_info);
-         tc_hooks = (uu___1789_23891.tc_hooks);
-         dsenv = (uu___1789_23891.dsenv);
-         nbe = (uu___1789_23891.nbe);
-         strict_args_tab = (uu___1789_23891.strict_args_tab);
-         erasable_types_tab = (uu___1789_23891.erasable_types_tab)
+         generalize = (uu___1786_23872.generalize);
+         letrecs = (uu___1786_23872.letrecs);
+         top_level = (uu___1786_23872.top_level);
+         check_uvars = (uu___1786_23872.check_uvars);
+         use_eq = (uu___1786_23872.use_eq);
+         is_iface = (uu___1786_23872.is_iface);
+         admit = (uu___1786_23872.admit);
+         lax = (uu___1786_23872.lax);
+         lax_universes = (uu___1786_23872.lax_universes);
+         phase1 = (uu___1786_23872.phase1);
+         failhard = (uu___1786_23872.failhard);
+         nosynth = (uu___1786_23872.nosynth);
+         uvar_subtyping = (uu___1786_23872.uvar_subtyping);
+         tc_term = (uu___1786_23872.tc_term);
+         type_of = (uu___1786_23872.type_of);
+         universe_of = (uu___1786_23872.universe_of);
+         check_type_of = (uu___1786_23872.check_type_of);
+         use_bv_sorts = (uu___1786_23872.use_bv_sorts);
+         qtbl_name_and_index = (uu___1786_23872.qtbl_name_and_index);
+         normalized_eff_names = (uu___1786_23872.normalized_eff_names);
+         fv_delta_depths = (uu___1786_23872.fv_delta_depths);
+         proof_ns = (uu___1786_23872.proof_ns);
+         synth_hook = (uu___1786_23872.synth_hook);
+         splice = (uu___1786_23872.splice);
+         postprocess = (uu___1786_23872.postprocess);
+         is_native_tactic = (uu___1786_23872.is_native_tactic);
+         identifier_info = (uu___1786_23872.identifier_info);
+         tc_hooks = (uu___1786_23872.tc_hooks);
+         dsenv = (uu___1786_23872.dsenv);
+         nbe = (uu___1786_23872.nbe);
+         strict_args_tab = (uu___1786_23872.strict_args_tab);
+         erasable_types_tab = (uu___1786_23872.erasable_types_tab)
        })
   
 let (push_local_binding : env -> FStar_Syntax_Syntax.binding -> env) =
   fun env  ->
     fun b  ->
-      let uu___1793_23903 = env  in
+      let uu___1790_23884 = env  in
       {
-        solver = (uu___1793_23903.solver);
-        range = (uu___1793_23903.range);
-        curmodule = (uu___1793_23903.curmodule);
+        solver = (uu___1790_23884.solver);
+        range = (uu___1790_23884.range);
+        curmodule = (uu___1790_23884.curmodule);
         gamma = (b :: (env.gamma));
-        gamma_sig = (uu___1793_23903.gamma_sig);
-        gamma_cache = (uu___1793_23903.gamma_cache);
-        modules = (uu___1793_23903.modules);
-        expected_typ = (uu___1793_23903.expected_typ);
-        sigtab = (uu___1793_23903.sigtab);
-        attrtab = (uu___1793_23903.attrtab);
-        is_pattern = (uu___1793_23903.is_pattern);
-        instantiate_imp = (uu___1793_23903.instantiate_imp);
-        effects = (uu___1793_23903.effects);
-        generalize = (uu___1793_23903.generalize);
-        letrecs = (uu___1793_23903.letrecs);
-        top_level = (uu___1793_23903.top_level);
-        check_uvars = (uu___1793_23903.check_uvars);
-        use_eq = (uu___1793_23903.use_eq);
-        is_iface = (uu___1793_23903.is_iface);
-        admit = (uu___1793_23903.admit);
-        lax = (uu___1793_23903.lax);
-        lax_universes = (uu___1793_23903.lax_universes);
-        phase1 = (uu___1793_23903.phase1);
-        failhard = (uu___1793_23903.failhard);
-        nosynth = (uu___1793_23903.nosynth);
-        uvar_subtyping = (uu___1793_23903.uvar_subtyping);
-        tc_term = (uu___1793_23903.tc_term);
-        type_of = (uu___1793_23903.type_of);
-        universe_of = (uu___1793_23903.universe_of);
-        check_type_of = (uu___1793_23903.check_type_of);
-        use_bv_sorts = (uu___1793_23903.use_bv_sorts);
-        qtbl_name_and_index = (uu___1793_23903.qtbl_name_and_index);
-        normalized_eff_names = (uu___1793_23903.normalized_eff_names);
-        fv_delta_depths = (uu___1793_23903.fv_delta_depths);
-        proof_ns = (uu___1793_23903.proof_ns);
-        synth_hook = (uu___1793_23903.synth_hook);
-        splice = (uu___1793_23903.splice);
-        postprocess = (uu___1793_23903.postprocess);
-        is_native_tactic = (uu___1793_23903.is_native_tactic);
-        identifier_info = (uu___1793_23903.identifier_info);
-        tc_hooks = (uu___1793_23903.tc_hooks);
-        dsenv = (uu___1793_23903.dsenv);
-        nbe = (uu___1793_23903.nbe);
-        strict_args_tab = (uu___1793_23903.strict_args_tab);
-        erasable_types_tab = (uu___1793_23903.erasable_types_tab)
+        gamma_sig = (uu___1790_23884.gamma_sig);
+        gamma_cache = (uu___1790_23884.gamma_cache);
+        modules = (uu___1790_23884.modules);
+        expected_typ = (uu___1790_23884.expected_typ);
+        sigtab = (uu___1790_23884.sigtab);
+        attrtab = (uu___1790_23884.attrtab);
+        is_pattern = (uu___1790_23884.is_pattern);
+        instantiate_imp = (uu___1790_23884.instantiate_imp);
+        effects = (uu___1790_23884.effects);
+        generalize = (uu___1790_23884.generalize);
+        letrecs = (uu___1790_23884.letrecs);
+        top_level = (uu___1790_23884.top_level);
+        check_uvars = (uu___1790_23884.check_uvars);
+        use_eq = (uu___1790_23884.use_eq);
+        is_iface = (uu___1790_23884.is_iface);
+        admit = (uu___1790_23884.admit);
+        lax = (uu___1790_23884.lax);
+        lax_universes = (uu___1790_23884.lax_universes);
+        phase1 = (uu___1790_23884.phase1);
+        failhard = (uu___1790_23884.failhard);
+        nosynth = (uu___1790_23884.nosynth);
+        uvar_subtyping = (uu___1790_23884.uvar_subtyping);
+        tc_term = (uu___1790_23884.tc_term);
+        type_of = (uu___1790_23884.type_of);
+        universe_of = (uu___1790_23884.universe_of);
+        check_type_of = (uu___1790_23884.check_type_of);
+        use_bv_sorts = (uu___1790_23884.use_bv_sorts);
+        qtbl_name_and_index = (uu___1790_23884.qtbl_name_and_index);
+        normalized_eff_names = (uu___1790_23884.normalized_eff_names);
+        fv_delta_depths = (uu___1790_23884.fv_delta_depths);
+        proof_ns = (uu___1790_23884.proof_ns);
+        synth_hook = (uu___1790_23884.synth_hook);
+        splice = (uu___1790_23884.splice);
+        postprocess = (uu___1790_23884.postprocess);
+        is_native_tactic = (uu___1790_23884.is_native_tactic);
+        identifier_info = (uu___1790_23884.identifier_info);
+        tc_hooks = (uu___1790_23884.tc_hooks);
+        dsenv = (uu___1790_23884.dsenv);
+        nbe = (uu___1790_23884.nbe);
+        strict_args_tab = (uu___1790_23884.strict_args_tab);
+        erasable_types_tab = (uu___1790_23884.erasable_types_tab)
       }
   
 let (push_bv : env -> FStar_Syntax_Syntax.bv -> env) =
@@ -4742,63 +4731,63 @@ let (pop_bv :
     | (FStar_Syntax_Syntax.Binding_var x)::rest ->
         FStar_Pervasives_Native.Some
           (x,
-            (let uu___1806_23961 = env  in
+            (let uu___1803_23942 = env  in
              {
-               solver = (uu___1806_23961.solver);
-               range = (uu___1806_23961.range);
-               curmodule = (uu___1806_23961.curmodule);
+               solver = (uu___1803_23942.solver);
+               range = (uu___1803_23942.range);
+               curmodule = (uu___1803_23942.curmodule);
                gamma = rest;
-               gamma_sig = (uu___1806_23961.gamma_sig);
-               gamma_cache = (uu___1806_23961.gamma_cache);
-               modules = (uu___1806_23961.modules);
-               expected_typ = (uu___1806_23961.expected_typ);
-               sigtab = (uu___1806_23961.sigtab);
-               attrtab = (uu___1806_23961.attrtab);
-               is_pattern = (uu___1806_23961.is_pattern);
-               instantiate_imp = (uu___1806_23961.instantiate_imp);
-               effects = (uu___1806_23961.effects);
-               generalize = (uu___1806_23961.generalize);
-               letrecs = (uu___1806_23961.letrecs);
-               top_level = (uu___1806_23961.top_level);
-               check_uvars = (uu___1806_23961.check_uvars);
-               use_eq = (uu___1806_23961.use_eq);
-               is_iface = (uu___1806_23961.is_iface);
-               admit = (uu___1806_23961.admit);
-               lax = (uu___1806_23961.lax);
-               lax_universes = (uu___1806_23961.lax_universes);
-               phase1 = (uu___1806_23961.phase1);
-               failhard = (uu___1806_23961.failhard);
-               nosynth = (uu___1806_23961.nosynth);
-               uvar_subtyping = (uu___1806_23961.uvar_subtyping);
-               tc_term = (uu___1806_23961.tc_term);
-               type_of = (uu___1806_23961.type_of);
-               universe_of = (uu___1806_23961.universe_of);
-               check_type_of = (uu___1806_23961.check_type_of);
-               use_bv_sorts = (uu___1806_23961.use_bv_sorts);
-               qtbl_name_and_index = (uu___1806_23961.qtbl_name_and_index);
-               normalized_eff_names = (uu___1806_23961.normalized_eff_names);
-               fv_delta_depths = (uu___1806_23961.fv_delta_depths);
-               proof_ns = (uu___1806_23961.proof_ns);
-               synth_hook = (uu___1806_23961.synth_hook);
-               splice = (uu___1806_23961.splice);
-               postprocess = (uu___1806_23961.postprocess);
-               is_native_tactic = (uu___1806_23961.is_native_tactic);
-               identifier_info = (uu___1806_23961.identifier_info);
-               tc_hooks = (uu___1806_23961.tc_hooks);
-               dsenv = (uu___1806_23961.dsenv);
-               nbe = (uu___1806_23961.nbe);
-               strict_args_tab = (uu___1806_23961.strict_args_tab);
-               erasable_types_tab = (uu___1806_23961.erasable_types_tab)
+               gamma_sig = (uu___1803_23942.gamma_sig);
+               gamma_cache = (uu___1803_23942.gamma_cache);
+               modules = (uu___1803_23942.modules);
+               expected_typ = (uu___1803_23942.expected_typ);
+               sigtab = (uu___1803_23942.sigtab);
+               attrtab = (uu___1803_23942.attrtab);
+               is_pattern = (uu___1803_23942.is_pattern);
+               instantiate_imp = (uu___1803_23942.instantiate_imp);
+               effects = (uu___1803_23942.effects);
+               generalize = (uu___1803_23942.generalize);
+               letrecs = (uu___1803_23942.letrecs);
+               top_level = (uu___1803_23942.top_level);
+               check_uvars = (uu___1803_23942.check_uvars);
+               use_eq = (uu___1803_23942.use_eq);
+               is_iface = (uu___1803_23942.is_iface);
+               admit = (uu___1803_23942.admit);
+               lax = (uu___1803_23942.lax);
+               lax_universes = (uu___1803_23942.lax_universes);
+               phase1 = (uu___1803_23942.phase1);
+               failhard = (uu___1803_23942.failhard);
+               nosynth = (uu___1803_23942.nosynth);
+               uvar_subtyping = (uu___1803_23942.uvar_subtyping);
+               tc_term = (uu___1803_23942.tc_term);
+               type_of = (uu___1803_23942.type_of);
+               universe_of = (uu___1803_23942.universe_of);
+               check_type_of = (uu___1803_23942.check_type_of);
+               use_bv_sorts = (uu___1803_23942.use_bv_sorts);
+               qtbl_name_and_index = (uu___1803_23942.qtbl_name_and_index);
+               normalized_eff_names = (uu___1803_23942.normalized_eff_names);
+               fv_delta_depths = (uu___1803_23942.fv_delta_depths);
+               proof_ns = (uu___1803_23942.proof_ns);
+               synth_hook = (uu___1803_23942.synth_hook);
+               splice = (uu___1803_23942.splice);
+               postprocess = (uu___1803_23942.postprocess);
+               is_native_tactic = (uu___1803_23942.is_native_tactic);
+               identifier_info = (uu___1803_23942.identifier_info);
+               tc_hooks = (uu___1803_23942.tc_hooks);
+               dsenv = (uu___1803_23942.dsenv);
+               nbe = (uu___1803_23942.nbe);
+               strict_args_tab = (uu___1803_23942.strict_args_tab);
+               erasable_types_tab = (uu___1803_23942.erasable_types_tab)
              }))
-    | uu____23962 -> FStar_Pervasives_Native.None
+    | uu____23943 -> FStar_Pervasives_Native.None
   
 let (push_binders : env -> FStar_Syntax_Syntax.binders -> env) =
   fun env  ->
     fun bs  ->
       FStar_List.fold_left
         (fun env1  ->
-           fun uu____23991  ->
-             match uu____23991 with | (x,uu____23999) -> push_bv env1 x) env
+           fun uu____23972  ->
+             match uu____23972 with | (x,uu____23980) -> push_bv env1 x) env
         bs
   
 let (binding_of_lb :
@@ -4811,12 +4800,12 @@ let (binding_of_lb :
       match x with
       | FStar_Util.Inl x1 ->
           let x2 =
-            let uu___1820_24034 = x1  in
+            let uu___1817_24015 = x1  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___1820_24034.FStar_Syntax_Syntax.ppname);
+                (uu___1817_24015.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___1820_24034.FStar_Syntax_Syntax.index);
+                (uu___1817_24015.FStar_Syntax_Syntax.index);
               FStar_Syntax_Syntax.sort = (FStar_Pervasives_Native.snd t)
             }  in
           FStar_Syntax_Syntax.Binding_var x2
@@ -4848,64 +4837,64 @@ let (open_universes_in :
   fun env  ->
     fun uvs  ->
       fun terms  ->
-        let uu____24107 = FStar_Syntax_Subst.univ_var_opening uvs  in
-        match uu____24107 with
+        let uu____24088 = FStar_Syntax_Subst.univ_var_opening uvs  in
+        match uu____24088 with
         | (univ_subst,univ_vars) ->
             let env' = push_univ_vars env univ_vars  in
-            let uu____24135 =
+            let uu____24116 =
               FStar_List.map (FStar_Syntax_Subst.subst univ_subst) terms  in
-            (env', univ_vars, uu____24135)
+            (env', univ_vars, uu____24116)
   
 let (set_expected_typ : env -> FStar_Syntax_Syntax.typ -> env) =
   fun env  ->
     fun t  ->
-      let uu___1841_24151 = env  in
+      let uu___1838_24132 = env  in
       {
-        solver = (uu___1841_24151.solver);
-        range = (uu___1841_24151.range);
-        curmodule = (uu___1841_24151.curmodule);
-        gamma = (uu___1841_24151.gamma);
-        gamma_sig = (uu___1841_24151.gamma_sig);
-        gamma_cache = (uu___1841_24151.gamma_cache);
-        modules = (uu___1841_24151.modules);
+        solver = (uu___1838_24132.solver);
+        range = (uu___1838_24132.range);
+        curmodule = (uu___1838_24132.curmodule);
+        gamma = (uu___1838_24132.gamma);
+        gamma_sig = (uu___1838_24132.gamma_sig);
+        gamma_cache = (uu___1838_24132.gamma_cache);
+        modules = (uu___1838_24132.modules);
         expected_typ = (FStar_Pervasives_Native.Some t);
-        sigtab = (uu___1841_24151.sigtab);
-        attrtab = (uu___1841_24151.attrtab);
-        is_pattern = (uu___1841_24151.is_pattern);
-        instantiate_imp = (uu___1841_24151.instantiate_imp);
-        effects = (uu___1841_24151.effects);
-        generalize = (uu___1841_24151.generalize);
-        letrecs = (uu___1841_24151.letrecs);
-        top_level = (uu___1841_24151.top_level);
-        check_uvars = (uu___1841_24151.check_uvars);
+        sigtab = (uu___1838_24132.sigtab);
+        attrtab = (uu___1838_24132.attrtab);
+        is_pattern = (uu___1838_24132.is_pattern);
+        instantiate_imp = (uu___1838_24132.instantiate_imp);
+        effects = (uu___1838_24132.effects);
+        generalize = (uu___1838_24132.generalize);
+        letrecs = (uu___1838_24132.letrecs);
+        top_level = (uu___1838_24132.top_level);
+        check_uvars = (uu___1838_24132.check_uvars);
         use_eq = false;
-        is_iface = (uu___1841_24151.is_iface);
-        admit = (uu___1841_24151.admit);
-        lax = (uu___1841_24151.lax);
-        lax_universes = (uu___1841_24151.lax_universes);
-        phase1 = (uu___1841_24151.phase1);
-        failhard = (uu___1841_24151.failhard);
-        nosynth = (uu___1841_24151.nosynth);
-        uvar_subtyping = (uu___1841_24151.uvar_subtyping);
-        tc_term = (uu___1841_24151.tc_term);
-        type_of = (uu___1841_24151.type_of);
-        universe_of = (uu___1841_24151.universe_of);
-        check_type_of = (uu___1841_24151.check_type_of);
-        use_bv_sorts = (uu___1841_24151.use_bv_sorts);
-        qtbl_name_and_index = (uu___1841_24151.qtbl_name_and_index);
-        normalized_eff_names = (uu___1841_24151.normalized_eff_names);
-        fv_delta_depths = (uu___1841_24151.fv_delta_depths);
-        proof_ns = (uu___1841_24151.proof_ns);
-        synth_hook = (uu___1841_24151.synth_hook);
-        splice = (uu___1841_24151.splice);
-        postprocess = (uu___1841_24151.postprocess);
-        is_native_tactic = (uu___1841_24151.is_native_tactic);
-        identifier_info = (uu___1841_24151.identifier_info);
-        tc_hooks = (uu___1841_24151.tc_hooks);
-        dsenv = (uu___1841_24151.dsenv);
-        nbe = (uu___1841_24151.nbe);
-        strict_args_tab = (uu___1841_24151.strict_args_tab);
-        erasable_types_tab = (uu___1841_24151.erasable_types_tab)
+        is_iface = (uu___1838_24132.is_iface);
+        admit = (uu___1838_24132.admit);
+        lax = (uu___1838_24132.lax);
+        lax_universes = (uu___1838_24132.lax_universes);
+        phase1 = (uu___1838_24132.phase1);
+        failhard = (uu___1838_24132.failhard);
+        nosynth = (uu___1838_24132.nosynth);
+        uvar_subtyping = (uu___1838_24132.uvar_subtyping);
+        tc_term = (uu___1838_24132.tc_term);
+        type_of = (uu___1838_24132.type_of);
+        universe_of = (uu___1838_24132.universe_of);
+        check_type_of = (uu___1838_24132.check_type_of);
+        use_bv_sorts = (uu___1838_24132.use_bv_sorts);
+        qtbl_name_and_index = (uu___1838_24132.qtbl_name_and_index);
+        normalized_eff_names = (uu___1838_24132.normalized_eff_names);
+        fv_delta_depths = (uu___1838_24132.fv_delta_depths);
+        proof_ns = (uu___1838_24132.proof_ns);
+        synth_hook = (uu___1838_24132.synth_hook);
+        splice = (uu___1838_24132.splice);
+        postprocess = (uu___1838_24132.postprocess);
+        is_native_tactic = (uu___1838_24132.is_native_tactic);
+        identifier_info = (uu___1838_24132.identifier_info);
+        tc_hooks = (uu___1838_24132.tc_hooks);
+        dsenv = (uu___1838_24132.dsenv);
+        nbe = (uu___1838_24132.nbe);
+        strict_args_tab = (uu___1838_24132.strict_args_tab);
+        erasable_types_tab = (uu___1838_24132.erasable_types_tab)
       }
   
 let (expected_typ :
@@ -4918,124 +4907,124 @@ let (expected_typ :
 let (clear_expected_typ :
   env -> (env * FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option)) =
   fun env_  ->
-    let uu____24182 = expected_typ env_  in
-    ((let uu___1848_24188 = env_  in
+    let uu____24163 = expected_typ env_  in
+    ((let uu___1845_24169 = env_  in
       {
-        solver = (uu___1848_24188.solver);
-        range = (uu___1848_24188.range);
-        curmodule = (uu___1848_24188.curmodule);
-        gamma = (uu___1848_24188.gamma);
-        gamma_sig = (uu___1848_24188.gamma_sig);
-        gamma_cache = (uu___1848_24188.gamma_cache);
-        modules = (uu___1848_24188.modules);
+        solver = (uu___1845_24169.solver);
+        range = (uu___1845_24169.range);
+        curmodule = (uu___1845_24169.curmodule);
+        gamma = (uu___1845_24169.gamma);
+        gamma_sig = (uu___1845_24169.gamma_sig);
+        gamma_cache = (uu___1845_24169.gamma_cache);
+        modules = (uu___1845_24169.modules);
         expected_typ = FStar_Pervasives_Native.None;
-        sigtab = (uu___1848_24188.sigtab);
-        attrtab = (uu___1848_24188.attrtab);
-        is_pattern = (uu___1848_24188.is_pattern);
-        instantiate_imp = (uu___1848_24188.instantiate_imp);
-        effects = (uu___1848_24188.effects);
-        generalize = (uu___1848_24188.generalize);
-        letrecs = (uu___1848_24188.letrecs);
-        top_level = (uu___1848_24188.top_level);
-        check_uvars = (uu___1848_24188.check_uvars);
+        sigtab = (uu___1845_24169.sigtab);
+        attrtab = (uu___1845_24169.attrtab);
+        is_pattern = (uu___1845_24169.is_pattern);
+        instantiate_imp = (uu___1845_24169.instantiate_imp);
+        effects = (uu___1845_24169.effects);
+        generalize = (uu___1845_24169.generalize);
+        letrecs = (uu___1845_24169.letrecs);
+        top_level = (uu___1845_24169.top_level);
+        check_uvars = (uu___1845_24169.check_uvars);
         use_eq = false;
-        is_iface = (uu___1848_24188.is_iface);
-        admit = (uu___1848_24188.admit);
-        lax = (uu___1848_24188.lax);
-        lax_universes = (uu___1848_24188.lax_universes);
-        phase1 = (uu___1848_24188.phase1);
-        failhard = (uu___1848_24188.failhard);
-        nosynth = (uu___1848_24188.nosynth);
-        uvar_subtyping = (uu___1848_24188.uvar_subtyping);
-        tc_term = (uu___1848_24188.tc_term);
-        type_of = (uu___1848_24188.type_of);
-        universe_of = (uu___1848_24188.universe_of);
-        check_type_of = (uu___1848_24188.check_type_of);
-        use_bv_sorts = (uu___1848_24188.use_bv_sorts);
-        qtbl_name_and_index = (uu___1848_24188.qtbl_name_and_index);
-        normalized_eff_names = (uu___1848_24188.normalized_eff_names);
-        fv_delta_depths = (uu___1848_24188.fv_delta_depths);
-        proof_ns = (uu___1848_24188.proof_ns);
-        synth_hook = (uu___1848_24188.synth_hook);
-        splice = (uu___1848_24188.splice);
-        postprocess = (uu___1848_24188.postprocess);
-        is_native_tactic = (uu___1848_24188.is_native_tactic);
-        identifier_info = (uu___1848_24188.identifier_info);
-        tc_hooks = (uu___1848_24188.tc_hooks);
-        dsenv = (uu___1848_24188.dsenv);
-        nbe = (uu___1848_24188.nbe);
-        strict_args_tab = (uu___1848_24188.strict_args_tab);
-        erasable_types_tab = (uu___1848_24188.erasable_types_tab)
-      }), uu____24182)
+        is_iface = (uu___1845_24169.is_iface);
+        admit = (uu___1845_24169.admit);
+        lax = (uu___1845_24169.lax);
+        lax_universes = (uu___1845_24169.lax_universes);
+        phase1 = (uu___1845_24169.phase1);
+        failhard = (uu___1845_24169.failhard);
+        nosynth = (uu___1845_24169.nosynth);
+        uvar_subtyping = (uu___1845_24169.uvar_subtyping);
+        tc_term = (uu___1845_24169.tc_term);
+        type_of = (uu___1845_24169.type_of);
+        universe_of = (uu___1845_24169.universe_of);
+        check_type_of = (uu___1845_24169.check_type_of);
+        use_bv_sorts = (uu___1845_24169.use_bv_sorts);
+        qtbl_name_and_index = (uu___1845_24169.qtbl_name_and_index);
+        normalized_eff_names = (uu___1845_24169.normalized_eff_names);
+        fv_delta_depths = (uu___1845_24169.fv_delta_depths);
+        proof_ns = (uu___1845_24169.proof_ns);
+        synth_hook = (uu___1845_24169.synth_hook);
+        splice = (uu___1845_24169.splice);
+        postprocess = (uu___1845_24169.postprocess);
+        is_native_tactic = (uu___1845_24169.is_native_tactic);
+        identifier_info = (uu___1845_24169.identifier_info);
+        tc_hooks = (uu___1845_24169.tc_hooks);
+        dsenv = (uu___1845_24169.dsenv);
+        nbe = (uu___1845_24169.nbe);
+        strict_args_tab = (uu___1845_24169.strict_args_tab);
+        erasable_types_tab = (uu___1845_24169.erasable_types_tab)
+      }), uu____24163)
   
 let (finish_module : env -> FStar_Syntax_Syntax.modul -> env) =
   let empty_lid =
-    let uu____24200 =
-      let uu____24203 = FStar_Ident.id_of_text ""  in [uu____24203]  in
-    FStar_Ident.lid_of_ids uu____24200  in
+    let uu____24181 =
+      let uu____24184 = FStar_Ident.id_of_text ""  in [uu____24184]  in
+    FStar_Ident.lid_of_ids uu____24181  in
   fun env  ->
     fun m  ->
       let sigs =
-        let uu____24210 =
+        let uu____24191 =
           FStar_Ident.lid_equals m.FStar_Syntax_Syntax.name
             FStar_Parser_Const.prims_lid
            in
-        if uu____24210
+        if uu____24191
         then
-          let uu____24215 =
+          let uu____24196 =
             FStar_All.pipe_right env.gamma_sig
               (FStar_List.map FStar_Pervasives_Native.snd)
              in
-          FStar_All.pipe_right uu____24215 FStar_List.rev
+          FStar_All.pipe_right uu____24196 FStar_List.rev
         else m.FStar_Syntax_Syntax.exports  in
       add_sigelts env sigs;
-      (let uu___1856_24243 = env  in
+      (let uu___1853_24224 = env  in
        {
-         solver = (uu___1856_24243.solver);
-         range = (uu___1856_24243.range);
+         solver = (uu___1853_24224.solver);
+         range = (uu___1853_24224.range);
          curmodule = empty_lid;
          gamma = [];
          gamma_sig = [];
-         gamma_cache = (uu___1856_24243.gamma_cache);
+         gamma_cache = (uu___1853_24224.gamma_cache);
          modules = (m :: (env.modules));
-         expected_typ = (uu___1856_24243.expected_typ);
-         sigtab = (uu___1856_24243.sigtab);
-         attrtab = (uu___1856_24243.attrtab);
-         is_pattern = (uu___1856_24243.is_pattern);
-         instantiate_imp = (uu___1856_24243.instantiate_imp);
-         effects = (uu___1856_24243.effects);
-         generalize = (uu___1856_24243.generalize);
-         letrecs = (uu___1856_24243.letrecs);
-         top_level = (uu___1856_24243.top_level);
-         check_uvars = (uu___1856_24243.check_uvars);
-         use_eq = (uu___1856_24243.use_eq);
-         is_iface = (uu___1856_24243.is_iface);
-         admit = (uu___1856_24243.admit);
-         lax = (uu___1856_24243.lax);
-         lax_universes = (uu___1856_24243.lax_universes);
-         phase1 = (uu___1856_24243.phase1);
-         failhard = (uu___1856_24243.failhard);
-         nosynth = (uu___1856_24243.nosynth);
-         uvar_subtyping = (uu___1856_24243.uvar_subtyping);
-         tc_term = (uu___1856_24243.tc_term);
-         type_of = (uu___1856_24243.type_of);
-         universe_of = (uu___1856_24243.universe_of);
-         check_type_of = (uu___1856_24243.check_type_of);
-         use_bv_sorts = (uu___1856_24243.use_bv_sorts);
-         qtbl_name_and_index = (uu___1856_24243.qtbl_name_and_index);
-         normalized_eff_names = (uu___1856_24243.normalized_eff_names);
-         fv_delta_depths = (uu___1856_24243.fv_delta_depths);
-         proof_ns = (uu___1856_24243.proof_ns);
-         synth_hook = (uu___1856_24243.synth_hook);
-         splice = (uu___1856_24243.splice);
-         postprocess = (uu___1856_24243.postprocess);
-         is_native_tactic = (uu___1856_24243.is_native_tactic);
-         identifier_info = (uu___1856_24243.identifier_info);
-         tc_hooks = (uu___1856_24243.tc_hooks);
-         dsenv = (uu___1856_24243.dsenv);
-         nbe = (uu___1856_24243.nbe);
-         strict_args_tab = (uu___1856_24243.strict_args_tab);
-         erasable_types_tab = (uu___1856_24243.erasable_types_tab)
+         expected_typ = (uu___1853_24224.expected_typ);
+         sigtab = (uu___1853_24224.sigtab);
+         attrtab = (uu___1853_24224.attrtab);
+         is_pattern = (uu___1853_24224.is_pattern);
+         instantiate_imp = (uu___1853_24224.instantiate_imp);
+         effects = (uu___1853_24224.effects);
+         generalize = (uu___1853_24224.generalize);
+         letrecs = (uu___1853_24224.letrecs);
+         top_level = (uu___1853_24224.top_level);
+         check_uvars = (uu___1853_24224.check_uvars);
+         use_eq = (uu___1853_24224.use_eq);
+         is_iface = (uu___1853_24224.is_iface);
+         admit = (uu___1853_24224.admit);
+         lax = (uu___1853_24224.lax);
+         lax_universes = (uu___1853_24224.lax_universes);
+         phase1 = (uu___1853_24224.phase1);
+         failhard = (uu___1853_24224.failhard);
+         nosynth = (uu___1853_24224.nosynth);
+         uvar_subtyping = (uu___1853_24224.uvar_subtyping);
+         tc_term = (uu___1853_24224.tc_term);
+         type_of = (uu___1853_24224.type_of);
+         universe_of = (uu___1853_24224.universe_of);
+         check_type_of = (uu___1853_24224.check_type_of);
+         use_bv_sorts = (uu___1853_24224.use_bv_sorts);
+         qtbl_name_and_index = (uu___1853_24224.qtbl_name_and_index);
+         normalized_eff_names = (uu___1853_24224.normalized_eff_names);
+         fv_delta_depths = (uu___1853_24224.fv_delta_depths);
+         proof_ns = (uu___1853_24224.proof_ns);
+         synth_hook = (uu___1853_24224.synth_hook);
+         splice = (uu___1853_24224.splice);
+         postprocess = (uu___1853_24224.postprocess);
+         is_native_tactic = (uu___1853_24224.is_native_tactic);
+         identifier_info = (uu___1853_24224.identifier_info);
+         tc_hooks = (uu___1853_24224.tc_hooks);
+         dsenv = (uu___1853_24224.dsenv);
+         nbe = (uu___1853_24224.nbe);
+         strict_args_tab = (uu___1853_24224.strict_args_tab);
+         erasable_types_tab = (uu___1853_24224.erasable_types_tab)
        })
   
 let (uvars_in_env : env -> FStar_Syntax_Syntax.uvars) =
@@ -5045,22 +5034,22 @@ let (uvars_in_env : env -> FStar_Syntax_Syntax.uvars) =
     let rec aux out g =
       match g with
       | [] -> out
-      | (FStar_Syntax_Syntax.Binding_univ uu____24295)::tl1 -> aux out tl1
-      | (FStar_Syntax_Syntax.Binding_lid (uu____24299,(uu____24300,t)))::tl1
+      | (FStar_Syntax_Syntax.Binding_univ uu____24276)::tl1 -> aux out tl1
+      | (FStar_Syntax_Syntax.Binding_lid (uu____24280,(uu____24281,t)))::tl1
           ->
-          let uu____24321 =
-            let uu____24324 = FStar_Syntax_Free.uvars t  in
-            ext out uu____24324  in
-          aux uu____24321 tl1
+          let uu____24302 =
+            let uu____24305 = FStar_Syntax_Free.uvars t  in
+            ext out uu____24305  in
+          aux uu____24302 tl1
       | (FStar_Syntax_Syntax.Binding_var
-          { FStar_Syntax_Syntax.ppname = uu____24327;
-            FStar_Syntax_Syntax.index = uu____24328;
+          { FStar_Syntax_Syntax.ppname = uu____24308;
+            FStar_Syntax_Syntax.index = uu____24309;
             FStar_Syntax_Syntax.sort = t;_})::tl1
           ->
-          let uu____24336 =
-            let uu____24339 = FStar_Syntax_Free.uvars t  in
-            ext out uu____24339  in
-          aux uu____24336 tl1
+          let uu____24317 =
+            let uu____24320 = FStar_Syntax_Free.uvars t  in
+            ext out uu____24320  in
+          aux uu____24317 tl1
        in
     aux no_uvs env.gamma
   
@@ -5071,22 +5060,22 @@ let (univ_vars : env -> FStar_Syntax_Syntax.universe_uvar FStar_Util.set) =
     let rec aux out g =
       match g with
       | [] -> out
-      | (FStar_Syntax_Syntax.Binding_univ uu____24397)::tl1 -> aux out tl1
-      | (FStar_Syntax_Syntax.Binding_lid (uu____24401,(uu____24402,t)))::tl1
+      | (FStar_Syntax_Syntax.Binding_univ uu____24378)::tl1 -> aux out tl1
+      | (FStar_Syntax_Syntax.Binding_lid (uu____24382,(uu____24383,t)))::tl1
           ->
-          let uu____24423 =
-            let uu____24426 = FStar_Syntax_Free.univs t  in
-            ext out uu____24426  in
-          aux uu____24423 tl1
+          let uu____24404 =
+            let uu____24407 = FStar_Syntax_Free.univs t  in
+            ext out uu____24407  in
+          aux uu____24404 tl1
       | (FStar_Syntax_Syntax.Binding_var
-          { FStar_Syntax_Syntax.ppname = uu____24429;
-            FStar_Syntax_Syntax.index = uu____24430;
+          { FStar_Syntax_Syntax.ppname = uu____24410;
+            FStar_Syntax_Syntax.index = uu____24411;
             FStar_Syntax_Syntax.sort = t;_})::tl1
           ->
-          let uu____24438 =
-            let uu____24441 = FStar_Syntax_Free.univs t  in
-            ext out uu____24441  in
-          aux uu____24438 tl1
+          let uu____24419 =
+            let uu____24422 = FStar_Syntax_Free.univs t  in
+            ext out uu____24422  in
+          aux uu____24419 tl1
        in
     aux no_univs env.gamma
   
@@ -5098,23 +5087,23 @@ let (univnames : env -> FStar_Syntax_Syntax.univ_name FStar_Util.set) =
       match g with
       | [] -> out
       | (FStar_Syntax_Syntax.Binding_univ uname)::tl1 ->
-          let uu____24503 = FStar_Util.set_add uname out  in
-          aux uu____24503 tl1
-      | (FStar_Syntax_Syntax.Binding_lid (uu____24506,(uu____24507,t)))::tl1
+          let uu____24484 = FStar_Util.set_add uname out  in
+          aux uu____24484 tl1
+      | (FStar_Syntax_Syntax.Binding_lid (uu____24487,(uu____24488,t)))::tl1
           ->
-          let uu____24528 =
-            let uu____24531 = FStar_Syntax_Free.univnames t  in
-            ext out uu____24531  in
-          aux uu____24528 tl1
+          let uu____24509 =
+            let uu____24512 = FStar_Syntax_Free.univnames t  in
+            ext out uu____24512  in
+          aux uu____24509 tl1
       | (FStar_Syntax_Syntax.Binding_var
-          { FStar_Syntax_Syntax.ppname = uu____24534;
-            FStar_Syntax_Syntax.index = uu____24535;
+          { FStar_Syntax_Syntax.ppname = uu____24515;
+            FStar_Syntax_Syntax.index = uu____24516;
             FStar_Syntax_Syntax.sort = t;_})::tl1
           ->
-          let uu____24543 =
-            let uu____24546 = FStar_Syntax_Free.univnames t  in
-            ext out uu____24546  in
-          aux uu____24543 tl1
+          let uu____24524 =
+            let uu____24527 = FStar_Syntax_Free.univnames t  in
+            ext out uu____24527  in
+          aux uu____24524 tl1
        in
     aux no_univ_names env.gamma
   
@@ -5124,21 +5113,21 @@ let (bound_vars_of_bindings :
   fun bs  ->
     FStar_All.pipe_right bs
       (FStar_List.collect
-         (fun uu___11_24567  ->
-            match uu___11_24567 with
+         (fun uu___11_24548  ->
+            match uu___11_24548 with
             | FStar_Syntax_Syntax.Binding_var x -> [x]
-            | FStar_Syntax_Syntax.Binding_lid uu____24571 -> []
-            | FStar_Syntax_Syntax.Binding_univ uu____24584 -> []))
+            | FStar_Syntax_Syntax.Binding_lid uu____24552 -> []
+            | FStar_Syntax_Syntax.Binding_univ uu____24565 -> []))
   
 let (binders_of_bindings :
   FStar_Syntax_Syntax.binding Prims.list -> FStar_Syntax_Syntax.binders) =
   fun bs  ->
-    let uu____24595 =
-      let uu____24604 = bound_vars_of_bindings bs  in
-      FStar_All.pipe_right uu____24604
+    let uu____24576 =
+      let uu____24585 = bound_vars_of_bindings bs  in
+      FStar_All.pipe_right uu____24585
         (FStar_List.map FStar_Syntax_Syntax.mk_binder)
        in
-    FStar_All.pipe_right uu____24595 FStar_List.rev
+    FStar_All.pipe_right uu____24576 FStar_List.rev
   
 let (bound_vars : env -> FStar_Syntax_Syntax.bv Prims.list) =
   fun env  -> bound_vars_of_bindings env.gamma 
@@ -5146,38 +5135,38 @@ let (all_binders : env -> FStar_Syntax_Syntax.binders) =
   fun env  -> binders_of_bindings env.gamma 
 let (print_gamma : FStar_Syntax_Syntax.gamma -> Prims.string) =
   fun gamma  ->
-    let uu____24652 =
+    let uu____24633 =
       FStar_All.pipe_right gamma
         (FStar_List.map
-           (fun uu___12_24665  ->
-              match uu___12_24665 with
+           (fun uu___12_24646  ->
+              match uu___12_24646 with
               | FStar_Syntax_Syntax.Binding_var x ->
-                  let uu____24668 = FStar_Syntax_Print.bv_to_string x  in
-                  Prims.op_Hat "Binding_var " uu____24668
+                  let uu____24649 = FStar_Syntax_Print.bv_to_string x  in
+                  Prims.op_Hat "Binding_var " uu____24649
               | FStar_Syntax_Syntax.Binding_univ u ->
                   Prims.op_Hat "Binding_univ " u.FStar_Ident.idText
-              | FStar_Syntax_Syntax.Binding_lid (l,uu____24674) ->
-                  let uu____24691 = FStar_Ident.string_of_lid l  in
-                  Prims.op_Hat "Binding_lid " uu____24691))
+              | FStar_Syntax_Syntax.Binding_lid (l,uu____24655) ->
+                  let uu____24672 = FStar_Ident.string_of_lid l  in
+                  Prims.op_Hat "Binding_lid " uu____24672))
        in
-    FStar_All.pipe_right uu____24652 (FStar_String.concat "::\n")
+    FStar_All.pipe_right uu____24633 (FStar_String.concat "::\n")
   
 let (string_of_delta_level : delta_level -> Prims.string) =
-  fun uu___13_24705  ->
-    match uu___13_24705 with
+  fun uu___13_24686  ->
+    match uu___13_24686 with
     | NoDelta  -> "NoDelta"
     | InliningDelta  -> "Inlining"
     | Eager_unfolding_only  -> "Eager_unfolding_only"
     | Unfold d ->
-        let uu____24711 = FStar_Syntax_Print.delta_depth_to_string d  in
-        Prims.op_Hat "Unfold " uu____24711
+        let uu____24692 = FStar_Syntax_Print.delta_depth_to_string d  in
+        Prims.op_Hat "Unfold " uu____24692
   
 let (lidents : env -> FStar_Ident.lident Prims.list) =
   fun env  ->
     let keys = FStar_List.collect FStar_Pervasives_Native.fst env.gamma_sig
        in
     FStar_Util.smap_fold (sigtab env)
-      (fun uu____24734  ->
+      (fun uu____24715  ->
          fun v1  ->
            fun keys1  ->
              FStar_List.append (FStar_Syntax_Util.lids_of_sigelt v1) keys1)
@@ -5188,78 +5177,78 @@ let (should_enc_path : env -> Prims.string Prims.list -> Prims.bool) =
     fun path  ->
       let rec str_i_prefix xs ys =
         match (xs, ys) with
-        | ([],uu____24789) -> true
+        | ([],uu____24770) -> true
         | (x::xs1,y::ys1) ->
             ((FStar_String.lowercase x) = (FStar_String.lowercase y)) &&
               (str_i_prefix xs1 ys1)
-        | (uu____24822,uu____24823) -> false  in
-      let uu____24837 =
+        | (uu____24803,uu____24804) -> false  in
+      let uu____24818 =
         FStar_List.tryFind
-          (fun uu____24859  ->
-             match uu____24859 with | (p,uu____24870) -> str_i_prefix p path)
+          (fun uu____24840  ->
+             match uu____24840 with | (p,uu____24851) -> str_i_prefix p path)
           env.proof_ns
          in
-      match uu____24837 with
+      match uu____24818 with
       | FStar_Pervasives_Native.None  -> false
-      | FStar_Pervasives_Native.Some (uu____24889,b) -> b
+      | FStar_Pervasives_Native.Some (uu____24870,b) -> b
   
 let (should_enc_lid : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun lid  ->
-      let uu____24919 = FStar_Ident.path_of_lid lid  in
-      should_enc_path env uu____24919
+      let uu____24900 = FStar_Ident.path_of_lid lid  in
+      should_enc_path env uu____24900
   
 let (cons_proof_ns : Prims.bool -> env -> name_prefix -> env) =
   fun b  ->
     fun e  ->
       fun path  ->
-        let uu___1999_24941 = e  in
+        let uu___1996_24922 = e  in
         {
-          solver = (uu___1999_24941.solver);
-          range = (uu___1999_24941.range);
-          curmodule = (uu___1999_24941.curmodule);
-          gamma = (uu___1999_24941.gamma);
-          gamma_sig = (uu___1999_24941.gamma_sig);
-          gamma_cache = (uu___1999_24941.gamma_cache);
-          modules = (uu___1999_24941.modules);
-          expected_typ = (uu___1999_24941.expected_typ);
-          sigtab = (uu___1999_24941.sigtab);
-          attrtab = (uu___1999_24941.attrtab);
-          is_pattern = (uu___1999_24941.is_pattern);
-          instantiate_imp = (uu___1999_24941.instantiate_imp);
-          effects = (uu___1999_24941.effects);
-          generalize = (uu___1999_24941.generalize);
-          letrecs = (uu___1999_24941.letrecs);
-          top_level = (uu___1999_24941.top_level);
-          check_uvars = (uu___1999_24941.check_uvars);
-          use_eq = (uu___1999_24941.use_eq);
-          is_iface = (uu___1999_24941.is_iface);
-          admit = (uu___1999_24941.admit);
-          lax = (uu___1999_24941.lax);
-          lax_universes = (uu___1999_24941.lax_universes);
-          phase1 = (uu___1999_24941.phase1);
-          failhard = (uu___1999_24941.failhard);
-          nosynth = (uu___1999_24941.nosynth);
-          uvar_subtyping = (uu___1999_24941.uvar_subtyping);
-          tc_term = (uu___1999_24941.tc_term);
-          type_of = (uu___1999_24941.type_of);
-          universe_of = (uu___1999_24941.universe_of);
-          check_type_of = (uu___1999_24941.check_type_of);
-          use_bv_sorts = (uu___1999_24941.use_bv_sorts);
-          qtbl_name_and_index = (uu___1999_24941.qtbl_name_and_index);
-          normalized_eff_names = (uu___1999_24941.normalized_eff_names);
-          fv_delta_depths = (uu___1999_24941.fv_delta_depths);
+          solver = (uu___1996_24922.solver);
+          range = (uu___1996_24922.range);
+          curmodule = (uu___1996_24922.curmodule);
+          gamma = (uu___1996_24922.gamma);
+          gamma_sig = (uu___1996_24922.gamma_sig);
+          gamma_cache = (uu___1996_24922.gamma_cache);
+          modules = (uu___1996_24922.modules);
+          expected_typ = (uu___1996_24922.expected_typ);
+          sigtab = (uu___1996_24922.sigtab);
+          attrtab = (uu___1996_24922.attrtab);
+          is_pattern = (uu___1996_24922.is_pattern);
+          instantiate_imp = (uu___1996_24922.instantiate_imp);
+          effects = (uu___1996_24922.effects);
+          generalize = (uu___1996_24922.generalize);
+          letrecs = (uu___1996_24922.letrecs);
+          top_level = (uu___1996_24922.top_level);
+          check_uvars = (uu___1996_24922.check_uvars);
+          use_eq = (uu___1996_24922.use_eq);
+          is_iface = (uu___1996_24922.is_iface);
+          admit = (uu___1996_24922.admit);
+          lax = (uu___1996_24922.lax);
+          lax_universes = (uu___1996_24922.lax_universes);
+          phase1 = (uu___1996_24922.phase1);
+          failhard = (uu___1996_24922.failhard);
+          nosynth = (uu___1996_24922.nosynth);
+          uvar_subtyping = (uu___1996_24922.uvar_subtyping);
+          tc_term = (uu___1996_24922.tc_term);
+          type_of = (uu___1996_24922.type_of);
+          universe_of = (uu___1996_24922.universe_of);
+          check_type_of = (uu___1996_24922.check_type_of);
+          use_bv_sorts = (uu___1996_24922.use_bv_sorts);
+          qtbl_name_and_index = (uu___1996_24922.qtbl_name_and_index);
+          normalized_eff_names = (uu___1996_24922.normalized_eff_names);
+          fv_delta_depths = (uu___1996_24922.fv_delta_depths);
           proof_ns = ((path, b) :: (e.proof_ns));
-          synth_hook = (uu___1999_24941.synth_hook);
-          splice = (uu___1999_24941.splice);
-          postprocess = (uu___1999_24941.postprocess);
-          is_native_tactic = (uu___1999_24941.is_native_tactic);
-          identifier_info = (uu___1999_24941.identifier_info);
-          tc_hooks = (uu___1999_24941.tc_hooks);
-          dsenv = (uu___1999_24941.dsenv);
-          nbe = (uu___1999_24941.nbe);
-          strict_args_tab = (uu___1999_24941.strict_args_tab);
-          erasable_types_tab = (uu___1999_24941.erasable_types_tab)
+          synth_hook = (uu___1996_24922.synth_hook);
+          splice = (uu___1996_24922.splice);
+          postprocess = (uu___1996_24922.postprocess);
+          is_native_tactic = (uu___1996_24922.is_native_tactic);
+          identifier_info = (uu___1996_24922.identifier_info);
+          tc_hooks = (uu___1996_24922.tc_hooks);
+          dsenv = (uu___1996_24922.dsenv);
+          nbe = (uu___1996_24922.nbe);
+          strict_args_tab = (uu___1996_24922.strict_args_tab);
+          erasable_types_tab = (uu___1996_24922.erasable_types_tab)
         }
   
 let (add_proof_ns : env -> name_prefix -> env) =
@@ -5270,90 +5259,90 @@ let (get_proof_ns : env -> proof_namespace) = fun e  -> e.proof_ns
 let (set_proof_ns : proof_namespace -> env -> env) =
   fun ns  ->
     fun e  ->
-      let uu___2008_24989 = e  in
+      let uu___2005_24970 = e  in
       {
-        solver = (uu___2008_24989.solver);
-        range = (uu___2008_24989.range);
-        curmodule = (uu___2008_24989.curmodule);
-        gamma = (uu___2008_24989.gamma);
-        gamma_sig = (uu___2008_24989.gamma_sig);
-        gamma_cache = (uu___2008_24989.gamma_cache);
-        modules = (uu___2008_24989.modules);
-        expected_typ = (uu___2008_24989.expected_typ);
-        sigtab = (uu___2008_24989.sigtab);
-        attrtab = (uu___2008_24989.attrtab);
-        is_pattern = (uu___2008_24989.is_pattern);
-        instantiate_imp = (uu___2008_24989.instantiate_imp);
-        effects = (uu___2008_24989.effects);
-        generalize = (uu___2008_24989.generalize);
-        letrecs = (uu___2008_24989.letrecs);
-        top_level = (uu___2008_24989.top_level);
-        check_uvars = (uu___2008_24989.check_uvars);
-        use_eq = (uu___2008_24989.use_eq);
-        is_iface = (uu___2008_24989.is_iface);
-        admit = (uu___2008_24989.admit);
-        lax = (uu___2008_24989.lax);
-        lax_universes = (uu___2008_24989.lax_universes);
-        phase1 = (uu___2008_24989.phase1);
-        failhard = (uu___2008_24989.failhard);
-        nosynth = (uu___2008_24989.nosynth);
-        uvar_subtyping = (uu___2008_24989.uvar_subtyping);
-        tc_term = (uu___2008_24989.tc_term);
-        type_of = (uu___2008_24989.type_of);
-        universe_of = (uu___2008_24989.universe_of);
-        check_type_of = (uu___2008_24989.check_type_of);
-        use_bv_sorts = (uu___2008_24989.use_bv_sorts);
-        qtbl_name_and_index = (uu___2008_24989.qtbl_name_and_index);
-        normalized_eff_names = (uu___2008_24989.normalized_eff_names);
-        fv_delta_depths = (uu___2008_24989.fv_delta_depths);
+        solver = (uu___2005_24970.solver);
+        range = (uu___2005_24970.range);
+        curmodule = (uu___2005_24970.curmodule);
+        gamma = (uu___2005_24970.gamma);
+        gamma_sig = (uu___2005_24970.gamma_sig);
+        gamma_cache = (uu___2005_24970.gamma_cache);
+        modules = (uu___2005_24970.modules);
+        expected_typ = (uu___2005_24970.expected_typ);
+        sigtab = (uu___2005_24970.sigtab);
+        attrtab = (uu___2005_24970.attrtab);
+        is_pattern = (uu___2005_24970.is_pattern);
+        instantiate_imp = (uu___2005_24970.instantiate_imp);
+        effects = (uu___2005_24970.effects);
+        generalize = (uu___2005_24970.generalize);
+        letrecs = (uu___2005_24970.letrecs);
+        top_level = (uu___2005_24970.top_level);
+        check_uvars = (uu___2005_24970.check_uvars);
+        use_eq = (uu___2005_24970.use_eq);
+        is_iface = (uu___2005_24970.is_iface);
+        admit = (uu___2005_24970.admit);
+        lax = (uu___2005_24970.lax);
+        lax_universes = (uu___2005_24970.lax_universes);
+        phase1 = (uu___2005_24970.phase1);
+        failhard = (uu___2005_24970.failhard);
+        nosynth = (uu___2005_24970.nosynth);
+        uvar_subtyping = (uu___2005_24970.uvar_subtyping);
+        tc_term = (uu___2005_24970.tc_term);
+        type_of = (uu___2005_24970.type_of);
+        universe_of = (uu___2005_24970.universe_of);
+        check_type_of = (uu___2005_24970.check_type_of);
+        use_bv_sorts = (uu___2005_24970.use_bv_sorts);
+        qtbl_name_and_index = (uu___2005_24970.qtbl_name_and_index);
+        normalized_eff_names = (uu___2005_24970.normalized_eff_names);
+        fv_delta_depths = (uu___2005_24970.fv_delta_depths);
         proof_ns = ns;
-        synth_hook = (uu___2008_24989.synth_hook);
-        splice = (uu___2008_24989.splice);
-        postprocess = (uu___2008_24989.postprocess);
-        is_native_tactic = (uu___2008_24989.is_native_tactic);
-        identifier_info = (uu___2008_24989.identifier_info);
-        tc_hooks = (uu___2008_24989.tc_hooks);
-        dsenv = (uu___2008_24989.dsenv);
-        nbe = (uu___2008_24989.nbe);
-        strict_args_tab = (uu___2008_24989.strict_args_tab);
-        erasable_types_tab = (uu___2008_24989.erasable_types_tab)
+        synth_hook = (uu___2005_24970.synth_hook);
+        splice = (uu___2005_24970.splice);
+        postprocess = (uu___2005_24970.postprocess);
+        is_native_tactic = (uu___2005_24970.is_native_tactic);
+        identifier_info = (uu___2005_24970.identifier_info);
+        tc_hooks = (uu___2005_24970.tc_hooks);
+        dsenv = (uu___2005_24970.dsenv);
+        nbe = (uu___2005_24970.nbe);
+        strict_args_tab = (uu___2005_24970.strict_args_tab);
+        erasable_types_tab = (uu___2005_24970.erasable_types_tab)
       }
   
 let (unbound_vars :
   env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv FStar_Util.set) =
   fun e  ->
     fun t  ->
-      let uu____25005 = FStar_Syntax_Free.names t  in
-      let uu____25008 = bound_vars e  in
+      let uu____24986 = FStar_Syntax_Free.names t  in
+      let uu____24989 = bound_vars e  in
       FStar_List.fold_left (fun s  -> fun bv  -> FStar_Util.set_remove bv s)
-        uu____25005 uu____25008
+        uu____24986 uu____24989
   
 let (closed : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun e  ->
     fun t  ->
-      let uu____25031 = unbound_vars e t  in
-      FStar_Util.set_is_empty uu____25031
+      let uu____25012 = unbound_vars e t  in
+      FStar_Util.set_is_empty uu____25012
   
 let (closed' : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____25041 = FStar_Syntax_Free.names t  in
-    FStar_Util.set_is_empty uu____25041
+    let uu____25022 = FStar_Syntax_Free.names t  in
+    FStar_Util.set_is_empty uu____25022
   
 let (string_of_proof_ns : env -> Prims.string) =
   fun env  ->
-    let aux uu____25062 =
-      match uu____25062 with
+    let aux uu____25043 =
+      match uu____25043 with
       | (p,b) ->
           if (p = []) && b
           then "*"
           else
-            (let uu____25082 = FStar_Ident.text_of_path p  in
-             Prims.op_Hat (if b then "+" else "-") uu____25082)
+            (let uu____25063 = FStar_Ident.text_of_path p  in
+             Prims.op_Hat (if b then "+" else "-") uu____25063)
        in
-    let uu____25090 =
-      let uu____25094 = FStar_List.map aux env.proof_ns  in
-      FStar_All.pipe_right uu____25094 FStar_List.rev  in
-    FStar_All.pipe_right uu____25090 (FStar_String.concat " ")
+    let uu____25071 =
+      let uu____25075 = FStar_List.map aux env.proof_ns  in
+      FStar_All.pipe_right uu____25075 FStar_List.rev  in
+    FStar_All.pipe_right uu____25071 (FStar_String.concat " ")
   
 let (guard_of_guard_formula :
   FStar_TypeChecker_Common.guard_formula -> guard_t) =
@@ -5373,21 +5362,21 @@ let (is_trivial : guard_t -> Prims.bool) =
                 ((imp.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_should_check =
                    FStar_Syntax_Syntax.Allow_unresolved)
                   ||
-                  (let uu____25164 =
+                  (let uu____25145 =
                      FStar_Syntax_Unionfind.find
                        (imp.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head
                       in
-                   match uu____25164 with
-                   | FStar_Pervasives_Native.Some uu____25168 -> true
+                   match uu____25145 with
+                   | FStar_Pervasives_Native.Some uu____25149 -> true
                    | FStar_Pervasives_Native.None  -> false)))
-    | uu____25171 -> false
+    | uu____25152 -> false
   
 let (is_trivial_guard_formula : guard_t -> Prims.bool) =
   fun g  ->
     match g with
-    | { guard_f = FStar_TypeChecker_Common.Trivial ; deferred = uu____25181;
-        univ_ineqs = uu____25182; implicits = uu____25183;_} -> true
-    | uu____25195 -> false
+    | { guard_f = FStar_TypeChecker_Common.Trivial ; deferred = uu____25162;
+        univ_ineqs = uu____25163; implicits = uu____25164;_} -> true
+    | uu____25176 -> false
   
 let (trivial_guard : guard_t) =
   {
@@ -5408,12 +5397,12 @@ let (abstract_guard_n :
               (FStar_Pervasives_Native.Some
                  (FStar_Syntax_Util.residual_tot FStar_Syntax_Util.ktype0))
              in
-          let uu___2052_25226 = g  in
+          let uu___2049_25207 = g  in
           {
             guard_f = (FStar_TypeChecker_Common.NonTrivial f');
-            deferred = (uu___2052_25226.deferred);
-            univ_ineqs = (uu___2052_25226.univ_ineqs);
-            implicits = (uu___2052_25226.implicits)
+            deferred = (uu___2049_25207.deferred);
+            univ_ineqs = (uu___2049_25207.univ_ineqs);
+            implicits = (uu___2049_25207.implicits)
           }
   
 let (abstract_guard : FStar_Syntax_Syntax.binder -> guard_t -> guard_t) =
@@ -5428,31 +5417,31 @@ let (def_check_vars_in_set :
     fun msg  ->
       fun vset  ->
         fun t  ->
-          let uu____25265 = FStar_Options.defensive ()  in
-          if uu____25265
+          let uu____25246 = FStar_Options.defensive ()  in
+          if uu____25246
           then
             let s = FStar_Syntax_Free.names t  in
-            let uu____25271 =
-              let uu____25273 =
-                let uu____25275 = FStar_Util.set_difference s vset  in
-                FStar_All.pipe_left FStar_Util.set_is_empty uu____25275  in
-              Prims.op_Negation uu____25273  in
-            (if uu____25271
+            let uu____25252 =
+              let uu____25254 =
+                let uu____25256 = FStar_Util.set_difference s vset  in
+                FStar_All.pipe_left FStar_Util.set_is_empty uu____25256  in
+              Prims.op_Negation uu____25254  in
+            (if uu____25252
              then
-               let uu____25282 =
-                 let uu____25288 =
-                   let uu____25290 = FStar_Syntax_Print.term_to_string t  in
-                   let uu____25292 =
-                     let uu____25294 = FStar_Util.set_elements s  in
-                     FStar_All.pipe_right uu____25294
+               let uu____25263 =
+                 let uu____25269 =
+                   let uu____25271 = FStar_Syntax_Print.term_to_string t  in
+                   let uu____25273 =
+                     let uu____25275 = FStar_Util.set_elements s  in
+                     FStar_All.pipe_right uu____25275
                        (FStar_Syntax_Print.bvs_to_string ",\n\t")
                       in
                    FStar_Util.format3
                      "Internal: term is not closed (%s).\nt = (%s)\nFVs = (%s)\n"
-                     msg uu____25290 uu____25292
+                     msg uu____25271 uu____25273
                     in
-                 (FStar_Errors.Warning_Defensive, uu____25288)  in
-               FStar_Errors.log_issue rng uu____25282
+                 (FStar_Errors.Warning_Defensive, uu____25269)  in
+               FStar_Errors.log_issue rng uu____25263
              else ())
           else ()
   
@@ -5465,15 +5454,15 @@ let (def_check_closed_in :
     fun msg  ->
       fun l  ->
         fun t  ->
-          let uu____25334 =
-            let uu____25336 = FStar_Options.defensive ()  in
-            Prims.op_Negation uu____25336  in
-          if uu____25334
+          let uu____25315 =
+            let uu____25317 = FStar_Options.defensive ()  in
+            Prims.op_Negation uu____25317  in
+          if uu____25315
           then ()
           else
-            (let uu____25341 =
+            (let uu____25322 =
                FStar_Util.as_set l FStar_Syntax_Syntax.order_bv  in
-             def_check_vars_in_set rng msg uu____25341 t)
+             def_check_vars_in_set rng msg uu____25322 t)
   
 let (def_check_closed_in_env :
   FStar_Range.range ->
@@ -5483,14 +5472,14 @@ let (def_check_closed_in_env :
     fun msg  ->
       fun e  ->
         fun t  ->
-          let uu____25367 =
-            let uu____25369 = FStar_Options.defensive ()  in
-            Prims.op_Negation uu____25369  in
-          if uu____25367
+          let uu____25348 =
+            let uu____25350 = FStar_Options.defensive ()  in
+            Prims.op_Negation uu____25350  in
+          if uu____25348
           then ()
           else
-            (let uu____25374 = bound_vars e  in
-             def_check_closed_in rng msg uu____25374 t)
+            (let uu____25355 = bound_vars e  in
+             def_check_closed_in rng msg uu____25355 t)
   
 let (def_check_guard_wf :
   FStar_Range.range -> Prims.string -> env -> guard_t -> unit) =
@@ -5509,30 +5498,30 @@ let (apply_guard : guard_t -> FStar_Syntax_Syntax.term -> guard_t) =
       match g.guard_f with
       | FStar_TypeChecker_Common.Trivial  -> g
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___2089_25413 = g  in
-          let uu____25414 =
-            let uu____25415 =
-              let uu____25416 =
-                let uu____25423 =
-                  let uu____25424 =
-                    let uu____25441 =
-                      let uu____25452 = FStar_Syntax_Syntax.as_arg e  in
-                      [uu____25452]  in
-                    (f, uu____25441)  in
-                  FStar_Syntax_Syntax.Tm_app uu____25424  in
-                FStar_Syntax_Syntax.mk uu____25423  in
-              uu____25416 FStar_Pervasives_Native.None
+          let uu___2086_25394 = g  in
+          let uu____25395 =
+            let uu____25396 =
+              let uu____25397 =
+                let uu____25404 =
+                  let uu____25405 =
+                    let uu____25422 =
+                      let uu____25433 = FStar_Syntax_Syntax.as_arg e  in
+                      [uu____25433]  in
+                    (f, uu____25422)  in
+                  FStar_Syntax_Syntax.Tm_app uu____25405  in
+                FStar_Syntax_Syntax.mk uu____25404  in
+              uu____25397 FStar_Pervasives_Native.None
                 f.FStar_Syntax_Syntax.pos
                in
             FStar_All.pipe_left
-              (fun _25489  -> FStar_TypeChecker_Common.NonTrivial _25489)
-              uu____25415
+              (fun _25470  -> FStar_TypeChecker_Common.NonTrivial _25470)
+              uu____25396
              in
           {
-            guard_f = uu____25414;
-            deferred = (uu___2089_25413.deferred);
-            univ_ineqs = (uu___2089_25413.univ_ineqs);
-            implicits = (uu___2089_25413.implicits)
+            guard_f = uu____25395;
+            deferred = (uu___2086_25394.deferred);
+            univ_ineqs = (uu___2086_25394.univ_ineqs);
+            implicits = (uu___2086_25394.implicits)
           }
   
 let (map_guard :
@@ -5544,15 +5533,15 @@ let (map_guard :
       match g.guard_f with
       | FStar_TypeChecker_Common.Trivial  -> g
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___2096_25507 = g  in
-          let uu____25508 =
-            let uu____25509 = map1 f  in
-            FStar_TypeChecker_Common.NonTrivial uu____25509  in
+          let uu___2093_25488 = g  in
+          let uu____25489 =
+            let uu____25490 = map1 f  in
+            FStar_TypeChecker_Common.NonTrivial uu____25490  in
           {
-            guard_f = uu____25508;
-            deferred = (uu___2096_25507.deferred);
-            univ_ineqs = (uu___2096_25507.univ_ineqs);
-            implicits = (uu___2096_25507.implicits)
+            guard_f = uu____25489;
+            deferred = (uu___2093_25488.deferred);
+            univ_ineqs = (uu___2093_25488.univ_ineqs);
+            implicits = (uu___2093_25488.implicits)
           }
   
 let (always_map_guard :
@@ -5563,33 +5552,33 @@ let (always_map_guard :
     fun map1  ->
       match g.guard_f with
       | FStar_TypeChecker_Common.Trivial  ->
-          let uu___2101_25526 = g  in
-          let uu____25527 =
-            let uu____25528 = map1 FStar_Syntax_Util.t_true  in
-            FStar_TypeChecker_Common.NonTrivial uu____25528  in
+          let uu___2098_25507 = g  in
+          let uu____25508 =
+            let uu____25509 = map1 FStar_Syntax_Util.t_true  in
+            FStar_TypeChecker_Common.NonTrivial uu____25509  in
           {
-            guard_f = uu____25527;
-            deferred = (uu___2101_25526.deferred);
-            univ_ineqs = (uu___2101_25526.univ_ineqs);
-            implicits = (uu___2101_25526.implicits)
+            guard_f = uu____25508;
+            deferred = (uu___2098_25507.deferred);
+            univ_ineqs = (uu___2098_25507.univ_ineqs);
+            implicits = (uu___2098_25507.implicits)
           }
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___2105_25530 = g  in
-          let uu____25531 =
-            let uu____25532 = map1 f  in
-            FStar_TypeChecker_Common.NonTrivial uu____25532  in
+          let uu___2102_25511 = g  in
+          let uu____25512 =
+            let uu____25513 = map1 f  in
+            FStar_TypeChecker_Common.NonTrivial uu____25513  in
           {
-            guard_f = uu____25531;
-            deferred = (uu___2105_25530.deferred);
-            univ_ineqs = (uu___2105_25530.univ_ineqs);
-            implicits = (uu___2105_25530.implicits)
+            guard_f = uu____25512;
+            deferred = (uu___2102_25511.deferred);
+            univ_ineqs = (uu___2102_25511.univ_ineqs);
+            implicits = (uu___2102_25511.implicits)
           }
   
 let (trivial : FStar_TypeChecker_Common.guard_formula -> unit) =
   fun t  ->
     match t with
     | FStar_TypeChecker_Common.Trivial  -> ()
-    | FStar_TypeChecker_Common.NonTrivial uu____25539 ->
+    | FStar_TypeChecker_Common.NonTrivial uu____25520 ->
         failwith "impossible"
   
 let (conj_guard_f :
@@ -5604,20 +5593,20 @@ let (conj_guard_f :
       | (g,FStar_TypeChecker_Common.Trivial ) -> g
       | (FStar_TypeChecker_Common.NonTrivial
          f1,FStar_TypeChecker_Common.NonTrivial f2) ->
-          let uu____25556 = FStar_Syntax_Util.mk_conj f1 f2  in
-          FStar_TypeChecker_Common.NonTrivial uu____25556
+          let uu____25537 = FStar_Syntax_Util.mk_conj f1 f2  in
+          FStar_TypeChecker_Common.NonTrivial uu____25537
   
 let (check_trivial :
   FStar_Syntax_Syntax.term -> FStar_TypeChecker_Common.guard_formula) =
   fun t  ->
-    let uu____25563 =
-      let uu____25564 = FStar_Syntax_Util.unmeta t  in
-      uu____25564.FStar_Syntax_Syntax.n  in
-    match uu____25563 with
+    let uu____25544 =
+      let uu____25545 = FStar_Syntax_Util.unmeta t  in
+      uu____25545.FStar_Syntax_Syntax.n  in
+    match uu____25544 with
     | FStar_Syntax_Syntax.Tm_fvar tc when
         FStar_Syntax_Syntax.fv_eq_lid tc FStar_Parser_Const.true_lid ->
         FStar_TypeChecker_Common.Trivial
-    | uu____25568 -> FStar_TypeChecker_Common.NonTrivial t
+    | uu____25549 -> FStar_TypeChecker_Common.NonTrivial t
   
 let (imp_guard_f :
   FStar_TypeChecker_Common.guard_formula ->
@@ -5643,9 +5632,9 @@ let (binop_guard :
   fun f  ->
     fun g1  ->
       fun g2  ->
-        let uu____25611 = f g1.guard_f g2.guard_f  in
+        let uu____25592 = f g1.guard_f g2.guard_f  in
         {
-          guard_f = uu____25611;
+          guard_f = uu____25592;
           deferred = (FStar_List.append g1.deferred g2.deferred);
           univ_ineqs =
             ((FStar_List.append (FStar_Pervasives_Native.fst g1.univ_ineqs)
@@ -5676,20 +5665,20 @@ let (close_guard_univs :
                 (fun u  ->
                    fun b  ->
                      fun f1  ->
-                       let uu____25706 = FStar_Syntax_Syntax.is_null_binder b
+                       let uu____25687 = FStar_Syntax_Syntax.is_null_binder b
                           in
-                       if uu____25706
+                       if uu____25687
                        then f1
                        else
                          FStar_Syntax_Util.mk_forall u
                            (FStar_Pervasives_Native.fst b) f1) us bs f
                in
-            let uu___2160_25713 = g  in
+            let uu___2157_25694 = g  in
             {
               guard_f = (FStar_TypeChecker_Common.NonTrivial f1);
-              deferred = (uu___2160_25713.deferred);
-              univ_ineqs = (uu___2160_25713.univ_ineqs);
-              implicits = (uu___2160_25713.implicits)
+              deferred = (uu___2157_25694.deferred);
+              univ_ineqs = (uu___2157_25694.univ_ineqs);
+              implicits = (uu___2157_25694.implicits)
             }
   
 let (close_forall :
@@ -5703,8 +5692,8 @@ let (close_forall :
         FStar_List.fold_right
           (fun b  ->
              fun f1  ->
-               let uu____25747 = FStar_Syntax_Syntax.is_null_binder b  in
-               if uu____25747
+               let uu____25728 = FStar_Syntax_Syntax.is_null_binder b  in
+               if uu____25728
                then f1
                else
                  (let u =
@@ -5722,15 +5711,15 @@ let (close_guard : env -> FStar_Syntax_Syntax.binders -> guard_t -> guard_t)
         match g.guard_f with
         | FStar_TypeChecker_Common.Trivial  -> g
         | FStar_TypeChecker_Common.NonTrivial f ->
-            let uu___2175_25774 = g  in
-            let uu____25775 =
-              let uu____25776 = close_forall env binders f  in
-              FStar_TypeChecker_Common.NonTrivial uu____25776  in
+            let uu___2172_25755 = g  in
+            let uu____25756 =
+              let uu____25757 = close_forall env binders f  in
+              FStar_TypeChecker_Common.NonTrivial uu____25757  in
             {
-              guard_f = uu____25775;
-              deferred = (uu___2175_25774.deferred);
-              univ_ineqs = (uu___2175_25774.univ_ineqs);
-              implicits = (uu___2175_25774.implicits)
+              guard_f = uu____25756;
+              deferred = (uu___2172_25755.deferred);
+              univ_ineqs = (uu___2172_25755.univ_ineqs);
+              implicits = (uu___2172_25755.implicits)
             }
   
 let (new_implicit_var_aux :
@@ -5750,12 +5739,12 @@ let (new_implicit_var_aux :
         fun k  ->
           fun should_check  ->
             fun meta  ->
-              let uu____25834 =
+              let uu____25815 =
                 FStar_Syntax_Util.destruct k FStar_Parser_Const.range_of_lid
                  in
-              match uu____25834 with
+              match uu____25815 with
               | FStar_Pervasives_Native.Some
-                  (uu____25859::(tm,uu____25861)::[]) ->
+                  (uu____25840::(tm,uu____25842)::[]) ->
                   let t =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_constant
@@ -5764,13 +5753,13 @@ let (new_implicit_var_aux :
                       FStar_Pervasives_Native.None tm.FStar_Syntax_Syntax.pos
                      in
                   (t, [], trivial_guard)
-              | uu____25925 ->
+              | uu____25906 ->
                   let binders = all_binders env  in
                   let gamma = env.gamma  in
                   let ctx_uvar =
-                    let uu____25943 = FStar_Syntax_Unionfind.fresh ()  in
+                    let uu____25924 = FStar_Syntax_Unionfind.fresh ()  in
                     {
-                      FStar_Syntax_Syntax.ctx_uvar_head = uu____25943;
+                      FStar_Syntax_Syntax.ctx_uvar_head = uu____25924;
                       FStar_Syntax_Syntax.ctx_uvar_gamma = gamma;
                       FStar_Syntax_Syntax.ctx_uvar_binders = binders;
                       FStar_Syntax_Syntax.ctx_uvar_typ = k;
@@ -5796,33 +5785,33 @@ let (new_implicit_var_aux :
                         imp_range = r
                       }  in
                     let g =
-                      let uu___2197_25975 = trivial_guard  in
+                      let uu___2194_25956 = trivial_guard  in
                       {
-                        guard_f = (uu___2197_25975.guard_f);
-                        deferred = (uu___2197_25975.deferred);
-                        univ_ineqs = (uu___2197_25975.univ_ineqs);
+                        guard_f = (uu___2194_25956.guard_f);
+                        deferred = (uu___2194_25956.deferred);
+                        univ_ineqs = (uu___2194_25956.univ_ineqs);
                         implicits = [imp]
                       }  in
                     (t, [(ctx_uvar, r)], g)))
   
 let (dummy_solver : solver_t) =
   {
-    init = (fun uu____25993  -> ());
-    push = (fun uu____25995  -> ());
-    pop = (fun uu____25998  -> ());
+    init = (fun uu____25974  -> ());
+    push = (fun uu____25976  -> ());
+    pop = (fun uu____25979  -> ());
     snapshot =
-      (fun uu____26001  ->
+      (fun uu____25982  ->
          ((Prims.int_zero, Prims.int_zero, Prims.int_zero), ()));
-    rollback = (fun uu____26020  -> fun uu____26021  -> ());
-    encode_sig = (fun uu____26036  -> fun uu____26037  -> ());
+    rollback = (fun uu____26001  -> fun uu____26002  -> ());
+    encode_sig = (fun uu____26017  -> fun uu____26018  -> ());
     preprocess =
       (fun e  ->
          fun g  ->
-           let uu____26043 =
-             let uu____26050 = FStar_Options.peek ()  in (e, g, uu____26050)
+           let uu____26024 =
+             let uu____26031 = FStar_Options.peek ()  in (e, g, uu____26031)
               in
-           [uu____26043]);
-    solve = (fun uu____26066  -> fun uu____26067  -> fun uu____26068  -> ());
-    finish = (fun uu____26075  -> ());
-    refresh = (fun uu____26077  -> ())
+           [uu____26024]);
+    solve = (fun uu____26047  -> fun uu____26048  -> fun uu____26049  -> ());
+    finish = (fun uu____26056  -> ());
+    refresh = (fun uu____26058  -> ())
   } 

--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -28,114 +28,114 @@ type step =
   | NBE 
   | ForExtraction 
 let (uu___is_Beta : step -> Prims.bool) =
-  fun projectee  -> match projectee with | Beta  -> true | uu____110 -> false 
+  fun projectee  -> match projectee with | Beta  -> true | uu____111 -> false 
 let (uu___is_Iota : step -> Prims.bool) =
-  fun projectee  -> match projectee with | Iota  -> true | uu____121 -> false 
+  fun projectee  -> match projectee with | Iota  -> true | uu____122 -> false 
 let (uu___is_Zeta : step -> Prims.bool) =
-  fun projectee  -> match projectee with | Zeta  -> true | uu____132 -> false 
+  fun projectee  -> match projectee with | Zeta  -> true | uu____133 -> false 
 let (uu___is_Exclude : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Exclude _0 -> true | uu____144 -> false
+    match projectee with | Exclude _0 -> true | uu____145 -> false
   
 let (__proj__Exclude__item___0 : step -> step) =
   fun projectee  -> match projectee with | Exclude _0 -> _0 
 let (uu___is_Weak : step -> Prims.bool) =
-  fun projectee  -> match projectee with | Weak  -> true | uu____162 -> false 
+  fun projectee  -> match projectee with | Weak  -> true | uu____163 -> false 
 let (uu___is_HNF : step -> Prims.bool) =
-  fun projectee  -> match projectee with | HNF  -> true | uu____173 -> false 
+  fun projectee  -> match projectee with | HNF  -> true | uu____174 -> false 
 let (uu___is_Primops : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Primops  -> true | uu____184 -> false
+    match projectee with | Primops  -> true | uu____185 -> false
   
 let (uu___is_Eager_unfolding : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Eager_unfolding  -> true | uu____195 -> false
+    match projectee with | Eager_unfolding  -> true | uu____196 -> false
   
 let (uu___is_Inlining : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Inlining  -> true | uu____206 -> false
+    match projectee with | Inlining  -> true | uu____207 -> false
   
 let (uu___is_DoNotUnfoldPureLets : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | DoNotUnfoldPureLets  -> true | uu____217 -> false
+    match projectee with | DoNotUnfoldPureLets  -> true | uu____218 -> false
   
 let (uu___is_UnfoldUntil : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldUntil _0 -> true | uu____229 -> false
+    match projectee with | UnfoldUntil _0 -> true | uu____230 -> false
   
 let (__proj__UnfoldUntil__item___0 : step -> FStar_Syntax_Syntax.delta_depth)
   = fun projectee  -> match projectee with | UnfoldUntil _0 -> _0 
 let (uu___is_UnfoldOnly : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldOnly _0 -> true | uu____250 -> false
+    match projectee with | UnfoldOnly _0 -> true | uu____251 -> false
   
 let (__proj__UnfoldOnly__item___0 : step -> FStar_Ident.lid Prims.list) =
   fun projectee  -> match projectee with | UnfoldOnly _0 -> _0 
 let (uu___is_UnfoldFully : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldFully _0 -> true | uu____277 -> false
+    match projectee with | UnfoldFully _0 -> true | uu____278 -> false
   
 let (__proj__UnfoldFully__item___0 : step -> FStar_Ident.lid Prims.list) =
   fun projectee  -> match projectee with | UnfoldFully _0 -> _0 
 let (uu___is_UnfoldAttr : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldAttr _0 -> true | uu____304 -> false
+    match projectee with | UnfoldAttr _0 -> true | uu____305 -> false
   
 let (__proj__UnfoldAttr__item___0 : step -> FStar_Ident.lid Prims.list) =
   fun projectee  -> match projectee with | UnfoldAttr _0 -> _0 
 let (uu___is_UnfoldTac : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldTac  -> true | uu____328 -> false
+    match projectee with | UnfoldTac  -> true | uu____329 -> false
   
 let (uu___is_PureSubtermsWithinComputations : step -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | PureSubtermsWithinComputations  -> true
-    | uu____339 -> false
+    | uu____340 -> false
   
 let (uu___is_Simplify : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Simplify  -> true | uu____350 -> false
+    match projectee with | Simplify  -> true | uu____351 -> false
   
 let (uu___is_EraseUniverses : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | EraseUniverses  -> true | uu____361 -> false
+    match projectee with | EraseUniverses  -> true | uu____362 -> false
   
 let (uu___is_AllowUnboundUniverses : step -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | AllowUnboundUniverses  -> true
-    | uu____372 -> false
+    | uu____373 -> false
   
 let (uu___is_Reify : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Reify  -> true | uu____383 -> false
+    match projectee with | Reify  -> true | uu____384 -> false
   
 let (uu___is_CompressUvars : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CompressUvars  -> true | uu____394 -> false
+    match projectee with | CompressUvars  -> true | uu____395 -> false
   
 let (uu___is_NoFullNorm : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NoFullNorm  -> true | uu____405 -> false
+    match projectee with | NoFullNorm  -> true | uu____406 -> false
   
 let (uu___is_CheckNoUvars : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CheckNoUvars  -> true | uu____416 -> false
+    match projectee with | CheckNoUvars  -> true | uu____417 -> false
   
 let (uu___is_Unmeta : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Unmeta  -> true | uu____427 -> false
+    match projectee with | Unmeta  -> true | uu____428 -> false
   
 let (uu___is_Unascribe : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Unascribe  -> true | uu____438 -> false
+    match projectee with | Unascribe  -> true | uu____439 -> false
   
 let (uu___is_NBE : step -> Prims.bool) =
-  fun projectee  -> match projectee with | NBE  -> true | uu____449 -> false 
+  fun projectee  -> match projectee with | NBE  -> true | uu____450 -> false 
 let (uu___is_ForExtraction : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | ForExtraction  -> true | uu____460 -> false
+    match projectee with | ForExtraction  -> true | uu____461 -> false
   
 type steps = step Prims.list
 let rec (eq_step : step -> step -> Prims.bool) =
@@ -175,7 +175,7 @@ let rec (eq_step : step -> step -> Prims.bool) =
       | (UnfoldAttr lids1,UnfoldAttr lids2) ->
           ((FStar_List.length lids1) = (FStar_List.length lids2)) &&
             (FStar_List.forall2 FStar_Ident.lid_equals lids1 lids2)
-      | uu____520 -> false
+      | uu____521 -> false
   
 type sig_binding =
   (FStar_Ident.lident Prims.list * FStar_Syntax_Syntax.sigelt)
@@ -186,19 +186,19 @@ type delta_level =
   | Unfold of FStar_Syntax_Syntax.delta_depth 
 let (uu___is_NoDelta : delta_level -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NoDelta  -> true | uu____546 -> false
+    match projectee with | NoDelta  -> true | uu____547 -> false
   
 let (uu___is_InliningDelta : delta_level -> Prims.bool) =
   fun projectee  ->
-    match projectee with | InliningDelta  -> true | uu____557 -> false
+    match projectee with | InliningDelta  -> true | uu____558 -> false
   
 let (uu___is_Eager_unfolding_only : delta_level -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Eager_unfolding_only  -> true | uu____568 -> false
+    match projectee with | Eager_unfolding_only  -> true | uu____569 -> false
   
 let (uu___is_Unfold : delta_level -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Unfold _0 -> true | uu____580 -> false
+    match projectee with | Unfold _0 -> true | uu____581 -> false
   
 let (__proj__Unfold__item___0 :
   delta_level -> FStar_Syntax_Syntax.delta_depth) =
@@ -365,7 +365,8 @@ type env =
       env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
     ;
   strict_args_tab:
-    Prims.int Prims.list FStar_Pervasives_Native.option FStar_Util.smap }
+    Prims.int Prims.list FStar_Pervasives_Native.option FStar_Util.smap ;
+  erasable_types_tab: Prims.bool FStar_Util.smap }
 and solver_t =
   {
   init: env -> unit ;
@@ -418,7 +419,8 @@ let (__proj__Mkenv__item__solver : env -> solver_t) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> solver
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> solver
   
 let (__proj__Mkenv__item__range : env -> FStar_Range.range) =
   fun projectee  ->
@@ -431,7 +433,8 @@ let (__proj__Mkenv__item__range : env -> FStar_Range.range) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> range
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> range
   
 let (__proj__Mkenv__item__curmodule : env -> FStar_Ident.lident) =
   fun projectee  ->
@@ -444,7 +447,8 @@ let (__proj__Mkenv__item__curmodule : env -> FStar_Ident.lident) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> curmodule
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> curmodule
   
 let (__proj__Mkenv__item__gamma :
   env -> FStar_Syntax_Syntax.binding Prims.list) =
@@ -458,7 +462,8 @@ let (__proj__Mkenv__item__gamma :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> gamma
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> gamma
   
 let (__proj__Mkenv__item__gamma_sig : env -> sig_binding Prims.list) =
   fun projectee  ->
@@ -471,7 +476,8 @@ let (__proj__Mkenv__item__gamma_sig : env -> sig_binding Prims.list) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> gamma_sig
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> gamma_sig
   
 let (__proj__Mkenv__item__gamma_cache : env -> cached_elt FStar_Util.smap) =
   fun projectee  ->
@@ -484,7 +490,8 @@ let (__proj__Mkenv__item__gamma_cache : env -> cached_elt FStar_Util.smap) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> gamma_cache
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> gamma_cache
   
 let (__proj__Mkenv__item__modules :
   env -> FStar_Syntax_Syntax.modul Prims.list) =
@@ -498,7 +505,8 @@ let (__proj__Mkenv__item__modules :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> modules
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> modules
   
 let (__proj__Mkenv__item__expected_typ :
   env -> FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option) =
@@ -512,7 +520,8 @@ let (__proj__Mkenv__item__expected_typ :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> expected_typ
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> expected_typ
   
 let (__proj__Mkenv__item__sigtab :
   env -> FStar_Syntax_Syntax.sigelt FStar_Util.smap) =
@@ -526,7 +535,8 @@ let (__proj__Mkenv__item__sigtab :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> sigtab
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> sigtab
   
 let (__proj__Mkenv__item__attrtab :
   env -> FStar_Syntax_Syntax.sigelt Prims.list FStar_Util.smap) =
@@ -540,7 +550,8 @@ let (__proj__Mkenv__item__attrtab :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> attrtab
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> attrtab
   
 let (__proj__Mkenv__item__is_pattern : env -> Prims.bool) =
   fun projectee  ->
@@ -553,7 +564,8 @@ let (__proj__Mkenv__item__is_pattern : env -> Prims.bool) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> is_pattern
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> is_pattern
   
 let (__proj__Mkenv__item__instantiate_imp : env -> Prims.bool) =
   fun projectee  ->
@@ -566,7 +578,8 @@ let (__proj__Mkenv__item__instantiate_imp : env -> Prims.bool) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> instantiate_imp
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> instantiate_imp
   
 let (__proj__Mkenv__item__effects : env -> effects) =
   fun projectee  ->
@@ -579,7 +592,8 @@ let (__proj__Mkenv__item__effects : env -> effects) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> effects
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> effects
   
 let (__proj__Mkenv__item__generalize : env -> Prims.bool) =
   fun projectee  ->
@@ -592,7 +606,8 @@ let (__proj__Mkenv__item__generalize : env -> Prims.bool) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> generalize
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> generalize
   
 let (__proj__Mkenv__item__letrecs :
   env ->
@@ -609,7 +624,8 @@ let (__proj__Mkenv__item__letrecs :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> letrecs
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> letrecs
   
 let (__proj__Mkenv__item__top_level : env -> Prims.bool) =
   fun projectee  ->
@@ -622,7 +638,8 @@ let (__proj__Mkenv__item__top_level : env -> Prims.bool) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> top_level
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> top_level
   
 let (__proj__Mkenv__item__check_uvars : env -> Prims.bool) =
   fun projectee  ->
@@ -635,7 +652,8 @@ let (__proj__Mkenv__item__check_uvars : env -> Prims.bool) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> check_uvars
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> check_uvars
   
 let (__proj__Mkenv__item__use_eq : env -> Prims.bool) =
   fun projectee  ->
@@ -648,7 +666,8 @@ let (__proj__Mkenv__item__use_eq : env -> Prims.bool) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> use_eq
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> use_eq
   
 let (__proj__Mkenv__item__is_iface : env -> Prims.bool) =
   fun projectee  ->
@@ -661,7 +680,8 @@ let (__proj__Mkenv__item__is_iface : env -> Prims.bool) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> is_iface
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> is_iface
   
 let (__proj__Mkenv__item__admit : env -> Prims.bool) =
   fun projectee  ->
@@ -674,7 +694,8 @@ let (__proj__Mkenv__item__admit : env -> Prims.bool) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> admit1
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> admit1
   
 let (__proj__Mkenv__item__lax : env -> Prims.bool) =
   fun projectee  ->
@@ -687,7 +708,8 @@ let (__proj__Mkenv__item__lax : env -> Prims.bool) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> lax1
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> lax1
   
 let (__proj__Mkenv__item__lax_universes : env -> Prims.bool) =
   fun projectee  ->
@@ -700,7 +722,8 @@ let (__proj__Mkenv__item__lax_universes : env -> Prims.bool) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> lax_universes
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> lax_universes
   
 let (__proj__Mkenv__item__phase1 : env -> Prims.bool) =
   fun projectee  ->
@@ -713,7 +736,8 @@ let (__proj__Mkenv__item__phase1 : env -> Prims.bool) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> phase1
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> phase1
   
 let (__proj__Mkenv__item__failhard : env -> Prims.bool) =
   fun projectee  ->
@@ -726,7 +750,8 @@ let (__proj__Mkenv__item__failhard : env -> Prims.bool) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> failhard
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> failhard
   
 let (__proj__Mkenv__item__nosynth : env -> Prims.bool) =
   fun projectee  ->
@@ -739,7 +764,8 @@ let (__proj__Mkenv__item__nosynth : env -> Prims.bool) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> nosynth
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> nosynth
   
 let (__proj__Mkenv__item__uvar_subtyping : env -> Prims.bool) =
   fun projectee  ->
@@ -752,7 +778,8 @@ let (__proj__Mkenv__item__uvar_subtyping : env -> Prims.bool) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> uvar_subtyping
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> uvar_subtyping
   
 let (__proj__Mkenv__item__tc_term :
   env ->
@@ -770,7 +797,8 @@ let (__proj__Mkenv__item__tc_term :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> tc_term
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> tc_term
   
 let (__proj__Mkenv__item__type_of :
   env ->
@@ -788,7 +816,8 @@ let (__proj__Mkenv__item__type_of :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> type_of
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> type_of
   
 let (__proj__Mkenv__item__universe_of :
   env -> env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.universe) =
@@ -802,7 +831,8 @@ let (__proj__Mkenv__item__universe_of :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> universe_of
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> universe_of
   
 let (__proj__Mkenv__item__check_type_of :
   env ->
@@ -819,7 +849,8 @@ let (__proj__Mkenv__item__check_type_of :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> check_type_of
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> check_type_of
   
 let (__proj__Mkenv__item__use_bv_sorts : env -> Prims.bool) =
   fun projectee  ->
@@ -832,7 +863,8 @@ let (__proj__Mkenv__item__use_bv_sorts : env -> Prims.bool) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> use_bv_sorts
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> use_bv_sorts
   
 let (__proj__Mkenv__item__qtbl_name_and_index :
   env ->
@@ -849,8 +881,8 @@ let (__proj__Mkenv__item__qtbl_name_and_index :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} ->
-        qtbl_name_and_index
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> qtbl_name_and_index
   
 let (__proj__Mkenv__item__normalized_eff_names :
   env -> FStar_Ident.lident FStar_Util.smap) =
@@ -864,8 +896,8 @@ let (__proj__Mkenv__item__normalized_eff_names :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} ->
-        normalized_eff_names
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> normalized_eff_names
   
 let (__proj__Mkenv__item__fv_delta_depths :
   env -> FStar_Syntax_Syntax.delta_depth FStar_Util.smap) =
@@ -879,7 +911,8 @@ let (__proj__Mkenv__item__fv_delta_depths :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> fv_delta_depths
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> fv_delta_depths
   
 let (__proj__Mkenv__item__proof_ns : env -> proof_namespace) =
   fun projectee  ->
@@ -892,7 +925,8 @@ let (__proj__Mkenv__item__proof_ns : env -> proof_namespace) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> proof_ns
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> proof_ns
   
 let (__proj__Mkenv__item__synth_hook :
   env ->
@@ -910,7 +944,8 @@ let (__proj__Mkenv__item__synth_hook :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> synth_hook
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> synth_hook
   
 let (__proj__Mkenv__item__splice :
   env ->
@@ -926,7 +961,8 @@ let (__proj__Mkenv__item__splice :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> splice1
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> splice1
   
 let (__proj__Mkenv__item__postprocess :
   env ->
@@ -945,7 +981,8 @@ let (__proj__Mkenv__item__postprocess :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> postprocess
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> postprocess
   
 let (__proj__Mkenv__item__is_native_tactic :
   env -> FStar_Ident.lid -> Prims.bool) =
@@ -959,7 +996,8 @@ let (__proj__Mkenv__item__is_native_tactic :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> is_native_tactic
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> is_native_tactic
   
 let (__proj__Mkenv__item__identifier_info :
   env -> FStar_TypeChecker_Common.id_info_table FStar_ST.ref) =
@@ -973,7 +1011,8 @@ let (__proj__Mkenv__item__identifier_info :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> identifier_info
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> identifier_info
   
 let (__proj__Mkenv__item__tc_hooks : env -> tcenv_hooks) =
   fun projectee  ->
@@ -986,7 +1025,8 @@ let (__proj__Mkenv__item__tc_hooks : env -> tcenv_hooks) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> tc_hooks
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> tc_hooks
   
 let (__proj__Mkenv__item__dsenv : env -> FStar_Syntax_DsEnv.env) =
   fun projectee  ->
@@ -999,7 +1039,8 @@ let (__proj__Mkenv__item__dsenv : env -> FStar_Syntax_DsEnv.env) =
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> dsenv
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> dsenv
   
 let (__proj__Mkenv__item__nbe :
   env ->
@@ -1016,7 +1057,8 @@ let (__proj__Mkenv__item__nbe :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> nbe1
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> nbe1
   
 let (__proj__Mkenv__item__strict_args_tab :
   env -> Prims.int Prims.list FStar_Pervasives_Native.option FStar_Util.smap)
@@ -1031,7 +1073,23 @@ let (__proj__Mkenv__item__strict_args_tab :
         check_type_of; use_bv_sorts; qtbl_name_and_index;
         normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
         splice = splice1; postprocess; is_native_tactic; identifier_info;
-        tc_hooks; dsenv; nbe = nbe1; strict_args_tab;_} -> strict_args_tab
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> strict_args_tab
+  
+let (__proj__Mkenv__item__erasable_types_tab :
+  env -> Prims.bool FStar_Util.smap) =
+  fun projectee  ->
+    match projectee with
+    | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
+        expected_typ; sigtab; attrtab; is_pattern; instantiate_imp; effects;
+        generalize; letrecs; top_level; check_uvars; use_eq; is_iface;
+        admit = admit1; lax = lax1; lax_universes; phase1; failhard; 
+        nosynth; uvar_subtyping; tc_term; type_of; universe_of;
+        check_type_of; use_bv_sorts; qtbl_name_and_index;
+        normalized_eff_names; fv_delta_depths; proof_ns; synth_hook;
+        splice = splice1; postprocess; is_native_tactic; identifier_info;
+        tc_hooks; dsenv; nbe = nbe1; strict_args_tab; erasable_types_tab;_}
+        -> erasable_types_tab
   
 let (__proj__Mksolver_t__item__init : solver_t -> env -> unit) =
   fun projectee  ->
@@ -1191,190 +1249,193 @@ let (rename_gamma :
     fun gamma  ->
       FStar_All.pipe_right gamma
         (FStar_List.map
-           (fun uu___0_12370  ->
-              match uu___0_12370 with
+           (fun uu___0_12768  ->
+              match uu___0_12768 with
               | FStar_Syntax_Syntax.Binding_var x ->
                   let y =
-                    let uu____12373 = FStar_Syntax_Syntax.bv_to_name x  in
-                    FStar_Syntax_Subst.subst subst1 uu____12373  in
-                  let uu____12374 =
-                    let uu____12375 = FStar_Syntax_Subst.compress y  in
-                    uu____12375.FStar_Syntax_Syntax.n  in
-                  (match uu____12374 with
+                    let uu____12771 = FStar_Syntax_Syntax.bv_to_name x  in
+                    FStar_Syntax_Subst.subst subst1 uu____12771  in
+                  let uu____12772 =
+                    let uu____12773 = FStar_Syntax_Subst.compress y  in
+                    uu____12773.FStar_Syntax_Syntax.n  in
+                  (match uu____12772 with
                    | FStar_Syntax_Syntax.Tm_name y1 ->
-                       let uu____12379 =
-                         let uu___332_12380 = y1  in
-                         let uu____12381 =
+                       let uu____12777 =
+                         let uu___335_12778 = y1  in
+                         let uu____12779 =
                            FStar_Syntax_Subst.subst subst1
                              x.FStar_Syntax_Syntax.sort
                             in
                          {
                            FStar_Syntax_Syntax.ppname =
-                             (uu___332_12380.FStar_Syntax_Syntax.ppname);
+                             (uu___335_12778.FStar_Syntax_Syntax.ppname);
                            FStar_Syntax_Syntax.index =
-                             (uu___332_12380.FStar_Syntax_Syntax.index);
-                           FStar_Syntax_Syntax.sort = uu____12381
+                             (uu___335_12778.FStar_Syntax_Syntax.index);
+                           FStar_Syntax_Syntax.sort = uu____12779
                          }  in
-                       FStar_Syntax_Syntax.Binding_var uu____12379
-                   | uu____12384 -> failwith "Not a renaming")
+                       FStar_Syntax_Syntax.Binding_var uu____12777
+                   | uu____12782 -> failwith "Not a renaming")
               | b -> b))
   
 let (rename_env : FStar_Syntax_Syntax.subst_t -> env -> env) =
   fun subst1  ->
     fun env  ->
-      let uu___338_12398 = env  in
-      let uu____12399 = rename_gamma subst1 env.gamma  in
+      let uu___341_12796 = env  in
+      let uu____12797 = rename_gamma subst1 env.gamma  in
       {
-        solver = (uu___338_12398.solver);
-        range = (uu___338_12398.range);
-        curmodule = (uu___338_12398.curmodule);
-        gamma = uu____12399;
-        gamma_sig = (uu___338_12398.gamma_sig);
-        gamma_cache = (uu___338_12398.gamma_cache);
-        modules = (uu___338_12398.modules);
-        expected_typ = (uu___338_12398.expected_typ);
-        sigtab = (uu___338_12398.sigtab);
-        attrtab = (uu___338_12398.attrtab);
-        is_pattern = (uu___338_12398.is_pattern);
-        instantiate_imp = (uu___338_12398.instantiate_imp);
-        effects = (uu___338_12398.effects);
-        generalize = (uu___338_12398.generalize);
-        letrecs = (uu___338_12398.letrecs);
-        top_level = (uu___338_12398.top_level);
-        check_uvars = (uu___338_12398.check_uvars);
-        use_eq = (uu___338_12398.use_eq);
-        is_iface = (uu___338_12398.is_iface);
-        admit = (uu___338_12398.admit);
-        lax = (uu___338_12398.lax);
-        lax_universes = (uu___338_12398.lax_universes);
-        phase1 = (uu___338_12398.phase1);
-        failhard = (uu___338_12398.failhard);
-        nosynth = (uu___338_12398.nosynth);
-        uvar_subtyping = (uu___338_12398.uvar_subtyping);
-        tc_term = (uu___338_12398.tc_term);
-        type_of = (uu___338_12398.type_of);
-        universe_of = (uu___338_12398.universe_of);
-        check_type_of = (uu___338_12398.check_type_of);
-        use_bv_sorts = (uu___338_12398.use_bv_sorts);
-        qtbl_name_and_index = (uu___338_12398.qtbl_name_and_index);
-        normalized_eff_names = (uu___338_12398.normalized_eff_names);
-        fv_delta_depths = (uu___338_12398.fv_delta_depths);
-        proof_ns = (uu___338_12398.proof_ns);
-        synth_hook = (uu___338_12398.synth_hook);
-        splice = (uu___338_12398.splice);
-        postprocess = (uu___338_12398.postprocess);
-        is_native_tactic = (uu___338_12398.is_native_tactic);
-        identifier_info = (uu___338_12398.identifier_info);
-        tc_hooks = (uu___338_12398.tc_hooks);
-        dsenv = (uu___338_12398.dsenv);
-        nbe = (uu___338_12398.nbe);
-        strict_args_tab = (uu___338_12398.strict_args_tab)
+        solver = (uu___341_12796.solver);
+        range = (uu___341_12796.range);
+        curmodule = (uu___341_12796.curmodule);
+        gamma = uu____12797;
+        gamma_sig = (uu___341_12796.gamma_sig);
+        gamma_cache = (uu___341_12796.gamma_cache);
+        modules = (uu___341_12796.modules);
+        expected_typ = (uu___341_12796.expected_typ);
+        sigtab = (uu___341_12796.sigtab);
+        attrtab = (uu___341_12796.attrtab);
+        is_pattern = (uu___341_12796.is_pattern);
+        instantiate_imp = (uu___341_12796.instantiate_imp);
+        effects = (uu___341_12796.effects);
+        generalize = (uu___341_12796.generalize);
+        letrecs = (uu___341_12796.letrecs);
+        top_level = (uu___341_12796.top_level);
+        check_uvars = (uu___341_12796.check_uvars);
+        use_eq = (uu___341_12796.use_eq);
+        is_iface = (uu___341_12796.is_iface);
+        admit = (uu___341_12796.admit);
+        lax = (uu___341_12796.lax);
+        lax_universes = (uu___341_12796.lax_universes);
+        phase1 = (uu___341_12796.phase1);
+        failhard = (uu___341_12796.failhard);
+        nosynth = (uu___341_12796.nosynth);
+        uvar_subtyping = (uu___341_12796.uvar_subtyping);
+        tc_term = (uu___341_12796.tc_term);
+        type_of = (uu___341_12796.type_of);
+        universe_of = (uu___341_12796.universe_of);
+        check_type_of = (uu___341_12796.check_type_of);
+        use_bv_sorts = (uu___341_12796.use_bv_sorts);
+        qtbl_name_and_index = (uu___341_12796.qtbl_name_and_index);
+        normalized_eff_names = (uu___341_12796.normalized_eff_names);
+        fv_delta_depths = (uu___341_12796.fv_delta_depths);
+        proof_ns = (uu___341_12796.proof_ns);
+        synth_hook = (uu___341_12796.synth_hook);
+        splice = (uu___341_12796.splice);
+        postprocess = (uu___341_12796.postprocess);
+        is_native_tactic = (uu___341_12796.is_native_tactic);
+        identifier_info = (uu___341_12796.identifier_info);
+        tc_hooks = (uu___341_12796.tc_hooks);
+        dsenv = (uu___341_12796.dsenv);
+        nbe = (uu___341_12796.nbe);
+        strict_args_tab = (uu___341_12796.strict_args_tab);
+        erasable_types_tab = (uu___341_12796.erasable_types_tab)
       }
   
 let (default_tc_hooks : tcenv_hooks) =
-  { tc_push_in_gamma_hook = (fun uu____12407  -> fun uu____12408  -> ()) } 
+  { tc_push_in_gamma_hook = (fun uu____12805  -> fun uu____12806  -> ()) } 
 let (tc_hooks : env -> tcenv_hooks) = fun env  -> env.tc_hooks 
 let (set_tc_hooks : env -> tcenv_hooks -> env) =
   fun env  ->
     fun hooks  ->
-      let uu___345_12430 = env  in
+      let uu___348_12828 = env  in
       {
-        solver = (uu___345_12430.solver);
-        range = (uu___345_12430.range);
-        curmodule = (uu___345_12430.curmodule);
-        gamma = (uu___345_12430.gamma);
-        gamma_sig = (uu___345_12430.gamma_sig);
-        gamma_cache = (uu___345_12430.gamma_cache);
-        modules = (uu___345_12430.modules);
-        expected_typ = (uu___345_12430.expected_typ);
-        sigtab = (uu___345_12430.sigtab);
-        attrtab = (uu___345_12430.attrtab);
-        is_pattern = (uu___345_12430.is_pattern);
-        instantiate_imp = (uu___345_12430.instantiate_imp);
-        effects = (uu___345_12430.effects);
-        generalize = (uu___345_12430.generalize);
-        letrecs = (uu___345_12430.letrecs);
-        top_level = (uu___345_12430.top_level);
-        check_uvars = (uu___345_12430.check_uvars);
-        use_eq = (uu___345_12430.use_eq);
-        is_iface = (uu___345_12430.is_iface);
-        admit = (uu___345_12430.admit);
-        lax = (uu___345_12430.lax);
-        lax_universes = (uu___345_12430.lax_universes);
-        phase1 = (uu___345_12430.phase1);
-        failhard = (uu___345_12430.failhard);
-        nosynth = (uu___345_12430.nosynth);
-        uvar_subtyping = (uu___345_12430.uvar_subtyping);
-        tc_term = (uu___345_12430.tc_term);
-        type_of = (uu___345_12430.type_of);
-        universe_of = (uu___345_12430.universe_of);
-        check_type_of = (uu___345_12430.check_type_of);
-        use_bv_sorts = (uu___345_12430.use_bv_sorts);
-        qtbl_name_and_index = (uu___345_12430.qtbl_name_and_index);
-        normalized_eff_names = (uu___345_12430.normalized_eff_names);
-        fv_delta_depths = (uu___345_12430.fv_delta_depths);
-        proof_ns = (uu___345_12430.proof_ns);
-        synth_hook = (uu___345_12430.synth_hook);
-        splice = (uu___345_12430.splice);
-        postprocess = (uu___345_12430.postprocess);
-        is_native_tactic = (uu___345_12430.is_native_tactic);
-        identifier_info = (uu___345_12430.identifier_info);
+        solver = (uu___348_12828.solver);
+        range = (uu___348_12828.range);
+        curmodule = (uu___348_12828.curmodule);
+        gamma = (uu___348_12828.gamma);
+        gamma_sig = (uu___348_12828.gamma_sig);
+        gamma_cache = (uu___348_12828.gamma_cache);
+        modules = (uu___348_12828.modules);
+        expected_typ = (uu___348_12828.expected_typ);
+        sigtab = (uu___348_12828.sigtab);
+        attrtab = (uu___348_12828.attrtab);
+        is_pattern = (uu___348_12828.is_pattern);
+        instantiate_imp = (uu___348_12828.instantiate_imp);
+        effects = (uu___348_12828.effects);
+        generalize = (uu___348_12828.generalize);
+        letrecs = (uu___348_12828.letrecs);
+        top_level = (uu___348_12828.top_level);
+        check_uvars = (uu___348_12828.check_uvars);
+        use_eq = (uu___348_12828.use_eq);
+        is_iface = (uu___348_12828.is_iface);
+        admit = (uu___348_12828.admit);
+        lax = (uu___348_12828.lax);
+        lax_universes = (uu___348_12828.lax_universes);
+        phase1 = (uu___348_12828.phase1);
+        failhard = (uu___348_12828.failhard);
+        nosynth = (uu___348_12828.nosynth);
+        uvar_subtyping = (uu___348_12828.uvar_subtyping);
+        tc_term = (uu___348_12828.tc_term);
+        type_of = (uu___348_12828.type_of);
+        universe_of = (uu___348_12828.universe_of);
+        check_type_of = (uu___348_12828.check_type_of);
+        use_bv_sorts = (uu___348_12828.use_bv_sorts);
+        qtbl_name_and_index = (uu___348_12828.qtbl_name_and_index);
+        normalized_eff_names = (uu___348_12828.normalized_eff_names);
+        fv_delta_depths = (uu___348_12828.fv_delta_depths);
+        proof_ns = (uu___348_12828.proof_ns);
+        synth_hook = (uu___348_12828.synth_hook);
+        splice = (uu___348_12828.splice);
+        postprocess = (uu___348_12828.postprocess);
+        is_native_tactic = (uu___348_12828.is_native_tactic);
+        identifier_info = (uu___348_12828.identifier_info);
         tc_hooks = hooks;
-        dsenv = (uu___345_12430.dsenv);
-        nbe = (uu___345_12430.nbe);
-        strict_args_tab = (uu___345_12430.strict_args_tab)
+        dsenv = (uu___348_12828.dsenv);
+        nbe = (uu___348_12828.nbe);
+        strict_args_tab = (uu___348_12828.strict_args_tab);
+        erasable_types_tab = (uu___348_12828.erasable_types_tab)
       }
   
 let (set_dep_graph : env -> FStar_Parser_Dep.deps -> env) =
   fun e  ->
     fun g  ->
-      let uu___349_12442 = e  in
-      let uu____12443 = FStar_Syntax_DsEnv.set_dep_graph e.dsenv g  in
+      let uu___352_12840 = e  in
+      let uu____12841 = FStar_Syntax_DsEnv.set_dep_graph e.dsenv g  in
       {
-        solver = (uu___349_12442.solver);
-        range = (uu___349_12442.range);
-        curmodule = (uu___349_12442.curmodule);
-        gamma = (uu___349_12442.gamma);
-        gamma_sig = (uu___349_12442.gamma_sig);
-        gamma_cache = (uu___349_12442.gamma_cache);
-        modules = (uu___349_12442.modules);
-        expected_typ = (uu___349_12442.expected_typ);
-        sigtab = (uu___349_12442.sigtab);
-        attrtab = (uu___349_12442.attrtab);
-        is_pattern = (uu___349_12442.is_pattern);
-        instantiate_imp = (uu___349_12442.instantiate_imp);
-        effects = (uu___349_12442.effects);
-        generalize = (uu___349_12442.generalize);
-        letrecs = (uu___349_12442.letrecs);
-        top_level = (uu___349_12442.top_level);
-        check_uvars = (uu___349_12442.check_uvars);
-        use_eq = (uu___349_12442.use_eq);
-        is_iface = (uu___349_12442.is_iface);
-        admit = (uu___349_12442.admit);
-        lax = (uu___349_12442.lax);
-        lax_universes = (uu___349_12442.lax_universes);
-        phase1 = (uu___349_12442.phase1);
-        failhard = (uu___349_12442.failhard);
-        nosynth = (uu___349_12442.nosynth);
-        uvar_subtyping = (uu___349_12442.uvar_subtyping);
-        tc_term = (uu___349_12442.tc_term);
-        type_of = (uu___349_12442.type_of);
-        universe_of = (uu___349_12442.universe_of);
-        check_type_of = (uu___349_12442.check_type_of);
-        use_bv_sorts = (uu___349_12442.use_bv_sorts);
-        qtbl_name_and_index = (uu___349_12442.qtbl_name_and_index);
-        normalized_eff_names = (uu___349_12442.normalized_eff_names);
-        fv_delta_depths = (uu___349_12442.fv_delta_depths);
-        proof_ns = (uu___349_12442.proof_ns);
-        synth_hook = (uu___349_12442.synth_hook);
-        splice = (uu___349_12442.splice);
-        postprocess = (uu___349_12442.postprocess);
-        is_native_tactic = (uu___349_12442.is_native_tactic);
-        identifier_info = (uu___349_12442.identifier_info);
-        tc_hooks = (uu___349_12442.tc_hooks);
-        dsenv = uu____12443;
-        nbe = (uu___349_12442.nbe);
-        strict_args_tab = (uu___349_12442.strict_args_tab)
+        solver = (uu___352_12840.solver);
+        range = (uu___352_12840.range);
+        curmodule = (uu___352_12840.curmodule);
+        gamma = (uu___352_12840.gamma);
+        gamma_sig = (uu___352_12840.gamma_sig);
+        gamma_cache = (uu___352_12840.gamma_cache);
+        modules = (uu___352_12840.modules);
+        expected_typ = (uu___352_12840.expected_typ);
+        sigtab = (uu___352_12840.sigtab);
+        attrtab = (uu___352_12840.attrtab);
+        is_pattern = (uu___352_12840.is_pattern);
+        instantiate_imp = (uu___352_12840.instantiate_imp);
+        effects = (uu___352_12840.effects);
+        generalize = (uu___352_12840.generalize);
+        letrecs = (uu___352_12840.letrecs);
+        top_level = (uu___352_12840.top_level);
+        check_uvars = (uu___352_12840.check_uvars);
+        use_eq = (uu___352_12840.use_eq);
+        is_iface = (uu___352_12840.is_iface);
+        admit = (uu___352_12840.admit);
+        lax = (uu___352_12840.lax);
+        lax_universes = (uu___352_12840.lax_universes);
+        phase1 = (uu___352_12840.phase1);
+        failhard = (uu___352_12840.failhard);
+        nosynth = (uu___352_12840.nosynth);
+        uvar_subtyping = (uu___352_12840.uvar_subtyping);
+        tc_term = (uu___352_12840.tc_term);
+        type_of = (uu___352_12840.type_of);
+        universe_of = (uu___352_12840.universe_of);
+        check_type_of = (uu___352_12840.check_type_of);
+        use_bv_sorts = (uu___352_12840.use_bv_sorts);
+        qtbl_name_and_index = (uu___352_12840.qtbl_name_and_index);
+        normalized_eff_names = (uu___352_12840.normalized_eff_names);
+        fv_delta_depths = (uu___352_12840.fv_delta_depths);
+        proof_ns = (uu___352_12840.proof_ns);
+        synth_hook = (uu___352_12840.synth_hook);
+        splice = (uu___352_12840.splice);
+        postprocess = (uu___352_12840.postprocess);
+        is_native_tactic = (uu___352_12840.is_native_tactic);
+        identifier_info = (uu___352_12840.identifier_info);
+        tc_hooks = (uu___352_12840.tc_hooks);
+        dsenv = uu____12841;
+        nbe = (uu___352_12840.nbe);
+        strict_args_tab = (uu___352_12840.strict_args_tab);
+        erasable_types_tab = (uu___352_12840.erasable_types_tab)
       }
   
 let (dep_graph : env -> FStar_Parser_Dep.deps) =
@@ -1391,21 +1452,21 @@ let (visible_at : delta_level -> FStar_Syntax_Syntax.qualifier -> Prims.bool)
   fun d  ->
     fun q  ->
       match (d, q) with
-      | (NoDelta ,uu____12472) -> true
+      | (NoDelta ,uu____12870) -> true
       | (Eager_unfolding_only
          ,FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen ) -> true
       | (Unfold
-         uu____12475,FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen )
+         uu____12873,FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen )
           -> true
-      | (Unfold uu____12477,FStar_Syntax_Syntax.Visible_default ) -> true
+      | (Unfold uu____12875,FStar_Syntax_Syntax.Visible_default ) -> true
       | (InliningDelta ,FStar_Syntax_Syntax.Inline_for_extraction ) -> true
-      | uu____12480 -> false
+      | uu____12878 -> false
   
 let (default_table_size : Prims.int) = (Prims.of_int (200)) 
-let new_sigtab : 'Auu____12494 . unit -> 'Auu____12494 FStar_Util.smap =
-  fun uu____12501  -> FStar_Util.smap_create default_table_size 
-let new_gamma_cache : 'Auu____12507 . unit -> 'Auu____12507 FStar_Util.smap =
-  fun uu____12514  -> FStar_Util.smap_create (Prims.of_int (100)) 
+let new_sigtab : 'Auu____12892 . unit -> 'Auu____12892 FStar_Util.smap =
+  fun uu____12899  -> FStar_Util.smap_create default_table_size 
+let new_gamma_cache : 'Auu____12905 . unit -> 'Auu____12905 FStar_Util.smap =
+  fun uu____12912  -> FStar_Util.smap_create (Prims.of_int (100)) 
 let (initial_env :
   FStar_Parser_Dep.deps ->
     (env ->
@@ -1436,24 +1497,26 @@ let (initial_env :
             fun solver  ->
               fun module_lid  ->
                 fun nbe1  ->
-                  let uu____12652 = new_gamma_cache ()  in
-                  let uu____12655 = new_sigtab ()  in
-                  let uu____12658 = new_sigtab ()  in
-                  let uu____12665 =
-                    let uu____12680 =
+                  let uu____13050 = new_gamma_cache ()  in
+                  let uu____13053 = new_sigtab ()  in
+                  let uu____13056 = new_sigtab ()  in
+                  let uu____13063 =
+                    let uu____13078 =
                       FStar_Util.smap_create (Prims.of_int (10))  in
-                    (uu____12680, FStar_Pervasives_Native.None)  in
-                  let uu____12701 =
+                    (uu____13078, FStar_Pervasives_Native.None)  in
+                  let uu____13099 =
                     FStar_Util.smap_create (Prims.of_int (20))  in
-                  let uu____12705 =
+                  let uu____13103 =
                     FStar_Util.smap_create (Prims.of_int (50))  in
-                  let uu____12709 = FStar_Options.using_facts_from ()  in
-                  let uu____12710 =
+                  let uu____13107 = FStar_Options.using_facts_from ()  in
+                  let uu____13108 =
                     FStar_Util.mk_ref
                       FStar_TypeChecker_Common.id_info_table_empty
                      in
-                  let uu____12713 = FStar_Syntax_DsEnv.empty_env deps  in
-                  let uu____12714 =
+                  let uu____13111 = FStar_Syntax_DsEnv.empty_env deps  in
+                  let uu____13112 =
+                    FStar_Util.smap_create (Prims.of_int (20))  in
+                  let uu____13126 =
                     FStar_Util.smap_create (Prims.of_int (20))  in
                   {
                     solver;
@@ -1461,11 +1524,11 @@ let (initial_env :
                     curmodule = module_lid;
                     gamma = [];
                     gamma_sig = [];
-                    gamma_cache = uu____12652;
+                    gamma_cache = uu____13050;
                     modules = [];
                     expected_typ = FStar_Pervasives_Native.None;
-                    sigtab = uu____12655;
-                    attrtab = uu____12658;
+                    sigtab = uu____13053;
+                    attrtab = uu____13056;
                     is_pattern = false;
                     instantiate_imp = true;
                     effects = { decls = []; order = []; joins = [] };
@@ -1487,10 +1550,10 @@ let (initial_env :
                     universe_of;
                     check_type_of;
                     use_bv_sorts = false;
-                    qtbl_name_and_index = uu____12665;
-                    normalized_eff_names = uu____12701;
-                    fv_delta_depths = uu____12705;
-                    proof_ns = uu____12709;
+                    qtbl_name_and_index = uu____13063;
+                    normalized_eff_names = uu____13099;
+                    fv_delta_depths = uu____13103;
+                    proof_ns = uu____13107;
                     synth_hook =
                       (fun e  ->
                          fun g  ->
@@ -1502,12 +1565,13 @@ let (initial_env :
                          fun tau  ->
                            fun typ  ->
                              fun tm  -> failwith "no postprocessor available");
-                    is_native_tactic = (fun uu____12789  -> false);
-                    identifier_info = uu____12710;
+                    is_native_tactic = (fun uu____13193  -> false);
+                    identifier_info = uu____13108;
                     tc_hooks = default_tc_hooks;
-                    dsenv = uu____12713;
+                    dsenv = uu____13111;
                     nbe = nbe1;
-                    strict_args_tab = uu____12714
+                    strict_args_tab = uu____13112;
+                    erasable_types_tab = uu____13126
                   }
   
 let (dsenv : env -> FStar_Syntax_DsEnv.env) = fun env  -> env.dsenv 
@@ -1521,131 +1585,133 @@ let (query_indices :
   (FStar_Ident.lident * Prims.int) Prims.list Prims.list FStar_ST.ref) =
   FStar_Util.mk_ref [[]] 
 let (push_query_indices : unit -> unit) =
-  fun uu____12868  ->
-    let uu____12869 = FStar_ST.op_Bang query_indices  in
-    match uu____12869 with
+  fun uu____13272  ->
+    let uu____13273 = FStar_ST.op_Bang query_indices  in
+    match uu____13273 with
     | [] -> failwith "Empty query indices!"
-    | uu____12924 ->
-        let uu____12934 =
-          let uu____12944 =
-            let uu____12952 = FStar_ST.op_Bang query_indices  in
-            FStar_List.hd uu____12952  in
-          let uu____13006 = FStar_ST.op_Bang query_indices  in uu____12944 ::
-            uu____13006
+    | uu____13328 ->
+        let uu____13338 =
+          let uu____13348 =
+            let uu____13356 = FStar_ST.op_Bang query_indices  in
+            FStar_List.hd uu____13356  in
+          let uu____13410 = FStar_ST.op_Bang query_indices  in uu____13348 ::
+            uu____13410
            in
-        FStar_ST.op_Colon_Equals query_indices uu____12934
+        FStar_ST.op_Colon_Equals query_indices uu____13338
   
 let (pop_query_indices : unit -> unit) =
-  fun uu____13102  ->
-    let uu____13103 = FStar_ST.op_Bang query_indices  in
-    match uu____13103 with
+  fun uu____13506  ->
+    let uu____13507 = FStar_ST.op_Bang query_indices  in
+    match uu____13507 with
     | [] -> failwith "Empty query indices!"
     | hd1::tl1 -> FStar_ST.op_Colon_Equals query_indices tl1
   
 let (snapshot_query_indices : unit -> (Prims.int * unit)) =
-  fun uu____13230  ->
+  fun uu____13634  ->
     FStar_Common.snapshot push_query_indices query_indices ()
   
 let (rollback_query_indices :
   Prims.int FStar_Pervasives_Native.option -> unit) =
   fun depth  -> FStar_Common.rollback pop_query_indices query_indices depth 
 let (add_query_index : (FStar_Ident.lident * Prims.int) -> unit) =
-  fun uu____13267  ->
-    match uu____13267 with
+  fun uu____13671  ->
+    match uu____13671 with
     | (l,n1) ->
-        let uu____13277 = FStar_ST.op_Bang query_indices  in
-        (match uu____13277 with
+        let uu____13681 = FStar_ST.op_Bang query_indices  in
+        (match uu____13681 with
          | hd1::tl1 ->
              FStar_ST.op_Colon_Equals query_indices (((l, n1) :: hd1) :: tl1)
-         | uu____13399 -> failwith "Empty query indices")
+         | uu____13803 -> failwith "Empty query indices")
   
 let (peek_query_indices :
   unit -> (FStar_Ident.lident * Prims.int) Prims.list) =
-  fun uu____13422  ->
-    let uu____13423 = FStar_ST.op_Bang query_indices  in
-    FStar_List.hd uu____13423
+  fun uu____13826  ->
+    let uu____13827 = FStar_ST.op_Bang query_indices  in
+    FStar_List.hd uu____13827
   
 let (stack : env Prims.list FStar_ST.ref) = FStar_Util.mk_ref [] 
 let (push_stack : env -> env) =
   fun env  ->
-    (let uu____13491 =
-       let uu____13494 = FStar_ST.op_Bang stack  in env :: uu____13494  in
-     FStar_ST.op_Colon_Equals stack uu____13491);
-    (let uu___417_13543 = env  in
-     let uu____13544 = FStar_Util.smap_copy (gamma_cache env)  in
-     let uu____13547 = FStar_Util.smap_copy (sigtab env)  in
-     let uu____13550 = FStar_Util.smap_copy (attrtab env)  in
-     let uu____13557 =
-       let uu____13572 =
-         let uu____13576 =
+    (let uu____13895 =
+       let uu____13898 = FStar_ST.op_Bang stack  in env :: uu____13898  in
+     FStar_ST.op_Colon_Equals stack uu____13895);
+    (let uu___420_13947 = env  in
+     let uu____13948 = FStar_Util.smap_copy (gamma_cache env)  in
+     let uu____13951 = FStar_Util.smap_copy (sigtab env)  in
+     let uu____13954 = FStar_Util.smap_copy (attrtab env)  in
+     let uu____13961 =
+       let uu____13976 =
+         let uu____13980 =
            FStar_All.pipe_right env.qtbl_name_and_index
              FStar_Pervasives_Native.fst
             in
-         FStar_Util.smap_copy uu____13576  in
-       let uu____13608 =
+         FStar_Util.smap_copy uu____13980  in
+       let uu____14012 =
          FStar_All.pipe_right env.qtbl_name_and_index
            FStar_Pervasives_Native.snd
           in
-       (uu____13572, uu____13608)  in
-     let uu____13657 = FStar_Util.smap_copy env.normalized_eff_names  in
-     let uu____13660 = FStar_Util.smap_copy env.fv_delta_depths  in
-     let uu____13663 =
-       let uu____13666 = FStar_ST.op_Bang env.identifier_info  in
-       FStar_Util.mk_ref uu____13666  in
-     let uu____13686 = FStar_Util.smap_copy env.strict_args_tab  in
+       (uu____13976, uu____14012)  in
+     let uu____14061 = FStar_Util.smap_copy env.normalized_eff_names  in
+     let uu____14064 = FStar_Util.smap_copy env.fv_delta_depths  in
+     let uu____14067 =
+       let uu____14070 = FStar_ST.op_Bang env.identifier_info  in
+       FStar_Util.mk_ref uu____14070  in
+     let uu____14090 = FStar_Util.smap_copy env.strict_args_tab  in
+     let uu____14103 = FStar_Util.smap_copy env.erasable_types_tab  in
      {
-       solver = (uu___417_13543.solver);
-       range = (uu___417_13543.range);
-       curmodule = (uu___417_13543.curmodule);
-       gamma = (uu___417_13543.gamma);
-       gamma_sig = (uu___417_13543.gamma_sig);
-       gamma_cache = uu____13544;
-       modules = (uu___417_13543.modules);
-       expected_typ = (uu___417_13543.expected_typ);
-       sigtab = uu____13547;
-       attrtab = uu____13550;
-       is_pattern = (uu___417_13543.is_pattern);
-       instantiate_imp = (uu___417_13543.instantiate_imp);
-       effects = (uu___417_13543.effects);
-       generalize = (uu___417_13543.generalize);
-       letrecs = (uu___417_13543.letrecs);
-       top_level = (uu___417_13543.top_level);
-       check_uvars = (uu___417_13543.check_uvars);
-       use_eq = (uu___417_13543.use_eq);
-       is_iface = (uu___417_13543.is_iface);
-       admit = (uu___417_13543.admit);
-       lax = (uu___417_13543.lax);
-       lax_universes = (uu___417_13543.lax_universes);
-       phase1 = (uu___417_13543.phase1);
-       failhard = (uu___417_13543.failhard);
-       nosynth = (uu___417_13543.nosynth);
-       uvar_subtyping = (uu___417_13543.uvar_subtyping);
-       tc_term = (uu___417_13543.tc_term);
-       type_of = (uu___417_13543.type_of);
-       universe_of = (uu___417_13543.universe_of);
-       check_type_of = (uu___417_13543.check_type_of);
-       use_bv_sorts = (uu___417_13543.use_bv_sorts);
-       qtbl_name_and_index = uu____13557;
-       normalized_eff_names = uu____13657;
-       fv_delta_depths = uu____13660;
-       proof_ns = (uu___417_13543.proof_ns);
-       synth_hook = (uu___417_13543.synth_hook);
-       splice = (uu___417_13543.splice);
-       postprocess = (uu___417_13543.postprocess);
-       is_native_tactic = (uu___417_13543.is_native_tactic);
-       identifier_info = uu____13663;
-       tc_hooks = (uu___417_13543.tc_hooks);
-       dsenv = (uu___417_13543.dsenv);
-       nbe = (uu___417_13543.nbe);
-       strict_args_tab = uu____13686
+       solver = (uu___420_13947.solver);
+       range = (uu___420_13947.range);
+       curmodule = (uu___420_13947.curmodule);
+       gamma = (uu___420_13947.gamma);
+       gamma_sig = (uu___420_13947.gamma_sig);
+       gamma_cache = uu____13948;
+       modules = (uu___420_13947.modules);
+       expected_typ = (uu___420_13947.expected_typ);
+       sigtab = uu____13951;
+       attrtab = uu____13954;
+       is_pattern = (uu___420_13947.is_pattern);
+       instantiate_imp = (uu___420_13947.instantiate_imp);
+       effects = (uu___420_13947.effects);
+       generalize = (uu___420_13947.generalize);
+       letrecs = (uu___420_13947.letrecs);
+       top_level = (uu___420_13947.top_level);
+       check_uvars = (uu___420_13947.check_uvars);
+       use_eq = (uu___420_13947.use_eq);
+       is_iface = (uu___420_13947.is_iface);
+       admit = (uu___420_13947.admit);
+       lax = (uu___420_13947.lax);
+       lax_universes = (uu___420_13947.lax_universes);
+       phase1 = (uu___420_13947.phase1);
+       failhard = (uu___420_13947.failhard);
+       nosynth = (uu___420_13947.nosynth);
+       uvar_subtyping = (uu___420_13947.uvar_subtyping);
+       tc_term = (uu___420_13947.tc_term);
+       type_of = (uu___420_13947.type_of);
+       universe_of = (uu___420_13947.universe_of);
+       check_type_of = (uu___420_13947.check_type_of);
+       use_bv_sorts = (uu___420_13947.use_bv_sorts);
+       qtbl_name_and_index = uu____13961;
+       normalized_eff_names = uu____14061;
+       fv_delta_depths = uu____14064;
+       proof_ns = (uu___420_13947.proof_ns);
+       synth_hook = (uu___420_13947.synth_hook);
+       splice = (uu___420_13947.splice);
+       postprocess = (uu___420_13947.postprocess);
+       is_native_tactic = (uu___420_13947.is_native_tactic);
+       identifier_info = uu____14067;
+       tc_hooks = (uu___420_13947.tc_hooks);
+       dsenv = (uu___420_13947.dsenv);
+       nbe = (uu___420_13947.nbe);
+       strict_args_tab = uu____14090;
+       erasable_types_tab = uu____14103
      })
   
 let (pop_stack : unit -> env) =
-  fun uu____13704  ->
-    let uu____13705 = FStar_ST.op_Bang stack  in
-    match uu____13705 with
+  fun uu____14113  ->
+    let uu____14114 = FStar_ST.op_Bang stack  in
+    match uu____14114 with
     | env::tl1 -> (FStar_ST.op_Colon_Equals stack tl1; env)
-    | uu____13759 -> failwith "Impossible: Too many pops"
+    | uu____14168 -> failwith "Impossible: Too many pops"
   
 let (snapshot_stack : env -> (Prims.int * env)) =
   fun env  -> FStar_Common.snapshot push_stack stack env 
@@ -1656,80 +1722,82 @@ let (snapshot : env -> Prims.string -> (tcenv_depth_t * env)) =
   fun env  ->
     fun msg  ->
       FStar_Util.atomically
-        (fun uu____13849  ->
-           let uu____13850 = snapshot_stack env  in
-           match uu____13850 with
+        (fun uu____14258  ->
+           let uu____14259 = snapshot_stack env  in
+           match uu____14259 with
            | (stack_depth,env1) ->
-               let uu____13884 = snapshot_query_indices ()  in
-               (match uu____13884 with
+               let uu____14293 = snapshot_query_indices ()  in
+               (match uu____14293 with
                 | (query_indices_depth,()) ->
-                    let uu____13917 = (env1.solver).snapshot msg  in
-                    (match uu____13917 with
+                    let uu____14326 = (env1.solver).snapshot msg  in
+                    (match uu____14326 with
                      | (solver_depth,()) ->
-                         let uu____13974 =
+                         let uu____14383 =
                            FStar_Syntax_DsEnv.snapshot env1.dsenv  in
-                         (match uu____13974 with
+                         (match uu____14383 with
                           | (dsenv_depth,dsenv1) ->
                               ((stack_depth, query_indices_depth,
                                  solver_depth, dsenv_depth),
-                                (let uu___442_14041 = env1  in
+                                (let uu___445_14450 = env1  in
                                  {
-                                   solver = (uu___442_14041.solver);
-                                   range = (uu___442_14041.range);
-                                   curmodule = (uu___442_14041.curmodule);
-                                   gamma = (uu___442_14041.gamma);
-                                   gamma_sig = (uu___442_14041.gamma_sig);
-                                   gamma_cache = (uu___442_14041.gamma_cache);
-                                   modules = (uu___442_14041.modules);
+                                   solver = (uu___445_14450.solver);
+                                   range = (uu___445_14450.range);
+                                   curmodule = (uu___445_14450.curmodule);
+                                   gamma = (uu___445_14450.gamma);
+                                   gamma_sig = (uu___445_14450.gamma_sig);
+                                   gamma_cache = (uu___445_14450.gamma_cache);
+                                   modules = (uu___445_14450.modules);
                                    expected_typ =
-                                     (uu___442_14041.expected_typ);
-                                   sigtab = (uu___442_14041.sigtab);
-                                   attrtab = (uu___442_14041.attrtab);
-                                   is_pattern = (uu___442_14041.is_pattern);
+                                     (uu___445_14450.expected_typ);
+                                   sigtab = (uu___445_14450.sigtab);
+                                   attrtab = (uu___445_14450.attrtab);
+                                   is_pattern = (uu___445_14450.is_pattern);
                                    instantiate_imp =
-                                     (uu___442_14041.instantiate_imp);
-                                   effects = (uu___442_14041.effects);
-                                   generalize = (uu___442_14041.generalize);
-                                   letrecs = (uu___442_14041.letrecs);
-                                   top_level = (uu___442_14041.top_level);
-                                   check_uvars = (uu___442_14041.check_uvars);
-                                   use_eq = (uu___442_14041.use_eq);
-                                   is_iface = (uu___442_14041.is_iface);
-                                   admit = (uu___442_14041.admit);
-                                   lax = (uu___442_14041.lax);
+                                     (uu___445_14450.instantiate_imp);
+                                   effects = (uu___445_14450.effects);
+                                   generalize = (uu___445_14450.generalize);
+                                   letrecs = (uu___445_14450.letrecs);
+                                   top_level = (uu___445_14450.top_level);
+                                   check_uvars = (uu___445_14450.check_uvars);
+                                   use_eq = (uu___445_14450.use_eq);
+                                   is_iface = (uu___445_14450.is_iface);
+                                   admit = (uu___445_14450.admit);
+                                   lax = (uu___445_14450.lax);
                                    lax_universes =
-                                     (uu___442_14041.lax_universes);
-                                   phase1 = (uu___442_14041.phase1);
-                                   failhard = (uu___442_14041.failhard);
-                                   nosynth = (uu___442_14041.nosynth);
+                                     (uu___445_14450.lax_universes);
+                                   phase1 = (uu___445_14450.phase1);
+                                   failhard = (uu___445_14450.failhard);
+                                   nosynth = (uu___445_14450.nosynth);
                                    uvar_subtyping =
-                                     (uu___442_14041.uvar_subtyping);
-                                   tc_term = (uu___442_14041.tc_term);
-                                   type_of = (uu___442_14041.type_of);
-                                   universe_of = (uu___442_14041.universe_of);
+                                     (uu___445_14450.uvar_subtyping);
+                                   tc_term = (uu___445_14450.tc_term);
+                                   type_of = (uu___445_14450.type_of);
+                                   universe_of = (uu___445_14450.universe_of);
                                    check_type_of =
-                                     (uu___442_14041.check_type_of);
+                                     (uu___445_14450.check_type_of);
                                    use_bv_sorts =
-                                     (uu___442_14041.use_bv_sorts);
+                                     (uu___445_14450.use_bv_sorts);
                                    qtbl_name_and_index =
-                                     (uu___442_14041.qtbl_name_and_index);
+                                     (uu___445_14450.qtbl_name_and_index);
                                    normalized_eff_names =
-                                     (uu___442_14041.normalized_eff_names);
+                                     (uu___445_14450.normalized_eff_names);
                                    fv_delta_depths =
-                                     (uu___442_14041.fv_delta_depths);
-                                   proof_ns = (uu___442_14041.proof_ns);
-                                   synth_hook = (uu___442_14041.synth_hook);
-                                   splice = (uu___442_14041.splice);
-                                   postprocess = (uu___442_14041.postprocess);
+                                     (uu___445_14450.fv_delta_depths);
+                                   proof_ns = (uu___445_14450.proof_ns);
+                                   synth_hook = (uu___445_14450.synth_hook);
+                                   splice = (uu___445_14450.splice);
+                                   postprocess = (uu___445_14450.postprocess);
                                    is_native_tactic =
-                                     (uu___442_14041.is_native_tactic);
+                                     (uu___445_14450.is_native_tactic);
                                    identifier_info =
-                                     (uu___442_14041.identifier_info);
-                                   tc_hooks = (uu___442_14041.tc_hooks);
+                                     (uu___445_14450.identifier_info);
+                                   tc_hooks = (uu___445_14450.tc_hooks);
                                    dsenv = dsenv1;
-                                   nbe = (uu___442_14041.nbe);
+                                   nbe = (uu___445_14450.nbe);
                                    strict_args_tab =
-                                     (uu___442_14041.strict_args_tab)
+                                     (uu___445_14450.strict_args_tab);
+                                   erasable_types_tab =
+                                     (uu___445_14450.erasable_types_tab)
                                  }))))))
   
 let (rollback :
@@ -1740,8 +1808,8 @@ let (rollback :
     fun msg  ->
       fun depth  ->
         FStar_Util.atomically
-          (fun uu____14075  ->
-             let uu____14076 =
+          (fun uu____14484  ->
+             let uu____14485 =
                match depth with
                | FStar_Pervasives_Native.Some (s1,s2,s3,s4) ->
                    ((FStar_Pervasives_Native.Some s1),
@@ -1754,7 +1822,7 @@ let (rollback :
                      FStar_Pervasives_Native.None,
                      FStar_Pervasives_Native.None)
                 in
-             match uu____14076 with
+             match uu____14485 with
              | (stack_depth,query_indices_depth,solver_depth,dsenv_depth) ->
                  (solver.rollback msg solver_depth;
                   (match () with
@@ -1765,19 +1833,19 @@ let (rollback :
                              let tcenv = rollback_stack stack_depth  in
                              let dsenv1 =
                                FStar_Syntax_DsEnv.rollback dsenv_depth  in
-                             ((let uu____14256 =
+                             ((let uu____14665 =
                                  FStar_Util.physical_equality tcenv.dsenv
                                    dsenv1
                                   in
-                               FStar_Common.runtime_assert uu____14256
+                               FStar_Common.runtime_assert uu____14665
                                  "Inconsistent stack state");
                               tcenv))))))
   
 let (push : env -> Prims.string -> env) =
   fun env  ->
     fun msg  ->
-      let uu____14272 = snapshot env msg  in
-      FStar_Pervasives_Native.snd uu____14272
+      let uu____14681 = snapshot env msg  in
+      FStar_Pervasives_Native.snd uu____14681
   
 let (pop : env -> Prims.string -> env) =
   fun env  ->
@@ -1787,119 +1855,121 @@ let (incr_query_index : env -> env) =
   fun env  ->
     let qix = peek_query_indices ()  in
     match env.qtbl_name_and_index with
-    | (uu____14304,FStar_Pervasives_Native.None ) -> env
+    | (uu____14713,FStar_Pervasives_Native.None ) -> env
     | (tbl,FStar_Pervasives_Native.Some (l,n1)) ->
-        let uu____14346 =
+        let uu____14755 =
           FStar_All.pipe_right qix
             (FStar_List.tryFind
-               (fun uu____14376  ->
-                  match uu____14376 with
-                  | (m,uu____14384) -> FStar_Ident.lid_equals l m))
+               (fun uu____14785  ->
+                  match uu____14785 with
+                  | (m,uu____14793) -> FStar_Ident.lid_equals l m))
            in
-        (match uu____14346 with
+        (match uu____14755 with
          | FStar_Pervasives_Native.None  ->
              let next = n1 + Prims.int_one  in
              (add_query_index (l, next);
               FStar_Util.smap_add tbl l.FStar_Ident.str next;
-              (let uu___487_14399 = env  in
+              (let uu___490_14808 = env  in
                {
-                 solver = (uu___487_14399.solver);
-                 range = (uu___487_14399.range);
-                 curmodule = (uu___487_14399.curmodule);
-                 gamma = (uu___487_14399.gamma);
-                 gamma_sig = (uu___487_14399.gamma_sig);
-                 gamma_cache = (uu___487_14399.gamma_cache);
-                 modules = (uu___487_14399.modules);
-                 expected_typ = (uu___487_14399.expected_typ);
-                 sigtab = (uu___487_14399.sigtab);
-                 attrtab = (uu___487_14399.attrtab);
-                 is_pattern = (uu___487_14399.is_pattern);
-                 instantiate_imp = (uu___487_14399.instantiate_imp);
-                 effects = (uu___487_14399.effects);
-                 generalize = (uu___487_14399.generalize);
-                 letrecs = (uu___487_14399.letrecs);
-                 top_level = (uu___487_14399.top_level);
-                 check_uvars = (uu___487_14399.check_uvars);
-                 use_eq = (uu___487_14399.use_eq);
-                 is_iface = (uu___487_14399.is_iface);
-                 admit = (uu___487_14399.admit);
-                 lax = (uu___487_14399.lax);
-                 lax_universes = (uu___487_14399.lax_universes);
-                 phase1 = (uu___487_14399.phase1);
-                 failhard = (uu___487_14399.failhard);
-                 nosynth = (uu___487_14399.nosynth);
-                 uvar_subtyping = (uu___487_14399.uvar_subtyping);
-                 tc_term = (uu___487_14399.tc_term);
-                 type_of = (uu___487_14399.type_of);
-                 universe_of = (uu___487_14399.universe_of);
-                 check_type_of = (uu___487_14399.check_type_of);
-                 use_bv_sorts = (uu___487_14399.use_bv_sorts);
+                 solver = (uu___490_14808.solver);
+                 range = (uu___490_14808.range);
+                 curmodule = (uu___490_14808.curmodule);
+                 gamma = (uu___490_14808.gamma);
+                 gamma_sig = (uu___490_14808.gamma_sig);
+                 gamma_cache = (uu___490_14808.gamma_cache);
+                 modules = (uu___490_14808.modules);
+                 expected_typ = (uu___490_14808.expected_typ);
+                 sigtab = (uu___490_14808.sigtab);
+                 attrtab = (uu___490_14808.attrtab);
+                 is_pattern = (uu___490_14808.is_pattern);
+                 instantiate_imp = (uu___490_14808.instantiate_imp);
+                 effects = (uu___490_14808.effects);
+                 generalize = (uu___490_14808.generalize);
+                 letrecs = (uu___490_14808.letrecs);
+                 top_level = (uu___490_14808.top_level);
+                 check_uvars = (uu___490_14808.check_uvars);
+                 use_eq = (uu___490_14808.use_eq);
+                 is_iface = (uu___490_14808.is_iface);
+                 admit = (uu___490_14808.admit);
+                 lax = (uu___490_14808.lax);
+                 lax_universes = (uu___490_14808.lax_universes);
+                 phase1 = (uu___490_14808.phase1);
+                 failhard = (uu___490_14808.failhard);
+                 nosynth = (uu___490_14808.nosynth);
+                 uvar_subtyping = (uu___490_14808.uvar_subtyping);
+                 tc_term = (uu___490_14808.tc_term);
+                 type_of = (uu___490_14808.type_of);
+                 universe_of = (uu___490_14808.universe_of);
+                 check_type_of = (uu___490_14808.check_type_of);
+                 use_bv_sorts = (uu___490_14808.use_bv_sorts);
                  qtbl_name_and_index =
                    (tbl, (FStar_Pervasives_Native.Some (l, next)));
-                 normalized_eff_names = (uu___487_14399.normalized_eff_names);
-                 fv_delta_depths = (uu___487_14399.fv_delta_depths);
-                 proof_ns = (uu___487_14399.proof_ns);
-                 synth_hook = (uu___487_14399.synth_hook);
-                 splice = (uu___487_14399.splice);
-                 postprocess = (uu___487_14399.postprocess);
-                 is_native_tactic = (uu___487_14399.is_native_tactic);
-                 identifier_info = (uu___487_14399.identifier_info);
-                 tc_hooks = (uu___487_14399.tc_hooks);
-                 dsenv = (uu___487_14399.dsenv);
-                 nbe = (uu___487_14399.nbe);
-                 strict_args_tab = (uu___487_14399.strict_args_tab)
+                 normalized_eff_names = (uu___490_14808.normalized_eff_names);
+                 fv_delta_depths = (uu___490_14808.fv_delta_depths);
+                 proof_ns = (uu___490_14808.proof_ns);
+                 synth_hook = (uu___490_14808.synth_hook);
+                 splice = (uu___490_14808.splice);
+                 postprocess = (uu___490_14808.postprocess);
+                 is_native_tactic = (uu___490_14808.is_native_tactic);
+                 identifier_info = (uu___490_14808.identifier_info);
+                 tc_hooks = (uu___490_14808.tc_hooks);
+                 dsenv = (uu___490_14808.dsenv);
+                 nbe = (uu___490_14808.nbe);
+                 strict_args_tab = (uu___490_14808.strict_args_tab);
+                 erasable_types_tab = (uu___490_14808.erasable_types_tab)
                }))
-         | FStar_Pervasives_Native.Some (uu____14416,m) ->
+         | FStar_Pervasives_Native.Some (uu____14825,m) ->
              let next = m + Prims.int_one  in
              (add_query_index (l, next);
               FStar_Util.smap_add tbl l.FStar_Ident.str next;
-              (let uu___496_14432 = env  in
+              (let uu___499_14841 = env  in
                {
-                 solver = (uu___496_14432.solver);
-                 range = (uu___496_14432.range);
-                 curmodule = (uu___496_14432.curmodule);
-                 gamma = (uu___496_14432.gamma);
-                 gamma_sig = (uu___496_14432.gamma_sig);
-                 gamma_cache = (uu___496_14432.gamma_cache);
-                 modules = (uu___496_14432.modules);
-                 expected_typ = (uu___496_14432.expected_typ);
-                 sigtab = (uu___496_14432.sigtab);
-                 attrtab = (uu___496_14432.attrtab);
-                 is_pattern = (uu___496_14432.is_pattern);
-                 instantiate_imp = (uu___496_14432.instantiate_imp);
-                 effects = (uu___496_14432.effects);
-                 generalize = (uu___496_14432.generalize);
-                 letrecs = (uu___496_14432.letrecs);
-                 top_level = (uu___496_14432.top_level);
-                 check_uvars = (uu___496_14432.check_uvars);
-                 use_eq = (uu___496_14432.use_eq);
-                 is_iface = (uu___496_14432.is_iface);
-                 admit = (uu___496_14432.admit);
-                 lax = (uu___496_14432.lax);
-                 lax_universes = (uu___496_14432.lax_universes);
-                 phase1 = (uu___496_14432.phase1);
-                 failhard = (uu___496_14432.failhard);
-                 nosynth = (uu___496_14432.nosynth);
-                 uvar_subtyping = (uu___496_14432.uvar_subtyping);
-                 tc_term = (uu___496_14432.tc_term);
-                 type_of = (uu___496_14432.type_of);
-                 universe_of = (uu___496_14432.universe_of);
-                 check_type_of = (uu___496_14432.check_type_of);
-                 use_bv_sorts = (uu___496_14432.use_bv_sorts);
+                 solver = (uu___499_14841.solver);
+                 range = (uu___499_14841.range);
+                 curmodule = (uu___499_14841.curmodule);
+                 gamma = (uu___499_14841.gamma);
+                 gamma_sig = (uu___499_14841.gamma_sig);
+                 gamma_cache = (uu___499_14841.gamma_cache);
+                 modules = (uu___499_14841.modules);
+                 expected_typ = (uu___499_14841.expected_typ);
+                 sigtab = (uu___499_14841.sigtab);
+                 attrtab = (uu___499_14841.attrtab);
+                 is_pattern = (uu___499_14841.is_pattern);
+                 instantiate_imp = (uu___499_14841.instantiate_imp);
+                 effects = (uu___499_14841.effects);
+                 generalize = (uu___499_14841.generalize);
+                 letrecs = (uu___499_14841.letrecs);
+                 top_level = (uu___499_14841.top_level);
+                 check_uvars = (uu___499_14841.check_uvars);
+                 use_eq = (uu___499_14841.use_eq);
+                 is_iface = (uu___499_14841.is_iface);
+                 admit = (uu___499_14841.admit);
+                 lax = (uu___499_14841.lax);
+                 lax_universes = (uu___499_14841.lax_universes);
+                 phase1 = (uu___499_14841.phase1);
+                 failhard = (uu___499_14841.failhard);
+                 nosynth = (uu___499_14841.nosynth);
+                 uvar_subtyping = (uu___499_14841.uvar_subtyping);
+                 tc_term = (uu___499_14841.tc_term);
+                 type_of = (uu___499_14841.type_of);
+                 universe_of = (uu___499_14841.universe_of);
+                 check_type_of = (uu___499_14841.check_type_of);
+                 use_bv_sorts = (uu___499_14841.use_bv_sorts);
                  qtbl_name_and_index =
                    (tbl, (FStar_Pervasives_Native.Some (l, next)));
-                 normalized_eff_names = (uu___496_14432.normalized_eff_names);
-                 fv_delta_depths = (uu___496_14432.fv_delta_depths);
-                 proof_ns = (uu___496_14432.proof_ns);
-                 synth_hook = (uu___496_14432.synth_hook);
-                 splice = (uu___496_14432.splice);
-                 postprocess = (uu___496_14432.postprocess);
-                 is_native_tactic = (uu___496_14432.is_native_tactic);
-                 identifier_info = (uu___496_14432.identifier_info);
-                 tc_hooks = (uu___496_14432.tc_hooks);
-                 dsenv = (uu___496_14432.dsenv);
-                 nbe = (uu___496_14432.nbe);
-                 strict_args_tab = (uu___496_14432.strict_args_tab)
+                 normalized_eff_names = (uu___499_14841.normalized_eff_names);
+                 fv_delta_depths = (uu___499_14841.fv_delta_depths);
+                 proof_ns = (uu___499_14841.proof_ns);
+                 synth_hook = (uu___499_14841.synth_hook);
+                 splice = (uu___499_14841.splice);
+                 postprocess = (uu___499_14841.postprocess);
+                 is_native_tactic = (uu___499_14841.is_native_tactic);
+                 identifier_info = (uu___499_14841.identifier_info);
+                 tc_hooks = (uu___499_14841.tc_hooks);
+                 dsenv = (uu___499_14841.dsenv);
+                 nbe = (uu___499_14841.nbe);
+                 strict_args_tab = (uu___499_14841.strict_args_tab);
+                 erasable_types_tab = (uu___499_14841.erasable_types_tab)
                })))
   
 let (debug : env -> FStar_Options.debug_level_t -> Prims.bool) =
@@ -1912,91 +1982,92 @@ let (set_range : env -> FStar_Range.range -> env) =
       if r = FStar_Range.dummyRange
       then e
       else
-        (let uu___503_14475 = e  in
+        (let uu___506_14884 = e  in
          {
-           solver = (uu___503_14475.solver);
+           solver = (uu___506_14884.solver);
            range = r;
-           curmodule = (uu___503_14475.curmodule);
-           gamma = (uu___503_14475.gamma);
-           gamma_sig = (uu___503_14475.gamma_sig);
-           gamma_cache = (uu___503_14475.gamma_cache);
-           modules = (uu___503_14475.modules);
-           expected_typ = (uu___503_14475.expected_typ);
-           sigtab = (uu___503_14475.sigtab);
-           attrtab = (uu___503_14475.attrtab);
-           is_pattern = (uu___503_14475.is_pattern);
-           instantiate_imp = (uu___503_14475.instantiate_imp);
-           effects = (uu___503_14475.effects);
-           generalize = (uu___503_14475.generalize);
-           letrecs = (uu___503_14475.letrecs);
-           top_level = (uu___503_14475.top_level);
-           check_uvars = (uu___503_14475.check_uvars);
-           use_eq = (uu___503_14475.use_eq);
-           is_iface = (uu___503_14475.is_iface);
-           admit = (uu___503_14475.admit);
-           lax = (uu___503_14475.lax);
-           lax_universes = (uu___503_14475.lax_universes);
-           phase1 = (uu___503_14475.phase1);
-           failhard = (uu___503_14475.failhard);
-           nosynth = (uu___503_14475.nosynth);
-           uvar_subtyping = (uu___503_14475.uvar_subtyping);
-           tc_term = (uu___503_14475.tc_term);
-           type_of = (uu___503_14475.type_of);
-           universe_of = (uu___503_14475.universe_of);
-           check_type_of = (uu___503_14475.check_type_of);
-           use_bv_sorts = (uu___503_14475.use_bv_sorts);
-           qtbl_name_and_index = (uu___503_14475.qtbl_name_and_index);
-           normalized_eff_names = (uu___503_14475.normalized_eff_names);
-           fv_delta_depths = (uu___503_14475.fv_delta_depths);
-           proof_ns = (uu___503_14475.proof_ns);
-           synth_hook = (uu___503_14475.synth_hook);
-           splice = (uu___503_14475.splice);
-           postprocess = (uu___503_14475.postprocess);
-           is_native_tactic = (uu___503_14475.is_native_tactic);
-           identifier_info = (uu___503_14475.identifier_info);
-           tc_hooks = (uu___503_14475.tc_hooks);
-           dsenv = (uu___503_14475.dsenv);
-           nbe = (uu___503_14475.nbe);
-           strict_args_tab = (uu___503_14475.strict_args_tab)
+           curmodule = (uu___506_14884.curmodule);
+           gamma = (uu___506_14884.gamma);
+           gamma_sig = (uu___506_14884.gamma_sig);
+           gamma_cache = (uu___506_14884.gamma_cache);
+           modules = (uu___506_14884.modules);
+           expected_typ = (uu___506_14884.expected_typ);
+           sigtab = (uu___506_14884.sigtab);
+           attrtab = (uu___506_14884.attrtab);
+           is_pattern = (uu___506_14884.is_pattern);
+           instantiate_imp = (uu___506_14884.instantiate_imp);
+           effects = (uu___506_14884.effects);
+           generalize = (uu___506_14884.generalize);
+           letrecs = (uu___506_14884.letrecs);
+           top_level = (uu___506_14884.top_level);
+           check_uvars = (uu___506_14884.check_uvars);
+           use_eq = (uu___506_14884.use_eq);
+           is_iface = (uu___506_14884.is_iface);
+           admit = (uu___506_14884.admit);
+           lax = (uu___506_14884.lax);
+           lax_universes = (uu___506_14884.lax_universes);
+           phase1 = (uu___506_14884.phase1);
+           failhard = (uu___506_14884.failhard);
+           nosynth = (uu___506_14884.nosynth);
+           uvar_subtyping = (uu___506_14884.uvar_subtyping);
+           tc_term = (uu___506_14884.tc_term);
+           type_of = (uu___506_14884.type_of);
+           universe_of = (uu___506_14884.universe_of);
+           check_type_of = (uu___506_14884.check_type_of);
+           use_bv_sorts = (uu___506_14884.use_bv_sorts);
+           qtbl_name_and_index = (uu___506_14884.qtbl_name_and_index);
+           normalized_eff_names = (uu___506_14884.normalized_eff_names);
+           fv_delta_depths = (uu___506_14884.fv_delta_depths);
+           proof_ns = (uu___506_14884.proof_ns);
+           synth_hook = (uu___506_14884.synth_hook);
+           splice = (uu___506_14884.splice);
+           postprocess = (uu___506_14884.postprocess);
+           is_native_tactic = (uu___506_14884.is_native_tactic);
+           identifier_info = (uu___506_14884.identifier_info);
+           tc_hooks = (uu___506_14884.tc_hooks);
+           dsenv = (uu___506_14884.dsenv);
+           nbe = (uu___506_14884.nbe);
+           strict_args_tab = (uu___506_14884.strict_args_tab);
+           erasable_types_tab = (uu___506_14884.erasable_types_tab)
          })
   
 let (get_range : env -> FStar_Range.range) = fun e  -> e.range 
 let (toggle_id_info : env -> Prims.bool -> unit) =
   fun env  ->
     fun enabled  ->
-      let uu____14495 =
-        let uu____14496 = FStar_ST.op_Bang env.identifier_info  in
-        FStar_TypeChecker_Common.id_info_toggle uu____14496 enabled  in
-      FStar_ST.op_Colon_Equals env.identifier_info uu____14495
+      let uu____14904 =
+        let uu____14905 = FStar_ST.op_Bang env.identifier_info  in
+        FStar_TypeChecker_Common.id_info_toggle uu____14905 enabled  in
+      FStar_ST.op_Colon_Equals env.identifier_info uu____14904
   
 let (insert_bv_info :
   env -> FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.typ -> unit) =
   fun env  ->
     fun bv  ->
       fun ty  ->
-        let uu____14551 =
-          let uu____14552 = FStar_ST.op_Bang env.identifier_info  in
-          FStar_TypeChecker_Common.id_info_insert_bv uu____14552 bv ty  in
-        FStar_ST.op_Colon_Equals env.identifier_info uu____14551
+        let uu____14960 =
+          let uu____14961 = FStar_ST.op_Bang env.identifier_info  in
+          FStar_TypeChecker_Common.id_info_insert_bv uu____14961 bv ty  in
+        FStar_ST.op_Colon_Equals env.identifier_info uu____14960
   
 let (insert_fv_info :
   env -> FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.typ -> unit) =
   fun env  ->
     fun fv  ->
       fun ty  ->
-        let uu____14607 =
-          let uu____14608 = FStar_ST.op_Bang env.identifier_info  in
-          FStar_TypeChecker_Common.id_info_insert_fv uu____14608 fv ty  in
-        FStar_ST.op_Colon_Equals env.identifier_info uu____14607
+        let uu____15016 =
+          let uu____15017 = FStar_ST.op_Bang env.identifier_info  in
+          FStar_TypeChecker_Common.id_info_insert_fv uu____15017 fv ty  in
+        FStar_ST.op_Colon_Equals env.identifier_info uu____15016
   
 let (promote_id_info :
   env -> (FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) -> unit) =
   fun env  ->
     fun ty_map  ->
-      let uu____14663 =
-        let uu____14664 = FStar_ST.op_Bang env.identifier_info  in
-        FStar_TypeChecker_Common.id_info_promote uu____14664 ty_map  in
-      FStar_ST.op_Colon_Equals env.identifier_info uu____14663
+      let uu____15072 =
+        let uu____15073 = FStar_ST.op_Bang env.identifier_info  in
+        FStar_TypeChecker_Common.id_info_promote uu____15073 ty_map  in
+      FStar_ST.op_Colon_Equals env.identifier_info uu____15072
   
 let (modules : env -> FStar_Syntax_Syntax.modul Prims.list) =
   fun env  -> env.modules 
@@ -2004,52 +2075,53 @@ let (current_module : env -> FStar_Ident.lident) = fun env  -> env.curmodule
 let (set_current_module : env -> FStar_Ident.lident -> env) =
   fun env  ->
     fun lid  ->
-      let uu___520_14728 = env  in
+      let uu___523_15137 = env  in
       {
-        solver = (uu___520_14728.solver);
-        range = (uu___520_14728.range);
+        solver = (uu___523_15137.solver);
+        range = (uu___523_15137.range);
         curmodule = lid;
-        gamma = (uu___520_14728.gamma);
-        gamma_sig = (uu___520_14728.gamma_sig);
-        gamma_cache = (uu___520_14728.gamma_cache);
-        modules = (uu___520_14728.modules);
-        expected_typ = (uu___520_14728.expected_typ);
-        sigtab = (uu___520_14728.sigtab);
-        attrtab = (uu___520_14728.attrtab);
-        is_pattern = (uu___520_14728.is_pattern);
-        instantiate_imp = (uu___520_14728.instantiate_imp);
-        effects = (uu___520_14728.effects);
-        generalize = (uu___520_14728.generalize);
-        letrecs = (uu___520_14728.letrecs);
-        top_level = (uu___520_14728.top_level);
-        check_uvars = (uu___520_14728.check_uvars);
-        use_eq = (uu___520_14728.use_eq);
-        is_iface = (uu___520_14728.is_iface);
-        admit = (uu___520_14728.admit);
-        lax = (uu___520_14728.lax);
-        lax_universes = (uu___520_14728.lax_universes);
-        phase1 = (uu___520_14728.phase1);
-        failhard = (uu___520_14728.failhard);
-        nosynth = (uu___520_14728.nosynth);
-        uvar_subtyping = (uu___520_14728.uvar_subtyping);
-        tc_term = (uu___520_14728.tc_term);
-        type_of = (uu___520_14728.type_of);
-        universe_of = (uu___520_14728.universe_of);
-        check_type_of = (uu___520_14728.check_type_of);
-        use_bv_sorts = (uu___520_14728.use_bv_sorts);
-        qtbl_name_and_index = (uu___520_14728.qtbl_name_and_index);
-        normalized_eff_names = (uu___520_14728.normalized_eff_names);
-        fv_delta_depths = (uu___520_14728.fv_delta_depths);
-        proof_ns = (uu___520_14728.proof_ns);
-        synth_hook = (uu___520_14728.synth_hook);
-        splice = (uu___520_14728.splice);
-        postprocess = (uu___520_14728.postprocess);
-        is_native_tactic = (uu___520_14728.is_native_tactic);
-        identifier_info = (uu___520_14728.identifier_info);
-        tc_hooks = (uu___520_14728.tc_hooks);
-        dsenv = (uu___520_14728.dsenv);
-        nbe = (uu___520_14728.nbe);
-        strict_args_tab = (uu___520_14728.strict_args_tab)
+        gamma = (uu___523_15137.gamma);
+        gamma_sig = (uu___523_15137.gamma_sig);
+        gamma_cache = (uu___523_15137.gamma_cache);
+        modules = (uu___523_15137.modules);
+        expected_typ = (uu___523_15137.expected_typ);
+        sigtab = (uu___523_15137.sigtab);
+        attrtab = (uu___523_15137.attrtab);
+        is_pattern = (uu___523_15137.is_pattern);
+        instantiate_imp = (uu___523_15137.instantiate_imp);
+        effects = (uu___523_15137.effects);
+        generalize = (uu___523_15137.generalize);
+        letrecs = (uu___523_15137.letrecs);
+        top_level = (uu___523_15137.top_level);
+        check_uvars = (uu___523_15137.check_uvars);
+        use_eq = (uu___523_15137.use_eq);
+        is_iface = (uu___523_15137.is_iface);
+        admit = (uu___523_15137.admit);
+        lax = (uu___523_15137.lax);
+        lax_universes = (uu___523_15137.lax_universes);
+        phase1 = (uu___523_15137.phase1);
+        failhard = (uu___523_15137.failhard);
+        nosynth = (uu___523_15137.nosynth);
+        uvar_subtyping = (uu___523_15137.uvar_subtyping);
+        tc_term = (uu___523_15137.tc_term);
+        type_of = (uu___523_15137.type_of);
+        universe_of = (uu___523_15137.universe_of);
+        check_type_of = (uu___523_15137.check_type_of);
+        use_bv_sorts = (uu___523_15137.use_bv_sorts);
+        qtbl_name_and_index = (uu___523_15137.qtbl_name_and_index);
+        normalized_eff_names = (uu___523_15137.normalized_eff_names);
+        fv_delta_depths = (uu___523_15137.fv_delta_depths);
+        proof_ns = (uu___523_15137.proof_ns);
+        synth_hook = (uu___523_15137.synth_hook);
+        splice = (uu___523_15137.splice);
+        postprocess = (uu___523_15137.postprocess);
+        is_native_tactic = (uu___523_15137.is_native_tactic);
+        identifier_info = (uu___523_15137.identifier_info);
+        tc_hooks = (uu___523_15137.tc_hooks);
+        dsenv = (uu___523_15137.dsenv);
+        nbe = (uu___523_15137.nbe);
+        strict_args_tab = (uu___523_15137.strict_args_tab);
+        erasable_types_tab = (uu___523_15137.erasable_types_tab)
       }
   
 let (has_interface : env -> FStar_Ident.lident -> Prims.bool) =
@@ -2068,28 +2140,28 @@ let (find_in_sigtab :
   =
   fun env  ->
     fun lid  ->
-      let uu____14759 = FStar_Ident.text_of_lid lid  in
-      FStar_Util.smap_try_find (sigtab env) uu____14759
+      let uu____15168 = FStar_Ident.text_of_lid lid  in
+      FStar_Util.smap_try_find (sigtab env) uu____15168
   
 let (name_not_found :
   FStar_Ident.lid -> (FStar_Errors.raw_error * Prims.string)) =
   fun l  ->
-    let uu____14772 =
+    let uu____15181 =
       FStar_Util.format1 "Name \"%s\" not found" l.FStar_Ident.str  in
-    (FStar_Errors.Fatal_NameNotFound, uu____14772)
+    (FStar_Errors.Fatal_NameNotFound, uu____15181)
   
 let (variable_not_found :
   FStar_Syntax_Syntax.bv -> (FStar_Errors.raw_error * Prims.string)) =
   fun v1  ->
-    let uu____14787 =
-      let uu____14789 = FStar_Syntax_Print.bv_to_string v1  in
-      FStar_Util.format1 "Variable \"%s\" not found" uu____14789  in
-    (FStar_Errors.Fatal_VariableNotFound, uu____14787)
+    let uu____15196 =
+      let uu____15198 = FStar_Syntax_Print.bv_to_string v1  in
+      FStar_Util.format1 "Variable \"%s\" not found" uu____15198  in
+    (FStar_Errors.Fatal_VariableNotFound, uu____15196)
   
 let (new_u_univ : unit -> FStar_Syntax_Syntax.universe) =
-  fun uu____14798  ->
-    let uu____14799 = FStar_Syntax_Unionfind.univ_fresh ()  in
-    FStar_Syntax_Syntax.U_unif uu____14799
+  fun uu____15207  ->
+    let uu____15208 = FStar_Syntax_Unionfind.univ_fresh ()  in
+    FStar_Syntax_Syntax.U_unif uu____15208
   
 let (mk_univ_subst :
   FStar_Syntax_Syntax.univ_name Prims.list ->
@@ -2111,22 +2183,22 @@ let (inst_tscheme_with :
     fun us  ->
       match (ts, us) with
       | (([],t),[]) -> ([], t)
-      | ((formals,t),uu____14899) ->
+      | ((formals,t),uu____15308) ->
           let vs = mk_univ_subst formals us  in
-          let uu____14923 = FStar_Syntax_Subst.subst vs t  in
-          (us, uu____14923)
+          let uu____15332 = FStar_Syntax_Subst.subst vs t  in
+          (us, uu____15332)
   
 let (inst_tscheme :
   FStar_Syntax_Syntax.tscheme ->
     (FStar_Syntax_Syntax.universes * FStar_Syntax_Syntax.term))
   =
-  fun uu___1_14940  ->
-    match uu___1_14940 with
+  fun uu___1_15349  ->
+    match uu___1_15349 with
     | ([],t) -> ([], t)
     | (us,t) ->
         let us' =
           FStar_All.pipe_right us
-            (FStar_List.map (fun uu____14966  -> new_u_univ ()))
+            (FStar_List.map (fun uu____15375  -> new_u_univ ()))
            in
         inst_tscheme_with (us, t) us'
   
@@ -2137,11 +2209,11 @@ let (inst_tscheme_with_range :
   =
   fun r  ->
     fun t  ->
-      let uu____14986 = inst_tscheme t  in
-      match uu____14986 with
+      let uu____15395 = inst_tscheme t  in
+      match uu____15395 with
       | (us,t1) ->
-          let uu____14997 = FStar_Syntax_Subst.set_use_range r t1  in
-          (us, uu____14997)
+          let uu____15406 = FStar_Syntax_Subst.set_use_range r t1  in
+          (us, uu____15406)
   
 let (check_effect_is_not_a_template :
   FStar_Syntax_Syntax.eff_decl -> FStar_Range.range -> unit) =
@@ -2154,15 +2226,15 @@ let (check_effect_is_not_a_template :
              Prims.int_zero)
       then
         let msg =
-          let uu____15022 =
+          let uu____15431 =
             FStar_Syntax_Print.lid_to_string ed.FStar_Syntax_Syntax.mname  in
-          let uu____15024 =
+          let uu____15433 =
             FStar_Syntax_Print.binders_to_string ", "
               ed.FStar_Syntax_Syntax.binders
              in
           FStar_Util.format2
             "Effect template %s should be applied to arguments for its binders (%s) before it can be used at an effect position"
-            uu____15022 uu____15024
+            uu____15431 uu____15433
            in
         FStar_Errors.raise_error
           (FStar_Errors.Fatal_NotEnoughArgumentsForEffect, msg) rng
@@ -2177,34 +2249,34 @@ let (inst_effect_fun_with :
   fun insts  ->
     fun env  ->
       fun ed  ->
-        fun uu____15051  ->
-          match uu____15051 with
+        fun uu____15460  ->
+          match uu____15460 with
           | (us,t) ->
               (check_effect_is_not_a_template ed env.range;
                if (FStar_List.length insts) <> (FStar_List.length us)
                then
-                 (let uu____15065 =
-                    let uu____15067 =
+                 (let uu____15474 =
+                    let uu____15476 =
                       FStar_All.pipe_left FStar_Util.string_of_int
                         (FStar_List.length us)
                        in
-                    let uu____15071 =
+                    let uu____15480 =
                       FStar_All.pipe_left FStar_Util.string_of_int
                         (FStar_List.length insts)
                        in
-                    let uu____15075 =
+                    let uu____15484 =
                       FStar_Syntax_Print.lid_to_string
                         ed.FStar_Syntax_Syntax.mname
                        in
-                    let uu____15077 = FStar_Syntax_Print.term_to_string t  in
+                    let uu____15486 = FStar_Syntax_Print.term_to_string t  in
                     FStar_Util.format4
                       "Expected %s instantiations; got %s; failed universe instantiation in effect %s\n\t%s\n"
-                      uu____15067 uu____15071 uu____15075 uu____15077
+                      uu____15476 uu____15480 uu____15484 uu____15486
                      in
-                  failwith uu____15065)
+                  failwith uu____15474)
                else ();
-               (let uu____15082 = inst_tscheme_with (us, t) insts  in
-                FStar_Pervasives_Native.snd uu____15082))
+               (let uu____15491 = inst_tscheme_with (us, t) insts  in
+                FStar_Pervasives_Native.snd uu____15491))
   
 type tri =
   | Yes 
@@ -2212,13 +2284,13 @@ type tri =
   | Maybe 
 let (uu___is_Yes : tri -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Yes  -> true | uu____15100 -> false
+    match projectee with | Yes  -> true | uu____15509 -> false
   
 let (uu___is_No : tri -> Prims.bool) =
-  fun projectee  -> match projectee with | No  -> true | uu____15111 -> false 
+  fun projectee  -> match projectee with | No  -> true | uu____15520 -> false 
 let (uu___is_Maybe : tri -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Maybe  -> true | uu____15122 -> false
+    match projectee with | Maybe  -> true | uu____15531 -> false
   
 let (in_cur_mod : env -> FStar_Ident.lident -> tri) =
   fun env  ->
@@ -2235,12 +2307,12 @@ let (in_cur_mod : env -> FStar_Ident.lident -> tri) =
              FStar_List.append cur.FStar_Ident.ns [cur.FStar_Ident.ident]  in
            let rec aux c l1 =
              match (c, l1) with
-             | ([],uu____15170) -> Maybe
-             | (uu____15177,[]) -> No
+             | ([],uu____15579) -> Maybe
+             | (uu____15586,[]) -> No
              | (hd1::tl1,hd'::tl') when
                  hd1.FStar_Ident.idText = hd'.FStar_Ident.idText ->
                  aux tl1 tl'
-             | uu____15197 -> No  in
+             | uu____15606 -> No  in
            aux cur1 lns)
         else No
   
@@ -2260,56 +2332,56 @@ let (lookup_qname : env -> FStar_Ident.lident -> qninfo) =
       let found =
         if cur_mod <> No
         then
-          let uu____15291 =
+          let uu____15700 =
             FStar_Util.smap_try_find (gamma_cache env) lid.FStar_Ident.str
              in
-          match uu____15291 with
+          match uu____15700 with
           | FStar_Pervasives_Native.None  ->
-              let uu____15314 =
+              let uu____15723 =
                 FStar_Util.find_map env.gamma
-                  (fun uu___2_15358  ->
-                     match uu___2_15358 with
+                  (fun uu___2_15767  ->
+                     match uu___2_15767 with
                      | FStar_Syntax_Syntax.Binding_lid (l,t) ->
-                         let uu____15397 = FStar_Ident.lid_equals lid l  in
-                         if uu____15397
+                         let uu____15806 = FStar_Ident.lid_equals lid l  in
+                         if uu____15806
                          then
-                           let uu____15420 =
-                             let uu____15439 =
-                               let uu____15454 = inst_tscheme t  in
-                               FStar_Util.Inl uu____15454  in
-                             let uu____15469 = FStar_Ident.range_of_lid l  in
-                             (uu____15439, uu____15469)  in
-                           FStar_Pervasives_Native.Some uu____15420
+                           let uu____15829 =
+                             let uu____15848 =
+                               let uu____15863 = inst_tscheme t  in
+                               FStar_Util.Inl uu____15863  in
+                             let uu____15878 = FStar_Ident.range_of_lid l  in
+                             (uu____15848, uu____15878)  in
+                           FStar_Pervasives_Native.Some uu____15829
                          else FStar_Pervasives_Native.None
-                     | uu____15522 -> FStar_Pervasives_Native.None)
+                     | uu____15931 -> FStar_Pervasives_Native.None)
                  in
-              FStar_Util.catch_opt uu____15314
-                (fun uu____15560  ->
+              FStar_Util.catch_opt uu____15723
+                (fun uu____15969  ->
                    FStar_Util.find_map env.gamma_sig
-                     (fun uu___3_15569  ->
-                        match uu___3_15569 with
-                        | (uu____15572,{
+                     (fun uu___3_15978  ->
+                        match uu___3_15978 with
+                        | (uu____15981,{
                                          FStar_Syntax_Syntax.sigel =
                                            FStar_Syntax_Syntax.Sig_bundle
-                                           (ses,uu____15574);
+                                           (ses,uu____15983);
                                          FStar_Syntax_Syntax.sigrng =
-                                           uu____15575;
+                                           uu____15984;
                                          FStar_Syntax_Syntax.sigquals =
-                                           uu____15576;
+                                           uu____15985;
                                          FStar_Syntax_Syntax.sigmeta =
-                                           uu____15577;
+                                           uu____15986;
                                          FStar_Syntax_Syntax.sigattrs =
-                                           uu____15578;_})
+                                           uu____15987;_})
                             ->
                             FStar_Util.find_map ses
                               (fun se  ->
-                                 let uu____15598 =
+                                 let uu____16007 =
                                    FStar_All.pipe_right
                                      (FStar_Syntax_Util.lids_of_sigelt se)
                                      (FStar_Util.for_some
                                         (FStar_Ident.lid_equals lid))
                                     in
-                                 if uu____15598
+                                 if uu____16007
                                  then
                                    cache
                                      ((FStar_Util.Inr
@@ -2320,32 +2392,32 @@ let (lookup_qname : env -> FStar_Ident.lident -> qninfo) =
                             let maybe_cache t =
                               match s.FStar_Syntax_Syntax.sigel with
                               | FStar_Syntax_Syntax.Sig_declare_typ
-                                  uu____15650 ->
+                                  uu____16059 ->
                                   FStar_Pervasives_Native.Some t
-                              | uu____15657 -> cache t  in
-                            let uu____15658 =
+                              | uu____16066 -> cache t  in
+                            let uu____16067 =
                               FStar_List.tryFind (FStar_Ident.lid_equals lid)
                                 lids
                                in
-                            (match uu____15658 with
+                            (match uu____16067 with
                              | FStar_Pervasives_Native.None  ->
                                  FStar_Pervasives_Native.None
                              | FStar_Pervasives_Native.Some l ->
-                                 let uu____15664 =
-                                   let uu____15665 =
+                                 let uu____16073 =
+                                   let uu____16074 =
                                      FStar_Ident.range_of_lid l  in
                                    ((FStar_Util.Inr
                                        (s, FStar_Pervasives_Native.None)),
-                                     uu____15665)
+                                     uu____16074)
                                     in
-                                 maybe_cache uu____15664)))
+                                 maybe_cache uu____16073)))
           | se -> se
         else FStar_Pervasives_Native.None  in
       if FStar_Util.is_some found
       then found
       else
-        (let uu____15736 = find_in_sigtab env lid  in
-         match uu____15736 with
+        (let uu____16145 = find_in_sigtab env lid  in
+         match uu____16145 with
          | FStar_Pervasives_Native.Some se ->
              FStar_Pervasives_Native.Some
                ((FStar_Util.Inr (se, FStar_Pervasives_Native.None)),
@@ -2359,10 +2431,10 @@ let (lookup_sigelt :
   =
   fun env  ->
     fun lid  ->
-      let uu____15817 = lookup_qname env lid  in
-      match uu____15817 with
+      let uu____16226 = lookup_qname env lid  in
+      match uu____16226 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-      | FStar_Pervasives_Native.Some (FStar_Util.Inl uu____15838,rng) ->
+      | FStar_Pervasives_Native.Some (FStar_Util.Inl uu____16247,rng) ->
           FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some (FStar_Util.Inr (se,us),rng) ->
           FStar_Pervasives_Native.Some se
@@ -2371,8 +2443,8 @@ let (lookup_attr :
   env -> Prims.string -> FStar_Syntax_Syntax.sigelt Prims.list) =
   fun env  ->
     fun attr  ->
-      let uu____15952 = FStar_Util.smap_try_find (attrtab env) attr  in
-      match uu____15952 with
+      let uu____16361 = FStar_Util.smap_try_find (attrtab env) attr  in
+      match uu____16361 with
       | FStar_Pervasives_Native.Some ses -> ses
       | FStar_Pervasives_Native.None  -> []
   
@@ -2380,29 +2452,29 @@ let (add_se_to_attrtab : env -> FStar_Syntax_Syntax.sigelt -> unit) =
   fun env  ->
     fun se  ->
       let add_one1 env1 se1 attr =
-        let uu____15997 =
-          let uu____16000 = lookup_attr env1 attr  in se1 :: uu____16000  in
-        FStar_Util.smap_add (attrtab env1) attr uu____15997  in
+        let uu____16406 =
+          let uu____16409 = lookup_attr env1 attr  in se1 :: uu____16409  in
+        FStar_Util.smap_add (attrtab env1) attr uu____16406  in
       FStar_List.iter
         (fun attr  ->
-           let uu____16010 =
-             let uu____16011 = FStar_Syntax_Subst.compress attr  in
-             uu____16011.FStar_Syntax_Syntax.n  in
-           match uu____16010 with
+           let uu____16419 =
+             let uu____16420 = FStar_Syntax_Subst.compress attr  in
+             uu____16420.FStar_Syntax_Syntax.n  in
+           match uu____16419 with
            | FStar_Syntax_Syntax.Tm_fvar fv ->
-               let uu____16015 =
-                 let uu____16017 = FStar_Syntax_Syntax.lid_of_fv fv  in
-                 uu____16017.FStar_Ident.str  in
-               add_one1 env se uu____16015
-           | uu____16018 -> ()) se.FStar_Syntax_Syntax.sigattrs
+               let uu____16424 =
+                 let uu____16426 = FStar_Syntax_Syntax.lid_of_fv fv  in
+                 uu____16426.FStar_Ident.str  in
+               add_one1 env se uu____16424
+           | uu____16427 -> ()) se.FStar_Syntax_Syntax.sigattrs
   
 let rec (add_sigelt : env -> FStar_Syntax_Syntax.sigelt -> unit) =
   fun env  ->
     fun se  ->
       match se.FStar_Syntax_Syntax.sigel with
-      | FStar_Syntax_Syntax.Sig_bundle (ses,uu____16041) ->
+      | FStar_Syntax_Syntax.Sig_bundle (ses,uu____16450) ->
           add_sigelts env ses
-      | uu____16050 ->
+      | uu____16459 ->
           let lids = FStar_Syntax_Util.lids_of_sigelt se  in
           (FStar_List.iter
              (fun l  -> FStar_Util.smap_add (sigtab env) l.FStar_Ident.str se)
@@ -2422,14 +2494,14 @@ let (try_lookup_bv :
   fun env  ->
     fun bv  ->
       FStar_Util.find_map env.gamma
-        (fun uu___4_16088  ->
-           match uu___4_16088 with
+        (fun uu___4_16497  ->
+           match uu___4_16497 with
            | FStar_Syntax_Syntax.Binding_var id1 when
                FStar_Syntax_Syntax.bv_eq id1 bv ->
                FStar_Pervasives_Native.Some
                  ((id1.FStar_Syntax_Syntax.sort),
                    ((id1.FStar_Syntax_Syntax.ppname).FStar_Ident.idRange))
-           | uu____16106 -> FStar_Pervasives_Native.None)
+           | uu____16515 -> FStar_Pervasives_Native.None)
   
 let (lookup_type_of_let :
   FStar_Syntax_Syntax.universes FStar_Pervasives_Native.option ->
@@ -2446,41 +2518,41 @@ let (lookup_type_of_let :
           | FStar_Pervasives_Native.None  -> inst_tscheme ts
           | FStar_Pervasives_Native.Some us -> inst_tscheme_with ts us  in
         match se.FStar_Syntax_Syntax.sigel with
-        | FStar_Syntax_Syntax.Sig_let ((uu____16168,lb::[]),uu____16170) ->
-            let uu____16179 =
-              let uu____16188 =
+        | FStar_Syntax_Syntax.Sig_let ((uu____16577,lb::[]),uu____16579) ->
+            let uu____16588 =
+              let uu____16597 =
                 inst_tscheme1
                   ((lb.FStar_Syntax_Syntax.lbunivs),
                     (lb.FStar_Syntax_Syntax.lbtyp))
                  in
-              let uu____16197 =
+              let uu____16606 =
                 FStar_Syntax_Syntax.range_of_lbname
                   lb.FStar_Syntax_Syntax.lbname
                  in
-              (uu____16188, uu____16197)  in
-            FStar_Pervasives_Native.Some uu____16179
-        | FStar_Syntax_Syntax.Sig_let ((uu____16210,lbs),uu____16212) ->
+              (uu____16597, uu____16606)  in
+            FStar_Pervasives_Native.Some uu____16588
+        | FStar_Syntax_Syntax.Sig_let ((uu____16619,lbs),uu____16621) ->
             FStar_Util.find_map lbs
               (fun lb  ->
                  match lb.FStar_Syntax_Syntax.lbname with
-                 | FStar_Util.Inl uu____16244 -> failwith "impossible"
+                 | FStar_Util.Inl uu____16653 -> failwith "impossible"
                  | FStar_Util.Inr fv ->
-                     let uu____16257 = FStar_Syntax_Syntax.fv_eq_lid fv lid
+                     let uu____16666 = FStar_Syntax_Syntax.fv_eq_lid fv lid
                         in
-                     if uu____16257
+                     if uu____16666
                      then
-                       let uu____16270 =
-                         let uu____16279 =
+                       let uu____16679 =
+                         let uu____16688 =
                            inst_tscheme1
                              ((lb.FStar_Syntax_Syntax.lbunivs),
                                (lb.FStar_Syntax_Syntax.lbtyp))
                             in
-                         let uu____16288 = FStar_Syntax_Syntax.range_of_fv fv
+                         let uu____16697 = FStar_Syntax_Syntax.range_of_fv fv
                             in
-                         (uu____16279, uu____16288)  in
-                       FStar_Pervasives_Native.Some uu____16270
+                         (uu____16688, uu____16697)  in
+                       FStar_Pervasives_Native.Some uu____16679
                      else FStar_Pervasives_Native.None)
-        | uu____16311 -> FStar_Pervasives_Native.None
+        | uu____16720 -> FStar_Pervasives_Native.None
   
 let (effect_signature :
   FStar_Syntax_Syntax.universes FStar_Pervasives_Native.option ->
@@ -2508,54 +2580,54 @@ let (effect_signature :
                          (FStar_Pervasives_Native.fst
                             ne.FStar_Syntax_Syntax.signature))
                   then
-                    let uu____16403 =
-                      let uu____16405 =
-                        let uu____16407 =
-                          let uu____16409 =
-                            let uu____16411 =
+                    let uu____16812 =
+                      let uu____16814 =
+                        let uu____16816 =
+                          let uu____16818 =
+                            let uu____16820 =
                               FStar_Util.string_of_int
                                 (FStar_List.length
                                    (FStar_Pervasives_Native.fst
                                       ne.FStar_Syntax_Syntax.signature))
                                in
-                            let uu____16417 =
-                              let uu____16419 =
+                            let uu____16826 =
+                              let uu____16828 =
                                 FStar_Util.string_of_int
                                   (FStar_List.length us)
                                  in
-                              Prims.op_Hat ", got " uu____16419  in
-                            Prims.op_Hat uu____16411 uu____16417  in
-                          Prims.op_Hat ", expected " uu____16409  in
+                              Prims.op_Hat ", got " uu____16828  in
+                            Prims.op_Hat uu____16820 uu____16826  in
+                          Prims.op_Hat ", expected " uu____16818  in
                         Prims.op_Hat
                           (ne.FStar_Syntax_Syntax.mname).FStar_Ident.str
-                          uu____16407
+                          uu____16816
                          in
                       Prims.op_Hat
                         "effect_signature: incorrect number of universes for the signature of "
-                        uu____16405
+                        uu____16814
                        in
-                    failwith uu____16403
+                    failwith uu____16812
                   else ());
-             (let uu____16426 =
-                let uu____16435 =
+             (let uu____16835 =
+                let uu____16844 =
                   inst_ts us_opt ne.FStar_Syntax_Syntax.signature  in
-                (uu____16435, (se.FStar_Syntax_Syntax.sigrng))  in
-              FStar_Pervasives_Native.Some uu____16426))
+                (uu____16844, (se.FStar_Syntax_Syntax.sigrng))  in
+              FStar_Pervasives_Native.Some uu____16835))
         | FStar_Syntax_Syntax.Sig_effect_abbrev
-            (lid,us,binders,uu____16455,uu____16456) ->
-            let uu____16461 =
-              let uu____16470 =
-                let uu____16475 =
-                  let uu____16476 =
-                    let uu____16479 =
+            (lid,us,binders,uu____16864,uu____16865) ->
+            let uu____16870 =
+              let uu____16879 =
+                let uu____16884 =
+                  let uu____16885 =
+                    let uu____16888 =
                       FStar_Syntax_Syntax.mk_Total FStar_Syntax_Syntax.teff
                        in
-                    FStar_Syntax_Util.arrow binders uu____16479  in
-                  (us, uu____16476)  in
-                inst_ts us_opt uu____16475  in
-              (uu____16470, (se.FStar_Syntax_Syntax.sigrng))  in
-            FStar_Pervasives_Native.Some uu____16461
-        | uu____16498 -> FStar_Pervasives_Native.None
+                    FStar_Syntax_Util.arrow binders uu____16888  in
+                  (us, uu____16885)  in
+                inst_ts us_opt uu____16884  in
+              (uu____16879, (se.FStar_Syntax_Syntax.sigrng))  in
+            FStar_Pervasives_Native.Some uu____16870
+        | uu____16907 -> FStar_Pervasives_Native.None
   
 let (try_lookup_lid_aux :
   FStar_Syntax_Syntax.universes FStar_Pervasives_Native.option ->
@@ -2572,8 +2644,8 @@ let (try_lookup_lid_aux :
           match us_opt with
           | FStar_Pervasives_Native.None  -> inst_tscheme ts
           | FStar_Pervasives_Native.Some us -> inst_tscheme_with ts us  in
-        let mapper uu____16587 =
-          match uu____16587 with
+        let mapper uu____16996 =
+          match uu____16996 with
           | (lr,rng) ->
               (match lr with
                | FStar_Util.Inl t -> FStar_Pervasives_Native.Some (t, rng)
@@ -2581,161 +2653,161 @@ let (try_lookup_lid_aux :
                    ({
                       FStar_Syntax_Syntax.sigel =
                         FStar_Syntax_Syntax.Sig_datacon
-                        (uu____16683,uvs,t,uu____16686,uu____16687,uu____16688);
-                      FStar_Syntax_Syntax.sigrng = uu____16689;
-                      FStar_Syntax_Syntax.sigquals = uu____16690;
-                      FStar_Syntax_Syntax.sigmeta = uu____16691;
-                      FStar_Syntax_Syntax.sigattrs = uu____16692;_},FStar_Pervasives_Native.None
+                        (uu____17092,uvs,t,uu____17095,uu____17096,uu____17097);
+                      FStar_Syntax_Syntax.sigrng = uu____17098;
+                      FStar_Syntax_Syntax.sigquals = uu____17099;
+                      FStar_Syntax_Syntax.sigmeta = uu____17100;
+                      FStar_Syntax_Syntax.sigattrs = uu____17101;_},FStar_Pervasives_Native.None
                     )
                    ->
-                   let uu____16715 =
-                     let uu____16724 = inst_tscheme1 (uvs, t)  in
-                     (uu____16724, rng)  in
-                   FStar_Pervasives_Native.Some uu____16715
+                   let uu____17124 =
+                     let uu____17133 = inst_tscheme1 (uvs, t)  in
+                     (uu____17133, rng)  in
+                   FStar_Pervasives_Native.Some uu____17124
                | FStar_Util.Inr
                    ({
                       FStar_Syntax_Syntax.sigel =
                         FStar_Syntax_Syntax.Sig_declare_typ (l,uvs,t);
-                      FStar_Syntax_Syntax.sigrng = uu____16748;
+                      FStar_Syntax_Syntax.sigrng = uu____17157;
                       FStar_Syntax_Syntax.sigquals = qs;
-                      FStar_Syntax_Syntax.sigmeta = uu____16750;
-                      FStar_Syntax_Syntax.sigattrs = uu____16751;_},FStar_Pervasives_Native.None
+                      FStar_Syntax_Syntax.sigmeta = uu____17159;
+                      FStar_Syntax_Syntax.sigattrs = uu____17160;_},FStar_Pervasives_Native.None
                     )
                    ->
-                   let uu____16768 =
-                     let uu____16770 = in_cur_mod env l  in uu____16770 = Yes
+                   let uu____17177 =
+                     let uu____17179 = in_cur_mod env l  in uu____17179 = Yes
                       in
-                   if uu____16768
+                   if uu____17177
                    then
-                     let uu____16782 =
+                     let uu____17191 =
                        (FStar_All.pipe_right qs
                           (FStar_List.contains FStar_Syntax_Syntax.Assumption))
                          || env.is_iface
                         in
-                     (if uu____16782
+                     (if uu____17191
                       then
-                        let uu____16798 =
-                          let uu____16807 = inst_tscheme1 (uvs, t)  in
-                          (uu____16807, rng)  in
-                        FStar_Pervasives_Native.Some uu____16798
+                        let uu____17207 =
+                          let uu____17216 = inst_tscheme1 (uvs, t)  in
+                          (uu____17216, rng)  in
+                        FStar_Pervasives_Native.Some uu____17207
                       else FStar_Pervasives_Native.None)
                    else
-                     (let uu____16840 =
-                        let uu____16849 = inst_tscheme1 (uvs, t)  in
-                        (uu____16849, rng)  in
-                      FStar_Pervasives_Native.Some uu____16840)
+                     (let uu____17249 =
+                        let uu____17258 = inst_tscheme1 (uvs, t)  in
+                        (uu____17258, rng)  in
+                      FStar_Pervasives_Native.Some uu____17249)
                | FStar_Util.Inr
                    ({
                       FStar_Syntax_Syntax.sigel =
                         FStar_Syntax_Syntax.Sig_inductive_typ
-                        (lid1,uvs,tps,k,uu____16874,uu____16875);
-                      FStar_Syntax_Syntax.sigrng = uu____16876;
-                      FStar_Syntax_Syntax.sigquals = uu____16877;
-                      FStar_Syntax_Syntax.sigmeta = uu____16878;
-                      FStar_Syntax_Syntax.sigattrs = uu____16879;_},FStar_Pervasives_Native.None
+                        (lid1,uvs,tps,k,uu____17283,uu____17284);
+                      FStar_Syntax_Syntax.sigrng = uu____17285;
+                      FStar_Syntax_Syntax.sigquals = uu____17286;
+                      FStar_Syntax_Syntax.sigmeta = uu____17287;
+                      FStar_Syntax_Syntax.sigattrs = uu____17288;_},FStar_Pervasives_Native.None
                     )
                    ->
                    (match tps with
                     | [] ->
-                        let uu____16920 =
-                          let uu____16929 = inst_tscheme1 (uvs, k)  in
-                          (uu____16929, rng)  in
-                        FStar_Pervasives_Native.Some uu____16920
-                    | uu____16950 ->
-                        let uu____16951 =
-                          let uu____16960 =
-                            let uu____16965 =
-                              let uu____16966 =
-                                let uu____16969 =
+                        let uu____17329 =
+                          let uu____17338 = inst_tscheme1 (uvs, k)  in
+                          (uu____17338, rng)  in
+                        FStar_Pervasives_Native.Some uu____17329
+                    | uu____17359 ->
+                        let uu____17360 =
+                          let uu____17369 =
+                            let uu____17374 =
+                              let uu____17375 =
+                                let uu____17378 =
                                   FStar_Syntax_Syntax.mk_Total k  in
-                                FStar_Syntax_Util.flat_arrow tps uu____16969
+                                FStar_Syntax_Util.flat_arrow tps uu____17378
                                  in
-                              (uvs, uu____16966)  in
-                            inst_tscheme1 uu____16965  in
-                          (uu____16960, rng)  in
-                        FStar_Pervasives_Native.Some uu____16951)
+                              (uvs, uu____17375)  in
+                            inst_tscheme1 uu____17374  in
+                          (uu____17369, rng)  in
+                        FStar_Pervasives_Native.Some uu____17360)
                | FStar_Util.Inr
                    ({
                       FStar_Syntax_Syntax.sigel =
                         FStar_Syntax_Syntax.Sig_inductive_typ
-                        (lid1,uvs,tps,k,uu____16992,uu____16993);
-                      FStar_Syntax_Syntax.sigrng = uu____16994;
-                      FStar_Syntax_Syntax.sigquals = uu____16995;
-                      FStar_Syntax_Syntax.sigmeta = uu____16996;
-                      FStar_Syntax_Syntax.sigattrs = uu____16997;_},FStar_Pervasives_Native.Some
+                        (lid1,uvs,tps,k,uu____17401,uu____17402);
+                      FStar_Syntax_Syntax.sigrng = uu____17403;
+                      FStar_Syntax_Syntax.sigquals = uu____17404;
+                      FStar_Syntax_Syntax.sigmeta = uu____17405;
+                      FStar_Syntax_Syntax.sigattrs = uu____17406;_},FStar_Pervasives_Native.Some
                     us)
                    ->
                    (match tps with
                     | [] ->
-                        let uu____17039 =
-                          let uu____17048 = inst_tscheme_with (uvs, k) us  in
-                          (uu____17048, rng)  in
-                        FStar_Pervasives_Native.Some uu____17039
-                    | uu____17069 ->
-                        let uu____17070 =
-                          let uu____17079 =
-                            let uu____17084 =
-                              let uu____17085 =
-                                let uu____17088 =
+                        let uu____17448 =
+                          let uu____17457 = inst_tscheme_with (uvs, k) us  in
+                          (uu____17457, rng)  in
+                        FStar_Pervasives_Native.Some uu____17448
+                    | uu____17478 ->
+                        let uu____17479 =
+                          let uu____17488 =
+                            let uu____17493 =
+                              let uu____17494 =
+                                let uu____17497 =
                                   FStar_Syntax_Syntax.mk_Total k  in
-                                FStar_Syntax_Util.flat_arrow tps uu____17088
+                                FStar_Syntax_Util.flat_arrow tps uu____17497
                                  in
-                              (uvs, uu____17085)  in
-                            inst_tscheme_with uu____17084 us  in
-                          (uu____17079, rng)  in
-                        FStar_Pervasives_Native.Some uu____17070)
+                              (uvs, uu____17494)  in
+                            inst_tscheme_with uu____17493 us  in
+                          (uu____17488, rng)  in
+                        FStar_Pervasives_Native.Some uu____17479)
                | FStar_Util.Inr se ->
-                   let uu____17124 =
+                   let uu____17533 =
                      match se with
                      | ({
                           FStar_Syntax_Syntax.sigel =
-                            FStar_Syntax_Syntax.Sig_let uu____17145;
-                          FStar_Syntax_Syntax.sigrng = uu____17146;
-                          FStar_Syntax_Syntax.sigquals = uu____17147;
-                          FStar_Syntax_Syntax.sigmeta = uu____17148;
-                          FStar_Syntax_Syntax.sigattrs = uu____17149;_},FStar_Pervasives_Native.None
+                            FStar_Syntax_Syntax.Sig_let uu____17554;
+                          FStar_Syntax_Syntax.sigrng = uu____17555;
+                          FStar_Syntax_Syntax.sigquals = uu____17556;
+                          FStar_Syntax_Syntax.sigmeta = uu____17557;
+                          FStar_Syntax_Syntax.sigattrs = uu____17558;_},FStar_Pervasives_Native.None
                         ) ->
                          lookup_type_of_let us_opt
                            (FStar_Pervasives_Native.fst se) lid
-                     | uu____17164 ->
+                     | uu____17573 ->
                          effect_signature us_opt
                            (FStar_Pervasives_Native.fst se) env.range
                       in
-                   FStar_All.pipe_right uu____17124
+                   FStar_All.pipe_right uu____17533
                      (FStar_Util.map_option
-                        (fun uu____17212  ->
-                           match uu____17212 with
+                        (fun uu____17621  ->
+                           match uu____17621 with
                            | (us_t,rng1) -> (us_t, rng1))))
            in
-        let uu____17243 =
-          let uu____17254 = lookup_qname env lid  in
-          FStar_Util.bind_opt uu____17254 mapper  in
-        match uu____17243 with
+        let uu____17652 =
+          let uu____17663 = lookup_qname env lid  in
+          FStar_Util.bind_opt uu____17663 mapper  in
+        match uu____17652 with
         | FStar_Pervasives_Native.Some ((us,t),r) ->
-            let uu____17328 =
-              let uu____17339 =
-                let uu____17346 =
-                  let uu___851_17349 = t  in
-                  let uu____17350 = FStar_Ident.range_of_lid lid  in
+            let uu____17737 =
+              let uu____17748 =
+                let uu____17755 =
+                  let uu___854_17758 = t  in
+                  let uu____17759 = FStar_Ident.range_of_lid lid  in
                   {
                     FStar_Syntax_Syntax.n =
-                      (uu___851_17349.FStar_Syntax_Syntax.n);
-                    FStar_Syntax_Syntax.pos = uu____17350;
+                      (uu___854_17758.FStar_Syntax_Syntax.n);
+                    FStar_Syntax_Syntax.pos = uu____17759;
                     FStar_Syntax_Syntax.vars =
-                      (uu___851_17349.FStar_Syntax_Syntax.vars)
+                      (uu___854_17758.FStar_Syntax_Syntax.vars)
                   }  in
-                (us, uu____17346)  in
-              (uu____17339, r)  in
-            FStar_Pervasives_Native.Some uu____17328
+                (us, uu____17755)  in
+              (uu____17748, r)  in
+            FStar_Pervasives_Native.Some uu____17737
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
   
 let (lid_exists : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun l  ->
-      let uu____17399 = lookup_qname env l  in
-      match uu____17399 with
+      let uu____17808 = lookup_qname env l  in
+      match uu____17808 with
       | FStar_Pervasives_Native.None  -> false
-      | FStar_Pervasives_Native.Some uu____17420 -> true
+      | FStar_Pervasives_Native.Some uu____17829 -> true
   
 let (lookup_bv :
   env ->
@@ -2744,17 +2816,17 @@ let (lookup_bv :
   fun env  ->
     fun bv  ->
       let bvr = FStar_Syntax_Syntax.range_of_bv bv  in
-      let uu____17474 = try_lookup_bv env bv  in
-      match uu____17474 with
+      let uu____17883 = try_lookup_bv env bv  in
+      match uu____17883 with
       | FStar_Pervasives_Native.None  ->
-          let uu____17489 = variable_not_found bv  in
-          FStar_Errors.raise_error uu____17489 bvr
+          let uu____17898 = variable_not_found bv  in
+          FStar_Errors.raise_error uu____17898 bvr
       | FStar_Pervasives_Native.Some (t,r) ->
-          let uu____17505 = FStar_Syntax_Subst.set_use_range bvr t  in
-          let uu____17506 =
-            let uu____17507 = FStar_Range.use_range bvr  in
-            FStar_Range.set_use_range r uu____17507  in
-          (uu____17505, uu____17506)
+          let uu____17914 = FStar_Syntax_Subst.set_use_range bvr t  in
+          let uu____17915 =
+            let uu____17916 = FStar_Range.use_range bvr  in
+            FStar_Range.set_use_range r uu____17916  in
+          (uu____17914, uu____17915)
   
 let (try_lookup_lid :
   env ->
@@ -2764,22 +2836,22 @@ let (try_lookup_lid :
   =
   fun env  ->
     fun l  ->
-      let uu____17529 = try_lookup_lid_aux FStar_Pervasives_Native.None env l
+      let uu____17938 = try_lookup_lid_aux FStar_Pervasives_Native.None env l
          in
-      match uu____17529 with
+      match uu____17938 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some ((us,t),r) ->
           let use_range1 = FStar_Ident.range_of_lid l  in
           let r1 =
-            let uu____17595 = FStar_Range.use_range use_range1  in
-            FStar_Range.set_use_range r uu____17595  in
-          let uu____17596 =
-            let uu____17605 =
-              let uu____17610 = FStar_Syntax_Subst.set_use_range use_range1 t
+            let uu____18004 = FStar_Range.use_range use_range1  in
+            FStar_Range.set_use_range r uu____18004  in
+          let uu____18005 =
+            let uu____18014 =
+              let uu____18019 = FStar_Syntax_Subst.set_use_range use_range1 t
                  in
-              (us, uu____17610)  in
-            (uu____17605, r1)  in
-          FStar_Pervasives_Native.Some uu____17596
+              (us, uu____18019)  in
+            (uu____18014, r1)  in
+          FStar_Pervasives_Native.Some uu____18005
   
 let (try_lookup_and_inst_lid :
   env ->
@@ -2791,20 +2863,20 @@ let (try_lookup_and_inst_lid :
   fun env  ->
     fun us  ->
       fun l  ->
-        let uu____17645 =
+        let uu____18054 =
           try_lookup_lid_aux (FStar_Pervasives_Native.Some us) env l  in
-        match uu____17645 with
+        match uu____18054 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-        | FStar_Pervasives_Native.Some ((uu____17678,t),r) ->
+        | FStar_Pervasives_Native.Some ((uu____18087,t),r) ->
             let use_range1 = FStar_Ident.range_of_lid l  in
             let r1 =
-              let uu____17703 = FStar_Range.use_range use_range1  in
-              FStar_Range.set_use_range r uu____17703  in
-            let uu____17704 =
-              let uu____17709 = FStar_Syntax_Subst.set_use_range use_range1 t
+              let uu____18112 = FStar_Range.use_range use_range1  in
+              FStar_Range.set_use_range r uu____18112  in
+            let uu____18113 =
+              let uu____18118 = FStar_Syntax_Subst.set_use_range use_range1 t
                  in
-              (uu____17709, r1)  in
-            FStar_Pervasives_Native.Some uu____17704
+              (uu____18118, r1)  in
+            FStar_Pervasives_Native.Some uu____18113
   
 let (lookup_lid :
   env ->
@@ -2814,12 +2886,12 @@ let (lookup_lid :
   =
   fun env  ->
     fun l  ->
-      let uu____17733 = try_lookup_lid env l  in
-      match uu____17733 with
+      let uu____18142 = try_lookup_lid env l  in
+      match uu____18142 with
       | FStar_Pervasives_Native.None  ->
-          let uu____17760 = name_not_found l  in
-          let uu____17766 = FStar_Ident.range_of_lid l  in
-          FStar_Errors.raise_error uu____17760 uu____17766
+          let uu____18169 = name_not_found l  in
+          let uu____18175 = FStar_Ident.range_of_lid l  in
+          FStar_Errors.raise_error uu____18169 uu____18175
       | FStar_Pervasives_Native.Some v1 -> v1
   
 let (lookup_univ : env -> FStar_Syntax_Syntax.univ_name -> Prims.bool) =
@@ -2827,11 +2899,11 @@ let (lookup_univ : env -> FStar_Syntax_Syntax.univ_name -> Prims.bool) =
     fun x  ->
       FStar_All.pipe_right
         (FStar_List.find
-           (fun uu___5_17809  ->
-              match uu___5_17809 with
+           (fun uu___5_18218  ->
+              match uu___5_18218 with
               | FStar_Syntax_Syntax.Binding_univ y ->
                   x.FStar_Ident.idText = y.FStar_Ident.idText
-              | uu____17813 -> false) env.gamma) FStar_Option.isSome
+              | uu____18222 -> false) env.gamma) FStar_Option.isSome
   
 let (try_lookup_val_decl :
   env ->
@@ -2841,28 +2913,28 @@ let (try_lookup_val_decl :
   =
   fun env  ->
     fun lid  ->
-      let uu____17834 = lookup_qname env lid  in
-      match uu____17834 with
+      let uu____18243 = lookup_qname env lid  in
+      match uu____18243 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ
-                (uu____17843,uvs,t);
-              FStar_Syntax_Syntax.sigrng = uu____17846;
+                (uu____18252,uvs,t);
+              FStar_Syntax_Syntax.sigrng = uu____18255;
               FStar_Syntax_Syntax.sigquals = q;
-              FStar_Syntax_Syntax.sigmeta = uu____17848;
-              FStar_Syntax_Syntax.sigattrs = uu____17849;_},FStar_Pervasives_Native.None
-            ),uu____17850)
+              FStar_Syntax_Syntax.sigmeta = uu____18257;
+              FStar_Syntax_Syntax.sigattrs = uu____18258;_},FStar_Pervasives_Native.None
+            ),uu____18259)
           ->
-          let uu____17899 =
-            let uu____17906 =
-              let uu____17907 =
-                let uu____17910 = FStar_Ident.range_of_lid lid  in
-                FStar_Syntax_Subst.set_use_range uu____17910 t  in
-              (uvs, uu____17907)  in
-            (uu____17906, q)  in
-          FStar_Pervasives_Native.Some uu____17899
-      | uu____17923 -> FStar_Pervasives_Native.None
+          let uu____18308 =
+            let uu____18315 =
+              let uu____18316 =
+                let uu____18319 = FStar_Ident.range_of_lid lid  in
+                FStar_Syntax_Subst.set_use_range uu____18319 t  in
+              (uvs, uu____18316)  in
+            (uu____18315, q)  in
+          FStar_Pervasives_Native.Some uu____18308
+      | uu____18332 -> FStar_Pervasives_Native.None
   
 let (lookup_val_decl :
   env ->
@@ -2871,25 +2943,25 @@ let (lookup_val_decl :
   =
   fun env  ->
     fun lid  ->
-      let uu____17945 = lookup_qname env lid  in
-      match uu____17945 with
+      let uu____18354 = lookup_qname env lid  in
+      match uu____18354 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ
-                (uu____17950,uvs,t);
-              FStar_Syntax_Syntax.sigrng = uu____17953;
-              FStar_Syntax_Syntax.sigquals = uu____17954;
-              FStar_Syntax_Syntax.sigmeta = uu____17955;
-              FStar_Syntax_Syntax.sigattrs = uu____17956;_},FStar_Pervasives_Native.None
-            ),uu____17957)
+                (uu____18359,uvs,t);
+              FStar_Syntax_Syntax.sigrng = uu____18362;
+              FStar_Syntax_Syntax.sigquals = uu____18363;
+              FStar_Syntax_Syntax.sigmeta = uu____18364;
+              FStar_Syntax_Syntax.sigattrs = uu____18365;_},FStar_Pervasives_Native.None
+            ),uu____18366)
           ->
-          let uu____18006 = FStar_Ident.range_of_lid lid  in
-          inst_tscheme_with_range uu____18006 (uvs, t)
-      | uu____18011 ->
-          let uu____18012 = name_not_found lid  in
-          let uu____18018 = FStar_Ident.range_of_lid lid  in
-          FStar_Errors.raise_error uu____18012 uu____18018
+          let uu____18415 = FStar_Ident.range_of_lid lid  in
+          inst_tscheme_with_range uu____18415 (uvs, t)
+      | uu____18420 ->
+          let uu____18421 = name_not_found lid  in
+          let uu____18427 = FStar_Ident.range_of_lid lid  in
+          FStar_Errors.raise_error uu____18421 uu____18427
   
 let (lookup_datacon :
   env ->
@@ -2898,66 +2970,66 @@ let (lookup_datacon :
   =
   fun env  ->
     fun lid  ->
-      let uu____18038 = lookup_qname env lid  in
-      match uu____18038 with
+      let uu____18447 = lookup_qname env lid  in
+      match uu____18447 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-                (uu____18043,uvs,t,uu____18046,uu____18047,uu____18048);
-              FStar_Syntax_Syntax.sigrng = uu____18049;
-              FStar_Syntax_Syntax.sigquals = uu____18050;
-              FStar_Syntax_Syntax.sigmeta = uu____18051;
-              FStar_Syntax_Syntax.sigattrs = uu____18052;_},FStar_Pervasives_Native.None
-            ),uu____18053)
+                (uu____18452,uvs,t,uu____18455,uu____18456,uu____18457);
+              FStar_Syntax_Syntax.sigrng = uu____18458;
+              FStar_Syntax_Syntax.sigquals = uu____18459;
+              FStar_Syntax_Syntax.sigmeta = uu____18460;
+              FStar_Syntax_Syntax.sigattrs = uu____18461;_},FStar_Pervasives_Native.None
+            ),uu____18462)
           ->
-          let uu____18108 = FStar_Ident.range_of_lid lid  in
-          inst_tscheme_with_range uu____18108 (uvs, t)
-      | uu____18113 ->
-          let uu____18114 = name_not_found lid  in
-          let uu____18120 = FStar_Ident.range_of_lid lid  in
-          FStar_Errors.raise_error uu____18114 uu____18120
+          let uu____18517 = FStar_Ident.range_of_lid lid  in
+          inst_tscheme_with_range uu____18517 (uvs, t)
+      | uu____18522 ->
+          let uu____18523 = name_not_found lid  in
+          let uu____18529 = FStar_Ident.range_of_lid lid  in
+          FStar_Errors.raise_error uu____18523 uu____18529
   
 let (datacons_of_typ :
   env -> FStar_Ident.lident -> (Prims.bool * FStar_Ident.lident Prims.list))
   =
   fun env  ->
     fun lid  ->
-      let uu____18143 = lookup_qname env lid  in
-      match uu____18143 with
+      let uu____18552 = lookup_qname env lid  in
+      match uu____18552 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel =
                 FStar_Syntax_Syntax.Sig_inductive_typ
-                (uu____18151,uu____18152,uu____18153,uu____18154,uu____18155,dcs);
-              FStar_Syntax_Syntax.sigrng = uu____18157;
-              FStar_Syntax_Syntax.sigquals = uu____18158;
-              FStar_Syntax_Syntax.sigmeta = uu____18159;
-              FStar_Syntax_Syntax.sigattrs = uu____18160;_},uu____18161),uu____18162)
+                (uu____18560,uu____18561,uu____18562,uu____18563,uu____18564,dcs);
+              FStar_Syntax_Syntax.sigrng = uu____18566;
+              FStar_Syntax_Syntax.sigquals = uu____18567;
+              FStar_Syntax_Syntax.sigmeta = uu____18568;
+              FStar_Syntax_Syntax.sigattrs = uu____18569;_},uu____18570),uu____18571)
           -> (true, dcs)
-      | uu____18225 -> (false, [])
+      | uu____18634 -> (false, [])
   
 let (typ_of_datacon : env -> FStar_Ident.lident -> FStar_Ident.lident) =
   fun env  ->
     fun lid  ->
-      let uu____18241 = lookup_qname env lid  in
-      match uu____18241 with
+      let uu____18650 = lookup_qname env lid  in
+      match uu____18650 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-                (uu____18242,uu____18243,uu____18244,l,uu____18246,uu____18247);
-              FStar_Syntax_Syntax.sigrng = uu____18248;
-              FStar_Syntax_Syntax.sigquals = uu____18249;
-              FStar_Syntax_Syntax.sigmeta = uu____18250;
-              FStar_Syntax_Syntax.sigattrs = uu____18251;_},uu____18252),uu____18253)
+                (uu____18651,uu____18652,uu____18653,l,uu____18655,uu____18656);
+              FStar_Syntax_Syntax.sigrng = uu____18657;
+              FStar_Syntax_Syntax.sigquals = uu____18658;
+              FStar_Syntax_Syntax.sigmeta = uu____18659;
+              FStar_Syntax_Syntax.sigattrs = uu____18660;_},uu____18661),uu____18662)
           -> l
-      | uu____18310 ->
-          let uu____18311 =
-            let uu____18313 = FStar_Syntax_Print.lid_to_string lid  in
-            FStar_Util.format1 "Not a datacon: %s" uu____18313  in
-          failwith uu____18311
+      | uu____18719 ->
+          let uu____18720 =
+            let uu____18722 = FStar_Syntax_Print.lid_to_string lid  in
+            FStar_Util.format1 "Not a datacon: %s" uu____18722  in
+          failwith uu____18720
   
 let (lookup_definition_qninfo_aux :
   Prims.bool ->
@@ -2981,10 +3053,10 @@ let (lookup_definition_qninfo_aux :
              in
           match qninfo with
           | FStar_Pervasives_Native.Some
-              (FStar_Util.Inr (se,FStar_Pervasives_Native.None ),uu____18383)
+              (FStar_Util.Inr (se,FStar_Pervasives_Native.None ),uu____18792)
               ->
               (match se.FStar_Syntax_Syntax.sigel with
-               | FStar_Syntax_Syntax.Sig_let ((is_rec,lbs),uu____18440) when
+               | FStar_Syntax_Syntax.Sig_let ((is_rec,lbs),uu____18849) when
                    (visible se.FStar_Syntax_Syntax.sigquals) &&
                      ((Prims.op_Negation is_rec) || rec_ok)
                    ->
@@ -2992,16 +3064,16 @@ let (lookup_definition_qninfo_aux :
                      (fun lb  ->
                         let fv =
                           FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
-                        let uu____18464 =
+                        let uu____18873 =
                           FStar_Syntax_Syntax.fv_eq_lid fv lid  in
-                        if uu____18464
+                        if uu____18873
                         then
                           FStar_Pervasives_Native.Some
                             ((lb.FStar_Syntax_Syntax.lbunivs),
                               (lb.FStar_Syntax_Syntax.lbdef))
                         else FStar_Pervasives_Native.None)
-               | uu____18499 -> FStar_Pervasives_Native.None)
-          | uu____18508 -> FStar_Pervasives_Native.None
+               | uu____18908 -> FStar_Pervasives_Native.None)
+          | uu____18917 -> FStar_Pervasives_Native.None
   
 let (lookup_definition_qninfo :
   delta_level Prims.list ->
@@ -3025,9 +3097,9 @@ let (lookup_definition :
   fun delta_levels  ->
     fun env  ->
       fun lid  ->
-        let uu____18570 = lookup_qname env lid  in
+        let uu____18979 = lookup_qname env lid  in
         FStar_All.pipe_left (lookup_definition_qninfo delta_levels lid)
-          uu____18570
+          uu____18979
   
 let (lookup_nonrec_definition :
   delta_level Prims.list ->
@@ -3039,9 +3111,9 @@ let (lookup_nonrec_definition :
   fun delta_levels  ->
     fun env  ->
       fun lid  ->
-        let uu____18603 = lookup_qname env lid  in
+        let uu____19012 = lookup_qname env lid  in
         FStar_All.pipe_left
-          (lookup_definition_qninfo_aux false delta_levels lid) uu____18603
+          (lookup_definition_qninfo_aux false delta_levels lid) uu____19012
   
 let (delta_depth_of_qninfo :
   FStar_Syntax_Syntax.fv ->
@@ -3058,60 +3130,60 @@ let (delta_depth_of_qninfo :
              FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_zero)
          | FStar_Pervasives_Native.Some
-             (FStar_Util.Inl uu____18655,uu____18656) ->
+             (FStar_Util.Inl uu____19064,uu____19065) ->
              FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_zero)
          | FStar_Pervasives_Native.Some
-             (FStar_Util.Inr (se,uu____18705),uu____18706) ->
+             (FStar_Util.Inr (se,uu____19114),uu____19115) ->
              (match se.FStar_Syntax_Syntax.sigel with
-              | FStar_Syntax_Syntax.Sig_inductive_typ uu____18755 ->
+              | FStar_Syntax_Syntax.Sig_inductive_typ uu____19164 ->
                   FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.Delta_constant_at_level
                        Prims.int_zero)
-              | FStar_Syntax_Syntax.Sig_bundle uu____18773 ->
+              | FStar_Syntax_Syntax.Sig_bundle uu____19182 ->
                   FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.Delta_constant_at_level
                        Prims.int_zero)
-              | FStar_Syntax_Syntax.Sig_datacon uu____18783 ->
+              | FStar_Syntax_Syntax.Sig_datacon uu____19192 ->
                   FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.Delta_constant_at_level
                        Prims.int_zero)
-              | FStar_Syntax_Syntax.Sig_declare_typ uu____18800 ->
-                  let uu____18807 =
+              | FStar_Syntax_Syntax.Sig_declare_typ uu____19209 ->
+                  let uu____19216 =
                     FStar_Syntax_DsEnv.delta_depth_of_declaration lid
                       se.FStar_Syntax_Syntax.sigquals
                      in
-                  FStar_Pervasives_Native.Some uu____18807
-              | FStar_Syntax_Syntax.Sig_let ((uu____18808,lbs),uu____18810)
+                  FStar_Pervasives_Native.Some uu____19216
+              | FStar_Syntax_Syntax.Sig_let ((uu____19217,lbs),uu____19219)
                   ->
                   FStar_Util.find_map lbs
                     (fun lb  ->
                        let fv1 =
                          FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
-                       let uu____18826 =
+                       let uu____19235 =
                          FStar_Syntax_Syntax.fv_eq_lid fv1 lid  in
-                       if uu____18826
+                       if uu____19235
                        then
                          FStar_Pervasives_Native.Some
                            (fv1.FStar_Syntax_Syntax.fv_delta)
                        else FStar_Pervasives_Native.None)
-              | FStar_Syntax_Syntax.Sig_splice uu____18833 ->
+              | FStar_Syntax_Syntax.Sig_splice uu____19242 ->
                   FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.Delta_constant_at_level
                        Prims.int_one)
-              | FStar_Syntax_Syntax.Sig_main uu____18841 ->
+              | FStar_Syntax_Syntax.Sig_main uu____19250 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_assume uu____18842 ->
+              | FStar_Syntax_Syntax.Sig_assume uu____19251 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_new_effect uu____18849 ->
+              | FStar_Syntax_Syntax.Sig_new_effect uu____19258 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____18850 ->
+              | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____19259 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_sub_effect uu____18851 ->
+              | FStar_Syntax_Syntax.Sig_sub_effect uu____19260 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_effect_abbrev uu____18852 ->
+              | FStar_Syntax_Syntax.Sig_effect_abbrev uu____19261 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_pragma uu____18865 ->
+              | FStar_Syntax_Syntax.Sig_pragma uu____19274 ->
                   FStar_Pervasives_Native.None))
   
 let (delta_depth_of_fv :
@@ -3122,50 +3194,50 @@ let (delta_depth_of_fv :
       if lid.FStar_Ident.nsstr = "Prims"
       then fv.FStar_Syntax_Syntax.fv_delta
       else
-        (let uu____18883 =
+        (let uu____19292 =
            FStar_All.pipe_right lid.FStar_Ident.str
              (FStar_Util.smap_try_find env.fv_delta_depths)
             in
-         FStar_All.pipe_right uu____18883
+         FStar_All.pipe_right uu____19292
            (fun d_opt  ->
-              let uu____18896 = FStar_All.pipe_right d_opt FStar_Util.is_some
+              let uu____19305 = FStar_All.pipe_right d_opt FStar_Util.is_some
                  in
-              if uu____18896
+              if uu____19305
               then FStar_All.pipe_right d_opt FStar_Util.must
               else
-                (let uu____18906 =
-                   let uu____18909 =
+                (let uu____19315 =
+                   let uu____19318 =
                      lookup_qname env
                        (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                       in
-                   delta_depth_of_qninfo fv uu____18909  in
-                 match uu____18906 with
+                   delta_depth_of_qninfo fv uu____19318  in
+                 match uu____19315 with
                  | FStar_Pervasives_Native.None  ->
-                     let uu____18910 =
-                       let uu____18912 = FStar_Syntax_Print.fv_to_string fv
+                     let uu____19319 =
+                       let uu____19321 = FStar_Syntax_Print.fv_to_string fv
                           in
                        FStar_Util.format1 "Delta depth not found for %s"
-                         uu____18912
+                         uu____19321
                         in
-                     failwith uu____18910
+                     failwith uu____19319
                  | FStar_Pervasives_Native.Some d ->
-                     ((let uu____18917 =
+                     ((let uu____19326 =
                          (d <> fv.FStar_Syntax_Syntax.fv_delta) &&
                            (FStar_Options.debug_any ())
                           in
-                       if uu____18917
+                       if uu____19326
                        then
-                         let uu____18920 = FStar_Syntax_Print.fv_to_string fv
+                         let uu____19329 = FStar_Syntax_Print.fv_to_string fv
                             in
-                         let uu____18922 =
+                         let uu____19331 =
                            FStar_Syntax_Print.delta_depth_to_string
                              fv.FStar_Syntax_Syntax.fv_delta
                             in
-                         let uu____18924 =
+                         let uu____19333 =
                            FStar_Syntax_Print.delta_depth_to_string d  in
                          FStar_Util.print3
                            "WARNING WARNING WARNING fv=%s, delta_depth=%s, env.delta_depth=%s\n"
-                           uu____18920 uu____18922 uu____18924
+                           uu____19329 uu____19331 uu____19333
                        else ());
                       FStar_Util.smap_add env.fv_delta_depths
                         lid.FStar_Ident.str d;
@@ -3178,9 +3250,9 @@ let (quals_of_qninfo :
   fun qninfo  ->
     match qninfo with
     | FStar_Pervasives_Native.Some
-        (FStar_Util.Inr (se,uu____18949),uu____18950) ->
+        (FStar_Util.Inr (se,uu____19358),uu____19359) ->
         FStar_Pervasives_Native.Some (se.FStar_Syntax_Syntax.sigquals)
-    | uu____18999 -> FStar_Pervasives_Native.None
+    | uu____19408 -> FStar_Pervasives_Native.None
   
 let (attrs_of_qninfo :
   qninfo ->
@@ -3189,9 +3261,9 @@ let (attrs_of_qninfo :
   fun qninfo  ->
     match qninfo with
     | FStar_Pervasives_Native.Some
-        (FStar_Util.Inr (se,uu____19021),uu____19022) ->
+        (FStar_Util.Inr (se,uu____19430),uu____19431) ->
         FStar_Pervasives_Native.Some (se.FStar_Syntax_Syntax.sigattrs)
-    | uu____19071 -> FStar_Pervasives_Native.None
+    | uu____19480 -> FStar_Pervasives_Native.None
   
 let (lookup_attrs_of_lid :
   env ->
@@ -3200,29 +3272,40 @@ let (lookup_attrs_of_lid :
   =
   fun env  ->
     fun lid  ->
-      let uu____19093 = lookup_qname env lid  in
-      FStar_All.pipe_left attrs_of_qninfo uu____19093
+      let uu____19502 = lookup_qname env lid  in
+      FStar_All.pipe_left attrs_of_qninfo uu____19502
+  
+let (fv_exists_and_has_attr :
+  env -> FStar_Ident.lid -> FStar_Ident.lident -> (Prims.bool * Prims.bool))
+  =
+  fun env  ->
+    fun fv_lid1  ->
+      fun attr_lid  ->
+        let uu____19535 = lookup_attrs_of_lid env fv_lid1  in
+        match uu____19535 with
+        | FStar_Pervasives_Native.None  -> (false, false)
+        | FStar_Pervasives_Native.Some attrs ->
+            let uu____19557 =
+              FStar_All.pipe_right attrs
+                (FStar_Util.for_some
+                   (fun tm  ->
+                      let uu____19566 =
+                        let uu____19567 = FStar_Syntax_Util.un_uinst tm  in
+                        uu____19567.FStar_Syntax_Syntax.n  in
+                      match uu____19566 with
+                      | FStar_Syntax_Syntax.Tm_fvar fv ->
+                          FStar_Syntax_Syntax.fv_eq_lid fv attr_lid
+                      | uu____19572 -> false))
+               in
+            (true, uu____19557)
   
 let (fv_with_lid_has_attr :
   env -> FStar_Ident.lid -> FStar_Ident.lid -> Prims.bool) =
   fun env  ->
     fun fv_lid1  ->
       fun attr_lid  ->
-        let uu____19116 = lookup_attrs_of_lid env fv_lid1  in
-        match uu____19116 with
-        | FStar_Pervasives_Native.None  -> false
-        | FStar_Pervasives_Native.Some [] -> false
-        | FStar_Pervasives_Native.Some attrs ->
-            FStar_All.pipe_right attrs
-              (FStar_Util.for_some
-                 (fun tm  ->
-                    let uu____19140 =
-                      let uu____19141 = FStar_Syntax_Util.un_uinst tm  in
-                      uu____19141.FStar_Syntax_Syntax.n  in
-                    match uu____19140 with
-                    | FStar_Syntax_Syntax.Tm_fvar fv ->
-                        FStar_Syntax_Syntax.fv_eq_lid fv attr_lid
-                    | uu____19146 -> false))
+        let uu____19595 = fv_exists_and_has_attr env fv_lid1 attr_lid  in
+        FStar_Pervasives_Native.snd uu____19595
   
 let (fv_has_attr :
   env -> FStar_Syntax_Syntax.fv -> FStar_Ident.lid -> Prims.bool) =
@@ -3232,6 +3315,76 @@ let (fv_has_attr :
         fv_with_lid_has_attr env
           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v attr_lid
   
+let cache_in_fv_tab :
+  'a .
+    'a FStar_Util.smap ->
+      FStar_Syntax_Syntax.fv -> (unit -> (Prims.bool * 'a)) -> 'a
+  =
+  fun tab  ->
+    fun fv  ->
+      fun f  ->
+        let s =
+          let uu____19667 = FStar_Syntax_Syntax.lid_of_fv fv  in
+          uu____19667.FStar_Ident.str  in
+        let uu____19668 = FStar_Util.smap_try_find tab s  in
+        match uu____19668 with
+        | FStar_Pervasives_Native.None  ->
+            let uu____19671 = f ()  in
+            (match uu____19671 with
+             | (should_cache,res) ->
+                 (if should_cache then FStar_Util.smap_add tab s res else ();
+                  res))
+        | FStar_Pervasives_Native.Some r -> r
+  
+let (type_is_erasable : env -> FStar_Syntax_Syntax.fv -> Prims.bool) =
+  fun env  ->
+    fun fv  ->
+      let f uu____19709 =
+        let uu____19710 =
+          fv_exists_and_has_attr env
+            (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+            FStar_Parser_Const.erasable_attr
+           in
+        match uu____19710 with
+        | (ex,erasable1) ->
+            let uu____19729 =
+              fv_exists_and_has_attr env
+                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                FStar_Parser_Const.must_erase_for_extraction_attr
+               in
+            (match uu____19729 with
+             | (ex',must_erase_for_extraction_attr1) ->
+                 ((ex || ex'),
+                   (erasable1 || must_erase_for_extraction_attr1)))
+         in
+      cache_in_fv_tab env.erasable_types_tab fv f
+  
+let rec (non_informative : env -> FStar_Syntax_Syntax.typ -> Prims.bool) =
+  fun env  ->
+    fun t  ->
+      let uu____19763 =
+        let uu____19764 = FStar_Syntax_Util.unrefine t  in
+        uu____19764.FStar_Syntax_Syntax.n  in
+      match uu____19763 with
+      | FStar_Syntax_Syntax.Tm_type uu____19768 -> true
+      | FStar_Syntax_Syntax.Tm_fvar fv ->
+          (((FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.unit_lid) ||
+              (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid))
+             ||
+             (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.erased_lid))
+            || (type_is_erasable env fv)
+      | FStar_Syntax_Syntax.Tm_app (head1,uu____19772) ->
+          non_informative env head1
+      | FStar_Syntax_Syntax.Tm_uinst (t1,uu____19798) ->
+          non_informative env t1
+      | FStar_Syntax_Syntax.Tm_arrow (uu____19803,c) ->
+          ((FStar_Syntax_Util.is_pure_or_ghost_comp c) &&
+             (non_informative env (FStar_Syntax_Util.comp_result c)))
+            ||
+            (FStar_Syntax_Util.is_ghost_effect
+               (FStar_Syntax_Util.comp_effect_name c))
+      | uu____19825 -> false
+  
 let (fv_has_strict_args :
   env ->
     FStar_Syntax_Syntax.fv ->
@@ -3239,29 +3392,26 @@ let (fv_has_strict_args :
   =
   fun env  ->
     fun fv  ->
-      let s =
-        let uu____19183 = FStar_Syntax_Syntax.lid_of_fv fv  in
-        uu____19183.FStar_Ident.str  in
-      let uu____19184 = FStar_Util.smap_try_find env.strict_args_tab s  in
-      match uu____19184 with
-      | FStar_Pervasives_Native.None  ->
-          let attrs =
-            let uu____19212 = FStar_Syntax_Syntax.lid_of_fv fv  in
-            lookup_attrs_of_lid env uu____19212  in
-          (match attrs with
-           | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-           | FStar_Pervasives_Native.Some attrs1 ->
-               let res =
-                 FStar_Util.find_map attrs1
-                   (fun x  ->
-                      let uu____19240 =
-                        FStar_ToSyntax_ToSyntax.parse_attr_with_list false x
-                          FStar_Parser_Const.strict_on_arguments_attr
-                         in
-                      FStar_Pervasives_Native.fst uu____19240)
-                  in
-               (FStar_Util.smap_add env.strict_args_tab s res; res))
-      | FStar_Pervasives_Native.Some l -> l
+      let f uu____19858 =
+        let attrs =
+          let uu____19864 = FStar_Syntax_Syntax.lid_of_fv fv  in
+          lookup_attrs_of_lid env uu____19864  in
+        match attrs with
+        | FStar_Pervasives_Native.None  ->
+            (false, FStar_Pervasives_Native.None)
+        | FStar_Pervasives_Native.Some attrs1 ->
+            let res =
+              FStar_Util.find_map attrs1
+                (fun x  ->
+                   let uu____19904 =
+                     FStar_ToSyntax_ToSyntax.parse_attr_with_list false x
+                       FStar_Parser_Const.strict_on_arguments_attr
+                      in
+                   FStar_Pervasives_Native.fst uu____19904)
+               in
+            (true, res)
+         in
+      cache_in_fv_tab env.strict_args_tab fv f
   
 let (try_lookup_effect_lid :
   env ->
@@ -3270,31 +3420,31 @@ let (try_lookup_effect_lid :
   =
   fun env  ->
     fun ftv  ->
-      let uu____19290 = lookup_qname env ftv  in
-      match uu____19290 with
+      let uu____19949 = lookup_qname env ftv  in
+      match uu____19949 with
       | FStar_Pervasives_Native.Some
-          (FStar_Util.Inr (se,FStar_Pervasives_Native.None ),uu____19294) ->
-          let uu____19339 =
+          (FStar_Util.Inr (se,FStar_Pervasives_Native.None ),uu____19953) ->
+          let uu____19998 =
             effect_signature FStar_Pervasives_Native.None se env.range  in
-          (match uu____19339 with
+          (match uu____19998 with
            | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-           | FStar_Pervasives_Native.Some ((uu____19360,t),r) ->
-               let uu____19375 =
-                 let uu____19376 = FStar_Ident.range_of_lid ftv  in
-                 FStar_Syntax_Subst.set_use_range uu____19376 t  in
-               FStar_Pervasives_Native.Some uu____19375)
-      | uu____19377 -> FStar_Pervasives_Native.None
+           | FStar_Pervasives_Native.Some ((uu____20019,t),r) ->
+               let uu____20034 =
+                 let uu____20035 = FStar_Ident.range_of_lid ftv  in
+                 FStar_Syntax_Subst.set_use_range uu____20035 t  in
+               FStar_Pervasives_Native.Some uu____20034)
+      | uu____20036 -> FStar_Pervasives_Native.None
   
 let (lookup_effect_lid :
   env -> FStar_Ident.lident -> FStar_Syntax_Syntax.term) =
   fun env  ->
     fun ftv  ->
-      let uu____19389 = try_lookup_effect_lid env ftv  in
-      match uu____19389 with
+      let uu____20048 = try_lookup_effect_lid env ftv  in
+      match uu____20048 with
       | FStar_Pervasives_Native.None  ->
-          let uu____19392 = name_not_found ftv  in
-          let uu____19398 = FStar_Ident.range_of_lid ftv  in
-          FStar_Errors.raise_error uu____19392 uu____19398
+          let uu____20051 = name_not_found ftv  in
+          let uu____20057 = FStar_Ident.range_of_lid ftv  in
+          FStar_Errors.raise_error uu____20051 uu____20057
       | FStar_Pervasives_Native.Some k -> k
   
 let (lookup_effect_abbrev :
@@ -3307,37 +3457,37 @@ let (lookup_effect_abbrev :
   fun env  ->
     fun univ_insts  ->
       fun lid0  ->
-        let uu____19422 = lookup_qname env lid0  in
-        match uu____19422 with
+        let uu____20081 = lookup_qname env lid0  in
+        match uu____20081 with
         | FStar_Pervasives_Native.Some
             (FStar_Util.Inr
              ({
                 FStar_Syntax_Syntax.sigel =
                   FStar_Syntax_Syntax.Sig_effect_abbrev
-                  (lid,univs1,binders,c,uu____19433);
-                FStar_Syntax_Syntax.sigrng = uu____19434;
+                  (lid,univs1,binders,c,uu____20092);
+                FStar_Syntax_Syntax.sigrng = uu____20093;
                 FStar_Syntax_Syntax.sigquals = quals;
-                FStar_Syntax_Syntax.sigmeta = uu____19436;
-                FStar_Syntax_Syntax.sigattrs = uu____19437;_},FStar_Pervasives_Native.None
-              ),uu____19438)
+                FStar_Syntax_Syntax.sigmeta = uu____20095;
+                FStar_Syntax_Syntax.sigattrs = uu____20096;_},FStar_Pervasives_Native.None
+              ),uu____20097)
             ->
             let lid1 =
-              let uu____19492 =
-                let uu____19493 = FStar_Ident.range_of_lid lid  in
-                let uu____19494 =
-                  let uu____19495 = FStar_Ident.range_of_lid lid0  in
-                  FStar_Range.use_range uu____19495  in
-                FStar_Range.set_use_range uu____19493 uu____19494  in
-              FStar_Ident.set_lid_range lid uu____19492  in
-            let uu____19496 =
+              let uu____20151 =
+                let uu____20152 = FStar_Ident.range_of_lid lid  in
+                let uu____20153 =
+                  let uu____20154 = FStar_Ident.range_of_lid lid0  in
+                  FStar_Range.use_range uu____20154  in
+                FStar_Range.set_use_range uu____20152 uu____20153  in
+              FStar_Ident.set_lid_range lid uu____20151  in
+            let uu____20155 =
               FStar_All.pipe_right quals
                 (FStar_Util.for_some
-                   (fun uu___6_19502  ->
-                      match uu___6_19502 with
+                   (fun uu___6_20161  ->
+                      match uu___6_20161 with
                       | FStar_Syntax_Syntax.Irreducible  -> true
-                      | uu____19505 -> false))
+                      | uu____20164 -> false))
                in
-            if uu____19496
+            if uu____20155
             then FStar_Pervasives_Native.None
             else
               (let insts =
@@ -3346,212 +3496,212 @@ let (lookup_effect_abbrev :
                      (FStar_List.length univs1)
                  then univ_insts
                  else
-                   (let uu____19524 =
-                      let uu____19526 =
-                        let uu____19528 = get_range env  in
-                        FStar_Range.string_of_range uu____19528  in
-                      let uu____19529 = FStar_Syntax_Print.lid_to_string lid1
+                   (let uu____20183 =
+                      let uu____20185 =
+                        let uu____20187 = get_range env  in
+                        FStar_Range.string_of_range uu____20187  in
+                      let uu____20188 = FStar_Syntax_Print.lid_to_string lid1
                          in
-                      let uu____19531 =
+                      let uu____20190 =
                         FStar_All.pipe_right (FStar_List.length univ_insts)
                           FStar_Util.string_of_int
                          in
                       FStar_Util.format3
                         "(%s) Unexpected instantiation of effect %s with %s universes"
-                        uu____19526 uu____19529 uu____19531
+                        uu____20185 uu____20188 uu____20190
                        in
-                    failwith uu____19524)
+                    failwith uu____20183)
                   in
                match (binders, univs1) with
-               | ([],uu____19552) ->
+               | ([],uu____20211) ->
                    failwith
                      "Unexpected effect abbreviation with no arguments"
-               | (uu____19578,uu____19579::uu____19580::uu____19581) ->
-                   let uu____19602 =
-                     let uu____19604 = FStar_Syntax_Print.lid_to_string lid1
+               | (uu____20237,uu____20238::uu____20239::uu____20240) ->
+                   let uu____20261 =
+                     let uu____20263 = FStar_Syntax_Print.lid_to_string lid1
                         in
-                     let uu____19606 =
+                     let uu____20265 =
                        FStar_All.pipe_left FStar_Util.string_of_int
                          (FStar_List.length univs1)
                         in
                      FStar_Util.format2
                        "Unexpected effect abbreviation %s; polymorphic in %s universes"
-                       uu____19604 uu____19606
+                       uu____20263 uu____20265
                       in
-                   failwith uu____19602
-               | uu____19617 ->
-                   let uu____19632 =
-                     let uu____19637 =
-                       let uu____19638 = FStar_Syntax_Util.arrow binders c
+                   failwith uu____20261
+               | uu____20276 ->
+                   let uu____20291 =
+                     let uu____20296 =
+                       let uu____20297 = FStar_Syntax_Util.arrow binders c
                           in
-                       (univs1, uu____19638)  in
-                     inst_tscheme_with uu____19637 insts  in
-                   (match uu____19632 with
-                    | (uu____19651,t) ->
+                       (univs1, uu____20297)  in
+                     inst_tscheme_with uu____20296 insts  in
+                   (match uu____20291 with
+                    | (uu____20310,t) ->
                         let t1 =
-                          let uu____19654 = FStar_Ident.range_of_lid lid1  in
-                          FStar_Syntax_Subst.set_use_range uu____19654 t  in
-                        let uu____19655 =
-                          let uu____19656 = FStar_Syntax_Subst.compress t1
+                          let uu____20313 = FStar_Ident.range_of_lid lid1  in
+                          FStar_Syntax_Subst.set_use_range uu____20313 t  in
+                        let uu____20314 =
+                          let uu____20315 = FStar_Syntax_Subst.compress t1
                              in
-                          uu____19656.FStar_Syntax_Syntax.n  in
-                        (match uu____19655 with
+                          uu____20315.FStar_Syntax_Syntax.n  in
+                        (match uu____20314 with
                          | FStar_Syntax_Syntax.Tm_arrow (binders1,c1) ->
                              FStar_Pervasives_Native.Some (binders1, c1)
-                         | uu____19691 -> failwith "Impossible")))
-        | uu____19699 -> FStar_Pervasives_Native.None
+                         | uu____20350 -> failwith "Impossible")))
+        | uu____20358 -> FStar_Pervasives_Native.None
   
 let (norm_eff_name : env -> FStar_Ident.lident -> FStar_Ident.lident) =
   fun env  ->
     fun l  ->
       let rec find1 l1 =
-        let uu____19723 =
+        let uu____20382 =
           lookup_effect_abbrev env [FStar_Syntax_Syntax.U_unknown] l1  in
-        match uu____19723 with
+        match uu____20382 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-        | FStar_Pervasives_Native.Some (uu____19736,c) ->
+        | FStar_Pervasives_Native.Some (uu____20395,c) ->
             let l2 = FStar_Syntax_Util.comp_effect_name c  in
-            let uu____19743 = find1 l2  in
-            (match uu____19743 with
+            let uu____20402 = find1 l2  in
+            (match uu____20402 with
              | FStar_Pervasives_Native.None  ->
                  FStar_Pervasives_Native.Some l2
              | FStar_Pervasives_Native.Some l' ->
                  FStar_Pervasives_Native.Some l')
          in
       let res =
-        let uu____19750 =
+        let uu____20409 =
           FStar_Util.smap_try_find env.normalized_eff_names l.FStar_Ident.str
            in
-        match uu____19750 with
+        match uu____20409 with
         | FStar_Pervasives_Native.Some l1 -> l1
         | FStar_Pervasives_Native.None  ->
-            let uu____19754 = find1 l  in
-            (match uu____19754 with
+            let uu____20413 = find1 l  in
+            (match uu____20413 with
              | FStar_Pervasives_Native.None  -> l
              | FStar_Pervasives_Native.Some m ->
                  (FStar_Util.smap_add env.normalized_eff_names
                     l.FStar_Ident.str m;
                   m))
          in
-      let uu____19759 = FStar_Ident.range_of_lid l  in
-      FStar_Ident.set_lid_range res uu____19759
+      let uu____20418 = FStar_Ident.range_of_lid l  in
+      FStar_Ident.set_lid_range res uu____20418
   
 let (lookup_effect_quals :
   env -> FStar_Ident.lident -> FStar_Syntax_Syntax.qualifier Prims.list) =
   fun env  ->
     fun l  ->
       let l1 = norm_eff_name env l  in
-      let uu____19774 = lookup_qname env l1  in
-      match uu____19774 with
+      let uu____20433 = lookup_qname env l1  in
+      match uu____20433 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_new_effect
-                uu____19777;
-              FStar_Syntax_Syntax.sigrng = uu____19778;
+                uu____20436;
+              FStar_Syntax_Syntax.sigrng = uu____20437;
               FStar_Syntax_Syntax.sigquals = q;
-              FStar_Syntax_Syntax.sigmeta = uu____19780;
-              FStar_Syntax_Syntax.sigattrs = uu____19781;_},uu____19782),uu____19783)
+              FStar_Syntax_Syntax.sigmeta = uu____20439;
+              FStar_Syntax_Syntax.sigattrs = uu____20440;_},uu____20441),uu____20442)
           -> q
-      | uu____19834 -> []
+      | uu____20493 -> []
   
 let (lookup_projector :
   env -> FStar_Ident.lident -> Prims.int -> FStar_Ident.lident) =
   fun env  ->
     fun lid  ->
       fun i  ->
-        let fail1 uu____19858 =
-          let uu____19859 =
-            let uu____19861 = FStar_Util.string_of_int i  in
-            let uu____19863 = FStar_Syntax_Print.lid_to_string lid  in
+        let fail1 uu____20517 =
+          let uu____20518 =
+            let uu____20520 = FStar_Util.string_of_int i  in
+            let uu____20522 = FStar_Syntax_Print.lid_to_string lid  in
             FStar_Util.format2
               "Impossible: projecting field #%s from constructor %s is undefined"
-              uu____19861 uu____19863
+              uu____20520 uu____20522
              in
-          failwith uu____19859  in
-        let uu____19866 = lookup_datacon env lid  in
-        match uu____19866 with
-        | (uu____19871,t) ->
-            let uu____19873 =
-              let uu____19874 = FStar_Syntax_Subst.compress t  in
-              uu____19874.FStar_Syntax_Syntax.n  in
-            (match uu____19873 with
-             | FStar_Syntax_Syntax.Tm_arrow (binders,uu____19878) ->
+          failwith uu____20518  in
+        let uu____20525 = lookup_datacon env lid  in
+        match uu____20525 with
+        | (uu____20530,t) ->
+            let uu____20532 =
+              let uu____20533 = FStar_Syntax_Subst.compress t  in
+              uu____20533.FStar_Syntax_Syntax.n  in
+            (match uu____20532 with
+             | FStar_Syntax_Syntax.Tm_arrow (binders,uu____20537) ->
                  if
                    (i < Prims.int_zero) || (i >= (FStar_List.length binders))
                  then fail1 ()
                  else
                    (let b = FStar_List.nth binders i  in
-                    let uu____19922 =
+                    let uu____20581 =
                       FStar_Syntax_Util.mk_field_projector_name lid
                         (FStar_Pervasives_Native.fst b) i
                        in
-                    FStar_All.pipe_right uu____19922
+                    FStar_All.pipe_right uu____20581
                       FStar_Pervasives_Native.fst)
-             | uu____19933 -> fail1 ())
+             | uu____20592 -> fail1 ())
   
 let (is_projector : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun l  ->
-      let uu____19947 = lookup_qname env l  in
-      match uu____19947 with
+      let uu____20606 = lookup_qname env l  in
+      match uu____20606 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ
-                (uu____19949,uu____19950,uu____19951);
-              FStar_Syntax_Syntax.sigrng = uu____19952;
+                (uu____20608,uu____20609,uu____20610);
+              FStar_Syntax_Syntax.sigrng = uu____20611;
               FStar_Syntax_Syntax.sigquals = quals;
-              FStar_Syntax_Syntax.sigmeta = uu____19954;
-              FStar_Syntax_Syntax.sigattrs = uu____19955;_},uu____19956),uu____19957)
+              FStar_Syntax_Syntax.sigmeta = uu____20613;
+              FStar_Syntax_Syntax.sigattrs = uu____20614;_},uu____20615),uu____20616)
           ->
           FStar_Util.for_some
-            (fun uu___7_20010  ->
-               match uu___7_20010 with
-               | FStar_Syntax_Syntax.Projector uu____20012 -> true
-               | uu____20018 -> false) quals
-      | uu____20020 -> false
+            (fun uu___7_20669  ->
+               match uu___7_20669 with
+               | FStar_Syntax_Syntax.Projector uu____20671 -> true
+               | uu____20677 -> false) quals
+      | uu____20679 -> false
   
 let (is_datacon : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun lid  ->
-      let uu____20034 = lookup_qname env lid  in
-      match uu____20034 with
+      let uu____20693 = lookup_qname env lid  in
+      match uu____20693 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-                (uu____20036,uu____20037,uu____20038,uu____20039,uu____20040,uu____20041);
-              FStar_Syntax_Syntax.sigrng = uu____20042;
-              FStar_Syntax_Syntax.sigquals = uu____20043;
-              FStar_Syntax_Syntax.sigmeta = uu____20044;
-              FStar_Syntax_Syntax.sigattrs = uu____20045;_},uu____20046),uu____20047)
+                (uu____20695,uu____20696,uu____20697,uu____20698,uu____20699,uu____20700);
+              FStar_Syntax_Syntax.sigrng = uu____20701;
+              FStar_Syntax_Syntax.sigquals = uu____20702;
+              FStar_Syntax_Syntax.sigmeta = uu____20703;
+              FStar_Syntax_Syntax.sigattrs = uu____20704;_},uu____20705),uu____20706)
           -> true
-      | uu____20105 -> false
+      | uu____20764 -> false
   
 let (is_record : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun lid  ->
-      let uu____20119 = lookup_qname env lid  in
-      match uu____20119 with
+      let uu____20778 = lookup_qname env lid  in
+      match uu____20778 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel =
                 FStar_Syntax_Syntax.Sig_inductive_typ
-                (uu____20121,uu____20122,uu____20123,uu____20124,uu____20125,uu____20126);
-              FStar_Syntax_Syntax.sigrng = uu____20127;
+                (uu____20780,uu____20781,uu____20782,uu____20783,uu____20784,uu____20785);
+              FStar_Syntax_Syntax.sigrng = uu____20786;
               FStar_Syntax_Syntax.sigquals = quals;
-              FStar_Syntax_Syntax.sigmeta = uu____20129;
-              FStar_Syntax_Syntax.sigattrs = uu____20130;_},uu____20131),uu____20132)
+              FStar_Syntax_Syntax.sigmeta = uu____20788;
+              FStar_Syntax_Syntax.sigattrs = uu____20789;_},uu____20790),uu____20791)
           ->
           FStar_Util.for_some
-            (fun uu___8_20193  ->
-               match uu___8_20193 with
-               | FStar_Syntax_Syntax.RecordType uu____20195 -> true
-               | FStar_Syntax_Syntax.RecordConstructor uu____20205 -> true
-               | uu____20215 -> false) quals
-      | uu____20217 -> false
+            (fun uu___8_20852  ->
+               match uu___8_20852 with
+               | FStar_Syntax_Syntax.RecordType uu____20854 -> true
+               | FStar_Syntax_Syntax.RecordConstructor uu____20864 -> true
+               | uu____20874 -> false) quals
+      | uu____20876 -> false
   
 let (qninfo_is_action : qninfo -> Prims.bool) =
   fun qninfo  ->
@@ -3560,24 +3710,24 @@ let (qninfo_is_action : qninfo -> Prims.bool) =
         (FStar_Util.Inr
          ({
             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
-              (uu____20227,uu____20228);
-            FStar_Syntax_Syntax.sigrng = uu____20229;
+              (uu____20886,uu____20887);
+            FStar_Syntax_Syntax.sigrng = uu____20888;
             FStar_Syntax_Syntax.sigquals = quals;
-            FStar_Syntax_Syntax.sigmeta = uu____20231;
-            FStar_Syntax_Syntax.sigattrs = uu____20232;_},uu____20233),uu____20234)
+            FStar_Syntax_Syntax.sigmeta = uu____20890;
+            FStar_Syntax_Syntax.sigattrs = uu____20891;_},uu____20892),uu____20893)
         ->
         FStar_Util.for_some
-          (fun uu___9_20291  ->
-             match uu___9_20291 with
-             | FStar_Syntax_Syntax.Action uu____20293 -> true
-             | uu____20295 -> false) quals
-    | uu____20297 -> false
+          (fun uu___9_20950  ->
+             match uu___9_20950 with
+             | FStar_Syntax_Syntax.Action uu____20952 -> true
+             | uu____20954 -> false) quals
+    | uu____20956 -> false
   
 let (is_action : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun lid  ->
-      let uu____20311 = lookup_qname env lid  in
-      FStar_All.pipe_left qninfo_is_action uu____20311
+      let uu____20970 = lookup_qname env lid  in
+      FStar_All.pipe_left qninfo_is_action uu____20970
   
 let (is_interpreted : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   let interpreted_symbols =
@@ -3598,51 +3748,51 @@ let (is_interpreted : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
     FStar_Parser_Const.op_Negation]  in
   fun env  ->
     fun head1  ->
-      let uu____20328 =
-        let uu____20329 = FStar_Syntax_Util.un_uinst head1  in
-        uu____20329.FStar_Syntax_Syntax.n  in
-      match uu____20328 with
+      let uu____20987 =
+        let uu____20988 = FStar_Syntax_Util.un_uinst head1  in
+        uu____20988.FStar_Syntax_Syntax.n  in
+      match uu____20987 with
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           (match fv.FStar_Syntax_Syntax.fv_delta with
-           | FStar_Syntax_Syntax.Delta_equational_at_level uu____20335 ->
+           | FStar_Syntax_Syntax.Delta_equational_at_level uu____20994 ->
                true
-           | uu____20338 -> false)
-      | uu____20340 -> false
+           | uu____20997 -> false)
+      | uu____20999 -> false
   
 let (is_irreducible : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun l  ->
-      let uu____20354 = lookup_qname env l  in
-      match uu____20354 with
+      let uu____21013 = lookup_qname env l  in
+      match uu____21013 with
       | FStar_Pervasives_Native.Some
-          (FStar_Util.Inr (se,uu____20357),uu____20358) ->
+          (FStar_Util.Inr (se,uu____21016),uu____21017) ->
           FStar_Util.for_some
-            (fun uu___10_20406  ->
-               match uu___10_20406 with
+            (fun uu___10_21065  ->
+               match uu___10_21065 with
                | FStar_Syntax_Syntax.Irreducible  -> true
-               | uu____20409 -> false) se.FStar_Syntax_Syntax.sigquals
-      | uu____20411 -> false
+               | uu____21068 -> false) se.FStar_Syntax_Syntax.sigquals
+      | uu____21070 -> false
   
 let (is_type_constructor : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun lid  ->
       let mapper x =
         match FStar_Pervasives_Native.fst x with
-        | FStar_Util.Inl uu____20487 -> FStar_Pervasives_Native.Some false
-        | FStar_Util.Inr (se,uu____20505) ->
+        | FStar_Util.Inl uu____21146 -> FStar_Pervasives_Native.Some false
+        | FStar_Util.Inr (se,uu____21164) ->
             (match se.FStar_Syntax_Syntax.sigel with
-             | FStar_Syntax_Syntax.Sig_declare_typ uu____20523 ->
+             | FStar_Syntax_Syntax.Sig_declare_typ uu____21182 ->
                  FStar_Pervasives_Native.Some
                    (FStar_List.contains FStar_Syntax_Syntax.New
                       se.FStar_Syntax_Syntax.sigquals)
-             | FStar_Syntax_Syntax.Sig_inductive_typ uu____20531 ->
+             | FStar_Syntax_Syntax.Sig_inductive_typ uu____21190 ->
                  FStar_Pervasives_Native.Some true
-             | uu____20550 -> FStar_Pervasives_Native.Some false)
+             | uu____21209 -> FStar_Pervasives_Native.Some false)
          in
-      let uu____20553 =
-        let uu____20557 = lookup_qname env lid  in
-        FStar_Util.bind_opt uu____20557 mapper  in
-      match uu____20553 with
+      let uu____21212 =
+        let uu____21216 = lookup_qname env lid  in
+        FStar_Util.bind_opt uu____21216 mapper  in
+      match uu____21212 with
       | FStar_Pervasives_Native.Some b -> b
       | FStar_Pervasives_Native.None  -> false
   
@@ -3650,20 +3800,20 @@ let (num_inductive_ty_params :
   env -> FStar_Ident.lident -> Prims.int FStar_Pervasives_Native.option) =
   fun env  ->
     fun lid  ->
-      let uu____20617 = lookup_qname env lid  in
-      match uu____20617 with
+      let uu____21276 = lookup_qname env lid  in
+      match uu____21276 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel =
                 FStar_Syntax_Syntax.Sig_inductive_typ
-                (uu____20621,uu____20622,tps,uu____20624,uu____20625,uu____20626);
-              FStar_Syntax_Syntax.sigrng = uu____20627;
-              FStar_Syntax_Syntax.sigquals = uu____20628;
-              FStar_Syntax_Syntax.sigmeta = uu____20629;
-              FStar_Syntax_Syntax.sigattrs = uu____20630;_},uu____20631),uu____20632)
+                (uu____21280,uu____21281,tps,uu____21283,uu____21284,uu____21285);
+              FStar_Syntax_Syntax.sigrng = uu____21286;
+              FStar_Syntax_Syntax.sigquals = uu____21287;
+              FStar_Syntax_Syntax.sigmeta = uu____21288;
+              FStar_Syntax_Syntax.sigattrs = uu____21289;_},uu____21290),uu____21291)
           -> FStar_Pervasives_Native.Some (FStar_List.length tps)
-      | uu____20698 -> FStar_Pervasives_Native.None
+      | uu____21357 -> FStar_Pervasives_Native.None
   
 let (effect_decl_opt :
   env ->
@@ -3675,29 +3825,29 @@ let (effect_decl_opt :
     fun l  ->
       FStar_All.pipe_right (env.effects).decls
         (FStar_Util.find_opt
-           (fun uu____20744  ->
-              match uu____20744 with
-              | (d,uu____20753) ->
+           (fun uu____21403  ->
+              match uu____21403 with
+              | (d,uu____21412) ->
                   FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname l))
   
 let (get_effect_decl :
   env -> FStar_Ident.lident -> FStar_Syntax_Syntax.eff_decl) =
   fun env  ->
     fun l  ->
-      let uu____20769 = effect_decl_opt env l  in
-      match uu____20769 with
+      let uu____21428 = effect_decl_opt env l  in
+      match uu____21428 with
       | FStar_Pervasives_Native.None  ->
-          let uu____20784 = name_not_found l  in
-          let uu____20790 = FStar_Ident.range_of_lid l  in
-          FStar_Errors.raise_error uu____20784 uu____20790
+          let uu____21443 = name_not_found l  in
+          let uu____21449 = FStar_Ident.range_of_lid l  in
+          FStar_Errors.raise_error uu____21443 uu____21449
       | FStar_Pervasives_Native.Some md -> FStar_Pervasives_Native.fst md
   
 let (identity_mlift : mlift) =
   {
-    mlift_wp = (fun uu____20813  -> fun t  -> fun wp  -> wp);
+    mlift_wp = (fun uu____21472  -> fun t  -> fun wp  -> wp);
     mlift_term =
       (FStar_Pervasives_Native.Some
-         (fun uu____20832  ->
+         (fun uu____21491  ->
             fun t  -> fun wp  -> fun e  -> FStar_Util.return_all e))
   } 
 let (join :
@@ -3708,11 +3858,11 @@ let (join :
   fun env  ->
     fun l1  ->
       fun l2  ->
-        let uu____20864 = FStar_Ident.lid_equals l1 l2  in
-        if uu____20864
+        let uu____21523 = FStar_Ident.lid_equals l1 l2  in
+        if uu____21523
         then (l1, identity_mlift, identity_mlift)
         else
-          (let uu____20875 =
+          (let uu____21534 =
              ((FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_GTot_lid)
                 &&
                 (FStar_Ident.lid_equals l2 FStar_Parser_Const.effect_Tot_lid))
@@ -3722,37 +3872,37 @@ let (join :
                   (FStar_Ident.lid_equals l1
                      FStar_Parser_Const.effect_Tot_lid))
               in
-           if uu____20875
+           if uu____21534
            then
              (FStar_Parser_Const.effect_GTot_lid, identity_mlift,
                identity_mlift)
            else
-             (let uu____20886 =
+             (let uu____21545 =
                 FStar_All.pipe_right (env.effects).joins
                   (FStar_Util.find_opt
-                     (fun uu____20939  ->
-                        match uu____20939 with
-                        | (m1,m2,uu____20953,uu____20954,uu____20955) ->
+                     (fun uu____21598  ->
+                        match uu____21598 with
+                        | (m1,m2,uu____21612,uu____21613,uu____21614) ->
                             (FStar_Ident.lid_equals l1 m1) &&
                               (FStar_Ident.lid_equals l2 m2)))
                  in
-              match uu____20886 with
+              match uu____21545 with
               | FStar_Pervasives_Native.None  ->
-                  let uu____20972 =
-                    let uu____20978 =
-                      let uu____20980 = FStar_Syntax_Print.lid_to_string l1
+                  let uu____21631 =
+                    let uu____21637 =
+                      let uu____21639 = FStar_Syntax_Print.lid_to_string l1
                          in
-                      let uu____20982 = FStar_Syntax_Print.lid_to_string l2
+                      let uu____21641 = FStar_Syntax_Print.lid_to_string l2
                          in
                       FStar_Util.format2
-                        "Effects %s and %s cannot be composed" uu____20980
-                        uu____20982
+                        "Effects %s and %s cannot be composed" uu____21639
+                        uu____21641
                        in
-                    (FStar_Errors.Fatal_EffectsCannotBeComposed, uu____20978)
+                    (FStar_Errors.Fatal_EffectsCannotBeComposed, uu____21637)
                      in
-                  FStar_Errors.raise_error uu____20972 env.range
+                  FStar_Errors.raise_error uu____21631 env.range
               | FStar_Pervasives_Native.Some
-                  (uu____20992,uu____20993,m3,j1,j2) -> (m3, j1, j2)))
+                  (uu____21651,uu____21652,m3,j1,j2) -> (m3, j1, j2)))
   
 let (monad_leq :
   env ->
@@ -3762,12 +3912,12 @@ let (monad_leq :
   fun env  ->
     fun l1  ->
       fun l2  ->
-        let uu____21027 =
+        let uu____21686 =
           (FStar_Ident.lid_equals l1 l2) ||
             ((FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_Tot_lid) &&
                (FStar_Ident.lid_equals l2 FStar_Parser_Const.effect_GTot_lid))
            in
-        if uu____21027
+        if uu____21686
         then
           FStar_Pervasives_Native.Some
             { msource = l1; mtarget = l2; mlift = identity_mlift }
@@ -3779,44 +3929,44 @@ let (monad_leq :
                     (FStar_Ident.lid_equals l2 e.mtarget)))
   
 let wp_sig_aux :
-  'Auu____21047 .
-    (FStar_Syntax_Syntax.eff_decl * 'Auu____21047) Prims.list ->
+  'Auu____21706 .
+    (FStar_Syntax_Syntax.eff_decl * 'Auu____21706) Prims.list ->
       FStar_Ident.lident ->
         (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term'
           FStar_Syntax_Syntax.syntax)
   =
   fun decls  ->
     fun m  ->
-      let uu____21076 =
+      let uu____21735 =
         FStar_All.pipe_right decls
           (FStar_Util.find_opt
-             (fun uu____21102  ->
-                match uu____21102 with
-                | (d,uu____21109) ->
+             (fun uu____21761  ->
+                match uu____21761 with
+                | (d,uu____21768) ->
                     FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname m))
          in
-      match uu____21076 with
+      match uu____21735 with
       | FStar_Pervasives_Native.None  ->
-          let uu____21120 =
+          let uu____21779 =
             FStar_Util.format1
               "Impossible: declaration for monad %s not found"
               m.FStar_Ident.str
              in
-          failwith uu____21120
+          failwith uu____21779
       | FStar_Pervasives_Native.Some (md,_q) ->
-          let uu____21135 = inst_tscheme md.FStar_Syntax_Syntax.signature  in
-          (match uu____21135 with
-           | (uu____21146,s) ->
+          let uu____21794 = inst_tscheme md.FStar_Syntax_Syntax.signature  in
+          (match uu____21794 with
+           | (uu____21805,s) ->
                let s1 = FStar_Syntax_Subst.compress s  in
                (match ((md.FStar_Syntax_Syntax.binders),
                         (s1.FStar_Syntax_Syntax.n))
                 with
                 | ([],FStar_Syntax_Syntax.Tm_arrow
-                   ((a,uu____21164)::(wp,uu____21166)::[],c)) when
+                   ((a,uu____21823)::(wp,uu____21825)::[],c)) when
                     FStar_Syntax_Syntax.is_teff
                       (FStar_Syntax_Util.comp_result c)
                     -> (a, (wp.FStar_Syntax_Syntax.sort))
-                | uu____21222 -> failwith "Impossible"))
+                | uu____21881 -> failwith "Impossible"))
   
 let (wp_signature :
   env ->
@@ -3834,7 +3984,7 @@ let (comp_to_comp_typ :
         | FStar_Syntax_Syntax.GTotal (t,FStar_Pervasives_Native.None ) ->
             let u = env.universe_of env t  in
             FStar_Syntax_Syntax.mk_GTotal' t (FStar_Pervasives_Native.Some u)
-        | uu____21287 -> c  in
+        | uu____21946 -> c  in
       FStar_Syntax_Util.comp_to_comp_typ c1
   
 let rec (unfold_effect_abbrev :
@@ -3842,85 +3992,85 @@ let rec (unfold_effect_abbrev :
   fun env  ->
     fun comp  ->
       let c = comp_to_comp_typ env comp  in
-      let uu____21300 =
+      let uu____21959 =
         lookup_effect_abbrev env c.FStar_Syntax_Syntax.comp_univs
           c.FStar_Syntax_Syntax.effect_name
          in
-      match uu____21300 with
+      match uu____21959 with
       | FStar_Pervasives_Native.None  -> c
       | FStar_Pervasives_Native.Some (binders,cdef) ->
-          let uu____21317 = FStar_Syntax_Subst.open_comp binders cdef  in
-          (match uu____21317 with
+          let uu____21976 = FStar_Syntax_Subst.open_comp binders cdef  in
+          (match uu____21976 with
            | (binders1,cdef1) ->
                (if
                   (FStar_List.length binders1) <>
                     ((FStar_List.length c.FStar_Syntax_Syntax.effect_args) +
                        Prims.int_one)
                 then
-                  (let uu____21342 =
-                     let uu____21348 =
-                       let uu____21350 =
+                  (let uu____22001 =
+                     let uu____22007 =
+                       let uu____22009 =
                          FStar_Util.string_of_int
                            (FStar_List.length binders1)
                           in
-                       let uu____21358 =
+                       let uu____22017 =
                          FStar_Util.string_of_int
                            ((FStar_List.length
                                c.FStar_Syntax_Syntax.effect_args)
                               + Prims.int_one)
                           in
-                       let uu____21369 =
-                         let uu____21371 = FStar_Syntax_Syntax.mk_Comp c  in
-                         FStar_Syntax_Print.comp_to_string uu____21371  in
+                       let uu____22028 =
+                         let uu____22030 = FStar_Syntax_Syntax.mk_Comp c  in
+                         FStar_Syntax_Print.comp_to_string uu____22030  in
                        FStar_Util.format3
                          "Effect constructor is not fully applied; expected %s args, got %s args, i.e., %s"
-                         uu____21350 uu____21358 uu____21369
+                         uu____22009 uu____22017 uu____22028
                         in
                      (FStar_Errors.Fatal_ConstructorArgLengthMismatch,
-                       uu____21348)
+                       uu____22007)
                       in
-                   FStar_Errors.raise_error uu____21342
+                   FStar_Errors.raise_error uu____22001
                      comp.FStar_Syntax_Syntax.pos)
                 else ();
                 (let inst1 =
-                   let uu____21379 =
-                     let uu____21390 =
+                   let uu____22038 =
+                     let uu____22049 =
                        FStar_Syntax_Syntax.as_arg
                          c.FStar_Syntax_Syntax.result_typ
                         in
-                     uu____21390 :: (c.FStar_Syntax_Syntax.effect_args)  in
+                     uu____22049 :: (c.FStar_Syntax_Syntax.effect_args)  in
                    FStar_List.map2
-                     (fun uu____21427  ->
-                        fun uu____21428  ->
-                          match (uu____21427, uu____21428) with
-                          | ((x,uu____21458),(t,uu____21460)) ->
+                     (fun uu____22086  ->
+                        fun uu____22087  ->
+                          match (uu____22086, uu____22087) with
+                          | ((x,uu____22117),(t,uu____22119)) ->
                               FStar_Syntax_Syntax.NT (x, t)) binders1
-                     uu____21379
+                     uu____22038
                     in
                  let c1 = FStar_Syntax_Subst.subst_comp inst1 cdef1  in
                  let c2 =
-                   let uu____21491 =
-                     let uu___1539_21492 = comp_to_comp_typ env c1  in
+                   let uu____22150 =
+                     let uu___1582_22151 = comp_to_comp_typ env c1  in
                      {
                        FStar_Syntax_Syntax.comp_univs =
-                         (uu___1539_21492.FStar_Syntax_Syntax.comp_univs);
+                         (uu___1582_22151.FStar_Syntax_Syntax.comp_univs);
                        FStar_Syntax_Syntax.effect_name =
-                         (uu___1539_21492.FStar_Syntax_Syntax.effect_name);
+                         (uu___1582_22151.FStar_Syntax_Syntax.effect_name);
                        FStar_Syntax_Syntax.result_typ =
-                         (uu___1539_21492.FStar_Syntax_Syntax.result_typ);
+                         (uu___1582_22151.FStar_Syntax_Syntax.result_typ);
                        FStar_Syntax_Syntax.effect_args =
-                         (uu___1539_21492.FStar_Syntax_Syntax.effect_args);
+                         (uu___1582_22151.FStar_Syntax_Syntax.effect_args);
                        FStar_Syntax_Syntax.flags =
                          (c.FStar_Syntax_Syntax.flags)
                      }  in
-                   FStar_All.pipe_right uu____21491
+                   FStar_All.pipe_right uu____22150
                      FStar_Syntax_Syntax.mk_Comp
                     in
                  unfold_effect_abbrev env c2)))
   
 let effect_repr_aux :
-  'Auu____21504 .
-    'Auu____21504 ->
+  'Auu____22163 .
+    'Auu____22163 ->
       env ->
         FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
           FStar_Syntax_Syntax.universe ->
@@ -3933,55 +4083,55 @@ let effect_repr_aux :
         fun u_c  ->
           let effect_name =
             norm_eff_name env (FStar_Syntax_Util.comp_effect_name c)  in
-          let uu____21534 = effect_decl_opt env effect_name  in
-          match uu____21534 with
+          let uu____22193 = effect_decl_opt env effect_name  in
+          match uu____22193 with
           | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
           | FStar_Pervasives_Native.Some (ed,qualifiers) ->
               (match (FStar_Pervasives_Native.snd ed.FStar_Syntax_Syntax.repr).FStar_Syntax_Syntax.n
                with
                | FStar_Syntax_Syntax.Tm_unknown  ->
                    FStar_Pervasives_Native.None
-               | uu____21577 ->
+               | uu____22236 ->
                    let c1 = unfold_effect_abbrev env c  in
                    let res_typ = c1.FStar_Syntax_Syntax.result_typ  in
                    let wp =
                      match c1.FStar_Syntax_Syntax.effect_args with
-                     | hd1::uu____21600 -> hd1
+                     | hd1::uu____22259 -> hd1
                      | [] ->
                          let name = FStar_Ident.string_of_lid effect_name  in
                          let message =
-                           let uu____21639 =
+                           let uu____22298 =
                              FStar_Util.format1
                                "Not enough arguments for effect %s. " name
                               in
-                           Prims.op_Hat uu____21639
+                           Prims.op_Hat uu____22298
                              (Prims.op_Hat
                                 "This usually happens when you use a partially applied DM4F effect, "
                                 "like [TAC int] instead of [Tac int].")
                             in
-                         let uu____21644 = get_range env  in
+                         let uu____22303 = get_range env  in
                          FStar_Errors.raise_error
                            (FStar_Errors.Fatal_NotEnoughArgumentsForEffect,
-                             message) uu____21644
+                             message) uu____22303
                       in
                    let repr =
                      inst_effect_fun_with [u_c] env ed
                        ed.FStar_Syntax_Syntax.repr
                       in
-                   let uu____21655 =
-                     let uu____21658 = get_range env  in
-                     let uu____21659 =
-                       let uu____21666 =
-                         let uu____21667 =
-                           let uu____21684 =
-                             let uu____21695 =
+                   let uu____22314 =
+                     let uu____22317 = get_range env  in
+                     let uu____22318 =
+                       let uu____22325 =
+                         let uu____22326 =
+                           let uu____22343 =
+                             let uu____22354 =
                                FStar_Syntax_Syntax.as_arg res_typ  in
-                             [uu____21695; wp]  in
-                           (repr, uu____21684)  in
-                         FStar_Syntax_Syntax.Tm_app uu____21667  in
-                       FStar_Syntax_Syntax.mk uu____21666  in
-                     uu____21659 FStar_Pervasives_Native.None uu____21658  in
-                   FStar_Pervasives_Native.Some uu____21655)
+                             [uu____22354; wp]  in
+                           (repr, uu____22343)  in
+                         FStar_Syntax_Syntax.Tm_app uu____22326  in
+                       FStar_Syntax_Syntax.mk uu____22325  in
+                     uu____22318 FStar_Pervasives_Native.None uu____22317  in
+                   FStar_Pervasives_Native.Some uu____22314)
   
 let (effect_repr :
   env ->
@@ -4021,18 +4171,18 @@ let (is_reifiable_comp : env -> FStar_Syntax_Syntax.comp -> Prims.bool) =
       match c.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Comp ct ->
           is_reifiable_effect env ct.FStar_Syntax_Syntax.effect_name
-      | uu____21839 -> false
+      | uu____22498 -> false
   
 let (is_reifiable_function : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun env  ->
     fun t  ->
-      let uu____21854 =
-        let uu____21855 = FStar_Syntax_Subst.compress t  in
-        uu____21855.FStar_Syntax_Syntax.n  in
-      match uu____21854 with
-      | FStar_Syntax_Syntax.Tm_arrow (uu____21859,c) ->
+      let uu____22513 =
+        let uu____22514 = FStar_Syntax_Subst.compress t  in
+        uu____22514.FStar_Syntax_Syntax.n  in
+      match uu____22513 with
+      | FStar_Syntax_Syntax.Tm_arrow (uu____22518,c) ->
           is_reifiable_comp env c
-      | uu____21881 -> false
+      | uu____22540 -> false
   
 let (reify_comp :
   env ->
@@ -4043,22 +4193,22 @@ let (reify_comp :
     fun c  ->
       fun u_c  ->
         let l = FStar_Syntax_Util.comp_effect_name c  in
-        (let uu____21901 =
-           let uu____21903 = is_reifiable_effect env l  in
-           Prims.op_Negation uu____21903  in
-         if uu____21901
+        (let uu____22560 =
+           let uu____22562 = is_reifiable_effect env l  in
+           Prims.op_Negation uu____22562  in
+         if uu____22560
          then
-           let uu____21906 =
-             let uu____21912 =
-               let uu____21914 = FStar_Ident.string_of_lid l  in
-               FStar_Util.format1 "Effect %s cannot be reified" uu____21914
+           let uu____22565 =
+             let uu____22571 =
+               let uu____22573 = FStar_Ident.string_of_lid l  in
+               FStar_Util.format1 "Effect %s cannot be reified" uu____22573
                 in
-             (FStar_Errors.Fatal_EffectCannotBeReified, uu____21912)  in
-           let uu____21918 = get_range env  in
-           FStar_Errors.raise_error uu____21906 uu____21918
+             (FStar_Errors.Fatal_EffectCannotBeReified, uu____22571)  in
+           let uu____22577 = get_range env  in
+           FStar_Errors.raise_error uu____22565 uu____22577
          else ());
-        (let uu____21921 = effect_repr_aux true env c u_c  in
-         match uu____21921 with
+        (let uu____22580 = effect_repr_aux true env c u_c  in
+         match uu____22580 with
          | FStar_Pervasives_Native.None  ->
              failwith "internal error: reifiable effect has no repr?"
          | FStar_Pervasives_Native.Some tm -> tm)
@@ -4068,52 +4218,53 @@ let (push_sigelt : env -> FStar_Syntax_Syntax.sigelt -> env) =
     fun s  ->
       let sb = ((FStar_Syntax_Util.lids_of_sigelt s), s)  in
       let env1 =
-        let uu___1604_21957 = env  in
+        let uu___1647_22616 = env  in
         {
-          solver = (uu___1604_21957.solver);
-          range = (uu___1604_21957.range);
-          curmodule = (uu___1604_21957.curmodule);
-          gamma = (uu___1604_21957.gamma);
+          solver = (uu___1647_22616.solver);
+          range = (uu___1647_22616.range);
+          curmodule = (uu___1647_22616.curmodule);
+          gamma = (uu___1647_22616.gamma);
           gamma_sig = (sb :: (env.gamma_sig));
-          gamma_cache = (uu___1604_21957.gamma_cache);
-          modules = (uu___1604_21957.modules);
-          expected_typ = (uu___1604_21957.expected_typ);
-          sigtab = (uu___1604_21957.sigtab);
-          attrtab = (uu___1604_21957.attrtab);
-          is_pattern = (uu___1604_21957.is_pattern);
-          instantiate_imp = (uu___1604_21957.instantiate_imp);
-          effects = (uu___1604_21957.effects);
-          generalize = (uu___1604_21957.generalize);
-          letrecs = (uu___1604_21957.letrecs);
-          top_level = (uu___1604_21957.top_level);
-          check_uvars = (uu___1604_21957.check_uvars);
-          use_eq = (uu___1604_21957.use_eq);
-          is_iface = (uu___1604_21957.is_iface);
-          admit = (uu___1604_21957.admit);
-          lax = (uu___1604_21957.lax);
-          lax_universes = (uu___1604_21957.lax_universes);
-          phase1 = (uu___1604_21957.phase1);
-          failhard = (uu___1604_21957.failhard);
-          nosynth = (uu___1604_21957.nosynth);
-          uvar_subtyping = (uu___1604_21957.uvar_subtyping);
-          tc_term = (uu___1604_21957.tc_term);
-          type_of = (uu___1604_21957.type_of);
-          universe_of = (uu___1604_21957.universe_of);
-          check_type_of = (uu___1604_21957.check_type_of);
-          use_bv_sorts = (uu___1604_21957.use_bv_sorts);
-          qtbl_name_and_index = (uu___1604_21957.qtbl_name_and_index);
-          normalized_eff_names = (uu___1604_21957.normalized_eff_names);
-          fv_delta_depths = (uu___1604_21957.fv_delta_depths);
-          proof_ns = (uu___1604_21957.proof_ns);
-          synth_hook = (uu___1604_21957.synth_hook);
-          splice = (uu___1604_21957.splice);
-          postprocess = (uu___1604_21957.postprocess);
-          is_native_tactic = (uu___1604_21957.is_native_tactic);
-          identifier_info = (uu___1604_21957.identifier_info);
-          tc_hooks = (uu___1604_21957.tc_hooks);
-          dsenv = (uu___1604_21957.dsenv);
-          nbe = (uu___1604_21957.nbe);
-          strict_args_tab = (uu___1604_21957.strict_args_tab)
+          gamma_cache = (uu___1647_22616.gamma_cache);
+          modules = (uu___1647_22616.modules);
+          expected_typ = (uu___1647_22616.expected_typ);
+          sigtab = (uu___1647_22616.sigtab);
+          attrtab = (uu___1647_22616.attrtab);
+          is_pattern = (uu___1647_22616.is_pattern);
+          instantiate_imp = (uu___1647_22616.instantiate_imp);
+          effects = (uu___1647_22616.effects);
+          generalize = (uu___1647_22616.generalize);
+          letrecs = (uu___1647_22616.letrecs);
+          top_level = (uu___1647_22616.top_level);
+          check_uvars = (uu___1647_22616.check_uvars);
+          use_eq = (uu___1647_22616.use_eq);
+          is_iface = (uu___1647_22616.is_iface);
+          admit = (uu___1647_22616.admit);
+          lax = (uu___1647_22616.lax);
+          lax_universes = (uu___1647_22616.lax_universes);
+          phase1 = (uu___1647_22616.phase1);
+          failhard = (uu___1647_22616.failhard);
+          nosynth = (uu___1647_22616.nosynth);
+          uvar_subtyping = (uu___1647_22616.uvar_subtyping);
+          tc_term = (uu___1647_22616.tc_term);
+          type_of = (uu___1647_22616.type_of);
+          universe_of = (uu___1647_22616.universe_of);
+          check_type_of = (uu___1647_22616.check_type_of);
+          use_bv_sorts = (uu___1647_22616.use_bv_sorts);
+          qtbl_name_and_index = (uu___1647_22616.qtbl_name_and_index);
+          normalized_eff_names = (uu___1647_22616.normalized_eff_names);
+          fv_delta_depths = (uu___1647_22616.fv_delta_depths);
+          proof_ns = (uu___1647_22616.proof_ns);
+          synth_hook = (uu___1647_22616.synth_hook);
+          splice = (uu___1647_22616.splice);
+          postprocess = (uu___1647_22616.postprocess);
+          is_native_tactic = (uu___1647_22616.is_native_tactic);
+          identifier_info = (uu___1647_22616.identifier_info);
+          tc_hooks = (uu___1647_22616.tc_hooks);
+          dsenv = (uu___1647_22616.dsenv);
+          nbe = (uu___1647_22616.nbe);
+          strict_args_tab = (uu___1647_22616.strict_args_tab);
+          erasable_types_tab = (uu___1647_22616.erasable_types_tab)
         }  in
       add_sigelt env1 s;
       (env1.tc_hooks).tc_push_in_gamma_hook env1 (FStar_Util.Inr sb);
@@ -4125,62 +4276,63 @@ let (push_new_effect :
       -> env)
   =
   fun env  ->
-    fun uu____21976  ->
-      match uu____21976 with
+    fun uu____22635  ->
+      match uu____22635 with
       | (ed,quals) ->
           let effects =
-            let uu___1613_21990 = env.effects  in
+            let uu___1656_22649 = env.effects  in
             {
               decls = ((ed, quals) :: ((env.effects).decls));
-              order = (uu___1613_21990.order);
-              joins = (uu___1613_21990.joins)
+              order = (uu___1656_22649.order);
+              joins = (uu___1656_22649.joins)
             }  in
-          let uu___1616_21999 = env  in
+          let uu___1659_22658 = env  in
           {
-            solver = (uu___1616_21999.solver);
-            range = (uu___1616_21999.range);
-            curmodule = (uu___1616_21999.curmodule);
-            gamma = (uu___1616_21999.gamma);
-            gamma_sig = (uu___1616_21999.gamma_sig);
-            gamma_cache = (uu___1616_21999.gamma_cache);
-            modules = (uu___1616_21999.modules);
-            expected_typ = (uu___1616_21999.expected_typ);
-            sigtab = (uu___1616_21999.sigtab);
-            attrtab = (uu___1616_21999.attrtab);
-            is_pattern = (uu___1616_21999.is_pattern);
-            instantiate_imp = (uu___1616_21999.instantiate_imp);
+            solver = (uu___1659_22658.solver);
+            range = (uu___1659_22658.range);
+            curmodule = (uu___1659_22658.curmodule);
+            gamma = (uu___1659_22658.gamma);
+            gamma_sig = (uu___1659_22658.gamma_sig);
+            gamma_cache = (uu___1659_22658.gamma_cache);
+            modules = (uu___1659_22658.modules);
+            expected_typ = (uu___1659_22658.expected_typ);
+            sigtab = (uu___1659_22658.sigtab);
+            attrtab = (uu___1659_22658.attrtab);
+            is_pattern = (uu___1659_22658.is_pattern);
+            instantiate_imp = (uu___1659_22658.instantiate_imp);
             effects;
-            generalize = (uu___1616_21999.generalize);
-            letrecs = (uu___1616_21999.letrecs);
-            top_level = (uu___1616_21999.top_level);
-            check_uvars = (uu___1616_21999.check_uvars);
-            use_eq = (uu___1616_21999.use_eq);
-            is_iface = (uu___1616_21999.is_iface);
-            admit = (uu___1616_21999.admit);
-            lax = (uu___1616_21999.lax);
-            lax_universes = (uu___1616_21999.lax_universes);
-            phase1 = (uu___1616_21999.phase1);
-            failhard = (uu___1616_21999.failhard);
-            nosynth = (uu___1616_21999.nosynth);
-            uvar_subtyping = (uu___1616_21999.uvar_subtyping);
-            tc_term = (uu___1616_21999.tc_term);
-            type_of = (uu___1616_21999.type_of);
-            universe_of = (uu___1616_21999.universe_of);
-            check_type_of = (uu___1616_21999.check_type_of);
-            use_bv_sorts = (uu___1616_21999.use_bv_sorts);
-            qtbl_name_and_index = (uu___1616_21999.qtbl_name_and_index);
-            normalized_eff_names = (uu___1616_21999.normalized_eff_names);
-            fv_delta_depths = (uu___1616_21999.fv_delta_depths);
-            proof_ns = (uu___1616_21999.proof_ns);
-            synth_hook = (uu___1616_21999.synth_hook);
-            splice = (uu___1616_21999.splice);
-            postprocess = (uu___1616_21999.postprocess);
-            is_native_tactic = (uu___1616_21999.is_native_tactic);
-            identifier_info = (uu___1616_21999.identifier_info);
-            tc_hooks = (uu___1616_21999.tc_hooks);
-            dsenv = (uu___1616_21999.dsenv);
-            nbe = (uu___1616_21999.nbe);
-            strict_args_tab = (uu___1616_21999.strict_args_tab)
+            generalize = (uu___1659_22658.generalize);
+            letrecs = (uu___1659_22658.letrecs);
+            top_level = (uu___1659_22658.top_level);
+            check_uvars = (uu___1659_22658.check_uvars);
+            use_eq = (uu___1659_22658.use_eq);
+            is_iface = (uu___1659_22658.is_iface);
+            admit = (uu___1659_22658.admit);
+            lax = (uu___1659_22658.lax);
+            lax_universes = (uu___1659_22658.lax_universes);
+            phase1 = (uu___1659_22658.phase1);
+            failhard = (uu___1659_22658.failhard);
+            nosynth = (uu___1659_22658.nosynth);
+            uvar_subtyping = (uu___1659_22658.uvar_subtyping);
+            tc_term = (uu___1659_22658.tc_term);
+            type_of = (uu___1659_22658.type_of);
+            universe_of = (uu___1659_22658.universe_of);
+            check_type_of = (uu___1659_22658.check_type_of);
+            use_bv_sorts = (uu___1659_22658.use_bv_sorts);
+            qtbl_name_and_index = (uu___1659_22658.qtbl_name_and_index);
+            normalized_eff_names = (uu___1659_22658.normalized_eff_names);
+            fv_delta_depths = (uu___1659_22658.fv_delta_depths);
+            proof_ns = (uu___1659_22658.proof_ns);
+            synth_hook = (uu___1659_22658.synth_hook);
+            splice = (uu___1659_22658.splice);
+            postprocess = (uu___1659_22658.postprocess);
+            is_native_tactic = (uu___1659_22658.is_native_tactic);
+            identifier_info = (uu___1659_22658.identifier_info);
+            tc_hooks = (uu___1659_22658.tc_hooks);
+            dsenv = (uu___1659_22658.dsenv);
+            nbe = (uu___1659_22658.nbe);
+            strict_args_tab = (uu___1659_22658.strict_args_tab);
+            erasable_types_tab = (uu___1659_22658.erasable_types_tab)
           }
   
 let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
@@ -4189,8 +4341,8 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
       let compose_edges e1 e2 =
         let composed_lift =
           let mlift_wp u r wp1 =
-            let uu____22039 = (e1.mlift).mlift_wp u r wp1  in
-            (e2.mlift).mlift_wp u r uu____22039  in
+            let uu____22698 = (e1.mlift).mlift_wp u r wp1  in
+            (e2.mlift).mlift_wp u r uu____22698  in
           let mlift_term =
             match (((e1.mlift).mlift_term), ((e2.mlift).mlift_term)) with
             | (FStar_Pervasives_Native.Some l1,FStar_Pervasives_Native.Some
@@ -4200,10 +4352,10 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
                       fun t  ->
                         fun wp  ->
                           fun e  ->
-                            let uu____22197 = (e1.mlift).mlift_wp u t wp  in
-                            let uu____22198 = l1 u t wp e  in
-                            l2 u t uu____22197 uu____22198))
-            | uu____22199 -> FStar_Pervasives_Native.None  in
+                            let uu____22856 = (e1.mlift).mlift_wp u t wp  in
+                            let uu____22857 = l1 u t wp e  in
+                            l2 u t uu____22856 uu____22857))
+            | uu____22858 -> FStar_Pervasives_Native.None  in
           { mlift_wp; mlift_term }  in
         {
           msource = (e1.msource);
@@ -4211,22 +4363,22 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
           mlift = composed_lift
         }  in
       let mk_mlift_wp lift_t u r wp1 =
-        let uu____22271 = inst_tscheme_with lift_t [u]  in
-        match uu____22271 with
-        | (uu____22278,lift_t1) ->
-            let uu____22280 =
-              let uu____22287 =
-                let uu____22288 =
-                  let uu____22305 =
-                    let uu____22316 = FStar_Syntax_Syntax.as_arg r  in
-                    let uu____22325 =
-                      let uu____22336 = FStar_Syntax_Syntax.as_arg wp1  in
-                      [uu____22336]  in
-                    uu____22316 :: uu____22325  in
-                  (lift_t1, uu____22305)  in
-                FStar_Syntax_Syntax.Tm_app uu____22288  in
-              FStar_Syntax_Syntax.mk uu____22287  in
-            uu____22280 FStar_Pervasives_Native.None
+        let uu____22930 = inst_tscheme_with lift_t [u]  in
+        match uu____22930 with
+        | (uu____22937,lift_t1) ->
+            let uu____22939 =
+              let uu____22946 =
+                let uu____22947 =
+                  let uu____22964 =
+                    let uu____22975 = FStar_Syntax_Syntax.as_arg r  in
+                    let uu____22984 =
+                      let uu____22995 = FStar_Syntax_Syntax.as_arg wp1  in
+                      [uu____22995]  in
+                    uu____22975 :: uu____22984  in
+                  (lift_t1, uu____22964)  in
+                FStar_Syntax_Syntax.Tm_app uu____22947  in
+              FStar_Syntax_Syntax.mk uu____22946  in
+            uu____22939 FStar_Pervasives_Native.None
               wp1.FStar_Syntax_Syntax.pos
          in
       let sub_mlift_wp =
@@ -4236,25 +4388,25 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
             failwith "sub effect should've been elaborated at this stage"
          in
       let mk_mlift_term lift_t u r wp1 e =
-        let uu____22446 = inst_tscheme_with lift_t [u]  in
-        match uu____22446 with
-        | (uu____22453,lift_t1) ->
-            let uu____22455 =
-              let uu____22462 =
-                let uu____22463 =
-                  let uu____22480 =
-                    let uu____22491 = FStar_Syntax_Syntax.as_arg r  in
-                    let uu____22500 =
-                      let uu____22511 = FStar_Syntax_Syntax.as_arg wp1  in
-                      let uu____22520 =
-                        let uu____22531 = FStar_Syntax_Syntax.as_arg e  in
-                        [uu____22531]  in
-                      uu____22511 :: uu____22520  in
-                    uu____22491 :: uu____22500  in
-                  (lift_t1, uu____22480)  in
-                FStar_Syntax_Syntax.Tm_app uu____22463  in
-              FStar_Syntax_Syntax.mk uu____22462  in
-            uu____22455 FStar_Pervasives_Native.None
+        let uu____23105 = inst_tscheme_with lift_t [u]  in
+        match uu____23105 with
+        | (uu____23112,lift_t1) ->
+            let uu____23114 =
+              let uu____23121 =
+                let uu____23122 =
+                  let uu____23139 =
+                    let uu____23150 = FStar_Syntax_Syntax.as_arg r  in
+                    let uu____23159 =
+                      let uu____23170 = FStar_Syntax_Syntax.as_arg wp1  in
+                      let uu____23179 =
+                        let uu____23190 = FStar_Syntax_Syntax.as_arg e  in
+                        [uu____23190]  in
+                      uu____23170 :: uu____23179  in
+                    uu____23150 :: uu____23159  in
+                  (lift_t1, uu____23139)  in
+                FStar_Syntax_Syntax.Tm_app uu____23122  in
+              FStar_Syntax_Syntax.mk uu____23121  in
+            uu____23114 FStar_Pervasives_Native.None
               e.FStar_Syntax_Syntax.pos
          in
       let sub_mlift_term =
@@ -4273,45 +4425,45 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
         }  in
       let print_mlift l =
         let bogus_term s =
-          let uu____22633 =
-            let uu____22634 =
+          let uu____23292 =
+            let uu____23293 =
               FStar_Ident.lid_of_path [s] FStar_Range.dummyRange  in
-            FStar_Syntax_Syntax.lid_as_fv uu____22634
+            FStar_Syntax_Syntax.lid_as_fv uu____23293
               FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
              in
-          FStar_Syntax_Syntax.fv_to_tm uu____22633  in
+          FStar_Syntax_Syntax.fv_to_tm uu____23292  in
         let arg = bogus_term "ARG"  in
         let wp = bogus_term "WP"  in
         let e = bogus_term "COMP"  in
-        let uu____22643 =
-          let uu____22645 = l.mlift_wp FStar_Syntax_Syntax.U_zero arg wp  in
-          FStar_Syntax_Print.term_to_string uu____22645  in
-        let uu____22646 =
-          let uu____22648 =
+        let uu____23302 =
+          let uu____23304 = l.mlift_wp FStar_Syntax_Syntax.U_zero arg wp  in
+          FStar_Syntax_Print.term_to_string uu____23304  in
+        let uu____23305 =
+          let uu____23307 =
             FStar_Util.map_opt l.mlift_term
               (fun l1  ->
-                 let uu____22676 = l1 FStar_Syntax_Syntax.U_zero arg wp e  in
-                 FStar_Syntax_Print.term_to_string uu____22676)
+                 let uu____23335 = l1 FStar_Syntax_Syntax.U_zero arg wp e  in
+                 FStar_Syntax_Print.term_to_string uu____23335)
              in
-          FStar_Util.dflt "none" uu____22648  in
-        FStar_Util.format2 "{ wp : %s ; term : %s }" uu____22643 uu____22646
+          FStar_Util.dflt "none" uu____23307  in
+        FStar_Util.format2 "{ wp : %s ; term : %s }" uu____23302 uu____23305
          in
       let order = edge :: ((env.effects).order)  in
       let ms =
         FStar_All.pipe_right (env.effects).decls
           (FStar_List.map
-             (fun uu____22705  ->
-                match uu____22705 with
-                | (e,uu____22713) -> e.FStar_Syntax_Syntax.mname))
+             (fun uu____23364  ->
+                match uu____23364 with
+                | (e,uu____23372) -> e.FStar_Syntax_Syntax.mname))
          in
-      let find_edge order1 uu____22736 =
-        match uu____22736 with
+      let find_edge order1 uu____23395 =
+        match uu____23395 with
         | (i,j) ->
-            let uu____22747 = FStar_Ident.lid_equals i j  in
-            if uu____22747
+            let uu____23406 = FStar_Ident.lid_equals i j  in
+            if uu____23406
             then
               FStar_All.pipe_right (id_edge i)
-                (fun _22754  -> FStar_Pervasives_Native.Some _22754)
+                (fun _23413  -> FStar_Pervasives_Native.Some _23413)
             else
               FStar_All.pipe_right order1
                 (FStar_Util.find_opt
@@ -4321,37 +4473,37 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
          in
       let order1 =
         let fold_fun order1 k =
-          let uu____22783 =
+          let uu____23442 =
             FStar_All.pipe_right ms
               (FStar_List.collect
                  (fun i  ->
-                    let uu____22793 = FStar_Ident.lid_equals i k  in
-                    if uu____22793
+                    let uu____23452 = FStar_Ident.lid_equals i k  in
+                    if uu____23452
                     then []
                     else
                       FStar_All.pipe_right ms
                         (FStar_List.collect
                            (fun j  ->
-                              let uu____22807 = FStar_Ident.lid_equals j k
+                              let uu____23466 = FStar_Ident.lid_equals j k
                                  in
-                              if uu____22807
+                              if uu____23466
                               then []
                               else
-                                (let uu____22814 =
-                                   let uu____22823 = find_edge order1 (i, k)
+                                (let uu____23473 =
+                                   let uu____23482 = find_edge order1 (i, k)
                                       in
-                                   let uu____22826 = find_edge order1 (k, j)
+                                   let uu____23485 = find_edge order1 (k, j)
                                       in
-                                   (uu____22823, uu____22826)  in
-                                 match uu____22814 with
+                                   (uu____23482, uu____23485)  in
+                                 match uu____23473 with
                                  | (FStar_Pervasives_Native.Some
                                     e1,FStar_Pervasives_Native.Some e2) ->
-                                     let uu____22841 = compose_edges e1 e2
+                                     let uu____23500 = compose_edges e1 e2
                                         in
-                                     [uu____22841]
-                                 | uu____22842 -> [])))))
+                                     [uu____23500]
+                                 | uu____23501 -> [])))))
              in
-          FStar_List.append order1 uu____22783  in
+          FStar_List.append order1 uu____23442  in
         FStar_All.pipe_right ms (FStar_List.fold_left fold_fun order)  in
       let order2 =
         FStar_Util.remove_dups
@@ -4363,28 +4515,28 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
       FStar_All.pipe_right order2
         (FStar_List.iter
            (fun edge1  ->
-              let uu____22872 =
+              let uu____23531 =
                 (FStar_Ident.lid_equals edge1.msource
                    FStar_Parser_Const.effect_DIV_lid)
                   &&
-                  (let uu____22875 = lookup_effect_quals env edge1.mtarget
+                  (let uu____23534 = lookup_effect_quals env edge1.mtarget
                       in
-                   FStar_All.pipe_right uu____22875
+                   FStar_All.pipe_right uu____23534
                      (FStar_List.contains FStar_Syntax_Syntax.TotalEffect))
                  in
-              if uu____22872
+              if uu____23531
               then
-                let uu____22882 =
-                  let uu____22888 =
+                let uu____23541 =
+                  let uu____23547 =
                     FStar_Util.format1
                       "Divergent computations cannot be included in an effect %s marked 'total'"
                       (edge1.mtarget).FStar_Ident.str
                      in
                   (FStar_Errors.Fatal_DivergentComputationCannotBeIncludedInTotal,
-                    uu____22888)
+                    uu____23547)
                    in
-                let uu____22892 = get_range env  in
-                FStar_Errors.raise_error uu____22882 uu____22892
+                let uu____23551 = get_range env  in
+                FStar_Errors.raise_error uu____23541 uu____23551
               else ()));
       (let joins =
          FStar_All.pipe_right ms
@@ -4394,8 +4546,8 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
                    (FStar_List.collect
                       (fun j  ->
                          let join_opt =
-                           let uu____22970 = FStar_Ident.lid_equals i j  in
-                           if uu____22970
+                           let uu____23629 = FStar_Ident.lid_equals i j  in
+                           if uu____23629
                            then
                              FStar_Pervasives_Native.Some
                                (i, (id_edge i), (id_edge i))
@@ -4404,13 +4556,13 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
                                (FStar_List.fold_left
                                   (fun bopt  ->
                                      fun k  ->
-                                       let uu____23022 =
-                                         let uu____23031 =
+                                       let uu____23681 =
+                                         let uu____23690 =
                                            find_edge order2 (i, k)  in
-                                         let uu____23034 =
+                                         let uu____23693 =
                                            find_edge order2 (j, k)  in
-                                         (uu____23031, uu____23034)  in
-                                       match uu____23022 with
+                                         (uu____23690, uu____23693)  in
+                                       match uu____23681 with
                                        | (FStar_Pervasives_Native.Some
                                           ik,FStar_Pervasives_Native.Some jk)
                                            ->
@@ -4420,34 +4572,34 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
                                                 FStar_Pervasives_Native.Some
                                                   (k, ik, jk)
                                             | FStar_Pervasives_Native.Some
-                                                (ub,uu____23076,uu____23077)
+                                                (ub,uu____23735,uu____23736)
                                                 ->
-                                                let uu____23084 =
-                                                  let uu____23091 =
-                                                    let uu____23093 =
+                                                let uu____23743 =
+                                                  let uu____23750 =
+                                                    let uu____23752 =
                                                       find_edge order2
                                                         (k, ub)
                                                        in
                                                     FStar_Util.is_some
-                                                      uu____23093
+                                                      uu____23752
                                                      in
-                                                  let uu____23096 =
-                                                    let uu____23098 =
+                                                  let uu____23755 =
+                                                    let uu____23757 =
                                                       find_edge order2
                                                         (ub, k)
                                                        in
                                                     FStar_Util.is_some
-                                                      uu____23098
+                                                      uu____23757
                                                      in
-                                                  (uu____23091, uu____23096)
+                                                  (uu____23750, uu____23755)
                                                    in
-                                                (match uu____23084 with
+                                                (match uu____23743 with
                                                  | (true ,true ) ->
-                                                     let uu____23115 =
+                                                     let uu____23774 =
                                                        FStar_Ident.lid_equals
                                                          k ub
                                                         in
-                                                     if uu____23115
+                                                     if uu____23774
                                                      then
                                                        (FStar_Errors.log_issue
                                                           FStar_Range.dummyRange
@@ -4462,7 +4614,7 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
                                                      FStar_Pervasives_Native.Some
                                                        (k, ik, jk)
                                                  | (false ,true ) -> bopt))
-                                       | uu____23158 -> bopt)
+                                       | uu____23817 -> bopt)
                                   FStar_Pervasives_Native.None)
                             in
                          match join_opt with
@@ -4471,105 +4623,107 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
                              [(i, j, k, (e1.mlift), (e2.mlift))]))))
           in
        let effects =
-         let uu___1743_23231 = env.effects  in
-         { decls = (uu___1743_23231.decls); order = order2; joins }  in
-       let uu___1746_23232 = env  in
+         let uu___1786_23890 = env.effects  in
+         { decls = (uu___1786_23890.decls); order = order2; joins }  in
+       let uu___1789_23891 = env  in
        {
-         solver = (uu___1746_23232.solver);
-         range = (uu___1746_23232.range);
-         curmodule = (uu___1746_23232.curmodule);
-         gamma = (uu___1746_23232.gamma);
-         gamma_sig = (uu___1746_23232.gamma_sig);
-         gamma_cache = (uu___1746_23232.gamma_cache);
-         modules = (uu___1746_23232.modules);
-         expected_typ = (uu___1746_23232.expected_typ);
-         sigtab = (uu___1746_23232.sigtab);
-         attrtab = (uu___1746_23232.attrtab);
-         is_pattern = (uu___1746_23232.is_pattern);
-         instantiate_imp = (uu___1746_23232.instantiate_imp);
+         solver = (uu___1789_23891.solver);
+         range = (uu___1789_23891.range);
+         curmodule = (uu___1789_23891.curmodule);
+         gamma = (uu___1789_23891.gamma);
+         gamma_sig = (uu___1789_23891.gamma_sig);
+         gamma_cache = (uu___1789_23891.gamma_cache);
+         modules = (uu___1789_23891.modules);
+         expected_typ = (uu___1789_23891.expected_typ);
+         sigtab = (uu___1789_23891.sigtab);
+         attrtab = (uu___1789_23891.attrtab);
+         is_pattern = (uu___1789_23891.is_pattern);
+         instantiate_imp = (uu___1789_23891.instantiate_imp);
          effects;
-         generalize = (uu___1746_23232.generalize);
-         letrecs = (uu___1746_23232.letrecs);
-         top_level = (uu___1746_23232.top_level);
-         check_uvars = (uu___1746_23232.check_uvars);
-         use_eq = (uu___1746_23232.use_eq);
-         is_iface = (uu___1746_23232.is_iface);
-         admit = (uu___1746_23232.admit);
-         lax = (uu___1746_23232.lax);
-         lax_universes = (uu___1746_23232.lax_universes);
-         phase1 = (uu___1746_23232.phase1);
-         failhard = (uu___1746_23232.failhard);
-         nosynth = (uu___1746_23232.nosynth);
-         uvar_subtyping = (uu___1746_23232.uvar_subtyping);
-         tc_term = (uu___1746_23232.tc_term);
-         type_of = (uu___1746_23232.type_of);
-         universe_of = (uu___1746_23232.universe_of);
-         check_type_of = (uu___1746_23232.check_type_of);
-         use_bv_sorts = (uu___1746_23232.use_bv_sorts);
-         qtbl_name_and_index = (uu___1746_23232.qtbl_name_and_index);
-         normalized_eff_names = (uu___1746_23232.normalized_eff_names);
-         fv_delta_depths = (uu___1746_23232.fv_delta_depths);
-         proof_ns = (uu___1746_23232.proof_ns);
-         synth_hook = (uu___1746_23232.synth_hook);
-         splice = (uu___1746_23232.splice);
-         postprocess = (uu___1746_23232.postprocess);
-         is_native_tactic = (uu___1746_23232.is_native_tactic);
-         identifier_info = (uu___1746_23232.identifier_info);
-         tc_hooks = (uu___1746_23232.tc_hooks);
-         dsenv = (uu___1746_23232.dsenv);
-         nbe = (uu___1746_23232.nbe);
-         strict_args_tab = (uu___1746_23232.strict_args_tab)
+         generalize = (uu___1789_23891.generalize);
+         letrecs = (uu___1789_23891.letrecs);
+         top_level = (uu___1789_23891.top_level);
+         check_uvars = (uu___1789_23891.check_uvars);
+         use_eq = (uu___1789_23891.use_eq);
+         is_iface = (uu___1789_23891.is_iface);
+         admit = (uu___1789_23891.admit);
+         lax = (uu___1789_23891.lax);
+         lax_universes = (uu___1789_23891.lax_universes);
+         phase1 = (uu___1789_23891.phase1);
+         failhard = (uu___1789_23891.failhard);
+         nosynth = (uu___1789_23891.nosynth);
+         uvar_subtyping = (uu___1789_23891.uvar_subtyping);
+         tc_term = (uu___1789_23891.tc_term);
+         type_of = (uu___1789_23891.type_of);
+         universe_of = (uu___1789_23891.universe_of);
+         check_type_of = (uu___1789_23891.check_type_of);
+         use_bv_sorts = (uu___1789_23891.use_bv_sorts);
+         qtbl_name_and_index = (uu___1789_23891.qtbl_name_and_index);
+         normalized_eff_names = (uu___1789_23891.normalized_eff_names);
+         fv_delta_depths = (uu___1789_23891.fv_delta_depths);
+         proof_ns = (uu___1789_23891.proof_ns);
+         synth_hook = (uu___1789_23891.synth_hook);
+         splice = (uu___1789_23891.splice);
+         postprocess = (uu___1789_23891.postprocess);
+         is_native_tactic = (uu___1789_23891.is_native_tactic);
+         identifier_info = (uu___1789_23891.identifier_info);
+         tc_hooks = (uu___1789_23891.tc_hooks);
+         dsenv = (uu___1789_23891.dsenv);
+         nbe = (uu___1789_23891.nbe);
+         strict_args_tab = (uu___1789_23891.strict_args_tab);
+         erasable_types_tab = (uu___1789_23891.erasable_types_tab)
        })
   
 let (push_local_binding : env -> FStar_Syntax_Syntax.binding -> env) =
   fun env  ->
     fun b  ->
-      let uu___1750_23244 = env  in
+      let uu___1793_23903 = env  in
       {
-        solver = (uu___1750_23244.solver);
-        range = (uu___1750_23244.range);
-        curmodule = (uu___1750_23244.curmodule);
+        solver = (uu___1793_23903.solver);
+        range = (uu___1793_23903.range);
+        curmodule = (uu___1793_23903.curmodule);
         gamma = (b :: (env.gamma));
-        gamma_sig = (uu___1750_23244.gamma_sig);
-        gamma_cache = (uu___1750_23244.gamma_cache);
-        modules = (uu___1750_23244.modules);
-        expected_typ = (uu___1750_23244.expected_typ);
-        sigtab = (uu___1750_23244.sigtab);
-        attrtab = (uu___1750_23244.attrtab);
-        is_pattern = (uu___1750_23244.is_pattern);
-        instantiate_imp = (uu___1750_23244.instantiate_imp);
-        effects = (uu___1750_23244.effects);
-        generalize = (uu___1750_23244.generalize);
-        letrecs = (uu___1750_23244.letrecs);
-        top_level = (uu___1750_23244.top_level);
-        check_uvars = (uu___1750_23244.check_uvars);
-        use_eq = (uu___1750_23244.use_eq);
-        is_iface = (uu___1750_23244.is_iface);
-        admit = (uu___1750_23244.admit);
-        lax = (uu___1750_23244.lax);
-        lax_universes = (uu___1750_23244.lax_universes);
-        phase1 = (uu___1750_23244.phase1);
-        failhard = (uu___1750_23244.failhard);
-        nosynth = (uu___1750_23244.nosynth);
-        uvar_subtyping = (uu___1750_23244.uvar_subtyping);
-        tc_term = (uu___1750_23244.tc_term);
-        type_of = (uu___1750_23244.type_of);
-        universe_of = (uu___1750_23244.universe_of);
-        check_type_of = (uu___1750_23244.check_type_of);
-        use_bv_sorts = (uu___1750_23244.use_bv_sorts);
-        qtbl_name_and_index = (uu___1750_23244.qtbl_name_and_index);
-        normalized_eff_names = (uu___1750_23244.normalized_eff_names);
-        fv_delta_depths = (uu___1750_23244.fv_delta_depths);
-        proof_ns = (uu___1750_23244.proof_ns);
-        synth_hook = (uu___1750_23244.synth_hook);
-        splice = (uu___1750_23244.splice);
-        postprocess = (uu___1750_23244.postprocess);
-        is_native_tactic = (uu___1750_23244.is_native_tactic);
-        identifier_info = (uu___1750_23244.identifier_info);
-        tc_hooks = (uu___1750_23244.tc_hooks);
-        dsenv = (uu___1750_23244.dsenv);
-        nbe = (uu___1750_23244.nbe);
-        strict_args_tab = (uu___1750_23244.strict_args_tab)
+        gamma_sig = (uu___1793_23903.gamma_sig);
+        gamma_cache = (uu___1793_23903.gamma_cache);
+        modules = (uu___1793_23903.modules);
+        expected_typ = (uu___1793_23903.expected_typ);
+        sigtab = (uu___1793_23903.sigtab);
+        attrtab = (uu___1793_23903.attrtab);
+        is_pattern = (uu___1793_23903.is_pattern);
+        instantiate_imp = (uu___1793_23903.instantiate_imp);
+        effects = (uu___1793_23903.effects);
+        generalize = (uu___1793_23903.generalize);
+        letrecs = (uu___1793_23903.letrecs);
+        top_level = (uu___1793_23903.top_level);
+        check_uvars = (uu___1793_23903.check_uvars);
+        use_eq = (uu___1793_23903.use_eq);
+        is_iface = (uu___1793_23903.is_iface);
+        admit = (uu___1793_23903.admit);
+        lax = (uu___1793_23903.lax);
+        lax_universes = (uu___1793_23903.lax_universes);
+        phase1 = (uu___1793_23903.phase1);
+        failhard = (uu___1793_23903.failhard);
+        nosynth = (uu___1793_23903.nosynth);
+        uvar_subtyping = (uu___1793_23903.uvar_subtyping);
+        tc_term = (uu___1793_23903.tc_term);
+        type_of = (uu___1793_23903.type_of);
+        universe_of = (uu___1793_23903.universe_of);
+        check_type_of = (uu___1793_23903.check_type_of);
+        use_bv_sorts = (uu___1793_23903.use_bv_sorts);
+        qtbl_name_and_index = (uu___1793_23903.qtbl_name_and_index);
+        normalized_eff_names = (uu___1793_23903.normalized_eff_names);
+        fv_delta_depths = (uu___1793_23903.fv_delta_depths);
+        proof_ns = (uu___1793_23903.proof_ns);
+        synth_hook = (uu___1793_23903.synth_hook);
+        splice = (uu___1793_23903.splice);
+        postprocess = (uu___1793_23903.postprocess);
+        is_native_tactic = (uu___1793_23903.is_native_tactic);
+        identifier_info = (uu___1793_23903.identifier_info);
+        tc_hooks = (uu___1793_23903.tc_hooks);
+        dsenv = (uu___1793_23903.dsenv);
+        nbe = (uu___1793_23903.nbe);
+        strict_args_tab = (uu___1793_23903.strict_args_tab);
+        erasable_types_tab = (uu___1793_23903.erasable_types_tab)
       }
   
 let (push_bv : env -> FStar_Syntax_Syntax.bv -> env) =
@@ -4588,62 +4742,63 @@ let (pop_bv :
     | (FStar_Syntax_Syntax.Binding_var x)::rest ->
         FStar_Pervasives_Native.Some
           (x,
-            (let uu___1763_23302 = env  in
+            (let uu___1806_23961 = env  in
              {
-               solver = (uu___1763_23302.solver);
-               range = (uu___1763_23302.range);
-               curmodule = (uu___1763_23302.curmodule);
+               solver = (uu___1806_23961.solver);
+               range = (uu___1806_23961.range);
+               curmodule = (uu___1806_23961.curmodule);
                gamma = rest;
-               gamma_sig = (uu___1763_23302.gamma_sig);
-               gamma_cache = (uu___1763_23302.gamma_cache);
-               modules = (uu___1763_23302.modules);
-               expected_typ = (uu___1763_23302.expected_typ);
-               sigtab = (uu___1763_23302.sigtab);
-               attrtab = (uu___1763_23302.attrtab);
-               is_pattern = (uu___1763_23302.is_pattern);
-               instantiate_imp = (uu___1763_23302.instantiate_imp);
-               effects = (uu___1763_23302.effects);
-               generalize = (uu___1763_23302.generalize);
-               letrecs = (uu___1763_23302.letrecs);
-               top_level = (uu___1763_23302.top_level);
-               check_uvars = (uu___1763_23302.check_uvars);
-               use_eq = (uu___1763_23302.use_eq);
-               is_iface = (uu___1763_23302.is_iface);
-               admit = (uu___1763_23302.admit);
-               lax = (uu___1763_23302.lax);
-               lax_universes = (uu___1763_23302.lax_universes);
-               phase1 = (uu___1763_23302.phase1);
-               failhard = (uu___1763_23302.failhard);
-               nosynth = (uu___1763_23302.nosynth);
-               uvar_subtyping = (uu___1763_23302.uvar_subtyping);
-               tc_term = (uu___1763_23302.tc_term);
-               type_of = (uu___1763_23302.type_of);
-               universe_of = (uu___1763_23302.universe_of);
-               check_type_of = (uu___1763_23302.check_type_of);
-               use_bv_sorts = (uu___1763_23302.use_bv_sorts);
-               qtbl_name_and_index = (uu___1763_23302.qtbl_name_and_index);
-               normalized_eff_names = (uu___1763_23302.normalized_eff_names);
-               fv_delta_depths = (uu___1763_23302.fv_delta_depths);
-               proof_ns = (uu___1763_23302.proof_ns);
-               synth_hook = (uu___1763_23302.synth_hook);
-               splice = (uu___1763_23302.splice);
-               postprocess = (uu___1763_23302.postprocess);
-               is_native_tactic = (uu___1763_23302.is_native_tactic);
-               identifier_info = (uu___1763_23302.identifier_info);
-               tc_hooks = (uu___1763_23302.tc_hooks);
-               dsenv = (uu___1763_23302.dsenv);
-               nbe = (uu___1763_23302.nbe);
-               strict_args_tab = (uu___1763_23302.strict_args_tab)
+               gamma_sig = (uu___1806_23961.gamma_sig);
+               gamma_cache = (uu___1806_23961.gamma_cache);
+               modules = (uu___1806_23961.modules);
+               expected_typ = (uu___1806_23961.expected_typ);
+               sigtab = (uu___1806_23961.sigtab);
+               attrtab = (uu___1806_23961.attrtab);
+               is_pattern = (uu___1806_23961.is_pattern);
+               instantiate_imp = (uu___1806_23961.instantiate_imp);
+               effects = (uu___1806_23961.effects);
+               generalize = (uu___1806_23961.generalize);
+               letrecs = (uu___1806_23961.letrecs);
+               top_level = (uu___1806_23961.top_level);
+               check_uvars = (uu___1806_23961.check_uvars);
+               use_eq = (uu___1806_23961.use_eq);
+               is_iface = (uu___1806_23961.is_iface);
+               admit = (uu___1806_23961.admit);
+               lax = (uu___1806_23961.lax);
+               lax_universes = (uu___1806_23961.lax_universes);
+               phase1 = (uu___1806_23961.phase1);
+               failhard = (uu___1806_23961.failhard);
+               nosynth = (uu___1806_23961.nosynth);
+               uvar_subtyping = (uu___1806_23961.uvar_subtyping);
+               tc_term = (uu___1806_23961.tc_term);
+               type_of = (uu___1806_23961.type_of);
+               universe_of = (uu___1806_23961.universe_of);
+               check_type_of = (uu___1806_23961.check_type_of);
+               use_bv_sorts = (uu___1806_23961.use_bv_sorts);
+               qtbl_name_and_index = (uu___1806_23961.qtbl_name_and_index);
+               normalized_eff_names = (uu___1806_23961.normalized_eff_names);
+               fv_delta_depths = (uu___1806_23961.fv_delta_depths);
+               proof_ns = (uu___1806_23961.proof_ns);
+               synth_hook = (uu___1806_23961.synth_hook);
+               splice = (uu___1806_23961.splice);
+               postprocess = (uu___1806_23961.postprocess);
+               is_native_tactic = (uu___1806_23961.is_native_tactic);
+               identifier_info = (uu___1806_23961.identifier_info);
+               tc_hooks = (uu___1806_23961.tc_hooks);
+               dsenv = (uu___1806_23961.dsenv);
+               nbe = (uu___1806_23961.nbe);
+               strict_args_tab = (uu___1806_23961.strict_args_tab);
+               erasable_types_tab = (uu___1806_23961.erasable_types_tab)
              }))
-    | uu____23303 -> FStar_Pervasives_Native.None
+    | uu____23962 -> FStar_Pervasives_Native.None
   
 let (push_binders : env -> FStar_Syntax_Syntax.binders -> env) =
   fun env  ->
     fun bs  ->
       FStar_List.fold_left
         (fun env1  ->
-           fun uu____23332  ->
-             match uu____23332 with | (x,uu____23340) -> push_bv env1 x) env
+           fun uu____23991  ->
+             match uu____23991 with | (x,uu____23999) -> push_bv env1 x) env
         bs
   
 let (binding_of_lb :
@@ -4656,12 +4811,12 @@ let (binding_of_lb :
       match x with
       | FStar_Util.Inl x1 ->
           let x2 =
-            let uu___1777_23375 = x1  in
+            let uu___1820_24034 = x1  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___1777_23375.FStar_Syntax_Syntax.ppname);
+                (uu___1820_24034.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___1777_23375.FStar_Syntax_Syntax.index);
+                (uu___1820_24034.FStar_Syntax_Syntax.index);
               FStar_Syntax_Syntax.sort = (FStar_Pervasives_Native.snd t)
             }  in
           FStar_Syntax_Syntax.Binding_var x2
@@ -4693,63 +4848,64 @@ let (open_universes_in :
   fun env  ->
     fun uvs  ->
       fun terms  ->
-        let uu____23448 = FStar_Syntax_Subst.univ_var_opening uvs  in
-        match uu____23448 with
+        let uu____24107 = FStar_Syntax_Subst.univ_var_opening uvs  in
+        match uu____24107 with
         | (univ_subst,univ_vars) ->
             let env' = push_univ_vars env univ_vars  in
-            let uu____23476 =
+            let uu____24135 =
               FStar_List.map (FStar_Syntax_Subst.subst univ_subst) terms  in
-            (env', univ_vars, uu____23476)
+            (env', univ_vars, uu____24135)
   
 let (set_expected_typ : env -> FStar_Syntax_Syntax.typ -> env) =
   fun env  ->
     fun t  ->
-      let uu___1798_23492 = env  in
+      let uu___1841_24151 = env  in
       {
-        solver = (uu___1798_23492.solver);
-        range = (uu___1798_23492.range);
-        curmodule = (uu___1798_23492.curmodule);
-        gamma = (uu___1798_23492.gamma);
-        gamma_sig = (uu___1798_23492.gamma_sig);
-        gamma_cache = (uu___1798_23492.gamma_cache);
-        modules = (uu___1798_23492.modules);
+        solver = (uu___1841_24151.solver);
+        range = (uu___1841_24151.range);
+        curmodule = (uu___1841_24151.curmodule);
+        gamma = (uu___1841_24151.gamma);
+        gamma_sig = (uu___1841_24151.gamma_sig);
+        gamma_cache = (uu___1841_24151.gamma_cache);
+        modules = (uu___1841_24151.modules);
         expected_typ = (FStar_Pervasives_Native.Some t);
-        sigtab = (uu___1798_23492.sigtab);
-        attrtab = (uu___1798_23492.attrtab);
-        is_pattern = (uu___1798_23492.is_pattern);
-        instantiate_imp = (uu___1798_23492.instantiate_imp);
-        effects = (uu___1798_23492.effects);
-        generalize = (uu___1798_23492.generalize);
-        letrecs = (uu___1798_23492.letrecs);
-        top_level = (uu___1798_23492.top_level);
-        check_uvars = (uu___1798_23492.check_uvars);
+        sigtab = (uu___1841_24151.sigtab);
+        attrtab = (uu___1841_24151.attrtab);
+        is_pattern = (uu___1841_24151.is_pattern);
+        instantiate_imp = (uu___1841_24151.instantiate_imp);
+        effects = (uu___1841_24151.effects);
+        generalize = (uu___1841_24151.generalize);
+        letrecs = (uu___1841_24151.letrecs);
+        top_level = (uu___1841_24151.top_level);
+        check_uvars = (uu___1841_24151.check_uvars);
         use_eq = false;
-        is_iface = (uu___1798_23492.is_iface);
-        admit = (uu___1798_23492.admit);
-        lax = (uu___1798_23492.lax);
-        lax_universes = (uu___1798_23492.lax_universes);
-        phase1 = (uu___1798_23492.phase1);
-        failhard = (uu___1798_23492.failhard);
-        nosynth = (uu___1798_23492.nosynth);
-        uvar_subtyping = (uu___1798_23492.uvar_subtyping);
-        tc_term = (uu___1798_23492.tc_term);
-        type_of = (uu___1798_23492.type_of);
-        universe_of = (uu___1798_23492.universe_of);
-        check_type_of = (uu___1798_23492.check_type_of);
-        use_bv_sorts = (uu___1798_23492.use_bv_sorts);
-        qtbl_name_and_index = (uu___1798_23492.qtbl_name_and_index);
-        normalized_eff_names = (uu___1798_23492.normalized_eff_names);
-        fv_delta_depths = (uu___1798_23492.fv_delta_depths);
-        proof_ns = (uu___1798_23492.proof_ns);
-        synth_hook = (uu___1798_23492.synth_hook);
-        splice = (uu___1798_23492.splice);
-        postprocess = (uu___1798_23492.postprocess);
-        is_native_tactic = (uu___1798_23492.is_native_tactic);
-        identifier_info = (uu___1798_23492.identifier_info);
-        tc_hooks = (uu___1798_23492.tc_hooks);
-        dsenv = (uu___1798_23492.dsenv);
-        nbe = (uu___1798_23492.nbe);
-        strict_args_tab = (uu___1798_23492.strict_args_tab)
+        is_iface = (uu___1841_24151.is_iface);
+        admit = (uu___1841_24151.admit);
+        lax = (uu___1841_24151.lax);
+        lax_universes = (uu___1841_24151.lax_universes);
+        phase1 = (uu___1841_24151.phase1);
+        failhard = (uu___1841_24151.failhard);
+        nosynth = (uu___1841_24151.nosynth);
+        uvar_subtyping = (uu___1841_24151.uvar_subtyping);
+        tc_term = (uu___1841_24151.tc_term);
+        type_of = (uu___1841_24151.type_of);
+        universe_of = (uu___1841_24151.universe_of);
+        check_type_of = (uu___1841_24151.check_type_of);
+        use_bv_sorts = (uu___1841_24151.use_bv_sorts);
+        qtbl_name_and_index = (uu___1841_24151.qtbl_name_and_index);
+        normalized_eff_names = (uu___1841_24151.normalized_eff_names);
+        fv_delta_depths = (uu___1841_24151.fv_delta_depths);
+        proof_ns = (uu___1841_24151.proof_ns);
+        synth_hook = (uu___1841_24151.synth_hook);
+        splice = (uu___1841_24151.splice);
+        postprocess = (uu___1841_24151.postprocess);
+        is_native_tactic = (uu___1841_24151.is_native_tactic);
+        identifier_info = (uu___1841_24151.identifier_info);
+        tc_hooks = (uu___1841_24151.tc_hooks);
+        dsenv = (uu___1841_24151.dsenv);
+        nbe = (uu___1841_24151.nbe);
+        strict_args_tab = (uu___1841_24151.strict_args_tab);
+        erasable_types_tab = (uu___1841_24151.erasable_types_tab)
       }
   
 let (expected_typ :
@@ -4762,122 +4918,124 @@ let (expected_typ :
 let (clear_expected_typ :
   env -> (env * FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option)) =
   fun env_  ->
-    let uu____23523 = expected_typ env_  in
-    ((let uu___1805_23529 = env_  in
+    let uu____24182 = expected_typ env_  in
+    ((let uu___1848_24188 = env_  in
       {
-        solver = (uu___1805_23529.solver);
-        range = (uu___1805_23529.range);
-        curmodule = (uu___1805_23529.curmodule);
-        gamma = (uu___1805_23529.gamma);
-        gamma_sig = (uu___1805_23529.gamma_sig);
-        gamma_cache = (uu___1805_23529.gamma_cache);
-        modules = (uu___1805_23529.modules);
+        solver = (uu___1848_24188.solver);
+        range = (uu___1848_24188.range);
+        curmodule = (uu___1848_24188.curmodule);
+        gamma = (uu___1848_24188.gamma);
+        gamma_sig = (uu___1848_24188.gamma_sig);
+        gamma_cache = (uu___1848_24188.gamma_cache);
+        modules = (uu___1848_24188.modules);
         expected_typ = FStar_Pervasives_Native.None;
-        sigtab = (uu___1805_23529.sigtab);
-        attrtab = (uu___1805_23529.attrtab);
-        is_pattern = (uu___1805_23529.is_pattern);
-        instantiate_imp = (uu___1805_23529.instantiate_imp);
-        effects = (uu___1805_23529.effects);
-        generalize = (uu___1805_23529.generalize);
-        letrecs = (uu___1805_23529.letrecs);
-        top_level = (uu___1805_23529.top_level);
-        check_uvars = (uu___1805_23529.check_uvars);
+        sigtab = (uu___1848_24188.sigtab);
+        attrtab = (uu___1848_24188.attrtab);
+        is_pattern = (uu___1848_24188.is_pattern);
+        instantiate_imp = (uu___1848_24188.instantiate_imp);
+        effects = (uu___1848_24188.effects);
+        generalize = (uu___1848_24188.generalize);
+        letrecs = (uu___1848_24188.letrecs);
+        top_level = (uu___1848_24188.top_level);
+        check_uvars = (uu___1848_24188.check_uvars);
         use_eq = false;
-        is_iface = (uu___1805_23529.is_iface);
-        admit = (uu___1805_23529.admit);
-        lax = (uu___1805_23529.lax);
-        lax_universes = (uu___1805_23529.lax_universes);
-        phase1 = (uu___1805_23529.phase1);
-        failhard = (uu___1805_23529.failhard);
-        nosynth = (uu___1805_23529.nosynth);
-        uvar_subtyping = (uu___1805_23529.uvar_subtyping);
-        tc_term = (uu___1805_23529.tc_term);
-        type_of = (uu___1805_23529.type_of);
-        universe_of = (uu___1805_23529.universe_of);
-        check_type_of = (uu___1805_23529.check_type_of);
-        use_bv_sorts = (uu___1805_23529.use_bv_sorts);
-        qtbl_name_and_index = (uu___1805_23529.qtbl_name_and_index);
-        normalized_eff_names = (uu___1805_23529.normalized_eff_names);
-        fv_delta_depths = (uu___1805_23529.fv_delta_depths);
-        proof_ns = (uu___1805_23529.proof_ns);
-        synth_hook = (uu___1805_23529.synth_hook);
-        splice = (uu___1805_23529.splice);
-        postprocess = (uu___1805_23529.postprocess);
-        is_native_tactic = (uu___1805_23529.is_native_tactic);
-        identifier_info = (uu___1805_23529.identifier_info);
-        tc_hooks = (uu___1805_23529.tc_hooks);
-        dsenv = (uu___1805_23529.dsenv);
-        nbe = (uu___1805_23529.nbe);
-        strict_args_tab = (uu___1805_23529.strict_args_tab)
-      }), uu____23523)
+        is_iface = (uu___1848_24188.is_iface);
+        admit = (uu___1848_24188.admit);
+        lax = (uu___1848_24188.lax);
+        lax_universes = (uu___1848_24188.lax_universes);
+        phase1 = (uu___1848_24188.phase1);
+        failhard = (uu___1848_24188.failhard);
+        nosynth = (uu___1848_24188.nosynth);
+        uvar_subtyping = (uu___1848_24188.uvar_subtyping);
+        tc_term = (uu___1848_24188.tc_term);
+        type_of = (uu___1848_24188.type_of);
+        universe_of = (uu___1848_24188.universe_of);
+        check_type_of = (uu___1848_24188.check_type_of);
+        use_bv_sorts = (uu___1848_24188.use_bv_sorts);
+        qtbl_name_and_index = (uu___1848_24188.qtbl_name_and_index);
+        normalized_eff_names = (uu___1848_24188.normalized_eff_names);
+        fv_delta_depths = (uu___1848_24188.fv_delta_depths);
+        proof_ns = (uu___1848_24188.proof_ns);
+        synth_hook = (uu___1848_24188.synth_hook);
+        splice = (uu___1848_24188.splice);
+        postprocess = (uu___1848_24188.postprocess);
+        is_native_tactic = (uu___1848_24188.is_native_tactic);
+        identifier_info = (uu___1848_24188.identifier_info);
+        tc_hooks = (uu___1848_24188.tc_hooks);
+        dsenv = (uu___1848_24188.dsenv);
+        nbe = (uu___1848_24188.nbe);
+        strict_args_tab = (uu___1848_24188.strict_args_tab);
+        erasable_types_tab = (uu___1848_24188.erasable_types_tab)
+      }), uu____24182)
   
 let (finish_module : env -> FStar_Syntax_Syntax.modul -> env) =
   let empty_lid =
-    let uu____23541 =
-      let uu____23544 = FStar_Ident.id_of_text ""  in [uu____23544]  in
-    FStar_Ident.lid_of_ids uu____23541  in
+    let uu____24200 =
+      let uu____24203 = FStar_Ident.id_of_text ""  in [uu____24203]  in
+    FStar_Ident.lid_of_ids uu____24200  in
   fun env  ->
     fun m  ->
       let sigs =
-        let uu____23551 =
+        let uu____24210 =
           FStar_Ident.lid_equals m.FStar_Syntax_Syntax.name
             FStar_Parser_Const.prims_lid
            in
-        if uu____23551
+        if uu____24210
         then
-          let uu____23556 =
+          let uu____24215 =
             FStar_All.pipe_right env.gamma_sig
               (FStar_List.map FStar_Pervasives_Native.snd)
              in
-          FStar_All.pipe_right uu____23556 FStar_List.rev
+          FStar_All.pipe_right uu____24215 FStar_List.rev
         else m.FStar_Syntax_Syntax.exports  in
       add_sigelts env sigs;
-      (let uu___1813_23584 = env  in
+      (let uu___1856_24243 = env  in
        {
-         solver = (uu___1813_23584.solver);
-         range = (uu___1813_23584.range);
+         solver = (uu___1856_24243.solver);
+         range = (uu___1856_24243.range);
          curmodule = empty_lid;
          gamma = [];
          gamma_sig = [];
-         gamma_cache = (uu___1813_23584.gamma_cache);
+         gamma_cache = (uu___1856_24243.gamma_cache);
          modules = (m :: (env.modules));
-         expected_typ = (uu___1813_23584.expected_typ);
-         sigtab = (uu___1813_23584.sigtab);
-         attrtab = (uu___1813_23584.attrtab);
-         is_pattern = (uu___1813_23584.is_pattern);
-         instantiate_imp = (uu___1813_23584.instantiate_imp);
-         effects = (uu___1813_23584.effects);
-         generalize = (uu___1813_23584.generalize);
-         letrecs = (uu___1813_23584.letrecs);
-         top_level = (uu___1813_23584.top_level);
-         check_uvars = (uu___1813_23584.check_uvars);
-         use_eq = (uu___1813_23584.use_eq);
-         is_iface = (uu___1813_23584.is_iface);
-         admit = (uu___1813_23584.admit);
-         lax = (uu___1813_23584.lax);
-         lax_universes = (uu___1813_23584.lax_universes);
-         phase1 = (uu___1813_23584.phase1);
-         failhard = (uu___1813_23584.failhard);
-         nosynth = (uu___1813_23584.nosynth);
-         uvar_subtyping = (uu___1813_23584.uvar_subtyping);
-         tc_term = (uu___1813_23584.tc_term);
-         type_of = (uu___1813_23584.type_of);
-         universe_of = (uu___1813_23584.universe_of);
-         check_type_of = (uu___1813_23584.check_type_of);
-         use_bv_sorts = (uu___1813_23584.use_bv_sorts);
-         qtbl_name_and_index = (uu___1813_23584.qtbl_name_and_index);
-         normalized_eff_names = (uu___1813_23584.normalized_eff_names);
-         fv_delta_depths = (uu___1813_23584.fv_delta_depths);
-         proof_ns = (uu___1813_23584.proof_ns);
-         synth_hook = (uu___1813_23584.synth_hook);
-         splice = (uu___1813_23584.splice);
-         postprocess = (uu___1813_23584.postprocess);
-         is_native_tactic = (uu___1813_23584.is_native_tactic);
-         identifier_info = (uu___1813_23584.identifier_info);
-         tc_hooks = (uu___1813_23584.tc_hooks);
-         dsenv = (uu___1813_23584.dsenv);
-         nbe = (uu___1813_23584.nbe);
-         strict_args_tab = (uu___1813_23584.strict_args_tab)
+         expected_typ = (uu___1856_24243.expected_typ);
+         sigtab = (uu___1856_24243.sigtab);
+         attrtab = (uu___1856_24243.attrtab);
+         is_pattern = (uu___1856_24243.is_pattern);
+         instantiate_imp = (uu___1856_24243.instantiate_imp);
+         effects = (uu___1856_24243.effects);
+         generalize = (uu___1856_24243.generalize);
+         letrecs = (uu___1856_24243.letrecs);
+         top_level = (uu___1856_24243.top_level);
+         check_uvars = (uu___1856_24243.check_uvars);
+         use_eq = (uu___1856_24243.use_eq);
+         is_iface = (uu___1856_24243.is_iface);
+         admit = (uu___1856_24243.admit);
+         lax = (uu___1856_24243.lax);
+         lax_universes = (uu___1856_24243.lax_universes);
+         phase1 = (uu___1856_24243.phase1);
+         failhard = (uu___1856_24243.failhard);
+         nosynth = (uu___1856_24243.nosynth);
+         uvar_subtyping = (uu___1856_24243.uvar_subtyping);
+         tc_term = (uu___1856_24243.tc_term);
+         type_of = (uu___1856_24243.type_of);
+         universe_of = (uu___1856_24243.universe_of);
+         check_type_of = (uu___1856_24243.check_type_of);
+         use_bv_sorts = (uu___1856_24243.use_bv_sorts);
+         qtbl_name_and_index = (uu___1856_24243.qtbl_name_and_index);
+         normalized_eff_names = (uu___1856_24243.normalized_eff_names);
+         fv_delta_depths = (uu___1856_24243.fv_delta_depths);
+         proof_ns = (uu___1856_24243.proof_ns);
+         synth_hook = (uu___1856_24243.synth_hook);
+         splice = (uu___1856_24243.splice);
+         postprocess = (uu___1856_24243.postprocess);
+         is_native_tactic = (uu___1856_24243.is_native_tactic);
+         identifier_info = (uu___1856_24243.identifier_info);
+         tc_hooks = (uu___1856_24243.tc_hooks);
+         dsenv = (uu___1856_24243.dsenv);
+         nbe = (uu___1856_24243.nbe);
+         strict_args_tab = (uu___1856_24243.strict_args_tab);
+         erasable_types_tab = (uu___1856_24243.erasable_types_tab)
        })
   
 let (uvars_in_env : env -> FStar_Syntax_Syntax.uvars) =
@@ -4887,22 +5045,22 @@ let (uvars_in_env : env -> FStar_Syntax_Syntax.uvars) =
     let rec aux out g =
       match g with
       | [] -> out
-      | (FStar_Syntax_Syntax.Binding_univ uu____23636)::tl1 -> aux out tl1
-      | (FStar_Syntax_Syntax.Binding_lid (uu____23640,(uu____23641,t)))::tl1
+      | (FStar_Syntax_Syntax.Binding_univ uu____24295)::tl1 -> aux out tl1
+      | (FStar_Syntax_Syntax.Binding_lid (uu____24299,(uu____24300,t)))::tl1
           ->
-          let uu____23662 =
-            let uu____23665 = FStar_Syntax_Free.uvars t  in
-            ext out uu____23665  in
-          aux uu____23662 tl1
+          let uu____24321 =
+            let uu____24324 = FStar_Syntax_Free.uvars t  in
+            ext out uu____24324  in
+          aux uu____24321 tl1
       | (FStar_Syntax_Syntax.Binding_var
-          { FStar_Syntax_Syntax.ppname = uu____23668;
-            FStar_Syntax_Syntax.index = uu____23669;
+          { FStar_Syntax_Syntax.ppname = uu____24327;
+            FStar_Syntax_Syntax.index = uu____24328;
             FStar_Syntax_Syntax.sort = t;_})::tl1
           ->
-          let uu____23677 =
-            let uu____23680 = FStar_Syntax_Free.uvars t  in
-            ext out uu____23680  in
-          aux uu____23677 tl1
+          let uu____24336 =
+            let uu____24339 = FStar_Syntax_Free.uvars t  in
+            ext out uu____24339  in
+          aux uu____24336 tl1
        in
     aux no_uvs env.gamma
   
@@ -4913,22 +5071,22 @@ let (univ_vars : env -> FStar_Syntax_Syntax.universe_uvar FStar_Util.set) =
     let rec aux out g =
       match g with
       | [] -> out
-      | (FStar_Syntax_Syntax.Binding_univ uu____23738)::tl1 -> aux out tl1
-      | (FStar_Syntax_Syntax.Binding_lid (uu____23742,(uu____23743,t)))::tl1
+      | (FStar_Syntax_Syntax.Binding_univ uu____24397)::tl1 -> aux out tl1
+      | (FStar_Syntax_Syntax.Binding_lid (uu____24401,(uu____24402,t)))::tl1
           ->
-          let uu____23764 =
-            let uu____23767 = FStar_Syntax_Free.univs t  in
-            ext out uu____23767  in
-          aux uu____23764 tl1
+          let uu____24423 =
+            let uu____24426 = FStar_Syntax_Free.univs t  in
+            ext out uu____24426  in
+          aux uu____24423 tl1
       | (FStar_Syntax_Syntax.Binding_var
-          { FStar_Syntax_Syntax.ppname = uu____23770;
-            FStar_Syntax_Syntax.index = uu____23771;
+          { FStar_Syntax_Syntax.ppname = uu____24429;
+            FStar_Syntax_Syntax.index = uu____24430;
             FStar_Syntax_Syntax.sort = t;_})::tl1
           ->
-          let uu____23779 =
-            let uu____23782 = FStar_Syntax_Free.univs t  in
-            ext out uu____23782  in
-          aux uu____23779 tl1
+          let uu____24438 =
+            let uu____24441 = FStar_Syntax_Free.univs t  in
+            ext out uu____24441  in
+          aux uu____24438 tl1
        in
     aux no_univs env.gamma
   
@@ -4940,23 +5098,23 @@ let (univnames : env -> FStar_Syntax_Syntax.univ_name FStar_Util.set) =
       match g with
       | [] -> out
       | (FStar_Syntax_Syntax.Binding_univ uname)::tl1 ->
-          let uu____23844 = FStar_Util.set_add uname out  in
-          aux uu____23844 tl1
-      | (FStar_Syntax_Syntax.Binding_lid (uu____23847,(uu____23848,t)))::tl1
+          let uu____24503 = FStar_Util.set_add uname out  in
+          aux uu____24503 tl1
+      | (FStar_Syntax_Syntax.Binding_lid (uu____24506,(uu____24507,t)))::tl1
           ->
-          let uu____23869 =
-            let uu____23872 = FStar_Syntax_Free.univnames t  in
-            ext out uu____23872  in
-          aux uu____23869 tl1
+          let uu____24528 =
+            let uu____24531 = FStar_Syntax_Free.univnames t  in
+            ext out uu____24531  in
+          aux uu____24528 tl1
       | (FStar_Syntax_Syntax.Binding_var
-          { FStar_Syntax_Syntax.ppname = uu____23875;
-            FStar_Syntax_Syntax.index = uu____23876;
+          { FStar_Syntax_Syntax.ppname = uu____24534;
+            FStar_Syntax_Syntax.index = uu____24535;
             FStar_Syntax_Syntax.sort = t;_})::tl1
           ->
-          let uu____23884 =
-            let uu____23887 = FStar_Syntax_Free.univnames t  in
-            ext out uu____23887  in
-          aux uu____23884 tl1
+          let uu____24543 =
+            let uu____24546 = FStar_Syntax_Free.univnames t  in
+            ext out uu____24546  in
+          aux uu____24543 tl1
        in
     aux no_univ_names env.gamma
   
@@ -4966,21 +5124,21 @@ let (bound_vars_of_bindings :
   fun bs  ->
     FStar_All.pipe_right bs
       (FStar_List.collect
-         (fun uu___11_23908  ->
-            match uu___11_23908 with
+         (fun uu___11_24567  ->
+            match uu___11_24567 with
             | FStar_Syntax_Syntax.Binding_var x -> [x]
-            | FStar_Syntax_Syntax.Binding_lid uu____23912 -> []
-            | FStar_Syntax_Syntax.Binding_univ uu____23925 -> []))
+            | FStar_Syntax_Syntax.Binding_lid uu____24571 -> []
+            | FStar_Syntax_Syntax.Binding_univ uu____24584 -> []))
   
 let (binders_of_bindings :
   FStar_Syntax_Syntax.binding Prims.list -> FStar_Syntax_Syntax.binders) =
   fun bs  ->
-    let uu____23936 =
-      let uu____23945 = bound_vars_of_bindings bs  in
-      FStar_All.pipe_right uu____23945
+    let uu____24595 =
+      let uu____24604 = bound_vars_of_bindings bs  in
+      FStar_All.pipe_right uu____24604
         (FStar_List.map FStar_Syntax_Syntax.mk_binder)
        in
-    FStar_All.pipe_right uu____23936 FStar_List.rev
+    FStar_All.pipe_right uu____24595 FStar_List.rev
   
 let (bound_vars : env -> FStar_Syntax_Syntax.bv Prims.list) =
   fun env  -> bound_vars_of_bindings env.gamma 
@@ -4988,38 +5146,38 @@ let (all_binders : env -> FStar_Syntax_Syntax.binders) =
   fun env  -> binders_of_bindings env.gamma 
 let (print_gamma : FStar_Syntax_Syntax.gamma -> Prims.string) =
   fun gamma  ->
-    let uu____23993 =
+    let uu____24652 =
       FStar_All.pipe_right gamma
         (FStar_List.map
-           (fun uu___12_24006  ->
-              match uu___12_24006 with
+           (fun uu___12_24665  ->
+              match uu___12_24665 with
               | FStar_Syntax_Syntax.Binding_var x ->
-                  let uu____24009 = FStar_Syntax_Print.bv_to_string x  in
-                  Prims.op_Hat "Binding_var " uu____24009
+                  let uu____24668 = FStar_Syntax_Print.bv_to_string x  in
+                  Prims.op_Hat "Binding_var " uu____24668
               | FStar_Syntax_Syntax.Binding_univ u ->
                   Prims.op_Hat "Binding_univ " u.FStar_Ident.idText
-              | FStar_Syntax_Syntax.Binding_lid (l,uu____24015) ->
-                  let uu____24032 = FStar_Ident.string_of_lid l  in
-                  Prims.op_Hat "Binding_lid " uu____24032))
+              | FStar_Syntax_Syntax.Binding_lid (l,uu____24674) ->
+                  let uu____24691 = FStar_Ident.string_of_lid l  in
+                  Prims.op_Hat "Binding_lid " uu____24691))
        in
-    FStar_All.pipe_right uu____23993 (FStar_String.concat "::\n")
+    FStar_All.pipe_right uu____24652 (FStar_String.concat "::\n")
   
 let (string_of_delta_level : delta_level -> Prims.string) =
-  fun uu___13_24046  ->
-    match uu___13_24046 with
+  fun uu___13_24705  ->
+    match uu___13_24705 with
     | NoDelta  -> "NoDelta"
     | InliningDelta  -> "Inlining"
     | Eager_unfolding_only  -> "Eager_unfolding_only"
     | Unfold d ->
-        let uu____24052 = FStar_Syntax_Print.delta_depth_to_string d  in
-        Prims.op_Hat "Unfold " uu____24052
+        let uu____24711 = FStar_Syntax_Print.delta_depth_to_string d  in
+        Prims.op_Hat "Unfold " uu____24711
   
 let (lidents : env -> FStar_Ident.lident Prims.list) =
   fun env  ->
     let keys = FStar_List.collect FStar_Pervasives_Native.fst env.gamma_sig
        in
     FStar_Util.smap_fold (sigtab env)
-      (fun uu____24075  ->
+      (fun uu____24734  ->
          fun v1  ->
            fun keys1  ->
              FStar_List.append (FStar_Syntax_Util.lids_of_sigelt v1) keys1)
@@ -5030,77 +5188,78 @@ let (should_enc_path : env -> Prims.string Prims.list -> Prims.bool) =
     fun path  ->
       let rec str_i_prefix xs ys =
         match (xs, ys) with
-        | ([],uu____24130) -> true
+        | ([],uu____24789) -> true
         | (x::xs1,y::ys1) ->
             ((FStar_String.lowercase x) = (FStar_String.lowercase y)) &&
               (str_i_prefix xs1 ys1)
-        | (uu____24163,uu____24164) -> false  in
-      let uu____24178 =
+        | (uu____24822,uu____24823) -> false  in
+      let uu____24837 =
         FStar_List.tryFind
-          (fun uu____24200  ->
-             match uu____24200 with | (p,uu____24211) -> str_i_prefix p path)
+          (fun uu____24859  ->
+             match uu____24859 with | (p,uu____24870) -> str_i_prefix p path)
           env.proof_ns
          in
-      match uu____24178 with
+      match uu____24837 with
       | FStar_Pervasives_Native.None  -> false
-      | FStar_Pervasives_Native.Some (uu____24230,b) -> b
+      | FStar_Pervasives_Native.Some (uu____24889,b) -> b
   
 let (should_enc_lid : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun lid  ->
-      let uu____24260 = FStar_Ident.path_of_lid lid  in
-      should_enc_path env uu____24260
+      let uu____24919 = FStar_Ident.path_of_lid lid  in
+      should_enc_path env uu____24919
   
 let (cons_proof_ns : Prims.bool -> env -> name_prefix -> env) =
   fun b  ->
     fun e  ->
       fun path  ->
-        let uu___1956_24282 = e  in
+        let uu___1999_24941 = e  in
         {
-          solver = (uu___1956_24282.solver);
-          range = (uu___1956_24282.range);
-          curmodule = (uu___1956_24282.curmodule);
-          gamma = (uu___1956_24282.gamma);
-          gamma_sig = (uu___1956_24282.gamma_sig);
-          gamma_cache = (uu___1956_24282.gamma_cache);
-          modules = (uu___1956_24282.modules);
-          expected_typ = (uu___1956_24282.expected_typ);
-          sigtab = (uu___1956_24282.sigtab);
-          attrtab = (uu___1956_24282.attrtab);
-          is_pattern = (uu___1956_24282.is_pattern);
-          instantiate_imp = (uu___1956_24282.instantiate_imp);
-          effects = (uu___1956_24282.effects);
-          generalize = (uu___1956_24282.generalize);
-          letrecs = (uu___1956_24282.letrecs);
-          top_level = (uu___1956_24282.top_level);
-          check_uvars = (uu___1956_24282.check_uvars);
-          use_eq = (uu___1956_24282.use_eq);
-          is_iface = (uu___1956_24282.is_iface);
-          admit = (uu___1956_24282.admit);
-          lax = (uu___1956_24282.lax);
-          lax_universes = (uu___1956_24282.lax_universes);
-          phase1 = (uu___1956_24282.phase1);
-          failhard = (uu___1956_24282.failhard);
-          nosynth = (uu___1956_24282.nosynth);
-          uvar_subtyping = (uu___1956_24282.uvar_subtyping);
-          tc_term = (uu___1956_24282.tc_term);
-          type_of = (uu___1956_24282.type_of);
-          universe_of = (uu___1956_24282.universe_of);
-          check_type_of = (uu___1956_24282.check_type_of);
-          use_bv_sorts = (uu___1956_24282.use_bv_sorts);
-          qtbl_name_and_index = (uu___1956_24282.qtbl_name_and_index);
-          normalized_eff_names = (uu___1956_24282.normalized_eff_names);
-          fv_delta_depths = (uu___1956_24282.fv_delta_depths);
+          solver = (uu___1999_24941.solver);
+          range = (uu___1999_24941.range);
+          curmodule = (uu___1999_24941.curmodule);
+          gamma = (uu___1999_24941.gamma);
+          gamma_sig = (uu___1999_24941.gamma_sig);
+          gamma_cache = (uu___1999_24941.gamma_cache);
+          modules = (uu___1999_24941.modules);
+          expected_typ = (uu___1999_24941.expected_typ);
+          sigtab = (uu___1999_24941.sigtab);
+          attrtab = (uu___1999_24941.attrtab);
+          is_pattern = (uu___1999_24941.is_pattern);
+          instantiate_imp = (uu___1999_24941.instantiate_imp);
+          effects = (uu___1999_24941.effects);
+          generalize = (uu___1999_24941.generalize);
+          letrecs = (uu___1999_24941.letrecs);
+          top_level = (uu___1999_24941.top_level);
+          check_uvars = (uu___1999_24941.check_uvars);
+          use_eq = (uu___1999_24941.use_eq);
+          is_iface = (uu___1999_24941.is_iface);
+          admit = (uu___1999_24941.admit);
+          lax = (uu___1999_24941.lax);
+          lax_universes = (uu___1999_24941.lax_universes);
+          phase1 = (uu___1999_24941.phase1);
+          failhard = (uu___1999_24941.failhard);
+          nosynth = (uu___1999_24941.nosynth);
+          uvar_subtyping = (uu___1999_24941.uvar_subtyping);
+          tc_term = (uu___1999_24941.tc_term);
+          type_of = (uu___1999_24941.type_of);
+          universe_of = (uu___1999_24941.universe_of);
+          check_type_of = (uu___1999_24941.check_type_of);
+          use_bv_sorts = (uu___1999_24941.use_bv_sorts);
+          qtbl_name_and_index = (uu___1999_24941.qtbl_name_and_index);
+          normalized_eff_names = (uu___1999_24941.normalized_eff_names);
+          fv_delta_depths = (uu___1999_24941.fv_delta_depths);
           proof_ns = ((path, b) :: (e.proof_ns));
-          synth_hook = (uu___1956_24282.synth_hook);
-          splice = (uu___1956_24282.splice);
-          postprocess = (uu___1956_24282.postprocess);
-          is_native_tactic = (uu___1956_24282.is_native_tactic);
-          identifier_info = (uu___1956_24282.identifier_info);
-          tc_hooks = (uu___1956_24282.tc_hooks);
-          dsenv = (uu___1956_24282.dsenv);
-          nbe = (uu___1956_24282.nbe);
-          strict_args_tab = (uu___1956_24282.strict_args_tab)
+          synth_hook = (uu___1999_24941.synth_hook);
+          splice = (uu___1999_24941.splice);
+          postprocess = (uu___1999_24941.postprocess);
+          is_native_tactic = (uu___1999_24941.is_native_tactic);
+          identifier_info = (uu___1999_24941.identifier_info);
+          tc_hooks = (uu___1999_24941.tc_hooks);
+          dsenv = (uu___1999_24941.dsenv);
+          nbe = (uu___1999_24941.nbe);
+          strict_args_tab = (uu___1999_24941.strict_args_tab);
+          erasable_types_tab = (uu___1999_24941.erasable_types_tab)
         }
   
 let (add_proof_ns : env -> name_prefix -> env) =
@@ -5111,89 +5270,90 @@ let (get_proof_ns : env -> proof_namespace) = fun e  -> e.proof_ns
 let (set_proof_ns : proof_namespace -> env -> env) =
   fun ns  ->
     fun e  ->
-      let uu___1965_24330 = e  in
+      let uu___2008_24989 = e  in
       {
-        solver = (uu___1965_24330.solver);
-        range = (uu___1965_24330.range);
-        curmodule = (uu___1965_24330.curmodule);
-        gamma = (uu___1965_24330.gamma);
-        gamma_sig = (uu___1965_24330.gamma_sig);
-        gamma_cache = (uu___1965_24330.gamma_cache);
-        modules = (uu___1965_24330.modules);
-        expected_typ = (uu___1965_24330.expected_typ);
-        sigtab = (uu___1965_24330.sigtab);
-        attrtab = (uu___1965_24330.attrtab);
-        is_pattern = (uu___1965_24330.is_pattern);
-        instantiate_imp = (uu___1965_24330.instantiate_imp);
-        effects = (uu___1965_24330.effects);
-        generalize = (uu___1965_24330.generalize);
-        letrecs = (uu___1965_24330.letrecs);
-        top_level = (uu___1965_24330.top_level);
-        check_uvars = (uu___1965_24330.check_uvars);
-        use_eq = (uu___1965_24330.use_eq);
-        is_iface = (uu___1965_24330.is_iface);
-        admit = (uu___1965_24330.admit);
-        lax = (uu___1965_24330.lax);
-        lax_universes = (uu___1965_24330.lax_universes);
-        phase1 = (uu___1965_24330.phase1);
-        failhard = (uu___1965_24330.failhard);
-        nosynth = (uu___1965_24330.nosynth);
-        uvar_subtyping = (uu___1965_24330.uvar_subtyping);
-        tc_term = (uu___1965_24330.tc_term);
-        type_of = (uu___1965_24330.type_of);
-        universe_of = (uu___1965_24330.universe_of);
-        check_type_of = (uu___1965_24330.check_type_of);
-        use_bv_sorts = (uu___1965_24330.use_bv_sorts);
-        qtbl_name_and_index = (uu___1965_24330.qtbl_name_and_index);
-        normalized_eff_names = (uu___1965_24330.normalized_eff_names);
-        fv_delta_depths = (uu___1965_24330.fv_delta_depths);
+        solver = (uu___2008_24989.solver);
+        range = (uu___2008_24989.range);
+        curmodule = (uu___2008_24989.curmodule);
+        gamma = (uu___2008_24989.gamma);
+        gamma_sig = (uu___2008_24989.gamma_sig);
+        gamma_cache = (uu___2008_24989.gamma_cache);
+        modules = (uu___2008_24989.modules);
+        expected_typ = (uu___2008_24989.expected_typ);
+        sigtab = (uu___2008_24989.sigtab);
+        attrtab = (uu___2008_24989.attrtab);
+        is_pattern = (uu___2008_24989.is_pattern);
+        instantiate_imp = (uu___2008_24989.instantiate_imp);
+        effects = (uu___2008_24989.effects);
+        generalize = (uu___2008_24989.generalize);
+        letrecs = (uu___2008_24989.letrecs);
+        top_level = (uu___2008_24989.top_level);
+        check_uvars = (uu___2008_24989.check_uvars);
+        use_eq = (uu___2008_24989.use_eq);
+        is_iface = (uu___2008_24989.is_iface);
+        admit = (uu___2008_24989.admit);
+        lax = (uu___2008_24989.lax);
+        lax_universes = (uu___2008_24989.lax_universes);
+        phase1 = (uu___2008_24989.phase1);
+        failhard = (uu___2008_24989.failhard);
+        nosynth = (uu___2008_24989.nosynth);
+        uvar_subtyping = (uu___2008_24989.uvar_subtyping);
+        tc_term = (uu___2008_24989.tc_term);
+        type_of = (uu___2008_24989.type_of);
+        universe_of = (uu___2008_24989.universe_of);
+        check_type_of = (uu___2008_24989.check_type_of);
+        use_bv_sorts = (uu___2008_24989.use_bv_sorts);
+        qtbl_name_and_index = (uu___2008_24989.qtbl_name_and_index);
+        normalized_eff_names = (uu___2008_24989.normalized_eff_names);
+        fv_delta_depths = (uu___2008_24989.fv_delta_depths);
         proof_ns = ns;
-        synth_hook = (uu___1965_24330.synth_hook);
-        splice = (uu___1965_24330.splice);
-        postprocess = (uu___1965_24330.postprocess);
-        is_native_tactic = (uu___1965_24330.is_native_tactic);
-        identifier_info = (uu___1965_24330.identifier_info);
-        tc_hooks = (uu___1965_24330.tc_hooks);
-        dsenv = (uu___1965_24330.dsenv);
-        nbe = (uu___1965_24330.nbe);
-        strict_args_tab = (uu___1965_24330.strict_args_tab)
+        synth_hook = (uu___2008_24989.synth_hook);
+        splice = (uu___2008_24989.splice);
+        postprocess = (uu___2008_24989.postprocess);
+        is_native_tactic = (uu___2008_24989.is_native_tactic);
+        identifier_info = (uu___2008_24989.identifier_info);
+        tc_hooks = (uu___2008_24989.tc_hooks);
+        dsenv = (uu___2008_24989.dsenv);
+        nbe = (uu___2008_24989.nbe);
+        strict_args_tab = (uu___2008_24989.strict_args_tab);
+        erasable_types_tab = (uu___2008_24989.erasable_types_tab)
       }
   
 let (unbound_vars :
   env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv FStar_Util.set) =
   fun e  ->
     fun t  ->
-      let uu____24346 = FStar_Syntax_Free.names t  in
-      let uu____24349 = bound_vars e  in
+      let uu____25005 = FStar_Syntax_Free.names t  in
+      let uu____25008 = bound_vars e  in
       FStar_List.fold_left (fun s  -> fun bv  -> FStar_Util.set_remove bv s)
-        uu____24346 uu____24349
+        uu____25005 uu____25008
   
 let (closed : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun e  ->
     fun t  ->
-      let uu____24372 = unbound_vars e t  in
-      FStar_Util.set_is_empty uu____24372
+      let uu____25031 = unbound_vars e t  in
+      FStar_Util.set_is_empty uu____25031
   
 let (closed' : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____24382 = FStar_Syntax_Free.names t  in
-    FStar_Util.set_is_empty uu____24382
+    let uu____25041 = FStar_Syntax_Free.names t  in
+    FStar_Util.set_is_empty uu____25041
   
 let (string_of_proof_ns : env -> Prims.string) =
   fun env  ->
-    let aux uu____24403 =
-      match uu____24403 with
+    let aux uu____25062 =
+      match uu____25062 with
       | (p,b) ->
           if (p = []) && b
           then "*"
           else
-            (let uu____24423 = FStar_Ident.text_of_path p  in
-             Prims.op_Hat (if b then "+" else "-") uu____24423)
+            (let uu____25082 = FStar_Ident.text_of_path p  in
+             Prims.op_Hat (if b then "+" else "-") uu____25082)
        in
-    let uu____24431 =
-      let uu____24435 = FStar_List.map aux env.proof_ns  in
-      FStar_All.pipe_right uu____24435 FStar_List.rev  in
-    FStar_All.pipe_right uu____24431 (FStar_String.concat " ")
+    let uu____25090 =
+      let uu____25094 = FStar_List.map aux env.proof_ns  in
+      FStar_All.pipe_right uu____25094 FStar_List.rev  in
+    FStar_All.pipe_right uu____25090 (FStar_String.concat " ")
   
 let (guard_of_guard_formula :
   FStar_TypeChecker_Common.guard_formula -> guard_t) =
@@ -5213,21 +5373,21 @@ let (is_trivial : guard_t -> Prims.bool) =
                 ((imp.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_should_check =
                    FStar_Syntax_Syntax.Allow_unresolved)
                   ||
-                  (let uu____24505 =
+                  (let uu____25164 =
                      FStar_Syntax_Unionfind.find
                        (imp.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head
                       in
-                   match uu____24505 with
-                   | FStar_Pervasives_Native.Some uu____24509 -> true
+                   match uu____25164 with
+                   | FStar_Pervasives_Native.Some uu____25168 -> true
                    | FStar_Pervasives_Native.None  -> false)))
-    | uu____24512 -> false
+    | uu____25171 -> false
   
 let (is_trivial_guard_formula : guard_t -> Prims.bool) =
   fun g  ->
     match g with
-    | { guard_f = FStar_TypeChecker_Common.Trivial ; deferred = uu____24522;
-        univ_ineqs = uu____24523; implicits = uu____24524;_} -> true
-    | uu____24536 -> false
+    | { guard_f = FStar_TypeChecker_Common.Trivial ; deferred = uu____25181;
+        univ_ineqs = uu____25182; implicits = uu____25183;_} -> true
+    | uu____25195 -> false
   
 let (trivial_guard : guard_t) =
   {
@@ -5248,12 +5408,12 @@ let (abstract_guard_n :
               (FStar_Pervasives_Native.Some
                  (FStar_Syntax_Util.residual_tot FStar_Syntax_Util.ktype0))
              in
-          let uu___2009_24567 = g  in
+          let uu___2052_25226 = g  in
           {
             guard_f = (FStar_TypeChecker_Common.NonTrivial f');
-            deferred = (uu___2009_24567.deferred);
-            univ_ineqs = (uu___2009_24567.univ_ineqs);
-            implicits = (uu___2009_24567.implicits)
+            deferred = (uu___2052_25226.deferred);
+            univ_ineqs = (uu___2052_25226.univ_ineqs);
+            implicits = (uu___2052_25226.implicits)
           }
   
 let (abstract_guard : FStar_Syntax_Syntax.binder -> guard_t -> guard_t) =
@@ -5268,31 +5428,31 @@ let (def_check_vars_in_set :
     fun msg  ->
       fun vset  ->
         fun t  ->
-          let uu____24606 = FStar_Options.defensive ()  in
-          if uu____24606
+          let uu____25265 = FStar_Options.defensive ()  in
+          if uu____25265
           then
             let s = FStar_Syntax_Free.names t  in
-            let uu____24612 =
-              let uu____24614 =
-                let uu____24616 = FStar_Util.set_difference s vset  in
-                FStar_All.pipe_left FStar_Util.set_is_empty uu____24616  in
-              Prims.op_Negation uu____24614  in
-            (if uu____24612
+            let uu____25271 =
+              let uu____25273 =
+                let uu____25275 = FStar_Util.set_difference s vset  in
+                FStar_All.pipe_left FStar_Util.set_is_empty uu____25275  in
+              Prims.op_Negation uu____25273  in
+            (if uu____25271
              then
-               let uu____24623 =
-                 let uu____24629 =
-                   let uu____24631 = FStar_Syntax_Print.term_to_string t  in
-                   let uu____24633 =
-                     let uu____24635 = FStar_Util.set_elements s  in
-                     FStar_All.pipe_right uu____24635
+               let uu____25282 =
+                 let uu____25288 =
+                   let uu____25290 = FStar_Syntax_Print.term_to_string t  in
+                   let uu____25292 =
+                     let uu____25294 = FStar_Util.set_elements s  in
+                     FStar_All.pipe_right uu____25294
                        (FStar_Syntax_Print.bvs_to_string ",\n\t")
                       in
                    FStar_Util.format3
                      "Internal: term is not closed (%s).\nt = (%s)\nFVs = (%s)\n"
-                     msg uu____24631 uu____24633
+                     msg uu____25290 uu____25292
                     in
-                 (FStar_Errors.Warning_Defensive, uu____24629)  in
-               FStar_Errors.log_issue rng uu____24623
+                 (FStar_Errors.Warning_Defensive, uu____25288)  in
+               FStar_Errors.log_issue rng uu____25282
              else ())
           else ()
   
@@ -5305,15 +5465,15 @@ let (def_check_closed_in :
     fun msg  ->
       fun l  ->
         fun t  ->
-          let uu____24675 =
-            let uu____24677 = FStar_Options.defensive ()  in
-            Prims.op_Negation uu____24677  in
-          if uu____24675
+          let uu____25334 =
+            let uu____25336 = FStar_Options.defensive ()  in
+            Prims.op_Negation uu____25336  in
+          if uu____25334
           then ()
           else
-            (let uu____24682 =
+            (let uu____25341 =
                FStar_Util.as_set l FStar_Syntax_Syntax.order_bv  in
-             def_check_vars_in_set rng msg uu____24682 t)
+             def_check_vars_in_set rng msg uu____25341 t)
   
 let (def_check_closed_in_env :
   FStar_Range.range ->
@@ -5323,14 +5483,14 @@ let (def_check_closed_in_env :
     fun msg  ->
       fun e  ->
         fun t  ->
-          let uu____24708 =
-            let uu____24710 = FStar_Options.defensive ()  in
-            Prims.op_Negation uu____24710  in
-          if uu____24708
+          let uu____25367 =
+            let uu____25369 = FStar_Options.defensive ()  in
+            Prims.op_Negation uu____25369  in
+          if uu____25367
           then ()
           else
-            (let uu____24715 = bound_vars e  in
-             def_check_closed_in rng msg uu____24715 t)
+            (let uu____25374 = bound_vars e  in
+             def_check_closed_in rng msg uu____25374 t)
   
 let (def_check_guard_wf :
   FStar_Range.range -> Prims.string -> env -> guard_t -> unit) =
@@ -5349,30 +5509,30 @@ let (apply_guard : guard_t -> FStar_Syntax_Syntax.term -> guard_t) =
       match g.guard_f with
       | FStar_TypeChecker_Common.Trivial  -> g
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___2046_24754 = g  in
-          let uu____24755 =
-            let uu____24756 =
-              let uu____24757 =
-                let uu____24764 =
-                  let uu____24765 =
-                    let uu____24782 =
-                      let uu____24793 = FStar_Syntax_Syntax.as_arg e  in
-                      [uu____24793]  in
-                    (f, uu____24782)  in
-                  FStar_Syntax_Syntax.Tm_app uu____24765  in
-                FStar_Syntax_Syntax.mk uu____24764  in
-              uu____24757 FStar_Pervasives_Native.None
+          let uu___2089_25413 = g  in
+          let uu____25414 =
+            let uu____25415 =
+              let uu____25416 =
+                let uu____25423 =
+                  let uu____25424 =
+                    let uu____25441 =
+                      let uu____25452 = FStar_Syntax_Syntax.as_arg e  in
+                      [uu____25452]  in
+                    (f, uu____25441)  in
+                  FStar_Syntax_Syntax.Tm_app uu____25424  in
+                FStar_Syntax_Syntax.mk uu____25423  in
+              uu____25416 FStar_Pervasives_Native.None
                 f.FStar_Syntax_Syntax.pos
                in
             FStar_All.pipe_left
-              (fun _24830  -> FStar_TypeChecker_Common.NonTrivial _24830)
-              uu____24756
+              (fun _25489  -> FStar_TypeChecker_Common.NonTrivial _25489)
+              uu____25415
              in
           {
-            guard_f = uu____24755;
-            deferred = (uu___2046_24754.deferred);
-            univ_ineqs = (uu___2046_24754.univ_ineqs);
-            implicits = (uu___2046_24754.implicits)
+            guard_f = uu____25414;
+            deferred = (uu___2089_25413.deferred);
+            univ_ineqs = (uu___2089_25413.univ_ineqs);
+            implicits = (uu___2089_25413.implicits)
           }
   
 let (map_guard :
@@ -5384,15 +5544,15 @@ let (map_guard :
       match g.guard_f with
       | FStar_TypeChecker_Common.Trivial  -> g
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___2053_24848 = g  in
-          let uu____24849 =
-            let uu____24850 = map1 f  in
-            FStar_TypeChecker_Common.NonTrivial uu____24850  in
+          let uu___2096_25507 = g  in
+          let uu____25508 =
+            let uu____25509 = map1 f  in
+            FStar_TypeChecker_Common.NonTrivial uu____25509  in
           {
-            guard_f = uu____24849;
-            deferred = (uu___2053_24848.deferred);
-            univ_ineqs = (uu___2053_24848.univ_ineqs);
-            implicits = (uu___2053_24848.implicits)
+            guard_f = uu____25508;
+            deferred = (uu___2096_25507.deferred);
+            univ_ineqs = (uu___2096_25507.univ_ineqs);
+            implicits = (uu___2096_25507.implicits)
           }
   
 let (always_map_guard :
@@ -5403,33 +5563,33 @@ let (always_map_guard :
     fun map1  ->
       match g.guard_f with
       | FStar_TypeChecker_Common.Trivial  ->
-          let uu___2058_24867 = g  in
-          let uu____24868 =
-            let uu____24869 = map1 FStar_Syntax_Util.t_true  in
-            FStar_TypeChecker_Common.NonTrivial uu____24869  in
+          let uu___2101_25526 = g  in
+          let uu____25527 =
+            let uu____25528 = map1 FStar_Syntax_Util.t_true  in
+            FStar_TypeChecker_Common.NonTrivial uu____25528  in
           {
-            guard_f = uu____24868;
-            deferred = (uu___2058_24867.deferred);
-            univ_ineqs = (uu___2058_24867.univ_ineqs);
-            implicits = (uu___2058_24867.implicits)
+            guard_f = uu____25527;
+            deferred = (uu___2101_25526.deferred);
+            univ_ineqs = (uu___2101_25526.univ_ineqs);
+            implicits = (uu___2101_25526.implicits)
           }
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___2062_24871 = g  in
-          let uu____24872 =
-            let uu____24873 = map1 f  in
-            FStar_TypeChecker_Common.NonTrivial uu____24873  in
+          let uu___2105_25530 = g  in
+          let uu____25531 =
+            let uu____25532 = map1 f  in
+            FStar_TypeChecker_Common.NonTrivial uu____25532  in
           {
-            guard_f = uu____24872;
-            deferred = (uu___2062_24871.deferred);
-            univ_ineqs = (uu___2062_24871.univ_ineqs);
-            implicits = (uu___2062_24871.implicits)
+            guard_f = uu____25531;
+            deferred = (uu___2105_25530.deferred);
+            univ_ineqs = (uu___2105_25530.univ_ineqs);
+            implicits = (uu___2105_25530.implicits)
           }
   
 let (trivial : FStar_TypeChecker_Common.guard_formula -> unit) =
   fun t  ->
     match t with
     | FStar_TypeChecker_Common.Trivial  -> ()
-    | FStar_TypeChecker_Common.NonTrivial uu____24880 ->
+    | FStar_TypeChecker_Common.NonTrivial uu____25539 ->
         failwith "impossible"
   
 let (conj_guard_f :
@@ -5444,20 +5604,20 @@ let (conj_guard_f :
       | (g,FStar_TypeChecker_Common.Trivial ) -> g
       | (FStar_TypeChecker_Common.NonTrivial
          f1,FStar_TypeChecker_Common.NonTrivial f2) ->
-          let uu____24897 = FStar_Syntax_Util.mk_conj f1 f2  in
-          FStar_TypeChecker_Common.NonTrivial uu____24897
+          let uu____25556 = FStar_Syntax_Util.mk_conj f1 f2  in
+          FStar_TypeChecker_Common.NonTrivial uu____25556
   
 let (check_trivial :
   FStar_Syntax_Syntax.term -> FStar_TypeChecker_Common.guard_formula) =
   fun t  ->
-    let uu____24904 =
-      let uu____24905 = FStar_Syntax_Util.unmeta t  in
-      uu____24905.FStar_Syntax_Syntax.n  in
-    match uu____24904 with
+    let uu____25563 =
+      let uu____25564 = FStar_Syntax_Util.unmeta t  in
+      uu____25564.FStar_Syntax_Syntax.n  in
+    match uu____25563 with
     | FStar_Syntax_Syntax.Tm_fvar tc when
         FStar_Syntax_Syntax.fv_eq_lid tc FStar_Parser_Const.true_lid ->
         FStar_TypeChecker_Common.Trivial
-    | uu____24909 -> FStar_TypeChecker_Common.NonTrivial t
+    | uu____25568 -> FStar_TypeChecker_Common.NonTrivial t
   
 let (imp_guard_f :
   FStar_TypeChecker_Common.guard_formula ->
@@ -5483,9 +5643,9 @@ let (binop_guard :
   fun f  ->
     fun g1  ->
       fun g2  ->
-        let uu____24952 = f g1.guard_f g2.guard_f  in
+        let uu____25611 = f g1.guard_f g2.guard_f  in
         {
-          guard_f = uu____24952;
+          guard_f = uu____25611;
           deferred = (FStar_List.append g1.deferred g2.deferred);
           univ_ineqs =
             ((FStar_List.append (FStar_Pervasives_Native.fst g1.univ_ineqs)
@@ -5516,20 +5676,20 @@ let (close_guard_univs :
                 (fun u  ->
                    fun b  ->
                      fun f1  ->
-                       let uu____25047 = FStar_Syntax_Syntax.is_null_binder b
+                       let uu____25706 = FStar_Syntax_Syntax.is_null_binder b
                           in
-                       if uu____25047
+                       if uu____25706
                        then f1
                        else
                          FStar_Syntax_Util.mk_forall u
                            (FStar_Pervasives_Native.fst b) f1) us bs f
                in
-            let uu___2117_25054 = g  in
+            let uu___2160_25713 = g  in
             {
               guard_f = (FStar_TypeChecker_Common.NonTrivial f1);
-              deferred = (uu___2117_25054.deferred);
-              univ_ineqs = (uu___2117_25054.univ_ineqs);
-              implicits = (uu___2117_25054.implicits)
+              deferred = (uu___2160_25713.deferred);
+              univ_ineqs = (uu___2160_25713.univ_ineqs);
+              implicits = (uu___2160_25713.implicits)
             }
   
 let (close_forall :
@@ -5543,8 +5703,8 @@ let (close_forall :
         FStar_List.fold_right
           (fun b  ->
              fun f1  ->
-               let uu____25088 = FStar_Syntax_Syntax.is_null_binder b  in
-               if uu____25088
+               let uu____25747 = FStar_Syntax_Syntax.is_null_binder b  in
+               if uu____25747
                then f1
                else
                  (let u =
@@ -5562,15 +5722,15 @@ let (close_guard : env -> FStar_Syntax_Syntax.binders -> guard_t -> guard_t)
         match g.guard_f with
         | FStar_TypeChecker_Common.Trivial  -> g
         | FStar_TypeChecker_Common.NonTrivial f ->
-            let uu___2132_25115 = g  in
-            let uu____25116 =
-              let uu____25117 = close_forall env binders f  in
-              FStar_TypeChecker_Common.NonTrivial uu____25117  in
+            let uu___2175_25774 = g  in
+            let uu____25775 =
+              let uu____25776 = close_forall env binders f  in
+              FStar_TypeChecker_Common.NonTrivial uu____25776  in
             {
-              guard_f = uu____25116;
-              deferred = (uu___2132_25115.deferred);
-              univ_ineqs = (uu___2132_25115.univ_ineqs);
-              implicits = (uu___2132_25115.implicits)
+              guard_f = uu____25775;
+              deferred = (uu___2175_25774.deferred);
+              univ_ineqs = (uu___2175_25774.univ_ineqs);
+              implicits = (uu___2175_25774.implicits)
             }
   
 let (new_implicit_var_aux :
@@ -5590,12 +5750,12 @@ let (new_implicit_var_aux :
         fun k  ->
           fun should_check  ->
             fun meta  ->
-              let uu____25175 =
+              let uu____25834 =
                 FStar_Syntax_Util.destruct k FStar_Parser_Const.range_of_lid
                  in
-              match uu____25175 with
+              match uu____25834 with
               | FStar_Pervasives_Native.Some
-                  (uu____25200::(tm,uu____25202)::[]) ->
+                  (uu____25859::(tm,uu____25861)::[]) ->
                   let t =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_constant
@@ -5604,13 +5764,13 @@ let (new_implicit_var_aux :
                       FStar_Pervasives_Native.None tm.FStar_Syntax_Syntax.pos
                      in
                   (t, [], trivial_guard)
-              | uu____25266 ->
+              | uu____25925 ->
                   let binders = all_binders env  in
                   let gamma = env.gamma  in
                   let ctx_uvar =
-                    let uu____25284 = FStar_Syntax_Unionfind.fresh ()  in
+                    let uu____25943 = FStar_Syntax_Unionfind.fresh ()  in
                     {
-                      FStar_Syntax_Syntax.ctx_uvar_head = uu____25284;
+                      FStar_Syntax_Syntax.ctx_uvar_head = uu____25943;
                       FStar_Syntax_Syntax.ctx_uvar_gamma = gamma;
                       FStar_Syntax_Syntax.ctx_uvar_binders = binders;
                       FStar_Syntax_Syntax.ctx_uvar_typ = k;
@@ -5636,33 +5796,33 @@ let (new_implicit_var_aux :
                         imp_range = r
                       }  in
                     let g =
-                      let uu___2154_25316 = trivial_guard  in
+                      let uu___2197_25975 = trivial_guard  in
                       {
-                        guard_f = (uu___2154_25316.guard_f);
-                        deferred = (uu___2154_25316.deferred);
-                        univ_ineqs = (uu___2154_25316.univ_ineqs);
+                        guard_f = (uu___2197_25975.guard_f);
+                        deferred = (uu___2197_25975.deferred);
+                        univ_ineqs = (uu___2197_25975.univ_ineqs);
                         implicits = [imp]
                       }  in
                     (t, [(ctx_uvar, r)], g)))
   
 let (dummy_solver : solver_t) =
   {
-    init = (fun uu____25334  -> ());
-    push = (fun uu____25336  -> ());
-    pop = (fun uu____25339  -> ());
+    init = (fun uu____25993  -> ());
+    push = (fun uu____25995  -> ());
+    pop = (fun uu____25998  -> ());
     snapshot =
-      (fun uu____25342  ->
+      (fun uu____26001  ->
          ((Prims.int_zero, Prims.int_zero, Prims.int_zero), ()));
-    rollback = (fun uu____25361  -> fun uu____25362  -> ());
-    encode_sig = (fun uu____25377  -> fun uu____25378  -> ());
+    rollback = (fun uu____26020  -> fun uu____26021  -> ());
+    encode_sig = (fun uu____26036  -> fun uu____26037  -> ());
     preprocess =
       (fun e  ->
          fun g  ->
-           let uu____25384 =
-             let uu____25391 = FStar_Options.peek ()  in (e, g, uu____25391)
+           let uu____26043 =
+             let uu____26050 = FStar_Options.peek ()  in (e, g, uu____26050)
               in
-           [uu____25384]);
-    solve = (fun uu____25407  -> fun uu____25408  -> fun uu____25409  -> ());
-    finish = (fun uu____25416  -> ());
-    refresh = (fun uu____25418  -> ())
+           [uu____26043]);
+    solve = (fun uu____26066  -> fun uu____26067  -> fun uu____26068  -> ());
+    finish = (fun uu____26075  -> ());
+    refresh = (fun uu____26077  -> ())
   } 

--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -7762,7 +7762,7 @@ let (ghost_to_pure :
          in
       let non_info t =
         let uu____26183 = norm cfg [] [] t  in
-        FStar_Syntax_Util.non_informative uu____26183  in
+        FStar_TypeChecker_Env.non_informative env uu____26183  in
       match c.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Total uu____26190 -> c
       | FStar_Syntax_Syntax.GTotal (t,uopt) when non_info t ->
@@ -7861,7 +7861,7 @@ let (ghost_to_pure_lcomp :
          in
       let non_info t =
         let uu____26260 = norm cfg [] [] t  in
-        FStar_Syntax_Util.non_informative uu____26260  in
+        FStar_TypeChecker_Env.non_informative env uu____26260  in
       let uu____26267 =
         (FStar_Syntax_Util.is_ghost_effect lc.FStar_Syntax_Syntax.eff_name)
           && (non_info lc.FStar_Syntax_Syntax.res_typ)
@@ -8169,7 +8169,9 @@ let (eta_expand :
                                    FStar_TypeChecker_Env.nbe =
                                      (uu___3292_26735.FStar_TypeChecker_Env.nbe);
                                    FStar_TypeChecker_Env.strict_args_tab =
-                                     (uu___3292_26735.FStar_TypeChecker_Env.strict_args_tab)
+                                     (uu___3292_26735.FStar_TypeChecker_Env.strict_args_tab);
+                                   FStar_TypeChecker_Env.erasable_types_tab =
+                                     (uu___3292_26735.FStar_TypeChecker_Env.erasable_types_tab)
                                  }) t
                                in
                             match uu____26727 with
@@ -8265,7 +8267,9 @@ let (eta_expand :
                            FStar_TypeChecker_Env.nbe =
                              (uu___3299_26750.FStar_TypeChecker_Env.nbe);
                            FStar_TypeChecker_Env.strict_args_tab =
-                             (uu___3299_26750.FStar_TypeChecker_Env.strict_args_tab)
+                             (uu___3299_26750.FStar_TypeChecker_Env.strict_args_tab);
+                           FStar_TypeChecker_Env.erasable_types_tab =
+                             (uu___3299_26750.FStar_TypeChecker_Env.erasable_types_tab)
                          }) t
                        in
                     (match uu____26742 with

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -250,7 +250,9 @@ let (copy_uvar :
               FStar_TypeChecker_Env.nbe =
                 (uu___77_569.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___77_569.FStar_TypeChecker_Env.strict_args_tab)
+                (uu___77_569.FStar_TypeChecker_Env.strict_args_tab);
+              FStar_TypeChecker_Env.erasable_types_tab =
+                (uu___77_569.FStar_TypeChecker_Env.erasable_types_tab)
             }  in
           let env1 = FStar_TypeChecker_Env.push_binders env bs  in
           let uu____571 = FStar_TypeChecker_Env.all_binders env1  in
@@ -7195,7 +7197,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                               FStar_TypeChecker_Env.nbe =
                                 (uu___2967_21047.FStar_TypeChecker_Env.nbe);
                               FStar_TypeChecker_Env.strict_args_tab =
-                                (uu___2967_21047.FStar_TypeChecker_Env.strict_args_tab)
+                                (uu___2967_21047.FStar_TypeChecker_Env.strict_args_tab);
+                              FStar_TypeChecker_Env.erasable_types_tab =
+                                (uu___2967_21047.FStar_TypeChecker_Env.erasable_types_tab)
                             }) t
                           in
                        match uu____21039 with
@@ -7470,7 +7474,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                               FStar_TypeChecker_Env.nbe =
                                 (uu___2967_21386.FStar_TypeChecker_Env.nbe);
                               FStar_TypeChecker_Env.strict_args_tab =
-                                (uu___2967_21386.FStar_TypeChecker_Env.strict_args_tab)
+                                (uu___2967_21386.FStar_TypeChecker_Env.strict_args_tab);
+                              FStar_TypeChecker_Env.erasable_types_tab =
+                                (uu___2967_21386.FStar_TypeChecker_Env.erasable_types_tab)
                             }) t
                           in
                        match uu____21378 with
@@ -11550,7 +11556,10 @@ let (resolve_implicits' :
                                       FStar_TypeChecker_Env.nbe =
                                         (uu___4025_29585.FStar_TypeChecker_Env.nbe);
                                       FStar_TypeChecker_Env.strict_args_tab =
-                                        (uu___4025_29585.FStar_TypeChecker_Env.strict_args_tab)
+                                        (uu___4025_29585.FStar_TypeChecker_Env.strict_args_tab);
+                                      FStar_TypeChecker_Env.erasable_types_tab
+                                        =
+                                        (uu___4025_29585.FStar_TypeChecker_Env.erasable_types_tab)
                                     }  in
                                   let tm1 =
                                     FStar_TypeChecker_Normalize.normalize
@@ -11655,7 +11664,10 @@ let (resolve_implicits' :
                                           (uu___4030_29589.FStar_TypeChecker_Env.nbe);
                                         FStar_TypeChecker_Env.strict_args_tab
                                           =
-                                          (uu___4030_29589.FStar_TypeChecker_Env.strict_args_tab)
+                                          (uu___4030_29589.FStar_TypeChecker_Env.strict_args_tab);
+                                        FStar_TypeChecker_Env.erasable_types_tab
+                                          =
+                                          (uu___4030_29589.FStar_TypeChecker_Env.erasable_types_tab)
                                       }
                                     else env1  in
                                   (let uu____29594 =

--- a/src/ocaml-output/FStar_TypeChecker_Tc.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Tc.ml
@@ -114,7 +114,9 @@ let (set_hint_correlator :
             FStar_TypeChecker_Env.nbe =
               (uu___16_73.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___16_73.FStar_TypeChecker_Env.strict_args_tab)
+              (uu___16_73.FStar_TypeChecker_Env.strict_args_tab);
+            FStar_TypeChecker_Env.erasable_types_tab =
+              (uu___16_73.FStar_TypeChecker_Env.erasable_types_tab)
           }
       | FStar_Pervasives_Native.None  ->
           let lids = FStar_Syntax_Util.lids_of_sigelt se  in
@@ -221,7 +223,9 @@ let (set_hint_correlator :
             FStar_TypeChecker_Env.nbe =
               (uu___25_137.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___25_137.FStar_TypeChecker_Env.strict_args_tab)
+              (uu___25_137.FStar_TypeChecker_Env.strict_args_tab);
+            FStar_TypeChecker_Env.erasable_types_tab =
+              (uu___25_137.FStar_TypeChecker_Env.erasable_types_tab)
           }
   
 let (log : FStar_TypeChecker_Env.env -> Prims.bool) =
@@ -1722,7 +1726,10 @@ let (tc_eff_decl :
                                                                  (uu___310_2898.FStar_TypeChecker_Env.nbe);
                                                                FStar_TypeChecker_Env.strict_args_tab
                                                                  =
-                                                                 (uu___310_2898.FStar_TypeChecker_Env.strict_args_tab)
+                                                                 (uu___310_2898.FStar_TypeChecker_Env.strict_args_tab);
+                                                               FStar_TypeChecker_Env.erasable_types_tab
+                                                                 =
+                                                                 (uu___310_2898.FStar_TypeChecker_Env.erasable_types_tab)
                                                              })
                                                             (fun _2900  ->
                                                                FStar_Pervasives_Native.Some
@@ -1989,7 +1996,10 @@ let (tc_eff_decl :
                                                              (uu___340_3042.FStar_TypeChecker_Env.nbe);
                                                            FStar_TypeChecker_Env.strict_args_tab
                                                              =
-                                                             (uu___340_3042.FStar_TypeChecker_Env.strict_args_tab)
+                                                             (uu___340_3042.FStar_TypeChecker_Env.strict_args_tab);
+                                                           FStar_TypeChecker_Env.erasable_types_tab
+                                                             =
+                                                             (uu___340_3042.FStar_TypeChecker_Env.erasable_types_tab)
                                                          }  in
                                                        ((let uu____3045 =
                                                            FStar_TypeChecker_Env.debug
@@ -4521,158 +4531,179 @@ let (tc_decl' :
        | FStar_Syntax_Syntax.Sig_bundle (ses,lids) ->
            let env1 = FStar_TypeChecker_Env.set_range env r  in
            let ses1 =
-             let uu____8316 =
+             FStar_All.pipe_right ses
+               (FStar_List.map
+                  (fun e  ->
+                     let uu___1011_8323 = e  in
+                     {
+                       FStar_Syntax_Syntax.sigel =
+                         (uu___1011_8323.FStar_Syntax_Syntax.sigel);
+                       FStar_Syntax_Syntax.sigrng =
+                         (uu___1011_8323.FStar_Syntax_Syntax.sigrng);
+                       FStar_Syntax_Syntax.sigquals =
+                         (uu___1011_8323.FStar_Syntax_Syntax.sigquals);
+                       FStar_Syntax_Syntax.sigmeta =
+                         (uu___1011_8323.FStar_Syntax_Syntax.sigmeta);
+                       FStar_Syntax_Syntax.sigattrs =
+                         (FStar_List.append e.FStar_Syntax_Syntax.sigattrs
+                            se.FStar_Syntax_Syntax.sigattrs)
+                     }))
+              in
+           let ses2 =
+             let uu____8327 =
                (FStar_Options.use_two_phase_tc ()) &&
                  (FStar_TypeChecker_Env.should_verify env1)
                 in
-             if uu____8316
+             if uu____8327
              then
-               let ses1 =
-                 let uu____8324 =
-                   let uu____8325 =
-                     let uu____8326 =
+               let ses2 =
+                 let uu____8335 =
+                   let uu____8336 =
+                     let uu____8337 =
                        tc_inductive
-                         (let uu___1011_8335 = env1  in
+                         (let uu___1015_8346 = env1  in
                           {
                             FStar_TypeChecker_Env.solver =
-                              (uu___1011_8335.FStar_TypeChecker_Env.solver);
+                              (uu___1015_8346.FStar_TypeChecker_Env.solver);
                             FStar_TypeChecker_Env.range =
-                              (uu___1011_8335.FStar_TypeChecker_Env.range);
+                              (uu___1015_8346.FStar_TypeChecker_Env.range);
                             FStar_TypeChecker_Env.curmodule =
-                              (uu___1011_8335.FStar_TypeChecker_Env.curmodule);
+                              (uu___1015_8346.FStar_TypeChecker_Env.curmodule);
                             FStar_TypeChecker_Env.gamma =
-                              (uu___1011_8335.FStar_TypeChecker_Env.gamma);
+                              (uu___1015_8346.FStar_TypeChecker_Env.gamma);
                             FStar_TypeChecker_Env.gamma_sig =
-                              (uu___1011_8335.FStar_TypeChecker_Env.gamma_sig);
+                              (uu___1015_8346.FStar_TypeChecker_Env.gamma_sig);
                             FStar_TypeChecker_Env.gamma_cache =
-                              (uu___1011_8335.FStar_TypeChecker_Env.gamma_cache);
+                              (uu___1015_8346.FStar_TypeChecker_Env.gamma_cache);
                             FStar_TypeChecker_Env.modules =
-                              (uu___1011_8335.FStar_TypeChecker_Env.modules);
+                              (uu___1015_8346.FStar_TypeChecker_Env.modules);
                             FStar_TypeChecker_Env.expected_typ =
-                              (uu___1011_8335.FStar_TypeChecker_Env.expected_typ);
+                              (uu___1015_8346.FStar_TypeChecker_Env.expected_typ);
                             FStar_TypeChecker_Env.sigtab =
-                              (uu___1011_8335.FStar_TypeChecker_Env.sigtab);
+                              (uu___1015_8346.FStar_TypeChecker_Env.sigtab);
                             FStar_TypeChecker_Env.attrtab =
-                              (uu___1011_8335.FStar_TypeChecker_Env.attrtab);
+                              (uu___1015_8346.FStar_TypeChecker_Env.attrtab);
                             FStar_TypeChecker_Env.is_pattern =
-                              (uu___1011_8335.FStar_TypeChecker_Env.is_pattern);
+                              (uu___1015_8346.FStar_TypeChecker_Env.is_pattern);
                             FStar_TypeChecker_Env.instantiate_imp =
-                              (uu___1011_8335.FStar_TypeChecker_Env.instantiate_imp);
+                              (uu___1015_8346.FStar_TypeChecker_Env.instantiate_imp);
                             FStar_TypeChecker_Env.effects =
-                              (uu___1011_8335.FStar_TypeChecker_Env.effects);
+                              (uu___1015_8346.FStar_TypeChecker_Env.effects);
                             FStar_TypeChecker_Env.generalize =
-                              (uu___1011_8335.FStar_TypeChecker_Env.generalize);
+                              (uu___1015_8346.FStar_TypeChecker_Env.generalize);
                             FStar_TypeChecker_Env.letrecs =
-                              (uu___1011_8335.FStar_TypeChecker_Env.letrecs);
+                              (uu___1015_8346.FStar_TypeChecker_Env.letrecs);
                             FStar_TypeChecker_Env.top_level =
-                              (uu___1011_8335.FStar_TypeChecker_Env.top_level);
+                              (uu___1015_8346.FStar_TypeChecker_Env.top_level);
                             FStar_TypeChecker_Env.check_uvars =
-                              (uu___1011_8335.FStar_TypeChecker_Env.check_uvars);
+                              (uu___1015_8346.FStar_TypeChecker_Env.check_uvars);
                             FStar_TypeChecker_Env.use_eq =
-                              (uu___1011_8335.FStar_TypeChecker_Env.use_eq);
+                              (uu___1015_8346.FStar_TypeChecker_Env.use_eq);
                             FStar_TypeChecker_Env.is_iface =
-                              (uu___1011_8335.FStar_TypeChecker_Env.is_iface);
+                              (uu___1015_8346.FStar_TypeChecker_Env.is_iface);
                             FStar_TypeChecker_Env.admit =
-                              (uu___1011_8335.FStar_TypeChecker_Env.admit);
+                              (uu___1015_8346.FStar_TypeChecker_Env.admit);
                             FStar_TypeChecker_Env.lax = true;
                             FStar_TypeChecker_Env.lax_universes =
-                              (uu___1011_8335.FStar_TypeChecker_Env.lax_universes);
+                              (uu___1015_8346.FStar_TypeChecker_Env.lax_universes);
                             FStar_TypeChecker_Env.phase1 = true;
                             FStar_TypeChecker_Env.failhard =
-                              (uu___1011_8335.FStar_TypeChecker_Env.failhard);
+                              (uu___1015_8346.FStar_TypeChecker_Env.failhard);
                             FStar_TypeChecker_Env.nosynth =
-                              (uu___1011_8335.FStar_TypeChecker_Env.nosynth);
+                              (uu___1015_8346.FStar_TypeChecker_Env.nosynth);
                             FStar_TypeChecker_Env.uvar_subtyping =
-                              (uu___1011_8335.FStar_TypeChecker_Env.uvar_subtyping);
+                              (uu___1015_8346.FStar_TypeChecker_Env.uvar_subtyping);
                             FStar_TypeChecker_Env.tc_term =
-                              (uu___1011_8335.FStar_TypeChecker_Env.tc_term);
+                              (uu___1015_8346.FStar_TypeChecker_Env.tc_term);
                             FStar_TypeChecker_Env.type_of =
-                              (uu___1011_8335.FStar_TypeChecker_Env.type_of);
+                              (uu___1015_8346.FStar_TypeChecker_Env.type_of);
                             FStar_TypeChecker_Env.universe_of =
-                              (uu___1011_8335.FStar_TypeChecker_Env.universe_of);
+                              (uu___1015_8346.FStar_TypeChecker_Env.universe_of);
                             FStar_TypeChecker_Env.check_type_of =
-                              (uu___1011_8335.FStar_TypeChecker_Env.check_type_of);
+                              (uu___1015_8346.FStar_TypeChecker_Env.check_type_of);
                             FStar_TypeChecker_Env.use_bv_sorts =
-                              (uu___1011_8335.FStar_TypeChecker_Env.use_bv_sorts);
+                              (uu___1015_8346.FStar_TypeChecker_Env.use_bv_sorts);
                             FStar_TypeChecker_Env.qtbl_name_and_index =
-                              (uu___1011_8335.FStar_TypeChecker_Env.qtbl_name_and_index);
+                              (uu___1015_8346.FStar_TypeChecker_Env.qtbl_name_and_index);
                             FStar_TypeChecker_Env.normalized_eff_names =
-                              (uu___1011_8335.FStar_TypeChecker_Env.normalized_eff_names);
+                              (uu___1015_8346.FStar_TypeChecker_Env.normalized_eff_names);
                             FStar_TypeChecker_Env.fv_delta_depths =
-                              (uu___1011_8335.FStar_TypeChecker_Env.fv_delta_depths);
+                              (uu___1015_8346.FStar_TypeChecker_Env.fv_delta_depths);
                             FStar_TypeChecker_Env.proof_ns =
-                              (uu___1011_8335.FStar_TypeChecker_Env.proof_ns);
+                              (uu___1015_8346.FStar_TypeChecker_Env.proof_ns);
                             FStar_TypeChecker_Env.synth_hook =
-                              (uu___1011_8335.FStar_TypeChecker_Env.synth_hook);
+                              (uu___1015_8346.FStar_TypeChecker_Env.synth_hook);
                             FStar_TypeChecker_Env.splice =
-                              (uu___1011_8335.FStar_TypeChecker_Env.splice);
+                              (uu___1015_8346.FStar_TypeChecker_Env.splice);
                             FStar_TypeChecker_Env.postprocess =
-                              (uu___1011_8335.FStar_TypeChecker_Env.postprocess);
+                              (uu___1015_8346.FStar_TypeChecker_Env.postprocess);
                             FStar_TypeChecker_Env.is_native_tactic =
-                              (uu___1011_8335.FStar_TypeChecker_Env.is_native_tactic);
+                              (uu___1015_8346.FStar_TypeChecker_Env.is_native_tactic);
                             FStar_TypeChecker_Env.identifier_info =
-                              (uu___1011_8335.FStar_TypeChecker_Env.identifier_info);
+                              (uu___1015_8346.FStar_TypeChecker_Env.identifier_info);
                             FStar_TypeChecker_Env.tc_hooks =
-                              (uu___1011_8335.FStar_TypeChecker_Env.tc_hooks);
+                              (uu___1015_8346.FStar_TypeChecker_Env.tc_hooks);
                             FStar_TypeChecker_Env.dsenv =
-                              (uu___1011_8335.FStar_TypeChecker_Env.dsenv);
+                              (uu___1015_8346.FStar_TypeChecker_Env.dsenv);
                             FStar_TypeChecker_Env.nbe =
-                              (uu___1011_8335.FStar_TypeChecker_Env.nbe);
+                              (uu___1015_8346.FStar_TypeChecker_Env.nbe);
                             FStar_TypeChecker_Env.strict_args_tab =
-                              (uu___1011_8335.FStar_TypeChecker_Env.strict_args_tab)
-                          }) ses se.FStar_Syntax_Syntax.sigquals lids
+                              (uu___1015_8346.FStar_TypeChecker_Env.strict_args_tab);
+                            FStar_TypeChecker_Env.erasable_types_tab =
+                              (uu___1015_8346.FStar_TypeChecker_Env.erasable_types_tab)
+                          }) ses1 se.FStar_Syntax_Syntax.sigquals lids
                         in
-                     FStar_All.pipe_right uu____8326
+                     FStar_All.pipe_right uu____8337
                        FStar_Pervasives_Native.fst
                       in
-                   FStar_All.pipe_right uu____8325
+                   FStar_All.pipe_right uu____8336
                      (FStar_TypeChecker_Normalize.elim_uvars env1)
                     in
-                 FStar_All.pipe_right uu____8324
+                 FStar_All.pipe_right uu____8335
                    FStar_Syntax_Util.ses_of_sigbundle
                   in
-               ((let uu____8349 =
+               ((let uu____8360 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                      (FStar_Options.Other "TwoPhases")
                     in
-                 if uu____8349
+                 if uu____8360
                  then
-                   let uu____8354 =
+                   let uu____8365 =
                      FStar_Syntax_Print.sigelt_to_string
-                       (let uu___1015_8358 = se  in
+                       (let uu___1019_8369 = se  in
                         {
                           FStar_Syntax_Syntax.sigel =
-                            (FStar_Syntax_Syntax.Sig_bundle (ses1, lids));
+                            (FStar_Syntax_Syntax.Sig_bundle (ses2, lids));
                           FStar_Syntax_Syntax.sigrng =
-                            (uu___1015_8358.FStar_Syntax_Syntax.sigrng);
+                            (uu___1019_8369.FStar_Syntax_Syntax.sigrng);
                           FStar_Syntax_Syntax.sigquals =
-                            (uu___1015_8358.FStar_Syntax_Syntax.sigquals);
+                            (uu___1019_8369.FStar_Syntax_Syntax.sigquals);
                           FStar_Syntax_Syntax.sigmeta =
-                            (uu___1015_8358.FStar_Syntax_Syntax.sigmeta);
+                            (uu___1019_8369.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (uu___1015_8358.FStar_Syntax_Syntax.sigattrs)
+                            (uu___1019_8369.FStar_Syntax_Syntax.sigattrs)
                         })
                       in
                    FStar_Util.print1 "Inductive after phase 1: %s\n"
-                     uu____8354
+                     uu____8365
                  else ());
-                ses1)
-             else ses  in
-           let uu____8368 =
-             tc_inductive env1 ses1 se.FStar_Syntax_Syntax.sigquals lids  in
-           (match uu____8368 with
+                ses2)
+             else ses1  in
+           let uu____8379 =
+             tc_inductive env1 ses2 se.FStar_Syntax_Syntax.sigquals lids  in
+           (match uu____8379 with
             | (sigbndle,projectors_ses) ->
                 let sigbndle1 =
-                  let uu___1022_8392 = sigbndle  in
+                  let uu___1026_8403 = sigbndle  in
                   {
                     FStar_Syntax_Syntax.sigel =
-                      (uu___1022_8392.FStar_Syntax_Syntax.sigel);
+                      (uu___1026_8403.FStar_Syntax_Syntax.sigel);
                     FStar_Syntax_Syntax.sigrng =
-                      (uu___1022_8392.FStar_Syntax_Syntax.sigrng);
+                      (uu___1026_8403.FStar_Syntax_Syntax.sigrng);
                     FStar_Syntax_Syntax.sigquals =
-                      (uu___1022_8392.FStar_Syntax_Syntax.sigquals);
+                      (uu___1026_8403.FStar_Syntax_Syntax.sigquals);
                     FStar_Syntax_Syntax.sigmeta =
-                      (uu___1022_8392.FStar_Syntax_Syntax.sigmeta);
+                      (uu___1026_8403.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
                       (se.FStar_Syntax_Syntax.sigattrs)
                   }  in
@@ -4680,208 +4711,210 @@ let (tc_decl' :
        | FStar_Syntax_Syntax.Sig_pragma p ->
            (FStar_Syntax_Util.process_pragma p r; ([se], [], env0))
        | FStar_Syntax_Syntax.Sig_new_effect_for_free ne ->
-           let uu____8404 = cps_and_elaborate env ne  in
-           (match uu____8404 with
+           let uu____8415 = cps_and_elaborate env ne  in
+           (match uu____8415 with
             | (ses,ne1,lift_from_pure_opt) ->
                 let effect_and_lift_ses =
                   match lift_from_pure_opt with
                   | FStar_Pervasives_Native.Some lift ->
-                      [(let uu___1036_8443 = se  in
+                      [(let uu___1040_8454 = se  in
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_new_effect ne1);
                           FStar_Syntax_Syntax.sigrng =
-                            (uu___1036_8443.FStar_Syntax_Syntax.sigrng);
+                            (uu___1040_8454.FStar_Syntax_Syntax.sigrng);
                           FStar_Syntax_Syntax.sigquals =
-                            (uu___1036_8443.FStar_Syntax_Syntax.sigquals);
+                            (uu___1040_8454.FStar_Syntax_Syntax.sigquals);
                           FStar_Syntax_Syntax.sigmeta =
-                            (uu___1036_8443.FStar_Syntax_Syntax.sigmeta);
+                            (uu___1040_8454.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (uu___1036_8443.FStar_Syntax_Syntax.sigattrs)
+                            (uu___1040_8454.FStar_Syntax_Syntax.sigattrs)
                         });
                       lift]
                   | FStar_Pervasives_Native.None  ->
-                      [(let uu___1039_8445 = se  in
+                      [(let uu___1043_8456 = se  in
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_new_effect ne1);
                           FStar_Syntax_Syntax.sigrng =
-                            (uu___1039_8445.FStar_Syntax_Syntax.sigrng);
+                            (uu___1043_8456.FStar_Syntax_Syntax.sigrng);
                           FStar_Syntax_Syntax.sigquals =
-                            (uu___1039_8445.FStar_Syntax_Syntax.sigquals);
+                            (uu___1043_8456.FStar_Syntax_Syntax.sigquals);
                           FStar_Syntax_Syntax.sigmeta =
-                            (uu___1039_8445.FStar_Syntax_Syntax.sigmeta);
+                            (uu___1043_8456.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (uu___1039_8445.FStar_Syntax_Syntax.sigattrs)
+                            (uu___1043_8456.FStar_Syntax_Syntax.sigattrs)
                         })]
                    in
                 ([], (FStar_List.append ses effect_and_lift_ses), env0))
        | FStar_Syntax_Syntax.Sig_new_effect ne ->
            let ne1 =
-             let uu____8452 =
+             let uu____8463 =
                (FStar_Options.use_two_phase_tc ()) &&
                  (FStar_TypeChecker_Env.should_verify env)
                 in
-             if uu____8452
+             if uu____8463
              then
                let ne1 =
-                 let uu____8456 =
-                   let uu____8457 =
-                     let uu____8458 =
+                 let uu____8467 =
+                   let uu____8468 =
+                     let uu____8469 =
                        tc_eff_decl
-                         (let uu___1045_8461 = env  in
+                         (let uu___1049_8472 = env  in
                           {
                             FStar_TypeChecker_Env.solver =
-                              (uu___1045_8461.FStar_TypeChecker_Env.solver);
+                              (uu___1049_8472.FStar_TypeChecker_Env.solver);
                             FStar_TypeChecker_Env.range =
-                              (uu___1045_8461.FStar_TypeChecker_Env.range);
+                              (uu___1049_8472.FStar_TypeChecker_Env.range);
                             FStar_TypeChecker_Env.curmodule =
-                              (uu___1045_8461.FStar_TypeChecker_Env.curmodule);
+                              (uu___1049_8472.FStar_TypeChecker_Env.curmodule);
                             FStar_TypeChecker_Env.gamma =
-                              (uu___1045_8461.FStar_TypeChecker_Env.gamma);
+                              (uu___1049_8472.FStar_TypeChecker_Env.gamma);
                             FStar_TypeChecker_Env.gamma_sig =
-                              (uu___1045_8461.FStar_TypeChecker_Env.gamma_sig);
+                              (uu___1049_8472.FStar_TypeChecker_Env.gamma_sig);
                             FStar_TypeChecker_Env.gamma_cache =
-                              (uu___1045_8461.FStar_TypeChecker_Env.gamma_cache);
+                              (uu___1049_8472.FStar_TypeChecker_Env.gamma_cache);
                             FStar_TypeChecker_Env.modules =
-                              (uu___1045_8461.FStar_TypeChecker_Env.modules);
+                              (uu___1049_8472.FStar_TypeChecker_Env.modules);
                             FStar_TypeChecker_Env.expected_typ =
-                              (uu___1045_8461.FStar_TypeChecker_Env.expected_typ);
+                              (uu___1049_8472.FStar_TypeChecker_Env.expected_typ);
                             FStar_TypeChecker_Env.sigtab =
-                              (uu___1045_8461.FStar_TypeChecker_Env.sigtab);
+                              (uu___1049_8472.FStar_TypeChecker_Env.sigtab);
                             FStar_TypeChecker_Env.attrtab =
-                              (uu___1045_8461.FStar_TypeChecker_Env.attrtab);
+                              (uu___1049_8472.FStar_TypeChecker_Env.attrtab);
                             FStar_TypeChecker_Env.is_pattern =
-                              (uu___1045_8461.FStar_TypeChecker_Env.is_pattern);
+                              (uu___1049_8472.FStar_TypeChecker_Env.is_pattern);
                             FStar_TypeChecker_Env.instantiate_imp =
-                              (uu___1045_8461.FStar_TypeChecker_Env.instantiate_imp);
+                              (uu___1049_8472.FStar_TypeChecker_Env.instantiate_imp);
                             FStar_TypeChecker_Env.effects =
-                              (uu___1045_8461.FStar_TypeChecker_Env.effects);
+                              (uu___1049_8472.FStar_TypeChecker_Env.effects);
                             FStar_TypeChecker_Env.generalize =
-                              (uu___1045_8461.FStar_TypeChecker_Env.generalize);
+                              (uu___1049_8472.FStar_TypeChecker_Env.generalize);
                             FStar_TypeChecker_Env.letrecs =
-                              (uu___1045_8461.FStar_TypeChecker_Env.letrecs);
+                              (uu___1049_8472.FStar_TypeChecker_Env.letrecs);
                             FStar_TypeChecker_Env.top_level =
-                              (uu___1045_8461.FStar_TypeChecker_Env.top_level);
+                              (uu___1049_8472.FStar_TypeChecker_Env.top_level);
                             FStar_TypeChecker_Env.check_uvars =
-                              (uu___1045_8461.FStar_TypeChecker_Env.check_uvars);
+                              (uu___1049_8472.FStar_TypeChecker_Env.check_uvars);
                             FStar_TypeChecker_Env.use_eq =
-                              (uu___1045_8461.FStar_TypeChecker_Env.use_eq);
+                              (uu___1049_8472.FStar_TypeChecker_Env.use_eq);
                             FStar_TypeChecker_Env.is_iface =
-                              (uu___1045_8461.FStar_TypeChecker_Env.is_iface);
+                              (uu___1049_8472.FStar_TypeChecker_Env.is_iface);
                             FStar_TypeChecker_Env.admit =
-                              (uu___1045_8461.FStar_TypeChecker_Env.admit);
+                              (uu___1049_8472.FStar_TypeChecker_Env.admit);
                             FStar_TypeChecker_Env.lax = true;
                             FStar_TypeChecker_Env.lax_universes =
-                              (uu___1045_8461.FStar_TypeChecker_Env.lax_universes);
+                              (uu___1049_8472.FStar_TypeChecker_Env.lax_universes);
                             FStar_TypeChecker_Env.phase1 = true;
                             FStar_TypeChecker_Env.failhard =
-                              (uu___1045_8461.FStar_TypeChecker_Env.failhard);
+                              (uu___1049_8472.FStar_TypeChecker_Env.failhard);
                             FStar_TypeChecker_Env.nosynth =
-                              (uu___1045_8461.FStar_TypeChecker_Env.nosynth);
+                              (uu___1049_8472.FStar_TypeChecker_Env.nosynth);
                             FStar_TypeChecker_Env.uvar_subtyping =
-                              (uu___1045_8461.FStar_TypeChecker_Env.uvar_subtyping);
+                              (uu___1049_8472.FStar_TypeChecker_Env.uvar_subtyping);
                             FStar_TypeChecker_Env.tc_term =
-                              (uu___1045_8461.FStar_TypeChecker_Env.tc_term);
+                              (uu___1049_8472.FStar_TypeChecker_Env.tc_term);
                             FStar_TypeChecker_Env.type_of =
-                              (uu___1045_8461.FStar_TypeChecker_Env.type_of);
+                              (uu___1049_8472.FStar_TypeChecker_Env.type_of);
                             FStar_TypeChecker_Env.universe_of =
-                              (uu___1045_8461.FStar_TypeChecker_Env.universe_of);
+                              (uu___1049_8472.FStar_TypeChecker_Env.universe_of);
                             FStar_TypeChecker_Env.check_type_of =
-                              (uu___1045_8461.FStar_TypeChecker_Env.check_type_of);
+                              (uu___1049_8472.FStar_TypeChecker_Env.check_type_of);
                             FStar_TypeChecker_Env.use_bv_sorts =
-                              (uu___1045_8461.FStar_TypeChecker_Env.use_bv_sorts);
+                              (uu___1049_8472.FStar_TypeChecker_Env.use_bv_sorts);
                             FStar_TypeChecker_Env.qtbl_name_and_index =
-                              (uu___1045_8461.FStar_TypeChecker_Env.qtbl_name_and_index);
+                              (uu___1049_8472.FStar_TypeChecker_Env.qtbl_name_and_index);
                             FStar_TypeChecker_Env.normalized_eff_names =
-                              (uu___1045_8461.FStar_TypeChecker_Env.normalized_eff_names);
+                              (uu___1049_8472.FStar_TypeChecker_Env.normalized_eff_names);
                             FStar_TypeChecker_Env.fv_delta_depths =
-                              (uu___1045_8461.FStar_TypeChecker_Env.fv_delta_depths);
+                              (uu___1049_8472.FStar_TypeChecker_Env.fv_delta_depths);
                             FStar_TypeChecker_Env.proof_ns =
-                              (uu___1045_8461.FStar_TypeChecker_Env.proof_ns);
+                              (uu___1049_8472.FStar_TypeChecker_Env.proof_ns);
                             FStar_TypeChecker_Env.synth_hook =
-                              (uu___1045_8461.FStar_TypeChecker_Env.synth_hook);
+                              (uu___1049_8472.FStar_TypeChecker_Env.synth_hook);
                             FStar_TypeChecker_Env.splice =
-                              (uu___1045_8461.FStar_TypeChecker_Env.splice);
+                              (uu___1049_8472.FStar_TypeChecker_Env.splice);
                             FStar_TypeChecker_Env.postprocess =
-                              (uu___1045_8461.FStar_TypeChecker_Env.postprocess);
+                              (uu___1049_8472.FStar_TypeChecker_Env.postprocess);
                             FStar_TypeChecker_Env.is_native_tactic =
-                              (uu___1045_8461.FStar_TypeChecker_Env.is_native_tactic);
+                              (uu___1049_8472.FStar_TypeChecker_Env.is_native_tactic);
                             FStar_TypeChecker_Env.identifier_info =
-                              (uu___1045_8461.FStar_TypeChecker_Env.identifier_info);
+                              (uu___1049_8472.FStar_TypeChecker_Env.identifier_info);
                             FStar_TypeChecker_Env.tc_hooks =
-                              (uu___1045_8461.FStar_TypeChecker_Env.tc_hooks);
+                              (uu___1049_8472.FStar_TypeChecker_Env.tc_hooks);
                             FStar_TypeChecker_Env.dsenv =
-                              (uu___1045_8461.FStar_TypeChecker_Env.dsenv);
+                              (uu___1049_8472.FStar_TypeChecker_Env.dsenv);
                             FStar_TypeChecker_Env.nbe =
-                              (uu___1045_8461.FStar_TypeChecker_Env.nbe);
+                              (uu___1049_8472.FStar_TypeChecker_Env.nbe);
                             FStar_TypeChecker_Env.strict_args_tab =
-                              (uu___1045_8461.FStar_TypeChecker_Env.strict_args_tab)
+                              (uu___1049_8472.FStar_TypeChecker_Env.strict_args_tab);
+                            FStar_TypeChecker_Env.erasable_types_tab =
+                              (uu___1049_8472.FStar_TypeChecker_Env.erasable_types_tab)
                           }) ne
                         in
-                     FStar_All.pipe_right uu____8458
+                     FStar_All.pipe_right uu____8469
                        (fun ne1  ->
-                          let uu___1048_8467 = se  in
+                          let uu___1052_8478 = se  in
                           {
                             FStar_Syntax_Syntax.sigel =
                               (FStar_Syntax_Syntax.Sig_new_effect ne1);
                             FStar_Syntax_Syntax.sigrng =
-                              (uu___1048_8467.FStar_Syntax_Syntax.sigrng);
+                              (uu___1052_8478.FStar_Syntax_Syntax.sigrng);
                             FStar_Syntax_Syntax.sigquals =
-                              (uu___1048_8467.FStar_Syntax_Syntax.sigquals);
+                              (uu___1052_8478.FStar_Syntax_Syntax.sigquals);
                             FStar_Syntax_Syntax.sigmeta =
-                              (uu___1048_8467.FStar_Syntax_Syntax.sigmeta);
+                              (uu___1052_8478.FStar_Syntax_Syntax.sigmeta);
                             FStar_Syntax_Syntax.sigattrs =
-                              (uu___1048_8467.FStar_Syntax_Syntax.sigattrs)
+                              (uu___1052_8478.FStar_Syntax_Syntax.sigattrs)
                           })
                       in
-                   FStar_All.pipe_right uu____8457
+                   FStar_All.pipe_right uu____8468
                      (FStar_TypeChecker_Normalize.elim_uvars env)
                     in
-                 FStar_All.pipe_right uu____8456
+                 FStar_All.pipe_right uu____8467
                    FStar_Syntax_Util.eff_decl_of_new_effect
                   in
-               ((let uu____8469 =
+               ((let uu____8480 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                      (FStar_Options.Other "TwoPhases")
                     in
-                 if uu____8469
+                 if uu____8480
                  then
-                   let uu____8474 =
+                   let uu____8485 =
                      FStar_Syntax_Print.sigelt_to_string
-                       (let uu___1052_8478 = se  in
+                       (let uu___1056_8489 = se  in
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_new_effect ne1);
                           FStar_Syntax_Syntax.sigrng =
-                            (uu___1052_8478.FStar_Syntax_Syntax.sigrng);
+                            (uu___1056_8489.FStar_Syntax_Syntax.sigrng);
                           FStar_Syntax_Syntax.sigquals =
-                            (uu___1052_8478.FStar_Syntax_Syntax.sigquals);
+                            (uu___1056_8489.FStar_Syntax_Syntax.sigquals);
                           FStar_Syntax_Syntax.sigmeta =
-                            (uu___1052_8478.FStar_Syntax_Syntax.sigmeta);
+                            (uu___1056_8489.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (uu___1052_8478.FStar_Syntax_Syntax.sigattrs)
+                            (uu___1056_8489.FStar_Syntax_Syntax.sigattrs)
                         })
                       in
                    FStar_Util.print1 "Effect decl after phase 1: %s\n"
-                     uu____8474
+                     uu____8485
                  else ());
                 ne1)
              else ne  in
            let ne2 = tc_eff_decl env ne1  in
            let se1 =
-             let uu___1057_8486 = se  in
+             let uu___1061_8497 = se  in
              {
                FStar_Syntax_Syntax.sigel =
                  (FStar_Syntax_Syntax.Sig_new_effect ne2);
                FStar_Syntax_Syntax.sigrng =
-                 (uu___1057_8486.FStar_Syntax_Syntax.sigrng);
+                 (uu___1061_8497.FStar_Syntax_Syntax.sigrng);
                FStar_Syntax_Syntax.sigquals =
-                 (uu___1057_8486.FStar_Syntax_Syntax.sigquals);
+                 (uu___1061_8497.FStar_Syntax_Syntax.sigquals);
                FStar_Syntax_Syntax.sigmeta =
-                 (uu___1057_8486.FStar_Syntax_Syntax.sigmeta);
+                 (uu___1061_8497.FStar_Syntax_Syntax.sigmeta);
                FStar_Syntax_Syntax.sigattrs =
-                 (uu___1057_8486.FStar_Syntax_Syntax.sigattrs)
+                 (uu___1061_8497.FStar_Syntax_Syntax.sigattrs)
              }  in
            ([se1], [], env0)
        | FStar_Syntax_Syntax.Sig_sub_effect sub1 ->
@@ -4893,72 +4926,72 @@ let (tc_decl' :
              FStar_TypeChecker_Env.get_effect_decl env
                sub1.FStar_Syntax_Syntax.target
               in
-           let uu____8494 =
-             let uu____8501 =
+           let uu____8505 =
+             let uu____8512 =
                FStar_TypeChecker_Env.lookup_effect_lid env
                  sub1.FStar_Syntax_Syntax.source
                 in
-             monad_signature env sub1.FStar_Syntax_Syntax.source uu____8501
+             monad_signature env sub1.FStar_Syntax_Syntax.source uu____8512
               in
-           (match uu____8494 with
+           (match uu____8505 with
             | (a,wp_a_src) ->
-                let uu____8518 =
-                  let uu____8525 =
+                let uu____8529 =
+                  let uu____8536 =
                     FStar_TypeChecker_Env.lookup_effect_lid env
                       sub1.FStar_Syntax_Syntax.target
                      in
                   monad_signature env sub1.FStar_Syntax_Syntax.target
-                    uu____8525
+                    uu____8536
                    in
-                (match uu____8518 with
+                (match uu____8529 with
                  | (b,wp_b_tgt) ->
                      let wp_a_tgt =
-                       let uu____8543 =
-                         let uu____8546 =
-                           let uu____8547 =
-                             let uu____8554 =
+                       let uu____8554 =
+                         let uu____8557 =
+                           let uu____8558 =
+                             let uu____8565 =
                                FStar_Syntax_Syntax.bv_to_name a  in
-                             (b, uu____8554)  in
-                           FStar_Syntax_Syntax.NT uu____8547  in
-                         [uu____8546]  in
-                       FStar_Syntax_Subst.subst uu____8543 wp_b_tgt  in
+                             (b, uu____8565)  in
+                           FStar_Syntax_Syntax.NT uu____8558  in
+                         [uu____8557]  in
+                       FStar_Syntax_Subst.subst uu____8554 wp_b_tgt  in
                      let expected_k =
-                       let uu____8562 =
-                         let uu____8571 = FStar_Syntax_Syntax.mk_binder a  in
-                         let uu____8578 =
-                           let uu____8587 =
+                       let uu____8573 =
+                         let uu____8582 = FStar_Syntax_Syntax.mk_binder a  in
+                         let uu____8589 =
+                           let uu____8598 =
                              FStar_Syntax_Syntax.null_binder wp_a_src  in
-                           [uu____8587]  in
-                         uu____8571 :: uu____8578  in
-                       let uu____8612 = FStar_Syntax_Syntax.mk_Total wp_a_tgt
+                           [uu____8598]  in
+                         uu____8582 :: uu____8589  in
+                       let uu____8623 = FStar_Syntax_Syntax.mk_Total wp_a_tgt
                           in
-                       FStar_Syntax_Util.arrow uu____8562 uu____8612  in
+                       FStar_Syntax_Util.arrow uu____8573 uu____8623  in
                      let repr_type eff_name a1 wp =
-                       (let uu____8634 =
-                          let uu____8636 =
+                       (let uu____8645 =
+                          let uu____8647 =
                             FStar_TypeChecker_Env.is_reifiable_effect env
                               eff_name
                              in
-                          Prims.op_Negation uu____8636  in
-                        if uu____8634
+                          Prims.op_Negation uu____8647  in
+                        if uu____8645
                         then
-                          let uu____8639 =
-                            let uu____8645 =
+                          let uu____8650 =
+                            let uu____8656 =
                               FStar_Util.format1
                                 "Effect %s cannot be reified"
                                 eff_name.FStar_Ident.str
                                in
                             (FStar_Errors.Fatal_EffectCannotBeReified,
-                              uu____8645)
+                              uu____8656)
                              in
-                          let uu____8649 =
+                          let uu____8660 =
                             FStar_TypeChecker_Env.get_range env  in
-                          FStar_Errors.raise_error uu____8639 uu____8649
+                          FStar_Errors.raise_error uu____8650 uu____8660
                         else ());
-                       (let uu____8652 =
+                       (let uu____8663 =
                           FStar_TypeChecker_Env.effect_decl_opt env eff_name
                            in
-                        match uu____8652 with
+                        match uu____8663 with
                         | FStar_Pervasives_Native.None  ->
                             failwith
                               "internal error: reifiable effect has no decl?"
@@ -4968,26 +5001,26 @@ let (tc_decl' :
                                 [FStar_Syntax_Syntax.U_unknown] env ed
                                 ed.FStar_Syntax_Syntax.repr
                                in
-                            let uu____8685 =
+                            let uu____8696 =
                               FStar_TypeChecker_Env.get_range env  in
-                            let uu____8686 =
-                              let uu____8693 =
-                                let uu____8694 =
-                                  let uu____8711 =
-                                    let uu____8722 =
+                            let uu____8697 =
+                              let uu____8704 =
+                                let uu____8705 =
+                                  let uu____8722 =
+                                    let uu____8733 =
                                       FStar_Syntax_Syntax.as_arg a1  in
-                                    let uu____8731 =
-                                      let uu____8742 =
+                                    let uu____8742 =
+                                      let uu____8753 =
                                         FStar_Syntax_Syntax.as_arg wp  in
-                                      [uu____8742]  in
-                                    uu____8722 :: uu____8731  in
-                                  (repr, uu____8711)  in
-                                FStar_Syntax_Syntax.Tm_app uu____8694  in
-                              FStar_Syntax_Syntax.mk uu____8693  in
-                            uu____8686 FStar_Pervasives_Native.None
-                              uu____8685)
+                                      [uu____8753]  in
+                                    uu____8733 :: uu____8742  in
+                                  (repr, uu____8722)  in
+                                FStar_Syntax_Syntax.Tm_app uu____8705  in
+                              FStar_Syntax_Syntax.mk uu____8704  in
+                            uu____8697 FStar_Pervasives_Native.None
+                              uu____8696)
                         in
-                     let uu____8787 =
+                     let uu____8798 =
                        match ((sub1.FStar_Syntax_Syntax.lift),
                                (sub1.FStar_Syntax_Syntax.lift_wp))
                        with
@@ -4995,23 +5028,23 @@ let (tc_decl' :
                           ,FStar_Pervasives_Native.None ) ->
                            failwith "Impossible (parser)"
                        | (lift,FStar_Pervasives_Native.Some (uvs,lift_wp)) ->
-                           let uu____8960 =
+                           let uu____8971 =
                              if (FStar_List.length uvs) > Prims.int_zero
                              then
-                               let uu____8971 =
+                               let uu____8982 =
                                  FStar_Syntax_Subst.univ_var_opening uvs  in
-                               match uu____8971 with
+                               match uu____8982 with
                                | (usubst,uvs1) ->
-                                   let uu____8994 =
+                                   let uu____9005 =
                                      FStar_TypeChecker_Env.push_univ_vars env
                                        uvs1
                                       in
-                                   let uu____8995 =
+                                   let uu____9006 =
                                      FStar_Syntax_Subst.subst usubst lift_wp
                                       in
-                                   (uu____8994, uu____8995)
+                                   (uu____9005, uu____9006)
                              else (env, lift_wp)  in
-                           (match uu____8960 with
+                           (match uu____8971 with
                             | (env1,lift_wp1) ->
                                 let lift_wp2 =
                                   if (FStar_List.length uvs) = Prims.int_zero
@@ -5021,61 +5054,61 @@ let (tc_decl' :
                                        tc_check_trivial_guard env1 lift_wp1
                                          expected_k
                                         in
-                                     let uu____9045 =
+                                     let uu____9056 =
                                        FStar_Syntax_Subst.close_univ_vars uvs
                                          lift_wp2
                                         in
-                                     (uvs, uu____9045))
+                                     (uvs, uu____9056))
                                    in
                                 (lift, lift_wp2))
                        | (FStar_Pervasives_Native.Some
                           (what,lift),FStar_Pervasives_Native.None ) ->
-                           let uu____9116 =
+                           let uu____9127 =
                              if (FStar_List.length what) > Prims.int_zero
                              then
-                               let uu____9131 =
+                               let uu____9142 =
                                  FStar_Syntax_Subst.univ_var_opening what  in
-                               match uu____9131 with
+                               match uu____9142 with
                                | (usubst,uvs) ->
-                                   let uu____9156 =
+                                   let uu____9167 =
                                      FStar_Syntax_Subst.subst usubst lift  in
-                                   (uvs, uu____9156)
+                                   (uvs, uu____9167)
                              else ([], lift)  in
-                           (match uu____9116 with
+                           (match uu____9127 with
                             | (uvs,lift1) ->
-                                ((let uu____9192 =
+                                ((let uu____9203 =
                                     FStar_TypeChecker_Env.debug env
                                       (FStar_Options.Other "ED")
                                      in
-                                  if uu____9192
+                                  if uu____9203
                                   then
-                                    let uu____9196 =
+                                    let uu____9207 =
                                       FStar_Syntax_Print.term_to_string lift1
                                        in
                                     FStar_Util.print1 "Lift for free : %s\n"
-                                      uu____9196
+                                      uu____9207
                                   else ());
                                  (let dmff_env =
                                     FStar_TypeChecker_DMFF.empty env
                                       (FStar_TypeChecker_TcTerm.tc_constant
                                          env FStar_Range.dummyRange)
                                      in
-                                  let uu____9202 =
-                                    let uu____9209 =
+                                  let uu____9213 =
+                                    let uu____9220 =
                                       FStar_TypeChecker_Env.push_univ_vars
                                         env uvs
                                        in
                                     FStar_TypeChecker_TcTerm.tc_term
-                                      uu____9209 lift1
+                                      uu____9220 lift1
                                      in
-                                  match uu____9202 with
-                                  | (lift2,comp,uu____9234) ->
-                                      let uu____9235 =
+                                  match uu____9213 with
+                                  | (lift2,comp,uu____9245) ->
+                                      let uu____9246 =
                                         FStar_TypeChecker_DMFF.star_expr
                                           dmff_env lift2
                                          in
-                                      (match uu____9235 with
-                                       | (uu____9264,lift_wp,lift_elab) ->
+                                      (match uu____9246 with
+                                       | (uu____9275,lift_wp,lift_elab) ->
                                            let lift_wp1 =
                                              recheck_debug "lift-wp" env
                                                lift_wp
@@ -5088,164 +5121,166 @@ let (tc_decl' :
                                              (FStar_List.length uvs) =
                                                Prims.int_zero
                                            then
-                                             let uu____9296 =
-                                               let uu____9307 =
+                                             let uu____9307 =
+                                               let uu____9318 =
                                                  FStar_TypeChecker_Util.generalize_universes
                                                    env lift_elab1
                                                   in
                                                FStar_Pervasives_Native.Some
-                                                 uu____9307
+                                                 uu____9318
                                                 in
-                                             let uu____9324 =
+                                             let uu____9335 =
                                                FStar_TypeChecker_Util.generalize_universes
                                                  env lift_wp1
                                                 in
-                                             (uu____9296, uu____9324)
+                                             (uu____9307, uu____9335)
                                            else
-                                             (let uu____9353 =
-                                                let uu____9364 =
-                                                  let uu____9373 =
+                                             (let uu____9364 =
+                                                let uu____9375 =
+                                                  let uu____9384 =
                                                     FStar_Syntax_Subst.close_univ_vars
                                                       uvs lift_elab1
                                                      in
-                                                  (uvs, uu____9373)  in
+                                                  (uvs, uu____9384)  in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____9364
+                                                  uu____9375
                                                  in
-                                              let uu____9388 =
-                                                let uu____9397 =
+                                              let uu____9399 =
+                                                let uu____9408 =
                                                   FStar_Syntax_Subst.close_univ_vars
                                                     uvs lift_wp1
                                                    in
-                                                (uvs, uu____9397)  in
-                                              (uu____9353, uu____9388))))))
+                                                (uvs, uu____9408)  in
+                                              (uu____9364, uu____9399))))))
                         in
-                     (match uu____8787 with
+                     (match uu____8798 with
                       | (lift,lift_wp) ->
                           let env1 =
-                            let uu___1133_9471 = env  in
+                            let uu___1137_9482 = env  in
                             {
                               FStar_TypeChecker_Env.solver =
-                                (uu___1133_9471.FStar_TypeChecker_Env.solver);
+                                (uu___1137_9482.FStar_TypeChecker_Env.solver);
                               FStar_TypeChecker_Env.range =
-                                (uu___1133_9471.FStar_TypeChecker_Env.range);
+                                (uu___1137_9482.FStar_TypeChecker_Env.range);
                               FStar_TypeChecker_Env.curmodule =
-                                (uu___1133_9471.FStar_TypeChecker_Env.curmodule);
+                                (uu___1137_9482.FStar_TypeChecker_Env.curmodule);
                               FStar_TypeChecker_Env.gamma =
-                                (uu___1133_9471.FStar_TypeChecker_Env.gamma);
+                                (uu___1137_9482.FStar_TypeChecker_Env.gamma);
                               FStar_TypeChecker_Env.gamma_sig =
-                                (uu___1133_9471.FStar_TypeChecker_Env.gamma_sig);
+                                (uu___1137_9482.FStar_TypeChecker_Env.gamma_sig);
                               FStar_TypeChecker_Env.gamma_cache =
-                                (uu___1133_9471.FStar_TypeChecker_Env.gamma_cache);
+                                (uu___1137_9482.FStar_TypeChecker_Env.gamma_cache);
                               FStar_TypeChecker_Env.modules =
-                                (uu___1133_9471.FStar_TypeChecker_Env.modules);
+                                (uu___1137_9482.FStar_TypeChecker_Env.modules);
                               FStar_TypeChecker_Env.expected_typ =
-                                (uu___1133_9471.FStar_TypeChecker_Env.expected_typ);
+                                (uu___1137_9482.FStar_TypeChecker_Env.expected_typ);
                               FStar_TypeChecker_Env.sigtab =
-                                (uu___1133_9471.FStar_TypeChecker_Env.sigtab);
+                                (uu___1137_9482.FStar_TypeChecker_Env.sigtab);
                               FStar_TypeChecker_Env.attrtab =
-                                (uu___1133_9471.FStar_TypeChecker_Env.attrtab);
+                                (uu___1137_9482.FStar_TypeChecker_Env.attrtab);
                               FStar_TypeChecker_Env.is_pattern =
-                                (uu___1133_9471.FStar_TypeChecker_Env.is_pattern);
+                                (uu___1137_9482.FStar_TypeChecker_Env.is_pattern);
                               FStar_TypeChecker_Env.instantiate_imp =
-                                (uu___1133_9471.FStar_TypeChecker_Env.instantiate_imp);
+                                (uu___1137_9482.FStar_TypeChecker_Env.instantiate_imp);
                               FStar_TypeChecker_Env.effects =
-                                (uu___1133_9471.FStar_TypeChecker_Env.effects);
+                                (uu___1137_9482.FStar_TypeChecker_Env.effects);
                               FStar_TypeChecker_Env.generalize =
-                                (uu___1133_9471.FStar_TypeChecker_Env.generalize);
+                                (uu___1137_9482.FStar_TypeChecker_Env.generalize);
                               FStar_TypeChecker_Env.letrecs =
-                                (uu___1133_9471.FStar_TypeChecker_Env.letrecs);
+                                (uu___1137_9482.FStar_TypeChecker_Env.letrecs);
                               FStar_TypeChecker_Env.top_level =
-                                (uu___1133_9471.FStar_TypeChecker_Env.top_level);
+                                (uu___1137_9482.FStar_TypeChecker_Env.top_level);
                               FStar_TypeChecker_Env.check_uvars =
-                                (uu___1133_9471.FStar_TypeChecker_Env.check_uvars);
+                                (uu___1137_9482.FStar_TypeChecker_Env.check_uvars);
                               FStar_TypeChecker_Env.use_eq =
-                                (uu___1133_9471.FStar_TypeChecker_Env.use_eq);
+                                (uu___1137_9482.FStar_TypeChecker_Env.use_eq);
                               FStar_TypeChecker_Env.is_iface =
-                                (uu___1133_9471.FStar_TypeChecker_Env.is_iface);
+                                (uu___1137_9482.FStar_TypeChecker_Env.is_iface);
                               FStar_TypeChecker_Env.admit =
-                                (uu___1133_9471.FStar_TypeChecker_Env.admit);
+                                (uu___1137_9482.FStar_TypeChecker_Env.admit);
                               FStar_TypeChecker_Env.lax = true;
                               FStar_TypeChecker_Env.lax_universes =
-                                (uu___1133_9471.FStar_TypeChecker_Env.lax_universes);
+                                (uu___1137_9482.FStar_TypeChecker_Env.lax_universes);
                               FStar_TypeChecker_Env.phase1 =
-                                (uu___1133_9471.FStar_TypeChecker_Env.phase1);
+                                (uu___1137_9482.FStar_TypeChecker_Env.phase1);
                               FStar_TypeChecker_Env.failhard =
-                                (uu___1133_9471.FStar_TypeChecker_Env.failhard);
+                                (uu___1137_9482.FStar_TypeChecker_Env.failhard);
                               FStar_TypeChecker_Env.nosynth =
-                                (uu___1133_9471.FStar_TypeChecker_Env.nosynth);
+                                (uu___1137_9482.FStar_TypeChecker_Env.nosynth);
                               FStar_TypeChecker_Env.uvar_subtyping =
-                                (uu___1133_9471.FStar_TypeChecker_Env.uvar_subtyping);
+                                (uu___1137_9482.FStar_TypeChecker_Env.uvar_subtyping);
                               FStar_TypeChecker_Env.tc_term =
-                                (uu___1133_9471.FStar_TypeChecker_Env.tc_term);
+                                (uu___1137_9482.FStar_TypeChecker_Env.tc_term);
                               FStar_TypeChecker_Env.type_of =
-                                (uu___1133_9471.FStar_TypeChecker_Env.type_of);
+                                (uu___1137_9482.FStar_TypeChecker_Env.type_of);
                               FStar_TypeChecker_Env.universe_of =
-                                (uu___1133_9471.FStar_TypeChecker_Env.universe_of);
+                                (uu___1137_9482.FStar_TypeChecker_Env.universe_of);
                               FStar_TypeChecker_Env.check_type_of =
-                                (uu___1133_9471.FStar_TypeChecker_Env.check_type_of);
+                                (uu___1137_9482.FStar_TypeChecker_Env.check_type_of);
                               FStar_TypeChecker_Env.use_bv_sorts =
-                                (uu___1133_9471.FStar_TypeChecker_Env.use_bv_sorts);
+                                (uu___1137_9482.FStar_TypeChecker_Env.use_bv_sorts);
                               FStar_TypeChecker_Env.qtbl_name_and_index =
-                                (uu___1133_9471.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                (uu___1137_9482.FStar_TypeChecker_Env.qtbl_name_and_index);
                               FStar_TypeChecker_Env.normalized_eff_names =
-                                (uu___1133_9471.FStar_TypeChecker_Env.normalized_eff_names);
+                                (uu___1137_9482.FStar_TypeChecker_Env.normalized_eff_names);
                               FStar_TypeChecker_Env.fv_delta_depths =
-                                (uu___1133_9471.FStar_TypeChecker_Env.fv_delta_depths);
+                                (uu___1137_9482.FStar_TypeChecker_Env.fv_delta_depths);
                               FStar_TypeChecker_Env.proof_ns =
-                                (uu___1133_9471.FStar_TypeChecker_Env.proof_ns);
+                                (uu___1137_9482.FStar_TypeChecker_Env.proof_ns);
                               FStar_TypeChecker_Env.synth_hook =
-                                (uu___1133_9471.FStar_TypeChecker_Env.synth_hook);
+                                (uu___1137_9482.FStar_TypeChecker_Env.synth_hook);
                               FStar_TypeChecker_Env.splice =
-                                (uu___1133_9471.FStar_TypeChecker_Env.splice);
+                                (uu___1137_9482.FStar_TypeChecker_Env.splice);
                               FStar_TypeChecker_Env.postprocess =
-                                (uu___1133_9471.FStar_TypeChecker_Env.postprocess);
+                                (uu___1137_9482.FStar_TypeChecker_Env.postprocess);
                               FStar_TypeChecker_Env.is_native_tactic =
-                                (uu___1133_9471.FStar_TypeChecker_Env.is_native_tactic);
+                                (uu___1137_9482.FStar_TypeChecker_Env.is_native_tactic);
                               FStar_TypeChecker_Env.identifier_info =
-                                (uu___1133_9471.FStar_TypeChecker_Env.identifier_info);
+                                (uu___1137_9482.FStar_TypeChecker_Env.identifier_info);
                               FStar_TypeChecker_Env.tc_hooks =
-                                (uu___1133_9471.FStar_TypeChecker_Env.tc_hooks);
+                                (uu___1137_9482.FStar_TypeChecker_Env.tc_hooks);
                               FStar_TypeChecker_Env.dsenv =
-                                (uu___1133_9471.FStar_TypeChecker_Env.dsenv);
+                                (uu___1137_9482.FStar_TypeChecker_Env.dsenv);
                               FStar_TypeChecker_Env.nbe =
-                                (uu___1133_9471.FStar_TypeChecker_Env.nbe);
+                                (uu___1137_9482.FStar_TypeChecker_Env.nbe);
                               FStar_TypeChecker_Env.strict_args_tab =
-                                (uu___1133_9471.FStar_TypeChecker_Env.strict_args_tab)
+                                (uu___1137_9482.FStar_TypeChecker_Env.strict_args_tab);
+                              FStar_TypeChecker_Env.erasable_types_tab =
+                                (uu___1137_9482.FStar_TypeChecker_Env.erasable_types_tab)
                             }  in
                           let lift1 =
                             match lift with
                             | FStar_Pervasives_Native.None  ->
                                 FStar_Pervasives_Native.None
                             | FStar_Pervasives_Native.Some (uvs,lift1) ->
-                                let uu____9528 =
-                                  let uu____9533 =
+                                let uu____9539 =
+                                  let uu____9544 =
                                     FStar_Syntax_Subst.univ_var_opening uvs
                                      in
-                                  match uu____9533 with
+                                  match uu____9544 with
                                   | (usubst,uvs1) ->
-                                      let uu____9556 =
+                                      let uu____9567 =
                                         FStar_TypeChecker_Env.push_univ_vars
                                           env1 uvs1
                                          in
-                                      let uu____9557 =
+                                      let uu____9568 =
                                         FStar_Syntax_Subst.subst usubst lift1
                                          in
-                                      (uu____9556, uu____9557)
+                                      (uu____9567, uu____9568)
                                    in
-                                (match uu____9528 with
+                                (match uu____9539 with
                                  | (env2,lift2) ->
-                                     let uu____9570 =
-                                       let uu____9577 =
+                                     let uu____9581 =
+                                       let uu____9588 =
                                          FStar_TypeChecker_Env.lookup_effect_lid
                                            env2
                                            sub1.FStar_Syntax_Syntax.source
                                           in
                                        monad_signature env2
                                          sub1.FStar_Syntax_Syntax.source
-                                         uu____9577
+                                         uu____9588
                                         in
-                                     (match uu____9570 with
+                                     (match uu____9581 with
                                       | (a1,wp_a_src1) ->
                                           let wp_a =
                                             FStar_Syntax_Syntax.new_bv
@@ -5274,75 +5309,75 @@ let (tc_decl' :
                                                    lift_wp)
                                                in
                                             let lift_wp_a =
-                                              let uu____9611 =
+                                              let uu____9622 =
                                                 FStar_TypeChecker_Env.get_range
                                                   env2
                                                  in
-                                              let uu____9612 =
-                                                let uu____9619 =
-                                                  let uu____9620 =
-                                                    let uu____9637 =
-                                                      let uu____9648 =
+                                              let uu____9623 =
+                                                let uu____9630 =
+                                                  let uu____9631 =
+                                                    let uu____9648 =
+                                                      let uu____9659 =
                                                         FStar_Syntax_Syntax.as_arg
                                                           a_typ
                                                          in
-                                                      let uu____9657 =
-                                                        let uu____9668 =
+                                                      let uu____9668 =
+                                                        let uu____9679 =
                                                           FStar_Syntax_Syntax.as_arg
                                                             wp_a_typ
                                                            in
-                                                        [uu____9668]  in
-                                                      uu____9648 ::
-                                                        uu____9657
+                                                        [uu____9679]  in
+                                                      uu____9659 ::
+                                                        uu____9668
                                                        in
-                                                    (lift_wp1, uu____9637)
+                                                    (lift_wp1, uu____9648)
                                                      in
                                                   FStar_Syntax_Syntax.Tm_app
-                                                    uu____9620
+                                                    uu____9631
                                                    in
                                                 FStar_Syntax_Syntax.mk
-                                                  uu____9619
+                                                  uu____9630
                                                  in
-                                              uu____9612
+                                              uu____9623
                                                 FStar_Pervasives_Native.None
-                                                uu____9611
+                                                uu____9622
                                                in
                                             repr_type
                                               sub1.FStar_Syntax_Syntax.target
                                               a_typ lift_wp_a
                                              in
                                           let expected_k1 =
-                                            let uu____9716 =
-                                              let uu____9725 =
+                                            let uu____9727 =
+                                              let uu____9736 =
                                                 FStar_Syntax_Syntax.mk_binder
                                                   a1
                                                  in
-                                              let uu____9732 =
-                                                let uu____9741 =
+                                              let uu____9743 =
+                                                let uu____9752 =
                                                   FStar_Syntax_Syntax.mk_binder
                                                     wp_a
                                                    in
-                                                let uu____9748 =
-                                                  let uu____9757 =
+                                                let uu____9759 =
+                                                  let uu____9768 =
                                                     FStar_Syntax_Syntax.null_binder
                                                       repr_f
                                                      in
-                                                  [uu____9757]  in
-                                                uu____9741 :: uu____9748  in
-                                              uu____9725 :: uu____9732  in
-                                            let uu____9788 =
+                                                  [uu____9768]  in
+                                                uu____9752 :: uu____9759  in
+                                              uu____9736 :: uu____9743  in
+                                            let uu____9799 =
                                               FStar_Syntax_Syntax.mk_Total
                                                 repr_result
                                                in
                                             FStar_Syntax_Util.arrow
-                                              uu____9716 uu____9788
+                                              uu____9727 uu____9799
                                              in
-                                          let uu____9791 =
+                                          let uu____9802 =
                                             FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                               env2 expected_k1
                                              in
-                                          (match uu____9791 with
-                                           | (expected_k2,uu____9809,uu____9810)
+                                          (match uu____9802 with
+                                           | (expected_k2,uu____9820,uu____9821)
                                                ->
                                                let lift3 =
                                                  if
@@ -5357,178 +5392,178 @@ let (tc_decl' :
                                                         env2 lift2
                                                         expected_k2
                                                        in
-                                                    let uu____9834 =
+                                                    let uu____9845 =
                                                       FStar_Syntax_Subst.close_univ_vars
                                                         uvs lift3
                                                        in
-                                                    (uvs, uu____9834))
+                                                    (uvs, uu____9845))
                                                   in
                                                FStar_Pervasives_Native.Some
                                                  lift3)))
                              in
-                          ((let uu____9850 =
-                              let uu____9852 =
-                                let uu____9854 =
+                          ((let uu____9861 =
+                              let uu____9863 =
+                                let uu____9865 =
                                   FStar_All.pipe_right lift_wp
                                     FStar_Pervasives_Native.fst
                                    in
-                                FStar_All.pipe_right uu____9854
+                                FStar_All.pipe_right uu____9865
                                   FStar_List.length
                                  in
-                              uu____9852 <> Prims.int_one  in
-                            if uu____9850
+                              uu____9863 <> Prims.int_one  in
+                            if uu____9861
                             then
-                              let uu____9876 =
-                                let uu____9882 =
-                                  let uu____9884 =
+                              let uu____9888 =
+                                let uu____9894 =
+                                  let uu____9896 =
                                     FStar_Syntax_Print.lid_to_string
                                       sub1.FStar_Syntax_Syntax.source
                                      in
-                                  let uu____9886 =
+                                  let uu____9898 =
                                     FStar_Syntax_Print.lid_to_string
                                       sub1.FStar_Syntax_Syntax.target
                                      in
-                                  let uu____9888 =
-                                    let uu____9890 =
-                                      let uu____9892 =
+                                  let uu____9900 =
+                                    let uu____9902 =
+                                      let uu____9904 =
                                         FStar_All.pipe_right lift_wp
                                           FStar_Pervasives_Native.fst
                                          in
-                                      FStar_All.pipe_right uu____9892
+                                      FStar_All.pipe_right uu____9904
                                         FStar_List.length
                                        in
-                                    FStar_All.pipe_right uu____9890
+                                    FStar_All.pipe_right uu____9902
                                       FStar_Util.string_of_int
                                      in
                                   FStar_Util.format3
                                     "Sub effect wp must be polymorphic in exactly 1 universe; %s ~> %s has %s universes"
-                                    uu____9884 uu____9886 uu____9888
+                                    uu____9896 uu____9898 uu____9900
                                    in
                                 (FStar_Errors.Fatal_TooManyUniverse,
-                                  uu____9882)
+                                  uu____9894)
                                  in
-                              FStar_Errors.raise_error uu____9876 r
+                              FStar_Errors.raise_error uu____9888 r
                             else ());
-                           (let uu____9919 =
+                           (let uu____9931 =
                               (FStar_Util.is_some lift1) &&
-                                (let uu____9930 =
-                                   let uu____9932 =
-                                     let uu____9935 =
+                                (let uu____9942 =
+                                   let uu____9944 =
+                                     let uu____9947 =
                                        FStar_All.pipe_right lift1
                                          FStar_Util.must
                                         in
-                                     FStar_All.pipe_right uu____9935
+                                     FStar_All.pipe_right uu____9947
                                        FStar_Pervasives_Native.fst
                                       in
-                                   FStar_All.pipe_right uu____9932
+                                   FStar_All.pipe_right uu____9944
                                      FStar_List.length
                                     in
-                                 uu____9930 <> Prims.int_one)
+                                 uu____9942 <> Prims.int_one)
                                in
-                            if uu____9919
+                            if uu____9931
                             then
-                              let uu____9989 =
-                                let uu____9995 =
-                                  let uu____9997 =
+                              let uu____10001 =
+                                let uu____10007 =
+                                  let uu____10009 =
                                     FStar_Syntax_Print.lid_to_string
                                       sub1.FStar_Syntax_Syntax.source
                                      in
-                                  let uu____9999 =
+                                  let uu____10011 =
                                     FStar_Syntax_Print.lid_to_string
                                       sub1.FStar_Syntax_Syntax.target
                                      in
-                                  let uu____10001 =
-                                    let uu____10003 =
-                                      let uu____10005 =
-                                        let uu____10008 =
+                                  let uu____10013 =
+                                    let uu____10015 =
+                                      let uu____10017 =
+                                        let uu____10020 =
                                           FStar_All.pipe_right lift1
                                             FStar_Util.must
                                            in
-                                        FStar_All.pipe_right uu____10008
+                                        FStar_All.pipe_right uu____10020
                                           FStar_Pervasives_Native.fst
                                          in
-                                      FStar_All.pipe_right uu____10005
+                                      FStar_All.pipe_right uu____10017
                                         FStar_List.length
                                        in
-                                    FStar_All.pipe_right uu____10003
+                                    FStar_All.pipe_right uu____10015
                                       FStar_Util.string_of_int
                                      in
                                   FStar_Util.format3
                                     "Sub effect lift must be polymorphic in exactly 1 universe; %s ~> %s has %s universes"
-                                    uu____9997 uu____9999 uu____10001
+                                    uu____10009 uu____10011 uu____10013
                                    in
                                 (FStar_Errors.Fatal_TooManyUniverse,
-                                  uu____9995)
+                                  uu____10007)
                                  in
-                              FStar_Errors.raise_error uu____9989 r
+                              FStar_Errors.raise_error uu____10001 r
                             else ());
                            (let sub2 =
-                              let uu___1170_10067 = sub1  in
+                              let uu___1174_10079 = sub1  in
                               {
                                 FStar_Syntax_Syntax.source =
-                                  (uu___1170_10067.FStar_Syntax_Syntax.source);
+                                  (uu___1174_10079.FStar_Syntax_Syntax.source);
                                 FStar_Syntax_Syntax.target =
-                                  (uu___1170_10067.FStar_Syntax_Syntax.target);
+                                  (uu___1174_10079.FStar_Syntax_Syntax.target);
                                 FStar_Syntax_Syntax.lift_wp =
                                   (FStar_Pervasives_Native.Some lift_wp);
                                 FStar_Syntax_Syntax.lift = lift1
                               }  in
                             let se1 =
-                              let uu___1173_10069 = se  in
+                              let uu___1177_10081 = se  in
                               {
                                 FStar_Syntax_Syntax.sigel =
                                   (FStar_Syntax_Syntax.Sig_sub_effect sub2);
                                 FStar_Syntax_Syntax.sigrng =
-                                  (uu___1173_10069.FStar_Syntax_Syntax.sigrng);
+                                  (uu___1177_10081.FStar_Syntax_Syntax.sigrng);
                                 FStar_Syntax_Syntax.sigquals =
-                                  (uu___1173_10069.FStar_Syntax_Syntax.sigquals);
+                                  (uu___1177_10081.FStar_Syntax_Syntax.sigquals);
                                 FStar_Syntax_Syntax.sigmeta =
-                                  (uu___1173_10069.FStar_Syntax_Syntax.sigmeta);
+                                  (uu___1177_10081.FStar_Syntax_Syntax.sigmeta);
                                 FStar_Syntax_Syntax.sigattrs =
-                                  (uu___1173_10069.FStar_Syntax_Syntax.sigattrs)
+                                  (uu___1177_10081.FStar_Syntax_Syntax.sigattrs)
                               }  in
                             ([se1], [], env0))))))
        | FStar_Syntax_Syntax.Sig_effect_abbrev (lid,uvs,tps,c,flags) ->
-           let uu____10083 =
+           let uu____10095 =
              if (FStar_List.length uvs) = Prims.int_zero
              then (env, uvs, tps, c)
              else
-               (let uu____10111 = FStar_Syntax_Subst.univ_var_opening uvs  in
-                match uu____10111 with
+               (let uu____10123 = FStar_Syntax_Subst.univ_var_opening uvs  in
+                match uu____10123 with
                 | (usubst,uvs1) ->
                     let tps1 = FStar_Syntax_Subst.subst_binders usubst tps
                        in
                     let c1 =
-                      let uu____10142 =
+                      let uu____10154 =
                         FStar_Syntax_Subst.shift_subst
                           (FStar_List.length tps1) usubst
                          in
-                      FStar_Syntax_Subst.subst_comp uu____10142 c  in
-                    let uu____10151 =
+                      FStar_Syntax_Subst.subst_comp uu____10154 c  in
+                    let uu____10163 =
                       FStar_TypeChecker_Env.push_univ_vars env uvs1  in
-                    (uu____10151, uvs1, tps1, c1))
+                    (uu____10163, uvs1, tps1, c1))
               in
-           (match uu____10083 with
+           (match uu____10095 with
             | (env1,uvs1,tps1,c1) ->
                 let env2 = FStar_TypeChecker_Env.set_range env1 r  in
-                let uu____10173 = FStar_Syntax_Subst.open_comp tps1 c1  in
-                (match uu____10173 with
+                let uu____10185 = FStar_Syntax_Subst.open_comp tps1 c1  in
+                (match uu____10185 with
                  | (tps2,c2) ->
-                     let uu____10190 =
+                     let uu____10202 =
                        FStar_TypeChecker_TcTerm.tc_tparams env2 tps2  in
-                     (match uu____10190 with
+                     (match uu____10202 with
                       | (tps3,env3,us) ->
-                          let uu____10210 =
+                          let uu____10222 =
                             FStar_TypeChecker_TcTerm.tc_comp env3 c2  in
-                          (match uu____10210 with
+                          (match uu____10222 with
                            | (c3,u,g) ->
                                (FStar_TypeChecker_Rel.force_trivial_guard
                                   env3 g;
                                 (let expected_result_typ =
                                    match tps3 with
-                                   | (x,uu____10238)::uu____10239 ->
+                                   | (x,uu____10250)::uu____10251 ->
                                        FStar_Syntax_Syntax.bv_to_name x
-                                   | uu____10258 ->
+                                   | uu____10270 ->
                                        FStar_Errors.raise_error
                                          (FStar_Errors.Fatal_NotEnoughArgumentsForEffect,
                                            "Effect abbreviations must bind at least the result type")
@@ -5536,439 +5571,443 @@ let (tc_decl' :
                                     in
                                  let def_result_typ =
                                    FStar_Syntax_Util.comp_result c3  in
-                                 let uu____10266 =
-                                   let uu____10268 =
+                                 let uu____10278 =
+                                   let uu____10280 =
                                      FStar_TypeChecker_Rel.teq_nosmt_force
                                        env3 expected_result_typ
                                        def_result_typ
                                       in
-                                   Prims.op_Negation uu____10268  in
-                                 if uu____10266
+                                   Prims.op_Negation uu____10280  in
+                                 if uu____10278
                                  then
-                                   let uu____10271 =
-                                     let uu____10277 =
-                                       let uu____10279 =
+                                   let uu____10283 =
+                                     let uu____10289 =
+                                       let uu____10291 =
                                          FStar_Syntax_Print.term_to_string
                                            expected_result_typ
                                           in
-                                       let uu____10281 =
+                                       let uu____10293 =
                                          FStar_Syntax_Print.term_to_string
                                            def_result_typ
                                           in
                                        FStar_Util.format2
                                          "Result type of effect abbreviation `%s` does not match the result type of its definition `%s`"
-                                         uu____10279 uu____10281
+                                         uu____10291 uu____10293
                                         in
                                      (FStar_Errors.Fatal_EffectAbbreviationResultTypeMismatch,
-                                       uu____10277)
+                                       uu____10289)
                                       in
-                                   FStar_Errors.raise_error uu____10271 r
+                                   FStar_Errors.raise_error uu____10283 r
                                  else ());
                                 (let tps4 =
                                    FStar_Syntax_Subst.close_binders tps3  in
                                  let c4 =
                                    FStar_Syntax_Subst.close_comp tps4 c3  in
-                                 let uu____10289 =
-                                   let uu____10290 =
+                                 let uu____10301 =
+                                   let uu____10302 =
                                      FStar_Syntax_Syntax.mk
                                        (FStar_Syntax_Syntax.Tm_arrow
                                           (tps4, c4))
                                        FStar_Pervasives_Native.None r
                                       in
                                    FStar_TypeChecker_Util.generalize_universes
-                                     env0 uu____10290
+                                     env0 uu____10302
                                     in
-                                 match uu____10289 with
+                                 match uu____10301 with
                                  | (uvs2,t) ->
-                                     let uu____10321 =
-                                       let uu____10326 =
-                                         let uu____10339 =
-                                           let uu____10340 =
+                                     let uu____10333 =
+                                       let uu____10338 =
+                                         let uu____10351 =
+                                           let uu____10352 =
                                              FStar_Syntax_Subst.compress t
                                               in
-                                           uu____10340.FStar_Syntax_Syntax.n
+                                           uu____10352.FStar_Syntax_Syntax.n
                                             in
-                                         (tps4, uu____10339)  in
-                                       match uu____10326 with
+                                         (tps4, uu____10351)  in
+                                       match uu____10338 with
                                        | ([],FStar_Syntax_Syntax.Tm_arrow
-                                          (uu____10355,c5)) -> ([], c5)
-                                       | (uu____10397,FStar_Syntax_Syntax.Tm_arrow
+                                          (uu____10367,c5)) -> ([], c5)
+                                       | (uu____10409,FStar_Syntax_Syntax.Tm_arrow
                                           (tps5,c5)) -> (tps5, c5)
-                                       | uu____10436 ->
+                                       | uu____10448 ->
                                            failwith
                                              "Impossible (t is an arrow)"
                                         in
-                                     (match uu____10321 with
+                                     (match uu____10333 with
                                       | (tps5,c5) ->
                                           (if
                                              (FStar_List.length uvs2) <>
                                                Prims.int_one
                                            then
-                                             (let uu____10470 =
+                                             (let uu____10482 =
                                                 FStar_Syntax_Subst.open_univ_vars
                                                   uvs2 t
                                                  in
-                                              match uu____10470 with
-                                              | (uu____10475,t1) ->
-                                                  let uu____10477 =
-                                                    let uu____10483 =
-                                                      let uu____10485 =
+                                              match uu____10482 with
+                                              | (uu____10487,t1) ->
+                                                  let uu____10489 =
+                                                    let uu____10495 =
+                                                      let uu____10497 =
                                                         FStar_Syntax_Print.lid_to_string
                                                           lid
                                                          in
-                                                      let uu____10487 =
+                                                      let uu____10499 =
                                                         FStar_All.pipe_right
                                                           (FStar_List.length
                                                              uvs2)
                                                           FStar_Util.string_of_int
                                                          in
-                                                      let uu____10491 =
+                                                      let uu____10503 =
                                                         FStar_Syntax_Print.term_to_string
                                                           t1
                                                          in
                                                       FStar_Util.format3
                                                         "Effect abbreviations must be polymorphic in exactly 1 universe; %s has %s universes (%s)"
-                                                        uu____10485
-                                                        uu____10487
-                                                        uu____10491
+                                                        uu____10497
+                                                        uu____10499
+                                                        uu____10503
                                                        in
                                                     (FStar_Errors.Fatal_TooManyUniverse,
-                                                      uu____10483)
+                                                      uu____10495)
                                                      in
                                                   FStar_Errors.raise_error
-                                                    uu____10477 r)
+                                                    uu____10489 r)
                                            else ();
                                            (let se1 =
-                                              let uu___1243_10498 = se  in
+                                              let uu___1247_10510 = se  in
                                               {
                                                 FStar_Syntax_Syntax.sigel =
                                                   (FStar_Syntax_Syntax.Sig_effect_abbrev
                                                      (lid, uvs2, tps5, c5,
                                                        flags));
                                                 FStar_Syntax_Syntax.sigrng =
-                                                  (uu___1243_10498.FStar_Syntax_Syntax.sigrng);
+                                                  (uu___1247_10510.FStar_Syntax_Syntax.sigrng);
                                                 FStar_Syntax_Syntax.sigquals
                                                   =
-                                                  (uu___1243_10498.FStar_Syntax_Syntax.sigquals);
+                                                  (uu___1247_10510.FStar_Syntax_Syntax.sigquals);
                                                 FStar_Syntax_Syntax.sigmeta =
-                                                  (uu___1243_10498.FStar_Syntax_Syntax.sigmeta);
+                                                  (uu___1247_10510.FStar_Syntax_Syntax.sigmeta);
                                                 FStar_Syntax_Syntax.sigattrs
                                                   =
-                                                  (uu___1243_10498.FStar_Syntax_Syntax.sigattrs)
+                                                  (uu___1247_10510.FStar_Syntax_Syntax.sigattrs)
                                               }  in
                                             ([se1], [], env0))))))))))
        | FStar_Syntax_Syntax.Sig_declare_typ
-           (uu____10505,uu____10506,uu____10507) when
+           (uu____10517,uu____10518,uu____10519) when
            FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
              (FStar_Util.for_some
-                (fun uu___1_10512  ->
-                   match uu___1_10512 with
+                (fun uu___1_10524  ->
+                   match uu___1_10524 with
                    | FStar_Syntax_Syntax.OnlyName  -> true
-                   | uu____10515 -> false))
+                   | uu____10527 -> false))
            -> ([], [], env0)
-       | FStar_Syntax_Syntax.Sig_let (uu____10521,uu____10522) when
+       | FStar_Syntax_Syntax.Sig_let (uu____10533,uu____10534) when
            FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
              (FStar_Util.for_some
-                (fun uu___1_10531  ->
-                   match uu___1_10531 with
+                (fun uu___1_10543  ->
+                   match uu___1_10543 with
                    | FStar_Syntax_Syntax.OnlyName  -> true
-                   | uu____10534 -> false))
+                   | uu____10546 -> false))
            -> ([], [], env0)
        | FStar_Syntax_Syntax.Sig_declare_typ (lid,uvs,t) ->
            let env1 = FStar_TypeChecker_Env.set_range env r  in
-           ((let uu____10545 = FStar_TypeChecker_Env.lid_exists env1 lid  in
-             if uu____10545
+           ((let uu____10557 = FStar_TypeChecker_Env.lid_exists env1 lid  in
+             if uu____10557
              then
-               let uu____10548 =
-                 let uu____10554 =
-                   let uu____10556 = FStar_Ident.text_of_lid lid  in
+               let uu____10560 =
+                 let uu____10566 =
+                   let uu____10568 = FStar_Ident.text_of_lid lid  in
                    FStar_Util.format1
                      "Top-level declaration %s for a name that is already used in this module; top-level declarations must be unique in their module"
-                     uu____10556
+                     uu____10568
                     in
                  (FStar_Errors.Fatal_AlreadyDefinedTopLevelDeclaration,
-                   uu____10554)
+                   uu____10566)
                   in
-               FStar_Errors.raise_error uu____10548 r
+               FStar_Errors.raise_error uu____10560 r
              else ());
-            (let uu____10562 =
-               let uu____10571 =
+            (let uu____10574 =
+               let uu____10583 =
                  (FStar_Options.use_two_phase_tc ()) &&
                    (FStar_TypeChecker_Env.should_verify env1)
                   in
-               if uu____10571
+               if uu____10583
                then
-                 let uu____10582 =
+                 let uu____10594 =
                    tc_declare_typ
-                     (let uu___1267_10585 = env1  in
+                     (let uu___1271_10597 = env1  in
                       {
                         FStar_TypeChecker_Env.solver =
-                          (uu___1267_10585.FStar_TypeChecker_Env.solver);
+                          (uu___1271_10597.FStar_TypeChecker_Env.solver);
                         FStar_TypeChecker_Env.range =
-                          (uu___1267_10585.FStar_TypeChecker_Env.range);
+                          (uu___1271_10597.FStar_TypeChecker_Env.range);
                         FStar_TypeChecker_Env.curmodule =
-                          (uu___1267_10585.FStar_TypeChecker_Env.curmodule);
+                          (uu___1271_10597.FStar_TypeChecker_Env.curmodule);
                         FStar_TypeChecker_Env.gamma =
-                          (uu___1267_10585.FStar_TypeChecker_Env.gamma);
+                          (uu___1271_10597.FStar_TypeChecker_Env.gamma);
                         FStar_TypeChecker_Env.gamma_sig =
-                          (uu___1267_10585.FStar_TypeChecker_Env.gamma_sig);
+                          (uu___1271_10597.FStar_TypeChecker_Env.gamma_sig);
                         FStar_TypeChecker_Env.gamma_cache =
-                          (uu___1267_10585.FStar_TypeChecker_Env.gamma_cache);
+                          (uu___1271_10597.FStar_TypeChecker_Env.gamma_cache);
                         FStar_TypeChecker_Env.modules =
-                          (uu___1267_10585.FStar_TypeChecker_Env.modules);
+                          (uu___1271_10597.FStar_TypeChecker_Env.modules);
                         FStar_TypeChecker_Env.expected_typ =
-                          (uu___1267_10585.FStar_TypeChecker_Env.expected_typ);
+                          (uu___1271_10597.FStar_TypeChecker_Env.expected_typ);
                         FStar_TypeChecker_Env.sigtab =
-                          (uu___1267_10585.FStar_TypeChecker_Env.sigtab);
+                          (uu___1271_10597.FStar_TypeChecker_Env.sigtab);
                         FStar_TypeChecker_Env.attrtab =
-                          (uu___1267_10585.FStar_TypeChecker_Env.attrtab);
+                          (uu___1271_10597.FStar_TypeChecker_Env.attrtab);
                         FStar_TypeChecker_Env.is_pattern =
-                          (uu___1267_10585.FStar_TypeChecker_Env.is_pattern);
+                          (uu___1271_10597.FStar_TypeChecker_Env.is_pattern);
                         FStar_TypeChecker_Env.instantiate_imp =
-                          (uu___1267_10585.FStar_TypeChecker_Env.instantiate_imp);
+                          (uu___1271_10597.FStar_TypeChecker_Env.instantiate_imp);
                         FStar_TypeChecker_Env.effects =
-                          (uu___1267_10585.FStar_TypeChecker_Env.effects);
+                          (uu___1271_10597.FStar_TypeChecker_Env.effects);
                         FStar_TypeChecker_Env.generalize =
-                          (uu___1267_10585.FStar_TypeChecker_Env.generalize);
+                          (uu___1271_10597.FStar_TypeChecker_Env.generalize);
                         FStar_TypeChecker_Env.letrecs =
-                          (uu___1267_10585.FStar_TypeChecker_Env.letrecs);
+                          (uu___1271_10597.FStar_TypeChecker_Env.letrecs);
                         FStar_TypeChecker_Env.top_level =
-                          (uu___1267_10585.FStar_TypeChecker_Env.top_level);
+                          (uu___1271_10597.FStar_TypeChecker_Env.top_level);
                         FStar_TypeChecker_Env.check_uvars =
-                          (uu___1267_10585.FStar_TypeChecker_Env.check_uvars);
+                          (uu___1271_10597.FStar_TypeChecker_Env.check_uvars);
                         FStar_TypeChecker_Env.use_eq =
-                          (uu___1267_10585.FStar_TypeChecker_Env.use_eq);
+                          (uu___1271_10597.FStar_TypeChecker_Env.use_eq);
                         FStar_TypeChecker_Env.is_iface =
-                          (uu___1267_10585.FStar_TypeChecker_Env.is_iface);
+                          (uu___1271_10597.FStar_TypeChecker_Env.is_iface);
                         FStar_TypeChecker_Env.admit =
-                          (uu___1267_10585.FStar_TypeChecker_Env.admit);
+                          (uu___1271_10597.FStar_TypeChecker_Env.admit);
                         FStar_TypeChecker_Env.lax = true;
                         FStar_TypeChecker_Env.lax_universes =
-                          (uu___1267_10585.FStar_TypeChecker_Env.lax_universes);
+                          (uu___1271_10597.FStar_TypeChecker_Env.lax_universes);
                         FStar_TypeChecker_Env.phase1 =
-                          (uu___1267_10585.FStar_TypeChecker_Env.phase1);
+                          (uu___1271_10597.FStar_TypeChecker_Env.phase1);
                         FStar_TypeChecker_Env.failhard =
-                          (uu___1267_10585.FStar_TypeChecker_Env.failhard);
+                          (uu___1271_10597.FStar_TypeChecker_Env.failhard);
                         FStar_TypeChecker_Env.nosynth =
-                          (uu___1267_10585.FStar_TypeChecker_Env.nosynth);
+                          (uu___1271_10597.FStar_TypeChecker_Env.nosynth);
                         FStar_TypeChecker_Env.uvar_subtyping =
-                          (uu___1267_10585.FStar_TypeChecker_Env.uvar_subtyping);
+                          (uu___1271_10597.FStar_TypeChecker_Env.uvar_subtyping);
                         FStar_TypeChecker_Env.tc_term =
-                          (uu___1267_10585.FStar_TypeChecker_Env.tc_term);
+                          (uu___1271_10597.FStar_TypeChecker_Env.tc_term);
                         FStar_TypeChecker_Env.type_of =
-                          (uu___1267_10585.FStar_TypeChecker_Env.type_of);
+                          (uu___1271_10597.FStar_TypeChecker_Env.type_of);
                         FStar_TypeChecker_Env.universe_of =
-                          (uu___1267_10585.FStar_TypeChecker_Env.universe_of);
+                          (uu___1271_10597.FStar_TypeChecker_Env.universe_of);
                         FStar_TypeChecker_Env.check_type_of =
-                          (uu___1267_10585.FStar_TypeChecker_Env.check_type_of);
+                          (uu___1271_10597.FStar_TypeChecker_Env.check_type_of);
                         FStar_TypeChecker_Env.use_bv_sorts =
-                          (uu___1267_10585.FStar_TypeChecker_Env.use_bv_sorts);
+                          (uu___1271_10597.FStar_TypeChecker_Env.use_bv_sorts);
                         FStar_TypeChecker_Env.qtbl_name_and_index =
-                          (uu___1267_10585.FStar_TypeChecker_Env.qtbl_name_and_index);
+                          (uu___1271_10597.FStar_TypeChecker_Env.qtbl_name_and_index);
                         FStar_TypeChecker_Env.normalized_eff_names =
-                          (uu___1267_10585.FStar_TypeChecker_Env.normalized_eff_names);
+                          (uu___1271_10597.FStar_TypeChecker_Env.normalized_eff_names);
                         FStar_TypeChecker_Env.fv_delta_depths =
-                          (uu___1267_10585.FStar_TypeChecker_Env.fv_delta_depths);
+                          (uu___1271_10597.FStar_TypeChecker_Env.fv_delta_depths);
                         FStar_TypeChecker_Env.proof_ns =
-                          (uu___1267_10585.FStar_TypeChecker_Env.proof_ns);
+                          (uu___1271_10597.FStar_TypeChecker_Env.proof_ns);
                         FStar_TypeChecker_Env.synth_hook =
-                          (uu___1267_10585.FStar_TypeChecker_Env.synth_hook);
+                          (uu___1271_10597.FStar_TypeChecker_Env.synth_hook);
                         FStar_TypeChecker_Env.splice =
-                          (uu___1267_10585.FStar_TypeChecker_Env.splice);
+                          (uu___1271_10597.FStar_TypeChecker_Env.splice);
                         FStar_TypeChecker_Env.postprocess =
-                          (uu___1267_10585.FStar_TypeChecker_Env.postprocess);
+                          (uu___1271_10597.FStar_TypeChecker_Env.postprocess);
                         FStar_TypeChecker_Env.is_native_tactic =
-                          (uu___1267_10585.FStar_TypeChecker_Env.is_native_tactic);
+                          (uu___1271_10597.FStar_TypeChecker_Env.is_native_tactic);
                         FStar_TypeChecker_Env.identifier_info =
-                          (uu___1267_10585.FStar_TypeChecker_Env.identifier_info);
+                          (uu___1271_10597.FStar_TypeChecker_Env.identifier_info);
                         FStar_TypeChecker_Env.tc_hooks =
-                          (uu___1267_10585.FStar_TypeChecker_Env.tc_hooks);
+                          (uu___1271_10597.FStar_TypeChecker_Env.tc_hooks);
                         FStar_TypeChecker_Env.dsenv =
-                          (uu___1267_10585.FStar_TypeChecker_Env.dsenv);
+                          (uu___1271_10597.FStar_TypeChecker_Env.dsenv);
                         FStar_TypeChecker_Env.nbe =
-                          (uu___1267_10585.FStar_TypeChecker_Env.nbe);
+                          (uu___1271_10597.FStar_TypeChecker_Env.nbe);
                         FStar_TypeChecker_Env.strict_args_tab =
-                          (uu___1267_10585.FStar_TypeChecker_Env.strict_args_tab)
+                          (uu___1271_10597.FStar_TypeChecker_Env.strict_args_tab);
+                        FStar_TypeChecker_Env.erasable_types_tab =
+                          (uu___1271_10597.FStar_TypeChecker_Env.erasable_types_tab)
                       }) (uvs, t) se.FStar_Syntax_Syntax.sigrng
                     in
-                 match uu____10582 with
+                 match uu____10594 with
                  | (uvs1,t1) ->
-                     ((let uu____10610 =
+                     ((let uu____10622 =
                          FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug env1)
                            (FStar_Options.Other "TwoPhases")
                           in
-                       if uu____10610
+                       if uu____10622
                        then
-                         let uu____10615 =
+                         let uu____10627 =
                            FStar_Syntax_Print.term_to_string t1  in
-                         let uu____10617 =
+                         let uu____10629 =
                            FStar_Syntax_Print.univ_names_to_string uvs1  in
                          FStar_Util.print2
                            "Val declaration after phase 1: %s and uvs: %s\n"
-                           uu____10615 uu____10617
+                           uu____10627 uu____10629
                        else ());
                       (uvs1, t1))
                else (uvs, t)  in
-             match uu____10562 with
+             match uu____10574 with
              | (uvs1,t1) ->
-                 let uu____10652 =
+                 let uu____10664 =
                    tc_declare_typ env1 (uvs1, t1)
                      se.FStar_Syntax_Syntax.sigrng
                     in
-                 (match uu____10652 with
+                 (match uu____10664 with
                   | (uvs2,t2) ->
-                      ([(let uu___1280_10682 = se  in
+                      ([(let uu___1284_10694 = se  in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (FStar_Syntax_Syntax.Sig_declare_typ
                                 (lid, uvs2, t2));
                            FStar_Syntax_Syntax.sigrng =
-                             (uu___1280_10682.FStar_Syntax_Syntax.sigrng);
+                             (uu___1284_10694.FStar_Syntax_Syntax.sigrng);
                            FStar_Syntax_Syntax.sigquals =
-                             (uu___1280_10682.FStar_Syntax_Syntax.sigquals);
+                             (uu___1284_10694.FStar_Syntax_Syntax.sigquals);
                            FStar_Syntax_Syntax.sigmeta =
-                             (uu___1280_10682.FStar_Syntax_Syntax.sigmeta);
+                             (uu___1284_10694.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs =
-                             (uu___1280_10682.FStar_Syntax_Syntax.sigattrs)
+                             (uu___1284_10694.FStar_Syntax_Syntax.sigattrs)
                          })], [], env0))))
        | FStar_Syntax_Syntax.Sig_assume (lid,uvs,t) ->
            let env1 = FStar_TypeChecker_Env.set_range env r  in
-           let uu____10687 =
-             let uu____10696 =
+           let uu____10699 =
+             let uu____10708 =
                (FStar_Options.use_two_phase_tc ()) &&
                  (FStar_TypeChecker_Env.should_verify env1)
                 in
-             if uu____10696
+             if uu____10708
              then
-               let uu____10707 =
+               let uu____10719 =
                  tc_assume
-                   (let uu___1289_10710 = env1  in
+                   (let uu___1293_10722 = env1  in
                     {
                       FStar_TypeChecker_Env.solver =
-                        (uu___1289_10710.FStar_TypeChecker_Env.solver);
+                        (uu___1293_10722.FStar_TypeChecker_Env.solver);
                       FStar_TypeChecker_Env.range =
-                        (uu___1289_10710.FStar_TypeChecker_Env.range);
+                        (uu___1293_10722.FStar_TypeChecker_Env.range);
                       FStar_TypeChecker_Env.curmodule =
-                        (uu___1289_10710.FStar_TypeChecker_Env.curmodule);
+                        (uu___1293_10722.FStar_TypeChecker_Env.curmodule);
                       FStar_TypeChecker_Env.gamma =
-                        (uu___1289_10710.FStar_TypeChecker_Env.gamma);
+                        (uu___1293_10722.FStar_TypeChecker_Env.gamma);
                       FStar_TypeChecker_Env.gamma_sig =
-                        (uu___1289_10710.FStar_TypeChecker_Env.gamma_sig);
+                        (uu___1293_10722.FStar_TypeChecker_Env.gamma_sig);
                       FStar_TypeChecker_Env.gamma_cache =
-                        (uu___1289_10710.FStar_TypeChecker_Env.gamma_cache);
+                        (uu___1293_10722.FStar_TypeChecker_Env.gamma_cache);
                       FStar_TypeChecker_Env.modules =
-                        (uu___1289_10710.FStar_TypeChecker_Env.modules);
+                        (uu___1293_10722.FStar_TypeChecker_Env.modules);
                       FStar_TypeChecker_Env.expected_typ =
-                        (uu___1289_10710.FStar_TypeChecker_Env.expected_typ);
+                        (uu___1293_10722.FStar_TypeChecker_Env.expected_typ);
                       FStar_TypeChecker_Env.sigtab =
-                        (uu___1289_10710.FStar_TypeChecker_Env.sigtab);
+                        (uu___1293_10722.FStar_TypeChecker_Env.sigtab);
                       FStar_TypeChecker_Env.attrtab =
-                        (uu___1289_10710.FStar_TypeChecker_Env.attrtab);
+                        (uu___1293_10722.FStar_TypeChecker_Env.attrtab);
                       FStar_TypeChecker_Env.is_pattern =
-                        (uu___1289_10710.FStar_TypeChecker_Env.is_pattern);
+                        (uu___1293_10722.FStar_TypeChecker_Env.is_pattern);
                       FStar_TypeChecker_Env.instantiate_imp =
-                        (uu___1289_10710.FStar_TypeChecker_Env.instantiate_imp);
+                        (uu___1293_10722.FStar_TypeChecker_Env.instantiate_imp);
                       FStar_TypeChecker_Env.effects =
-                        (uu___1289_10710.FStar_TypeChecker_Env.effects);
+                        (uu___1293_10722.FStar_TypeChecker_Env.effects);
                       FStar_TypeChecker_Env.generalize =
-                        (uu___1289_10710.FStar_TypeChecker_Env.generalize);
+                        (uu___1293_10722.FStar_TypeChecker_Env.generalize);
                       FStar_TypeChecker_Env.letrecs =
-                        (uu___1289_10710.FStar_TypeChecker_Env.letrecs);
+                        (uu___1293_10722.FStar_TypeChecker_Env.letrecs);
                       FStar_TypeChecker_Env.top_level =
-                        (uu___1289_10710.FStar_TypeChecker_Env.top_level);
+                        (uu___1293_10722.FStar_TypeChecker_Env.top_level);
                       FStar_TypeChecker_Env.check_uvars =
-                        (uu___1289_10710.FStar_TypeChecker_Env.check_uvars);
+                        (uu___1293_10722.FStar_TypeChecker_Env.check_uvars);
                       FStar_TypeChecker_Env.use_eq =
-                        (uu___1289_10710.FStar_TypeChecker_Env.use_eq);
+                        (uu___1293_10722.FStar_TypeChecker_Env.use_eq);
                       FStar_TypeChecker_Env.is_iface =
-                        (uu___1289_10710.FStar_TypeChecker_Env.is_iface);
+                        (uu___1293_10722.FStar_TypeChecker_Env.is_iface);
                       FStar_TypeChecker_Env.admit =
-                        (uu___1289_10710.FStar_TypeChecker_Env.admit);
+                        (uu___1293_10722.FStar_TypeChecker_Env.admit);
                       FStar_TypeChecker_Env.lax = true;
                       FStar_TypeChecker_Env.lax_universes =
-                        (uu___1289_10710.FStar_TypeChecker_Env.lax_universes);
+                        (uu___1293_10722.FStar_TypeChecker_Env.lax_universes);
                       FStar_TypeChecker_Env.phase1 = true;
                       FStar_TypeChecker_Env.failhard =
-                        (uu___1289_10710.FStar_TypeChecker_Env.failhard);
+                        (uu___1293_10722.FStar_TypeChecker_Env.failhard);
                       FStar_TypeChecker_Env.nosynth =
-                        (uu___1289_10710.FStar_TypeChecker_Env.nosynth);
+                        (uu___1293_10722.FStar_TypeChecker_Env.nosynth);
                       FStar_TypeChecker_Env.uvar_subtyping =
-                        (uu___1289_10710.FStar_TypeChecker_Env.uvar_subtyping);
+                        (uu___1293_10722.FStar_TypeChecker_Env.uvar_subtyping);
                       FStar_TypeChecker_Env.tc_term =
-                        (uu___1289_10710.FStar_TypeChecker_Env.tc_term);
+                        (uu___1293_10722.FStar_TypeChecker_Env.tc_term);
                       FStar_TypeChecker_Env.type_of =
-                        (uu___1289_10710.FStar_TypeChecker_Env.type_of);
+                        (uu___1293_10722.FStar_TypeChecker_Env.type_of);
                       FStar_TypeChecker_Env.universe_of =
-                        (uu___1289_10710.FStar_TypeChecker_Env.universe_of);
+                        (uu___1293_10722.FStar_TypeChecker_Env.universe_of);
                       FStar_TypeChecker_Env.check_type_of =
-                        (uu___1289_10710.FStar_TypeChecker_Env.check_type_of);
+                        (uu___1293_10722.FStar_TypeChecker_Env.check_type_of);
                       FStar_TypeChecker_Env.use_bv_sorts =
-                        (uu___1289_10710.FStar_TypeChecker_Env.use_bv_sorts);
+                        (uu___1293_10722.FStar_TypeChecker_Env.use_bv_sorts);
                       FStar_TypeChecker_Env.qtbl_name_and_index =
-                        (uu___1289_10710.FStar_TypeChecker_Env.qtbl_name_and_index);
+                        (uu___1293_10722.FStar_TypeChecker_Env.qtbl_name_and_index);
                       FStar_TypeChecker_Env.normalized_eff_names =
-                        (uu___1289_10710.FStar_TypeChecker_Env.normalized_eff_names);
+                        (uu___1293_10722.FStar_TypeChecker_Env.normalized_eff_names);
                       FStar_TypeChecker_Env.fv_delta_depths =
-                        (uu___1289_10710.FStar_TypeChecker_Env.fv_delta_depths);
+                        (uu___1293_10722.FStar_TypeChecker_Env.fv_delta_depths);
                       FStar_TypeChecker_Env.proof_ns =
-                        (uu___1289_10710.FStar_TypeChecker_Env.proof_ns);
+                        (uu___1293_10722.FStar_TypeChecker_Env.proof_ns);
                       FStar_TypeChecker_Env.synth_hook =
-                        (uu___1289_10710.FStar_TypeChecker_Env.synth_hook);
+                        (uu___1293_10722.FStar_TypeChecker_Env.synth_hook);
                       FStar_TypeChecker_Env.splice =
-                        (uu___1289_10710.FStar_TypeChecker_Env.splice);
+                        (uu___1293_10722.FStar_TypeChecker_Env.splice);
                       FStar_TypeChecker_Env.postprocess =
-                        (uu___1289_10710.FStar_TypeChecker_Env.postprocess);
+                        (uu___1293_10722.FStar_TypeChecker_Env.postprocess);
                       FStar_TypeChecker_Env.is_native_tactic =
-                        (uu___1289_10710.FStar_TypeChecker_Env.is_native_tactic);
+                        (uu___1293_10722.FStar_TypeChecker_Env.is_native_tactic);
                       FStar_TypeChecker_Env.identifier_info =
-                        (uu___1289_10710.FStar_TypeChecker_Env.identifier_info);
+                        (uu___1293_10722.FStar_TypeChecker_Env.identifier_info);
                       FStar_TypeChecker_Env.tc_hooks =
-                        (uu___1289_10710.FStar_TypeChecker_Env.tc_hooks);
+                        (uu___1293_10722.FStar_TypeChecker_Env.tc_hooks);
                       FStar_TypeChecker_Env.dsenv =
-                        (uu___1289_10710.FStar_TypeChecker_Env.dsenv);
+                        (uu___1293_10722.FStar_TypeChecker_Env.dsenv);
                       FStar_TypeChecker_Env.nbe =
-                        (uu___1289_10710.FStar_TypeChecker_Env.nbe);
+                        (uu___1293_10722.FStar_TypeChecker_Env.nbe);
                       FStar_TypeChecker_Env.strict_args_tab =
-                        (uu___1289_10710.FStar_TypeChecker_Env.strict_args_tab)
+                        (uu___1293_10722.FStar_TypeChecker_Env.strict_args_tab);
+                      FStar_TypeChecker_Env.erasable_types_tab =
+                        (uu___1293_10722.FStar_TypeChecker_Env.erasable_types_tab)
                     }) (uvs, t) se.FStar_Syntax_Syntax.sigrng
                   in
-               match uu____10707 with
+               match uu____10719 with
                | (uvs1,t1) ->
-                   ((let uu____10736 =
+                   ((let uu____10748 =
                        FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                          (FStar_Options.Other "TwoPhases")
                         in
-                     if uu____10736
+                     if uu____10748
                      then
-                       let uu____10741 = FStar_Syntax_Print.term_to_string t1
+                       let uu____10753 = FStar_Syntax_Print.term_to_string t1
                           in
-                       let uu____10743 =
+                       let uu____10755 =
                          FStar_Syntax_Print.univ_names_to_string uvs1  in
                        FStar_Util.print2
-                         "Assume after phase 1: %s and uvs: %s\n" uu____10741
-                         uu____10743
+                         "Assume after phase 1: %s and uvs: %s\n" uu____10753
+                         uu____10755
                      else ());
                     (uvs1, t1))
              else (uvs, t)  in
-           (match uu____10687 with
+           (match uu____10699 with
             | (uvs1,t1) ->
-                let uu____10778 =
+                let uu____10790 =
                   tc_assume env1 (uvs1, t1) se.FStar_Syntax_Syntax.sigrng  in
-                (match uu____10778 with
+                (match uu____10790 with
                  | (uvs2,t2) ->
-                     ([(let uu___1302_10808 = se  in
+                     ([(let uu___1306_10820 = se  in
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_assume (lid, uvs2, t2));
                           FStar_Syntax_Syntax.sigrng =
-                            (uu___1302_10808.FStar_Syntax_Syntax.sigrng);
+                            (uu___1306_10820.FStar_Syntax_Syntax.sigrng);
                           FStar_Syntax_Syntax.sigquals =
-                            (uu___1302_10808.FStar_Syntax_Syntax.sigquals);
+                            (uu___1306_10820.FStar_Syntax_Syntax.sigquals);
                           FStar_Syntax_Syntax.sigmeta =
-                            (uu___1302_10808.FStar_Syntax_Syntax.sigmeta);
+                            (uu___1306_10820.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (uu___1302_10808.FStar_Syntax_Syntax.sigattrs)
+                            (uu___1306_10820.FStar_Syntax_Syntax.sigattrs)
                         })], [], env0)))
        | FStar_Syntax_Syntax.Sig_main e ->
            let env1 = FStar_TypeChecker_Env.set_range env r  in
@@ -5976,57 +6015,57 @@ let (tc_decl' :
              FStar_TypeChecker_Env.set_expected_typ env1
                FStar_Syntax_Syntax.t_unit
               in
-           let uu____10812 = FStar_TypeChecker_TcTerm.tc_term env2 e  in
-           (match uu____10812 with
+           let uu____10824 = FStar_TypeChecker_TcTerm.tc_term env2 e  in
+           (match uu____10824 with
             | (e1,c,g1) ->
-                let uu____10832 =
-                  let uu____10839 =
-                    let uu____10842 =
+                let uu____10844 =
+                  let uu____10851 =
+                    let uu____10854 =
                       FStar_Syntax_Util.ml_comp FStar_Syntax_Syntax.t_unit r
                        in
-                    FStar_Pervasives_Native.Some uu____10842  in
-                  let uu____10843 =
-                    let uu____10848 = FStar_Syntax_Syntax.lcomp_comp c  in
-                    (e1, uu____10848)  in
+                    FStar_Pervasives_Native.Some uu____10854  in
+                  let uu____10855 =
+                    let uu____10860 = FStar_Syntax_Syntax.lcomp_comp c  in
+                    (e1, uu____10860)  in
                   FStar_TypeChecker_TcTerm.check_expected_effect env2
-                    uu____10839 uu____10843
+                    uu____10851 uu____10855
                    in
-                (match uu____10832 with
-                 | (e2,uu____10860,g) ->
-                     ((let uu____10863 =
+                (match uu____10844 with
+                 | (e2,uu____10872,g) ->
+                     ((let uu____10875 =
                          FStar_TypeChecker_Env.conj_guard g1 g  in
                        FStar_TypeChecker_Rel.force_trivial_guard env2
-                         uu____10863);
+                         uu____10875);
                       (let se1 =
-                         let uu___1317_10865 = se  in
+                         let uu___1321_10877 = se  in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (FStar_Syntax_Syntax.Sig_main e2);
                            FStar_Syntax_Syntax.sigrng =
-                             (uu___1317_10865.FStar_Syntax_Syntax.sigrng);
+                             (uu___1321_10877.FStar_Syntax_Syntax.sigrng);
                            FStar_Syntax_Syntax.sigquals =
-                             (uu___1317_10865.FStar_Syntax_Syntax.sigquals);
+                             (uu___1321_10877.FStar_Syntax_Syntax.sigquals);
                            FStar_Syntax_Syntax.sigmeta =
-                             (uu___1317_10865.FStar_Syntax_Syntax.sigmeta);
+                             (uu___1321_10877.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs =
-                             (uu___1317_10865.FStar_Syntax_Syntax.sigattrs)
+                             (uu___1321_10877.FStar_Syntax_Syntax.sigattrs)
                          }  in
                        ([se1], [], env0)))))
        | FStar_Syntax_Syntax.Sig_splice (lids,t) ->
-           ((let uu____10877 = FStar_Options.debug_any ()  in
-             if uu____10877
+           ((let uu____10889 = FStar_Options.debug_any ()  in
+             if uu____10889
              then
-               let uu____10880 =
+               let uu____10892 =
                  FStar_Ident.string_of_lid
                    env.FStar_TypeChecker_Env.curmodule
                   in
-               let uu____10882 = FStar_Syntax_Print.term_to_string t  in
-               FStar_Util.print2 "%s: Found splice of (%s)\n" uu____10880
-                 uu____10882
+               let uu____10894 = FStar_Syntax_Print.term_to_string t  in
+               FStar_Util.print2 "%s: Found splice of (%s)\n" uu____10892
+                 uu____10894
              else ());
-            (let uu____10887 = FStar_TypeChecker_TcTerm.tc_tactic env t  in
-             match uu____10887 with
-             | (t1,uu____10905,g) ->
+            (let uu____10899 = FStar_TypeChecker_TcTerm.tc_tactic env t  in
+             match uu____10899 with
+             | (t1,uu____10917,g) ->
                  (FStar_TypeChecker_Rel.force_trivial_guard env g;
                   (let ses = env.FStar_TypeChecker_Env.splice env t1  in
                    let lids' =
@@ -6034,130 +6073,132 @@ let (tc_decl' :
                       in
                    FStar_List.iter
                      (fun lid  ->
-                        let uu____10919 =
+                        let uu____10931 =
                           FStar_List.tryFind (FStar_Ident.lid_equals lid)
                             lids'
                            in
-                        match uu____10919 with
+                        match uu____10931 with
                         | FStar_Pervasives_Native.None  when
                             Prims.op_Negation
                               env.FStar_TypeChecker_Env.nosynth
                             ->
-                            let uu____10922 =
-                              let uu____10928 =
-                                let uu____10930 =
+                            let uu____10934 =
+                              let uu____10940 =
+                                let uu____10942 =
                                   FStar_Ident.string_of_lid lid  in
-                                let uu____10932 =
-                                  let uu____10934 =
+                                let uu____10944 =
+                                  let uu____10946 =
                                     FStar_List.map FStar_Ident.string_of_lid
                                       lids'
                                      in
                                   FStar_All.pipe_left
-                                    (FStar_String.concat ", ") uu____10934
+                                    (FStar_String.concat ", ") uu____10946
                                    in
                                 FStar_Util.format2
                                   "Splice declared the name %s but it was not defined.\nThose defined were: %s"
-                                  uu____10930 uu____10932
+                                  uu____10942 uu____10944
                                  in
-                              (FStar_Errors.Fatal_SplicedUndef, uu____10928)
+                              (FStar_Errors.Fatal_SplicedUndef, uu____10940)
                                in
-                            FStar_Errors.raise_error uu____10922 r
-                        | uu____10946 -> ()) lids;
+                            FStar_Errors.raise_error uu____10934 r
+                        | uu____10958 -> ()) lids;
                    (let dsenv1 =
                       FStar_List.fold_left
                         FStar_Syntax_DsEnv.push_sigelt_force
                         env.FStar_TypeChecker_Env.dsenv ses
                        in
                     let env1 =
-                      let uu___1338_10951 = env  in
+                      let uu___1342_10963 = env  in
                       {
                         FStar_TypeChecker_Env.solver =
-                          (uu___1338_10951.FStar_TypeChecker_Env.solver);
+                          (uu___1342_10963.FStar_TypeChecker_Env.solver);
                         FStar_TypeChecker_Env.range =
-                          (uu___1338_10951.FStar_TypeChecker_Env.range);
+                          (uu___1342_10963.FStar_TypeChecker_Env.range);
                         FStar_TypeChecker_Env.curmodule =
-                          (uu___1338_10951.FStar_TypeChecker_Env.curmodule);
+                          (uu___1342_10963.FStar_TypeChecker_Env.curmodule);
                         FStar_TypeChecker_Env.gamma =
-                          (uu___1338_10951.FStar_TypeChecker_Env.gamma);
+                          (uu___1342_10963.FStar_TypeChecker_Env.gamma);
                         FStar_TypeChecker_Env.gamma_sig =
-                          (uu___1338_10951.FStar_TypeChecker_Env.gamma_sig);
+                          (uu___1342_10963.FStar_TypeChecker_Env.gamma_sig);
                         FStar_TypeChecker_Env.gamma_cache =
-                          (uu___1338_10951.FStar_TypeChecker_Env.gamma_cache);
+                          (uu___1342_10963.FStar_TypeChecker_Env.gamma_cache);
                         FStar_TypeChecker_Env.modules =
-                          (uu___1338_10951.FStar_TypeChecker_Env.modules);
+                          (uu___1342_10963.FStar_TypeChecker_Env.modules);
                         FStar_TypeChecker_Env.expected_typ =
-                          (uu___1338_10951.FStar_TypeChecker_Env.expected_typ);
+                          (uu___1342_10963.FStar_TypeChecker_Env.expected_typ);
                         FStar_TypeChecker_Env.sigtab =
-                          (uu___1338_10951.FStar_TypeChecker_Env.sigtab);
+                          (uu___1342_10963.FStar_TypeChecker_Env.sigtab);
                         FStar_TypeChecker_Env.attrtab =
-                          (uu___1338_10951.FStar_TypeChecker_Env.attrtab);
+                          (uu___1342_10963.FStar_TypeChecker_Env.attrtab);
                         FStar_TypeChecker_Env.is_pattern =
-                          (uu___1338_10951.FStar_TypeChecker_Env.is_pattern);
+                          (uu___1342_10963.FStar_TypeChecker_Env.is_pattern);
                         FStar_TypeChecker_Env.instantiate_imp =
-                          (uu___1338_10951.FStar_TypeChecker_Env.instantiate_imp);
+                          (uu___1342_10963.FStar_TypeChecker_Env.instantiate_imp);
                         FStar_TypeChecker_Env.effects =
-                          (uu___1338_10951.FStar_TypeChecker_Env.effects);
+                          (uu___1342_10963.FStar_TypeChecker_Env.effects);
                         FStar_TypeChecker_Env.generalize =
-                          (uu___1338_10951.FStar_TypeChecker_Env.generalize);
+                          (uu___1342_10963.FStar_TypeChecker_Env.generalize);
                         FStar_TypeChecker_Env.letrecs =
-                          (uu___1338_10951.FStar_TypeChecker_Env.letrecs);
+                          (uu___1342_10963.FStar_TypeChecker_Env.letrecs);
                         FStar_TypeChecker_Env.top_level =
-                          (uu___1338_10951.FStar_TypeChecker_Env.top_level);
+                          (uu___1342_10963.FStar_TypeChecker_Env.top_level);
                         FStar_TypeChecker_Env.check_uvars =
-                          (uu___1338_10951.FStar_TypeChecker_Env.check_uvars);
+                          (uu___1342_10963.FStar_TypeChecker_Env.check_uvars);
                         FStar_TypeChecker_Env.use_eq =
-                          (uu___1338_10951.FStar_TypeChecker_Env.use_eq);
+                          (uu___1342_10963.FStar_TypeChecker_Env.use_eq);
                         FStar_TypeChecker_Env.is_iface =
-                          (uu___1338_10951.FStar_TypeChecker_Env.is_iface);
+                          (uu___1342_10963.FStar_TypeChecker_Env.is_iface);
                         FStar_TypeChecker_Env.admit =
-                          (uu___1338_10951.FStar_TypeChecker_Env.admit);
+                          (uu___1342_10963.FStar_TypeChecker_Env.admit);
                         FStar_TypeChecker_Env.lax =
-                          (uu___1338_10951.FStar_TypeChecker_Env.lax);
+                          (uu___1342_10963.FStar_TypeChecker_Env.lax);
                         FStar_TypeChecker_Env.lax_universes =
-                          (uu___1338_10951.FStar_TypeChecker_Env.lax_universes);
+                          (uu___1342_10963.FStar_TypeChecker_Env.lax_universes);
                         FStar_TypeChecker_Env.phase1 =
-                          (uu___1338_10951.FStar_TypeChecker_Env.phase1);
+                          (uu___1342_10963.FStar_TypeChecker_Env.phase1);
                         FStar_TypeChecker_Env.failhard =
-                          (uu___1338_10951.FStar_TypeChecker_Env.failhard);
+                          (uu___1342_10963.FStar_TypeChecker_Env.failhard);
                         FStar_TypeChecker_Env.nosynth =
-                          (uu___1338_10951.FStar_TypeChecker_Env.nosynth);
+                          (uu___1342_10963.FStar_TypeChecker_Env.nosynth);
                         FStar_TypeChecker_Env.uvar_subtyping =
-                          (uu___1338_10951.FStar_TypeChecker_Env.uvar_subtyping);
+                          (uu___1342_10963.FStar_TypeChecker_Env.uvar_subtyping);
                         FStar_TypeChecker_Env.tc_term =
-                          (uu___1338_10951.FStar_TypeChecker_Env.tc_term);
+                          (uu___1342_10963.FStar_TypeChecker_Env.tc_term);
                         FStar_TypeChecker_Env.type_of =
-                          (uu___1338_10951.FStar_TypeChecker_Env.type_of);
+                          (uu___1342_10963.FStar_TypeChecker_Env.type_of);
                         FStar_TypeChecker_Env.universe_of =
-                          (uu___1338_10951.FStar_TypeChecker_Env.universe_of);
+                          (uu___1342_10963.FStar_TypeChecker_Env.universe_of);
                         FStar_TypeChecker_Env.check_type_of =
-                          (uu___1338_10951.FStar_TypeChecker_Env.check_type_of);
+                          (uu___1342_10963.FStar_TypeChecker_Env.check_type_of);
                         FStar_TypeChecker_Env.use_bv_sorts =
-                          (uu___1338_10951.FStar_TypeChecker_Env.use_bv_sorts);
+                          (uu___1342_10963.FStar_TypeChecker_Env.use_bv_sorts);
                         FStar_TypeChecker_Env.qtbl_name_and_index =
-                          (uu___1338_10951.FStar_TypeChecker_Env.qtbl_name_and_index);
+                          (uu___1342_10963.FStar_TypeChecker_Env.qtbl_name_and_index);
                         FStar_TypeChecker_Env.normalized_eff_names =
-                          (uu___1338_10951.FStar_TypeChecker_Env.normalized_eff_names);
+                          (uu___1342_10963.FStar_TypeChecker_Env.normalized_eff_names);
                         FStar_TypeChecker_Env.fv_delta_depths =
-                          (uu___1338_10951.FStar_TypeChecker_Env.fv_delta_depths);
+                          (uu___1342_10963.FStar_TypeChecker_Env.fv_delta_depths);
                         FStar_TypeChecker_Env.proof_ns =
-                          (uu___1338_10951.FStar_TypeChecker_Env.proof_ns);
+                          (uu___1342_10963.FStar_TypeChecker_Env.proof_ns);
                         FStar_TypeChecker_Env.synth_hook =
-                          (uu___1338_10951.FStar_TypeChecker_Env.synth_hook);
+                          (uu___1342_10963.FStar_TypeChecker_Env.synth_hook);
                         FStar_TypeChecker_Env.splice =
-                          (uu___1338_10951.FStar_TypeChecker_Env.splice);
+                          (uu___1342_10963.FStar_TypeChecker_Env.splice);
                         FStar_TypeChecker_Env.postprocess =
-                          (uu___1338_10951.FStar_TypeChecker_Env.postprocess);
+                          (uu___1342_10963.FStar_TypeChecker_Env.postprocess);
                         FStar_TypeChecker_Env.is_native_tactic =
-                          (uu___1338_10951.FStar_TypeChecker_Env.is_native_tactic);
+                          (uu___1342_10963.FStar_TypeChecker_Env.is_native_tactic);
                         FStar_TypeChecker_Env.identifier_info =
-                          (uu___1338_10951.FStar_TypeChecker_Env.identifier_info);
+                          (uu___1342_10963.FStar_TypeChecker_Env.identifier_info);
                         FStar_TypeChecker_Env.tc_hooks =
-                          (uu___1338_10951.FStar_TypeChecker_Env.tc_hooks);
+                          (uu___1342_10963.FStar_TypeChecker_Env.tc_hooks);
                         FStar_TypeChecker_Env.dsenv = dsenv1;
                         FStar_TypeChecker_Env.nbe =
-                          (uu___1338_10951.FStar_TypeChecker_Env.nbe);
+                          (uu___1342_10963.FStar_TypeChecker_Env.nbe);
                         FStar_TypeChecker_Env.strict_args_tab =
-                          (uu___1338_10951.FStar_TypeChecker_Env.strict_args_tab)
+                          (uu___1342_10963.FStar_TypeChecker_Env.strict_args_tab);
+                        FStar_TypeChecker_Env.erasable_types_tab =
+                          (uu___1342_10963.FStar_TypeChecker_Env.erasable_types_tab)
                       }  in
                     ([], ses, env1))))))
        | FStar_Syntax_Syntax.Sig_let (lbs,lids) ->
@@ -6172,55 +6213,55 @@ let (tc_decl' :
                      (fun x  ->
                         Prims.op_Negation (x = FStar_Syntax_Syntax.Logic))
                     in
-                 let uu____11019 =
-                   let uu____11021 =
-                     let uu____11030 = drop_logic val_q  in
-                     let uu____11033 = drop_logic q'  in
-                     (uu____11030, uu____11033)  in
-                   match uu____11021 with
+                 let uu____11031 =
+                   let uu____11033 =
+                     let uu____11042 = drop_logic val_q  in
+                     let uu____11045 = drop_logic q'  in
+                     (uu____11042, uu____11045)  in
+                   match uu____11033 with
                    | (val_q1,q'1) ->
                        ((FStar_List.length val_q1) = (FStar_List.length q'1))
                          &&
                          (FStar_List.forall2
                             FStar_Syntax_Util.qualifier_equal val_q1 q'1)
                     in
-                 if uu____11019
+                 if uu____11031
                  then FStar_Pervasives_Native.Some q'
                  else
-                   (let uu____11060 =
-                      let uu____11066 =
-                        let uu____11068 = FStar_Syntax_Print.lid_to_string l
+                   (let uu____11072 =
+                      let uu____11078 =
+                        let uu____11080 = FStar_Syntax_Print.lid_to_string l
                            in
-                        let uu____11070 =
+                        let uu____11082 =
                           FStar_Syntax_Print.quals_to_string val_q  in
-                        let uu____11072 =
+                        let uu____11084 =
                           FStar_Syntax_Print.quals_to_string q'  in
                         FStar_Util.format3
                           "Inconsistent qualifier annotations on %s; Expected {%s}, got {%s}"
-                          uu____11068 uu____11070 uu____11072
+                          uu____11080 uu____11082 uu____11084
                          in
                       (FStar_Errors.Fatal_InconsistentQualifierAnnotation,
-                        uu____11066)
+                        uu____11078)
                        in
-                    FStar_Errors.raise_error uu____11060 r)
+                    FStar_Errors.raise_error uu____11072 r)
               in
            let rename_parameters lb =
              let rename_in_typ def typ =
                let typ1 = FStar_Syntax_Subst.compress typ  in
                let def_bs =
-                 let uu____11109 =
-                   let uu____11110 = FStar_Syntax_Subst.compress def  in
-                   uu____11110.FStar_Syntax_Syntax.n  in
-                 match uu____11109 with
+                 let uu____11121 =
+                   let uu____11122 = FStar_Syntax_Subst.compress def  in
+                   uu____11122.FStar_Syntax_Syntax.n  in
+                 match uu____11121 with
                  | FStar_Syntax_Syntax.Tm_abs
-                     (binders,uu____11122,uu____11123) -> binders
-                 | uu____11148 -> []  in
+                     (binders,uu____11134,uu____11135) -> binders
+                 | uu____11160 -> []  in
                match typ1 with
                | {
                    FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_arrow
                      (val_bs,c);
                    FStar_Syntax_Syntax.pos = r1;
-                   FStar_Syntax_Syntax.vars = uu____11160;_} ->
+                   FStar_Syntax_Syntax.vars = uu____11172;_} ->
                    let has_auto_name bv =
                      FStar_Util.starts_with
                        (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
@@ -6228,79 +6269,79 @@ let (tc_decl' :
                       in
                    let rec rename_binders1 def_bs1 val_bs1 =
                      match (def_bs1, val_bs1) with
-                     | ([],uu____11265) -> val_bs1
-                     | (uu____11296,[]) -> val_bs1
-                     | ((body_bv,uu____11328)::bt,(val_bv,aqual)::vt) ->
-                         let uu____11385 = rename_binders1 bt vt  in
+                     | ([],uu____11277) -> val_bs1
+                     | (uu____11308,[]) -> val_bs1
+                     | ((body_bv,uu____11340)::bt,(val_bv,aqual)::vt) ->
+                         let uu____11397 = rename_binders1 bt vt  in
                          ((match ((has_auto_name body_bv),
                                    (has_auto_name val_bv))
                            with
-                           | (true ,uu____11409) -> (val_bv, aqual)
+                           | (true ,uu____11421) -> (val_bv, aqual)
                            | (false ,true ) ->
-                               ((let uu___1407_11423 = val_bv  in
+                               ((let uu___1411_11435 = val_bv  in
                                  {
                                    FStar_Syntax_Syntax.ppname =
-                                     (let uu___1409_11426 =
+                                     (let uu___1413_11438 =
                                         val_bv.FStar_Syntax_Syntax.ppname  in
                                       {
                                         FStar_Ident.idText =
                                           ((body_bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText);
                                         FStar_Ident.idRange =
-                                          (uu___1409_11426.FStar_Ident.idRange)
+                                          (uu___1413_11438.FStar_Ident.idRange)
                                       });
                                    FStar_Syntax_Syntax.index =
-                                     (uu___1407_11423.FStar_Syntax_Syntax.index);
+                                     (uu___1411_11435.FStar_Syntax_Syntax.index);
                                    FStar_Syntax_Syntax.sort =
-                                     (uu___1407_11423.FStar_Syntax_Syntax.sort)
+                                     (uu___1411_11435.FStar_Syntax_Syntax.sort)
                                  }), aqual)
                            | (false ,false ) -> (val_bv, aqual))) ::
-                           uu____11385
+                           uu____11397
                       in
-                   let uu____11433 =
-                     let uu____11440 =
-                       let uu____11441 =
-                         let uu____11456 = rename_binders1 def_bs val_bs  in
-                         (uu____11456, c)  in
-                       FStar_Syntax_Syntax.Tm_arrow uu____11441  in
-                     FStar_Syntax_Syntax.mk uu____11440  in
-                   uu____11433 FStar_Pervasives_Native.None r1
-               | uu____11475 -> typ1  in
-             let uu___1415_11476 = lb  in
-             let uu____11477 =
+                   let uu____11445 =
+                     let uu____11452 =
+                       let uu____11453 =
+                         let uu____11468 = rename_binders1 def_bs val_bs  in
+                         (uu____11468, c)  in
+                       FStar_Syntax_Syntax.Tm_arrow uu____11453  in
+                     FStar_Syntax_Syntax.mk uu____11452  in
+                   uu____11445 FStar_Pervasives_Native.None r1
+               | uu____11487 -> typ1  in
+             let uu___1419_11488 = lb  in
+             let uu____11489 =
                rename_in_typ lb.FStar_Syntax_Syntax.lbdef
                  lb.FStar_Syntax_Syntax.lbtyp
                 in
              {
                FStar_Syntax_Syntax.lbname =
-                 (uu___1415_11476.FStar_Syntax_Syntax.lbname);
+                 (uu___1419_11488.FStar_Syntax_Syntax.lbname);
                FStar_Syntax_Syntax.lbunivs =
-                 (uu___1415_11476.FStar_Syntax_Syntax.lbunivs);
-               FStar_Syntax_Syntax.lbtyp = uu____11477;
+                 (uu___1419_11488.FStar_Syntax_Syntax.lbunivs);
+               FStar_Syntax_Syntax.lbtyp = uu____11489;
                FStar_Syntax_Syntax.lbeff =
-                 (uu___1415_11476.FStar_Syntax_Syntax.lbeff);
+                 (uu___1419_11488.FStar_Syntax_Syntax.lbeff);
                FStar_Syntax_Syntax.lbdef =
-                 (uu___1415_11476.FStar_Syntax_Syntax.lbdef);
+                 (uu___1419_11488.FStar_Syntax_Syntax.lbdef);
                FStar_Syntax_Syntax.lbattrs =
-                 (uu___1415_11476.FStar_Syntax_Syntax.lbattrs);
+                 (uu___1419_11488.FStar_Syntax_Syntax.lbattrs);
                FStar_Syntax_Syntax.lbpos =
-                 (uu___1415_11476.FStar_Syntax_Syntax.lbpos)
+                 (uu___1419_11488.FStar_Syntax_Syntax.lbpos)
              }  in
-           let uu____11480 =
+           let uu____11492 =
              FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
                (FStar_List.fold_left
-                  (fun uu____11535  ->
+                  (fun uu____11547  ->
                      fun lb  ->
-                       match uu____11535 with
+                       match uu____11547 with
                        | (gen1,lbs1,quals_opt) ->
                            let lbname =
                              FStar_Util.right lb.FStar_Syntax_Syntax.lbname
                               in
-                           let uu____11581 =
-                             let uu____11593 =
+                           let uu____11593 =
+                             let uu____11605 =
                                FStar_TypeChecker_Env.try_lookup_val_decl env1
                                  (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                 in
-                             match uu____11593 with
+                             match uu____11605 with
                              | FStar_Pervasives_Native.None  ->
                                  if lb.FStar_Syntax_Syntax.lbunivs <> []
                                  then (false, lb, quals_opt)
@@ -6317,7 +6358,7 @@ let (tc_decl' :
                                    with
                                    | FStar_Syntax_Syntax.Tm_unknown  ->
                                        lb.FStar_Syntax_Syntax.lbdef
-                                   | uu____11673 ->
+                                   | uu____11685 ->
                                        FStar_Syntax_Syntax.mk
                                          (FStar_Syntax_Syntax.Tm_ascribed
                                             ((lb.FStar_Syntax_Syntax.lbdef),
@@ -6339,16 +6380,16 @@ let (tc_decl' :
                                         "Inline universes are incoherent with annotation from val declaration")
                                       r
                                   else ();
-                                  (let uu____11720 =
+                                  (let uu____11732 =
                                      FStar_Syntax_Syntax.mk_lb
                                        ((FStar_Util.Inr lbname), uvs,
                                          FStar_Parser_Const.effect_ALL_lid,
                                          tval, def, [],
                                          (lb.FStar_Syntax_Syntax.lbpos))
                                       in
-                                   (false, uu____11720, quals_opt1)))
+                                   (false, uu____11732, quals_opt1)))
                               in
-                           (match uu____11581 with
+                           (match uu____11593 with
                             | (gen2,lb1,quals_opt1) ->
                                 (gen2, (lb1 :: lbs1), quals_opt1)))
                   (true, [],
@@ -6358,348 +6399,353 @@ let (tc_decl' :
                        FStar_Pervasives_Native.Some
                          (se.FStar_Syntax_Syntax.sigquals))))
               in
-           (match uu____11480 with
+           (match uu____11492 with
             | (should_generalize,lbs',quals_opt) ->
                 let quals =
                   match quals_opt with
                   | FStar_Pervasives_Native.None  ->
                       [FStar_Syntax_Syntax.Visible_default]
                   | FStar_Pervasives_Native.Some q ->
-                      let uu____11824 =
+                      let uu____11836 =
                         FStar_All.pipe_right q
                           (FStar_Util.for_some
-                             (fun uu___2_11830  ->
-                                match uu___2_11830 with
+                             (fun uu___2_11842  ->
+                                match uu___2_11842 with
                                 | FStar_Syntax_Syntax.Irreducible  -> true
                                 | FStar_Syntax_Syntax.Visible_default  ->
                                     true
                                 | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen
                                      -> true
-                                | uu____11835 -> false))
+                                | uu____11847 -> false))
                          in
-                      if uu____11824
+                      if uu____11836
                       then q
                       else FStar_Syntax_Syntax.Visible_default :: q
                    in
                 let lbs'1 = FStar_List.rev lbs'  in
                 let e =
-                  let uu____11848 =
-                    let uu____11855 =
-                      let uu____11856 =
-                        let uu____11870 =
+                  let uu____11860 =
+                    let uu____11867 =
+                      let uu____11868 =
+                        let uu____11882 =
                           FStar_Syntax_Syntax.mk
                             (FStar_Syntax_Syntax.Tm_constant
                                FStar_Const.Const_unit)
                             FStar_Pervasives_Native.None r
                            in
                         (((FStar_Pervasives_Native.fst lbs), lbs'1),
-                          uu____11870)
+                          uu____11882)
                          in
-                      FStar_Syntax_Syntax.Tm_let uu____11856  in
-                    FStar_Syntax_Syntax.mk uu____11855  in
-                  uu____11848 FStar_Pervasives_Native.None r  in
+                      FStar_Syntax_Syntax.Tm_let uu____11868  in
+                    FStar_Syntax_Syntax.mk uu____11867  in
+                  uu____11860 FStar_Pervasives_Native.None r  in
                 let env' =
-                  let uu___1458_11889 = env1  in
+                  let uu___1462_11901 = env1  in
                   {
                     FStar_TypeChecker_Env.solver =
-                      (uu___1458_11889.FStar_TypeChecker_Env.solver);
+                      (uu___1462_11901.FStar_TypeChecker_Env.solver);
                     FStar_TypeChecker_Env.range =
-                      (uu___1458_11889.FStar_TypeChecker_Env.range);
+                      (uu___1462_11901.FStar_TypeChecker_Env.range);
                     FStar_TypeChecker_Env.curmodule =
-                      (uu___1458_11889.FStar_TypeChecker_Env.curmodule);
+                      (uu___1462_11901.FStar_TypeChecker_Env.curmodule);
                     FStar_TypeChecker_Env.gamma =
-                      (uu___1458_11889.FStar_TypeChecker_Env.gamma);
+                      (uu___1462_11901.FStar_TypeChecker_Env.gamma);
                     FStar_TypeChecker_Env.gamma_sig =
-                      (uu___1458_11889.FStar_TypeChecker_Env.gamma_sig);
+                      (uu___1462_11901.FStar_TypeChecker_Env.gamma_sig);
                     FStar_TypeChecker_Env.gamma_cache =
-                      (uu___1458_11889.FStar_TypeChecker_Env.gamma_cache);
+                      (uu___1462_11901.FStar_TypeChecker_Env.gamma_cache);
                     FStar_TypeChecker_Env.modules =
-                      (uu___1458_11889.FStar_TypeChecker_Env.modules);
+                      (uu___1462_11901.FStar_TypeChecker_Env.modules);
                     FStar_TypeChecker_Env.expected_typ =
-                      (uu___1458_11889.FStar_TypeChecker_Env.expected_typ);
+                      (uu___1462_11901.FStar_TypeChecker_Env.expected_typ);
                     FStar_TypeChecker_Env.sigtab =
-                      (uu___1458_11889.FStar_TypeChecker_Env.sigtab);
+                      (uu___1462_11901.FStar_TypeChecker_Env.sigtab);
                     FStar_TypeChecker_Env.attrtab =
-                      (uu___1458_11889.FStar_TypeChecker_Env.attrtab);
+                      (uu___1462_11901.FStar_TypeChecker_Env.attrtab);
                     FStar_TypeChecker_Env.is_pattern =
-                      (uu___1458_11889.FStar_TypeChecker_Env.is_pattern);
+                      (uu___1462_11901.FStar_TypeChecker_Env.is_pattern);
                     FStar_TypeChecker_Env.instantiate_imp =
-                      (uu___1458_11889.FStar_TypeChecker_Env.instantiate_imp);
+                      (uu___1462_11901.FStar_TypeChecker_Env.instantiate_imp);
                     FStar_TypeChecker_Env.effects =
-                      (uu___1458_11889.FStar_TypeChecker_Env.effects);
+                      (uu___1462_11901.FStar_TypeChecker_Env.effects);
                     FStar_TypeChecker_Env.generalize = should_generalize;
                     FStar_TypeChecker_Env.letrecs =
-                      (uu___1458_11889.FStar_TypeChecker_Env.letrecs);
+                      (uu___1462_11901.FStar_TypeChecker_Env.letrecs);
                     FStar_TypeChecker_Env.top_level = true;
                     FStar_TypeChecker_Env.check_uvars =
-                      (uu___1458_11889.FStar_TypeChecker_Env.check_uvars);
+                      (uu___1462_11901.FStar_TypeChecker_Env.check_uvars);
                     FStar_TypeChecker_Env.use_eq =
-                      (uu___1458_11889.FStar_TypeChecker_Env.use_eq);
+                      (uu___1462_11901.FStar_TypeChecker_Env.use_eq);
                     FStar_TypeChecker_Env.is_iface =
-                      (uu___1458_11889.FStar_TypeChecker_Env.is_iface);
+                      (uu___1462_11901.FStar_TypeChecker_Env.is_iface);
                     FStar_TypeChecker_Env.admit =
-                      (uu___1458_11889.FStar_TypeChecker_Env.admit);
+                      (uu___1462_11901.FStar_TypeChecker_Env.admit);
                     FStar_TypeChecker_Env.lax =
-                      (uu___1458_11889.FStar_TypeChecker_Env.lax);
+                      (uu___1462_11901.FStar_TypeChecker_Env.lax);
                     FStar_TypeChecker_Env.lax_universes =
-                      (uu___1458_11889.FStar_TypeChecker_Env.lax_universes);
+                      (uu___1462_11901.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
-                      (uu___1458_11889.FStar_TypeChecker_Env.phase1);
+                      (uu___1462_11901.FStar_TypeChecker_Env.phase1);
                     FStar_TypeChecker_Env.failhard =
-                      (uu___1458_11889.FStar_TypeChecker_Env.failhard);
+                      (uu___1462_11901.FStar_TypeChecker_Env.failhard);
                     FStar_TypeChecker_Env.nosynth =
-                      (uu___1458_11889.FStar_TypeChecker_Env.nosynth);
+                      (uu___1462_11901.FStar_TypeChecker_Env.nosynth);
                     FStar_TypeChecker_Env.uvar_subtyping =
-                      (uu___1458_11889.FStar_TypeChecker_Env.uvar_subtyping);
+                      (uu___1462_11901.FStar_TypeChecker_Env.uvar_subtyping);
                     FStar_TypeChecker_Env.tc_term =
-                      (uu___1458_11889.FStar_TypeChecker_Env.tc_term);
+                      (uu___1462_11901.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.type_of =
-                      (uu___1458_11889.FStar_TypeChecker_Env.type_of);
+                      (uu___1462_11901.FStar_TypeChecker_Env.type_of);
                     FStar_TypeChecker_Env.universe_of =
-                      (uu___1458_11889.FStar_TypeChecker_Env.universe_of);
+                      (uu___1462_11901.FStar_TypeChecker_Env.universe_of);
                     FStar_TypeChecker_Env.check_type_of =
-                      (uu___1458_11889.FStar_TypeChecker_Env.check_type_of);
+                      (uu___1462_11901.FStar_TypeChecker_Env.check_type_of);
                     FStar_TypeChecker_Env.use_bv_sorts =
-                      (uu___1458_11889.FStar_TypeChecker_Env.use_bv_sorts);
+                      (uu___1462_11901.FStar_TypeChecker_Env.use_bv_sorts);
                     FStar_TypeChecker_Env.qtbl_name_and_index =
-                      (uu___1458_11889.FStar_TypeChecker_Env.qtbl_name_and_index);
+                      (uu___1462_11901.FStar_TypeChecker_Env.qtbl_name_and_index);
                     FStar_TypeChecker_Env.normalized_eff_names =
-                      (uu___1458_11889.FStar_TypeChecker_Env.normalized_eff_names);
+                      (uu___1462_11901.FStar_TypeChecker_Env.normalized_eff_names);
                     FStar_TypeChecker_Env.fv_delta_depths =
-                      (uu___1458_11889.FStar_TypeChecker_Env.fv_delta_depths);
+                      (uu___1462_11901.FStar_TypeChecker_Env.fv_delta_depths);
                     FStar_TypeChecker_Env.proof_ns =
-                      (uu___1458_11889.FStar_TypeChecker_Env.proof_ns);
+                      (uu___1462_11901.FStar_TypeChecker_Env.proof_ns);
                     FStar_TypeChecker_Env.synth_hook =
-                      (uu___1458_11889.FStar_TypeChecker_Env.synth_hook);
+                      (uu___1462_11901.FStar_TypeChecker_Env.synth_hook);
                     FStar_TypeChecker_Env.splice =
-                      (uu___1458_11889.FStar_TypeChecker_Env.splice);
+                      (uu___1462_11901.FStar_TypeChecker_Env.splice);
                     FStar_TypeChecker_Env.postprocess =
-                      (uu___1458_11889.FStar_TypeChecker_Env.postprocess);
+                      (uu___1462_11901.FStar_TypeChecker_Env.postprocess);
                     FStar_TypeChecker_Env.is_native_tactic =
-                      (uu___1458_11889.FStar_TypeChecker_Env.is_native_tactic);
+                      (uu___1462_11901.FStar_TypeChecker_Env.is_native_tactic);
                     FStar_TypeChecker_Env.identifier_info =
-                      (uu___1458_11889.FStar_TypeChecker_Env.identifier_info);
+                      (uu___1462_11901.FStar_TypeChecker_Env.identifier_info);
                     FStar_TypeChecker_Env.tc_hooks =
-                      (uu___1458_11889.FStar_TypeChecker_Env.tc_hooks);
+                      (uu___1462_11901.FStar_TypeChecker_Env.tc_hooks);
                     FStar_TypeChecker_Env.dsenv =
-                      (uu___1458_11889.FStar_TypeChecker_Env.dsenv);
+                      (uu___1462_11901.FStar_TypeChecker_Env.dsenv);
                     FStar_TypeChecker_Env.nbe =
-                      (uu___1458_11889.FStar_TypeChecker_Env.nbe);
+                      (uu___1462_11901.FStar_TypeChecker_Env.nbe);
                     FStar_TypeChecker_Env.strict_args_tab =
-                      (uu___1458_11889.FStar_TypeChecker_Env.strict_args_tab)
+                      (uu___1462_11901.FStar_TypeChecker_Env.strict_args_tab);
+                    FStar_TypeChecker_Env.erasable_types_tab =
+                      (uu___1462_11901.FStar_TypeChecker_Env.erasable_types_tab)
                   }  in
                 let e1 =
-                  let uu____11892 =
+                  let uu____11904 =
                     (FStar_Options.use_two_phase_tc ()) &&
                       (FStar_TypeChecker_Env.should_verify env')
                      in
-                  if uu____11892
+                  if uu____11904
                   then
                     let drop_lbtyp e_lax =
-                      let uu____11901 =
-                        let uu____11902 = FStar_Syntax_Subst.compress e_lax
+                      let uu____11913 =
+                        let uu____11914 = FStar_Syntax_Subst.compress e_lax
                            in
-                        uu____11902.FStar_Syntax_Syntax.n  in
-                      match uu____11901 with
+                        uu____11914.FStar_Syntax_Syntax.n  in
+                      match uu____11913 with
                       | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),e2) ->
                           let lb_unannotated =
-                            let uu____11924 =
-                              let uu____11925 = FStar_Syntax_Subst.compress e
+                            let uu____11936 =
+                              let uu____11937 = FStar_Syntax_Subst.compress e
                                  in
-                              uu____11925.FStar_Syntax_Syntax.n  in
-                            match uu____11924 with
+                              uu____11937.FStar_Syntax_Syntax.n  in
+                            match uu____11936 with
                             | FStar_Syntax_Syntax.Tm_let
-                                ((uu____11929,lb1::[]),uu____11931) ->
-                                let uu____11947 =
-                                  let uu____11948 =
+                                ((uu____11941,lb1::[]),uu____11943) ->
+                                let uu____11959 =
+                                  let uu____11960 =
                                     FStar_Syntax_Subst.compress
                                       lb1.FStar_Syntax_Syntax.lbtyp
                                      in
-                                  uu____11948.FStar_Syntax_Syntax.n  in
-                                (match uu____11947 with
+                                  uu____11960.FStar_Syntax_Syntax.n  in
+                                (match uu____11959 with
                                  | FStar_Syntax_Syntax.Tm_unknown  -> true
-                                 | uu____11953 -> false)
-                            | uu____11955 ->
+                                 | uu____11965 -> false)
+                            | uu____11967 ->
                                 failwith
                                   "Impossible: first phase lb and second phase lb differ in structure!"
                              in
                           if lb_unannotated
                           then
-                            let uu___1483_11959 = e_lax  in
+                            let uu___1487_11971 = e_lax  in
                             {
                               FStar_Syntax_Syntax.n =
                                 (FStar_Syntax_Syntax.Tm_let
                                    ((false,
-                                      [(let uu___1485_11974 = lb  in
+                                      [(let uu___1489_11986 = lb  in
                                         {
                                           FStar_Syntax_Syntax.lbname =
-                                            (uu___1485_11974.FStar_Syntax_Syntax.lbname);
+                                            (uu___1489_11986.FStar_Syntax_Syntax.lbname);
                                           FStar_Syntax_Syntax.lbunivs =
-                                            (uu___1485_11974.FStar_Syntax_Syntax.lbunivs);
+                                            (uu___1489_11986.FStar_Syntax_Syntax.lbunivs);
                                           FStar_Syntax_Syntax.lbtyp =
                                             FStar_Syntax_Syntax.tun;
                                           FStar_Syntax_Syntax.lbeff =
-                                            (uu___1485_11974.FStar_Syntax_Syntax.lbeff);
+                                            (uu___1489_11986.FStar_Syntax_Syntax.lbeff);
                                           FStar_Syntax_Syntax.lbdef =
-                                            (uu___1485_11974.FStar_Syntax_Syntax.lbdef);
+                                            (uu___1489_11986.FStar_Syntax_Syntax.lbdef);
                                           FStar_Syntax_Syntax.lbattrs =
-                                            (uu___1485_11974.FStar_Syntax_Syntax.lbattrs);
+                                            (uu___1489_11986.FStar_Syntax_Syntax.lbattrs);
                                           FStar_Syntax_Syntax.lbpos =
-                                            (uu___1485_11974.FStar_Syntax_Syntax.lbpos)
+                                            (uu___1489_11986.FStar_Syntax_Syntax.lbpos)
                                         })]), e2));
                               FStar_Syntax_Syntax.pos =
-                                (uu___1483_11959.FStar_Syntax_Syntax.pos);
+                                (uu___1487_11971.FStar_Syntax_Syntax.pos);
                               FStar_Syntax_Syntax.vars =
-                                (uu___1483_11959.FStar_Syntax_Syntax.vars)
+                                (uu___1487_11971.FStar_Syntax_Syntax.vars)
                             }
                           else e_lax
-                      | uu____11977 -> e_lax  in
-                    let uu____11978 =
+                      | uu____11989 -> e_lax  in
+                    let uu____11990 =
                       FStar_Util.record_time
-                        (fun uu____11986  ->
-                           let uu____11987 =
-                             let uu____11988 =
-                               let uu____11989 =
+                        (fun uu____11998  ->
+                           let uu____11999 =
+                             let uu____12000 =
+                               let uu____12001 =
                                  FStar_TypeChecker_TcTerm.tc_maybe_toplevel_term
-                                   (let uu___1489_11998 = env'  in
+                                   (let uu___1493_12010 = env'  in
                                     {
                                       FStar_TypeChecker_Env.solver =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.solver);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.solver);
                                       FStar_TypeChecker_Env.range =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.range);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.range);
                                       FStar_TypeChecker_Env.curmodule =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.curmodule);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.curmodule);
                                       FStar_TypeChecker_Env.gamma =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.gamma);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.gamma);
                                       FStar_TypeChecker_Env.gamma_sig =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.gamma_sig);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.gamma_sig);
                                       FStar_TypeChecker_Env.gamma_cache =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.gamma_cache);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.gamma_cache);
                                       FStar_TypeChecker_Env.modules =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.modules);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.modules);
                                       FStar_TypeChecker_Env.expected_typ =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.expected_typ);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.expected_typ);
                                       FStar_TypeChecker_Env.sigtab =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.sigtab);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.sigtab);
                                       FStar_TypeChecker_Env.attrtab =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.attrtab);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.attrtab);
                                       FStar_TypeChecker_Env.is_pattern =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.is_pattern);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.is_pattern);
                                       FStar_TypeChecker_Env.instantiate_imp =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.instantiate_imp);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.instantiate_imp);
                                       FStar_TypeChecker_Env.effects =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.effects);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.effects);
                                       FStar_TypeChecker_Env.generalize =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.generalize);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.generalize);
                                       FStar_TypeChecker_Env.letrecs =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.letrecs);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.letrecs);
                                       FStar_TypeChecker_Env.top_level =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.top_level);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.top_level);
                                       FStar_TypeChecker_Env.check_uvars =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.check_uvars);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.check_uvars);
                                       FStar_TypeChecker_Env.use_eq =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.use_eq);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.use_eq);
                                       FStar_TypeChecker_Env.is_iface =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.is_iface);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.is_iface);
                                       FStar_TypeChecker_Env.admit =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.admit);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.admit);
                                       FStar_TypeChecker_Env.lax = true;
                                       FStar_TypeChecker_Env.lax_universes =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.lax_universes);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.lax_universes);
                                       FStar_TypeChecker_Env.phase1 = true;
                                       FStar_TypeChecker_Env.failhard =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.failhard);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.failhard);
                                       FStar_TypeChecker_Env.nosynth =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.nosynth);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.nosynth);
                                       FStar_TypeChecker_Env.uvar_subtyping =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.uvar_subtyping);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.uvar_subtyping);
                                       FStar_TypeChecker_Env.tc_term =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.tc_term);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.tc_term);
                                       FStar_TypeChecker_Env.type_of =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.type_of);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.type_of);
                                       FStar_TypeChecker_Env.universe_of =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.universe_of);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.universe_of);
                                       FStar_TypeChecker_Env.check_type_of =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.check_type_of);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.check_type_of);
                                       FStar_TypeChecker_Env.use_bv_sorts =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.use_bv_sorts);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.use_bv_sorts);
                                       FStar_TypeChecker_Env.qtbl_name_and_index
                                         =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.qtbl_name_and_index);
                                       FStar_TypeChecker_Env.normalized_eff_names
                                         =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.normalized_eff_names);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.normalized_eff_names);
                                       FStar_TypeChecker_Env.fv_delta_depths =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.fv_delta_depths);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.fv_delta_depths);
                                       FStar_TypeChecker_Env.proof_ns =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.proof_ns);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.proof_ns);
                                       FStar_TypeChecker_Env.synth_hook =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.synth_hook);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.synth_hook);
                                       FStar_TypeChecker_Env.splice =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.splice);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.splice);
                                       FStar_TypeChecker_Env.postprocess =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.postprocess);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.postprocess);
                                       FStar_TypeChecker_Env.is_native_tactic
                                         =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.is_native_tactic);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.is_native_tactic);
                                       FStar_TypeChecker_Env.identifier_info =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.identifier_info);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.identifier_info);
                                       FStar_TypeChecker_Env.tc_hooks =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.tc_hooks);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.tc_hooks);
                                       FStar_TypeChecker_Env.dsenv =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.dsenv);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.dsenv);
                                       FStar_TypeChecker_Env.nbe =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.nbe);
+                                        (uu___1493_12010.FStar_TypeChecker_Env.nbe);
                                       FStar_TypeChecker_Env.strict_args_tab =
-                                        (uu___1489_11998.FStar_TypeChecker_Env.strict_args_tab)
+                                        (uu___1493_12010.FStar_TypeChecker_Env.strict_args_tab);
+                                      FStar_TypeChecker_Env.erasable_types_tab
+                                        =
+                                        (uu___1493_12010.FStar_TypeChecker_Env.erasable_types_tab)
                                     }) e
                                   in
-                               FStar_All.pipe_right uu____11989
-                                 (fun uu____12011  ->
-                                    match uu____12011 with
-                                    | (e1,uu____12019,uu____12020) -> e1)
+                               FStar_All.pipe_right uu____12001
+                                 (fun uu____12023  ->
+                                    match uu____12023 with
+                                    | (e1,uu____12031,uu____12032) -> e1)
                                 in
-                             FStar_All.pipe_right uu____11988
+                             FStar_All.pipe_right uu____12000
                                (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                   env')
                               in
-                           FStar_All.pipe_right uu____11987 drop_lbtyp)
+                           FStar_All.pipe_right uu____11999 drop_lbtyp)
                        in
-                    match uu____11978 with
+                    match uu____11990 with
                     | (e1,ms) ->
-                        ((let uu____12026 =
+                        ((let uu____12038 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env1)
                               (FStar_Options.Other "TwoPhases")
                              in
-                          if uu____12026
+                          if uu____12038
                           then
-                            let uu____12031 =
+                            let uu____12043 =
                               FStar_Syntax_Print.term_to_string e1  in
                             FStar_Util.print1
-                              "Let binding after phase 1: %s\n" uu____12031
+                              "Let binding after phase 1: %s\n" uu____12043
                           else ());
-                         (let uu____12037 =
+                         (let uu____12049 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env1)
                               (FStar_Options.Other "TCDeclTime")
                              in
-                          if uu____12037
+                          if uu____12049
                           then
-                            let uu____12042 = FStar_Util.string_of_int ms  in
+                            let uu____12054 = FStar_Util.string_of_int ms  in
                             FStar_Util.print1
                               "Let binding elaborated (phase 1) in %s milliseconds\n"
-                              uu____12042
+                              uu____12054
                           else ());
                          e1)
                   else e  in
-                let uu____12049 =
-                  let uu____12058 =
+                let uu____12061 =
+                  let uu____12070 =
                     FStar_Syntax_Util.extract_attr'
                       FStar_Parser_Const.postprocess_with
                       se.FStar_Syntax_Syntax.sigattrs
                      in
-                  match uu____12058 with
+                  match uu____12070 with
                   | FStar_Pervasives_Native.None  ->
                       ((se.FStar_Syntax_Syntax.sigattrs),
                         FStar_Pervasives_Native.None)
@@ -6713,19 +6759,19 @@ let (tc_decl' :
                        ((se.FStar_Syntax_Syntax.sigattrs),
                          FStar_Pervasives_Native.None))
                    in
-                (match uu____12049 with
+                (match uu____12061 with
                  | (attrs,post_tau) ->
                      let se1 =
-                       let uu___1519_12163 = se  in
+                       let uu___1523_12175 = se  in
                        {
                          FStar_Syntax_Syntax.sigel =
-                           (uu___1519_12163.FStar_Syntax_Syntax.sigel);
+                           (uu___1523_12175.FStar_Syntax_Syntax.sigel);
                          FStar_Syntax_Syntax.sigrng =
-                           (uu___1519_12163.FStar_Syntax_Syntax.sigrng);
+                           (uu___1523_12175.FStar_Syntax_Syntax.sigrng);
                          FStar_Syntax_Syntax.sigquals =
-                           (uu___1519_12163.FStar_Syntax_Syntax.sigquals);
+                           (uu___1523_12175.FStar_Syntax_Syntax.sigquals);
                          FStar_Syntax_Syntax.sigmeta =
-                           (uu___1519_12163.FStar_Syntax_Syntax.sigmeta);
+                           (uu___1523_12175.FStar_Syntax_Syntax.sigmeta);
                          FStar_Syntax_Syntax.sigattrs = attrs
                        }  in
                      let postprocess_lb tau lb =
@@ -6734,62 +6780,62 @@ let (tc_decl' :
                            lb.FStar_Syntax_Syntax.lbtyp
                            lb.FStar_Syntax_Syntax.lbdef
                           in
-                       let uu___1526_12176 = lb  in
+                       let uu___1530_12188 = lb  in
                        {
                          FStar_Syntax_Syntax.lbname =
-                           (uu___1526_12176.FStar_Syntax_Syntax.lbname);
+                           (uu___1530_12188.FStar_Syntax_Syntax.lbname);
                          FStar_Syntax_Syntax.lbunivs =
-                           (uu___1526_12176.FStar_Syntax_Syntax.lbunivs);
+                           (uu___1530_12188.FStar_Syntax_Syntax.lbunivs);
                          FStar_Syntax_Syntax.lbtyp =
-                           (uu___1526_12176.FStar_Syntax_Syntax.lbtyp);
+                           (uu___1530_12188.FStar_Syntax_Syntax.lbtyp);
                          FStar_Syntax_Syntax.lbeff =
-                           (uu___1526_12176.FStar_Syntax_Syntax.lbeff);
+                           (uu___1530_12188.FStar_Syntax_Syntax.lbeff);
                          FStar_Syntax_Syntax.lbdef = lbdef;
                          FStar_Syntax_Syntax.lbattrs =
-                           (uu___1526_12176.FStar_Syntax_Syntax.lbattrs);
+                           (uu___1530_12188.FStar_Syntax_Syntax.lbattrs);
                          FStar_Syntax_Syntax.lbpos =
-                           (uu___1526_12176.FStar_Syntax_Syntax.lbpos)
+                           (uu___1530_12188.FStar_Syntax_Syntax.lbpos)
                        }  in
-                     let uu____12177 =
+                     let uu____12189 =
                        FStar_Util.record_time
-                         (fun uu____12196  ->
+                         (fun uu____12208  ->
                             FStar_TypeChecker_TcTerm.tc_maybe_toplevel_term
                               env' e1)
                         in
-                     (match uu____12177 with
+                     (match uu____12189 with
                       | (r1,ms) ->
-                          ((let uu____12224 =
+                          ((let uu____12236 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env1)
                                 (FStar_Options.Other "TCDeclTime")
                                in
-                            if uu____12224
+                            if uu____12236
                             then
-                              let uu____12229 = FStar_Util.string_of_int ms
+                              let uu____12241 = FStar_Util.string_of_int ms
                                  in
                               FStar_Util.print1
                                 "Let binding typechecked in phase 2 in %s milliseconds\n"
-                                uu____12229
+                                uu____12241
                             else ());
-                           (let uu____12234 =
+                           (let uu____12246 =
                               match r1 with
                               | ({
                                    FStar_Syntax_Syntax.n =
                                      FStar_Syntax_Syntax.Tm_let (lbs1,e2);
-                                   FStar_Syntax_Syntax.pos = uu____12259;
-                                   FStar_Syntax_Syntax.vars = uu____12260;_},uu____12261,g)
+                                   FStar_Syntax_Syntax.pos = uu____12271;
+                                   FStar_Syntax_Syntax.vars = uu____12272;_},uu____12273,g)
                                   when FStar_TypeChecker_Env.is_trivial g ->
                                   let lbs2 =
-                                    let uu____12291 =
+                                    let uu____12303 =
                                       FStar_All.pipe_right
                                         (FStar_Pervasives_Native.snd lbs1)
                                         (FStar_List.map rename_parameters)
                                        in
                                     ((FStar_Pervasives_Native.fst lbs1),
-                                      uu____12291)
+                                      uu____12303)
                                      in
                                   let lbs3 =
-                                    let uu____12315 =
+                                    let uu____12327 =
                                       match post_tau with
                                       | FStar_Pervasives_Native.Some tau ->
                                           FStar_List.map (postprocess_lb tau)
@@ -6798,36 +6844,36 @@ let (tc_decl' :
                                           FStar_Pervasives_Native.snd lbs2
                                        in
                                     ((FStar_Pervasives_Native.fst lbs2),
-                                      uu____12315)
+                                      uu____12327)
                                      in
                                   let quals1 =
                                     match e2.FStar_Syntax_Syntax.n with
                                     | FStar_Syntax_Syntax.Tm_meta
-                                        (uu____12338,FStar_Syntax_Syntax.Meta_desugared
+                                        (uu____12350,FStar_Syntax_Syntax.Meta_desugared
                                          (FStar_Syntax_Syntax.Masked_effect
                                          ))
                                         ->
                                         FStar_Syntax_Syntax.HasMaskedEffect
                                         :: quals
-                                    | uu____12343 -> quals  in
-                                  ((let uu___1556_12352 = se1  in
+                                    | uu____12355 -> quals  in
+                                  ((let uu___1560_12364 = se1  in
                                     {
                                       FStar_Syntax_Syntax.sigel =
                                         (FStar_Syntax_Syntax.Sig_let
                                            (lbs3, lids));
                                       FStar_Syntax_Syntax.sigrng =
-                                        (uu___1556_12352.FStar_Syntax_Syntax.sigrng);
+                                        (uu___1560_12364.FStar_Syntax_Syntax.sigrng);
                                       FStar_Syntax_Syntax.sigquals = quals1;
                                       FStar_Syntax_Syntax.sigmeta =
-                                        (uu___1556_12352.FStar_Syntax_Syntax.sigmeta);
+                                        (uu___1560_12364.FStar_Syntax_Syntax.sigmeta);
                                       FStar_Syntax_Syntax.sigattrs =
-                                        (uu___1556_12352.FStar_Syntax_Syntax.sigattrs)
+                                        (uu___1560_12364.FStar_Syntax_Syntax.sigattrs)
                                     }), lbs3)
-                              | uu____12355 ->
+                              | uu____12367 ->
                                   failwith
                                     "impossible (typechecking should preserve Tm_let)"
                                in
-                            match uu____12234 with
+                            match uu____12246 with
                             | (se2,lbs1) ->
                                 (FStar_All.pipe_right
                                    (FStar_Pervasives_Native.snd lbs1)
@@ -6840,53 +6886,53 @@ let (tc_decl' :
                                          FStar_TypeChecker_Env.insert_fv_info
                                            env1 fv
                                            lb.FStar_Syntax_Syntax.lbtyp));
-                                 (let uu____12411 = log env1  in
-                                  if uu____12411
+                                 (let uu____12423 = log env1  in
+                                  if uu____12423
                                   then
-                                    let uu____12414 =
-                                      let uu____12416 =
+                                    let uu____12426 =
+                                      let uu____12428 =
                                         FStar_All.pipe_right
                                           (FStar_Pervasives_Native.snd lbs1)
                                           (FStar_List.map
                                              (fun lb  ->
                                                 let should_log =
-                                                  let uu____12436 =
-                                                    let uu____12445 =
-                                                      let uu____12446 =
-                                                        let uu____12449 =
+                                                  let uu____12448 =
+                                                    let uu____12457 =
+                                                      let uu____12458 =
+                                                        let uu____12461 =
                                                           FStar_Util.right
                                                             lb.FStar_Syntax_Syntax.lbname
                                                            in
-                                                        uu____12449.FStar_Syntax_Syntax.fv_name
+                                                        uu____12461.FStar_Syntax_Syntax.fv_name
                                                          in
-                                                      uu____12446.FStar_Syntax_Syntax.v
+                                                      uu____12458.FStar_Syntax_Syntax.v
                                                        in
                                                     FStar_TypeChecker_Env.try_lookup_val_decl
-                                                      env1 uu____12445
+                                                      env1 uu____12457
                                                      in
-                                                  match uu____12436 with
+                                                  match uu____12448 with
                                                   | FStar_Pervasives_Native.None
                                                        -> true
-                                                  | uu____12458 -> false  in
+                                                  | uu____12470 -> false  in
                                                 if should_log
                                                 then
-                                                  let uu____12470 =
+                                                  let uu____12482 =
                                                     FStar_Syntax_Print.lbname_to_string
                                                       lb.FStar_Syntax_Syntax.lbname
                                                      in
-                                                  let uu____12472 =
+                                                  let uu____12484 =
                                                     FStar_Syntax_Print.term_to_string
                                                       lb.FStar_Syntax_Syntax.lbtyp
                                                      in
                                                   FStar_Util.format2
-                                                    "let %s : %s" uu____12470
-                                                    uu____12472
+                                                    "let %s : %s" uu____12482
+                                                    uu____12484
                                                 else ""))
                                          in
-                                      FStar_All.pipe_right uu____12416
+                                      FStar_All.pipe_right uu____12428
                                         (FStar_String.concat "\n")
                                        in
-                                    FStar_Util.print1 "%s\n" uu____12414
+                                    FStar_Util.print1 "%s\n" uu____12426
                                   else ());
                                  check_must_erase_attribute env0 se2;
                                  ([se2], [], env0))))))))
@@ -6900,135 +6946,137 @@ let (tc_decl :
   fun env  ->
     fun se  ->
       let env1 = set_hint_correlator env se  in
-      (let uu____12524 = FStar_TypeChecker_Env.debug env1 FStar_Options.Low
+      (let uu____12536 = FStar_TypeChecker_Env.debug env1 FStar_Options.Low
           in
-       if uu____12524
+       if uu____12536
        then
-         let uu____12527 = FStar_Syntax_Print.sigelt_to_string se  in
-         FStar_Util.print1 ">>>>>>>>>>>>>>tc_decl %s\n" uu____12527
+         let uu____12539 = FStar_Syntax_Print.sigelt_to_string se  in
+         FStar_Util.print1 ">>>>>>>>>>>>>>tc_decl %s\n" uu____12539
        else ());
-      (let uu____12532 = get_fail_se se  in
-       match uu____12532 with
-       | FStar_Pervasives_Native.Some (uu____12553,false ) when
-           let uu____12570 = FStar_TypeChecker_Env.should_verify env1  in
-           Prims.op_Negation uu____12570 -> ([], [], env1)
+      (let uu____12544 = get_fail_se se  in
+       match uu____12544 with
+       | FStar_Pervasives_Native.Some (uu____12565,false ) when
+           let uu____12582 = FStar_TypeChecker_Env.should_verify env1  in
+           Prims.op_Negation uu____12582 -> ([], [], env1)
        | FStar_Pervasives_Native.Some (errnos,lax1) ->
            let env' =
              if lax1
              then
-               let uu___1587_12596 = env1  in
+               let uu___1591_12608 = env1  in
                {
                  FStar_TypeChecker_Env.solver =
-                   (uu___1587_12596.FStar_TypeChecker_Env.solver);
+                   (uu___1591_12608.FStar_TypeChecker_Env.solver);
                  FStar_TypeChecker_Env.range =
-                   (uu___1587_12596.FStar_TypeChecker_Env.range);
+                   (uu___1591_12608.FStar_TypeChecker_Env.range);
                  FStar_TypeChecker_Env.curmodule =
-                   (uu___1587_12596.FStar_TypeChecker_Env.curmodule);
+                   (uu___1591_12608.FStar_TypeChecker_Env.curmodule);
                  FStar_TypeChecker_Env.gamma =
-                   (uu___1587_12596.FStar_TypeChecker_Env.gamma);
+                   (uu___1591_12608.FStar_TypeChecker_Env.gamma);
                  FStar_TypeChecker_Env.gamma_sig =
-                   (uu___1587_12596.FStar_TypeChecker_Env.gamma_sig);
+                   (uu___1591_12608.FStar_TypeChecker_Env.gamma_sig);
                  FStar_TypeChecker_Env.gamma_cache =
-                   (uu___1587_12596.FStar_TypeChecker_Env.gamma_cache);
+                   (uu___1591_12608.FStar_TypeChecker_Env.gamma_cache);
                  FStar_TypeChecker_Env.modules =
-                   (uu___1587_12596.FStar_TypeChecker_Env.modules);
+                   (uu___1591_12608.FStar_TypeChecker_Env.modules);
                  FStar_TypeChecker_Env.expected_typ =
-                   (uu___1587_12596.FStar_TypeChecker_Env.expected_typ);
+                   (uu___1591_12608.FStar_TypeChecker_Env.expected_typ);
                  FStar_TypeChecker_Env.sigtab =
-                   (uu___1587_12596.FStar_TypeChecker_Env.sigtab);
+                   (uu___1591_12608.FStar_TypeChecker_Env.sigtab);
                  FStar_TypeChecker_Env.attrtab =
-                   (uu___1587_12596.FStar_TypeChecker_Env.attrtab);
+                   (uu___1591_12608.FStar_TypeChecker_Env.attrtab);
                  FStar_TypeChecker_Env.is_pattern =
-                   (uu___1587_12596.FStar_TypeChecker_Env.is_pattern);
+                   (uu___1591_12608.FStar_TypeChecker_Env.is_pattern);
                  FStar_TypeChecker_Env.instantiate_imp =
-                   (uu___1587_12596.FStar_TypeChecker_Env.instantiate_imp);
+                   (uu___1591_12608.FStar_TypeChecker_Env.instantiate_imp);
                  FStar_TypeChecker_Env.effects =
-                   (uu___1587_12596.FStar_TypeChecker_Env.effects);
+                   (uu___1591_12608.FStar_TypeChecker_Env.effects);
                  FStar_TypeChecker_Env.generalize =
-                   (uu___1587_12596.FStar_TypeChecker_Env.generalize);
+                   (uu___1591_12608.FStar_TypeChecker_Env.generalize);
                  FStar_TypeChecker_Env.letrecs =
-                   (uu___1587_12596.FStar_TypeChecker_Env.letrecs);
+                   (uu___1591_12608.FStar_TypeChecker_Env.letrecs);
                  FStar_TypeChecker_Env.top_level =
-                   (uu___1587_12596.FStar_TypeChecker_Env.top_level);
+                   (uu___1591_12608.FStar_TypeChecker_Env.top_level);
                  FStar_TypeChecker_Env.check_uvars =
-                   (uu___1587_12596.FStar_TypeChecker_Env.check_uvars);
+                   (uu___1591_12608.FStar_TypeChecker_Env.check_uvars);
                  FStar_TypeChecker_Env.use_eq =
-                   (uu___1587_12596.FStar_TypeChecker_Env.use_eq);
+                   (uu___1591_12608.FStar_TypeChecker_Env.use_eq);
                  FStar_TypeChecker_Env.is_iface =
-                   (uu___1587_12596.FStar_TypeChecker_Env.is_iface);
+                   (uu___1591_12608.FStar_TypeChecker_Env.is_iface);
                  FStar_TypeChecker_Env.admit =
-                   (uu___1587_12596.FStar_TypeChecker_Env.admit);
+                   (uu___1591_12608.FStar_TypeChecker_Env.admit);
                  FStar_TypeChecker_Env.lax = true;
                  FStar_TypeChecker_Env.lax_universes =
-                   (uu___1587_12596.FStar_TypeChecker_Env.lax_universes);
+                   (uu___1591_12608.FStar_TypeChecker_Env.lax_universes);
                  FStar_TypeChecker_Env.phase1 =
-                   (uu___1587_12596.FStar_TypeChecker_Env.phase1);
+                   (uu___1591_12608.FStar_TypeChecker_Env.phase1);
                  FStar_TypeChecker_Env.failhard =
-                   (uu___1587_12596.FStar_TypeChecker_Env.failhard);
+                   (uu___1591_12608.FStar_TypeChecker_Env.failhard);
                  FStar_TypeChecker_Env.nosynth =
-                   (uu___1587_12596.FStar_TypeChecker_Env.nosynth);
+                   (uu___1591_12608.FStar_TypeChecker_Env.nosynth);
                  FStar_TypeChecker_Env.uvar_subtyping =
-                   (uu___1587_12596.FStar_TypeChecker_Env.uvar_subtyping);
+                   (uu___1591_12608.FStar_TypeChecker_Env.uvar_subtyping);
                  FStar_TypeChecker_Env.tc_term =
-                   (uu___1587_12596.FStar_TypeChecker_Env.tc_term);
+                   (uu___1591_12608.FStar_TypeChecker_Env.tc_term);
                  FStar_TypeChecker_Env.type_of =
-                   (uu___1587_12596.FStar_TypeChecker_Env.type_of);
+                   (uu___1591_12608.FStar_TypeChecker_Env.type_of);
                  FStar_TypeChecker_Env.universe_of =
-                   (uu___1587_12596.FStar_TypeChecker_Env.universe_of);
+                   (uu___1591_12608.FStar_TypeChecker_Env.universe_of);
                  FStar_TypeChecker_Env.check_type_of =
-                   (uu___1587_12596.FStar_TypeChecker_Env.check_type_of);
+                   (uu___1591_12608.FStar_TypeChecker_Env.check_type_of);
                  FStar_TypeChecker_Env.use_bv_sorts =
-                   (uu___1587_12596.FStar_TypeChecker_Env.use_bv_sorts);
+                   (uu___1591_12608.FStar_TypeChecker_Env.use_bv_sorts);
                  FStar_TypeChecker_Env.qtbl_name_and_index =
-                   (uu___1587_12596.FStar_TypeChecker_Env.qtbl_name_and_index);
+                   (uu___1591_12608.FStar_TypeChecker_Env.qtbl_name_and_index);
                  FStar_TypeChecker_Env.normalized_eff_names =
-                   (uu___1587_12596.FStar_TypeChecker_Env.normalized_eff_names);
+                   (uu___1591_12608.FStar_TypeChecker_Env.normalized_eff_names);
                  FStar_TypeChecker_Env.fv_delta_depths =
-                   (uu___1587_12596.FStar_TypeChecker_Env.fv_delta_depths);
+                   (uu___1591_12608.FStar_TypeChecker_Env.fv_delta_depths);
                  FStar_TypeChecker_Env.proof_ns =
-                   (uu___1587_12596.FStar_TypeChecker_Env.proof_ns);
+                   (uu___1591_12608.FStar_TypeChecker_Env.proof_ns);
                  FStar_TypeChecker_Env.synth_hook =
-                   (uu___1587_12596.FStar_TypeChecker_Env.synth_hook);
+                   (uu___1591_12608.FStar_TypeChecker_Env.synth_hook);
                  FStar_TypeChecker_Env.splice =
-                   (uu___1587_12596.FStar_TypeChecker_Env.splice);
+                   (uu___1591_12608.FStar_TypeChecker_Env.splice);
                  FStar_TypeChecker_Env.postprocess =
-                   (uu___1587_12596.FStar_TypeChecker_Env.postprocess);
+                   (uu___1591_12608.FStar_TypeChecker_Env.postprocess);
                  FStar_TypeChecker_Env.is_native_tactic =
-                   (uu___1587_12596.FStar_TypeChecker_Env.is_native_tactic);
+                   (uu___1591_12608.FStar_TypeChecker_Env.is_native_tactic);
                  FStar_TypeChecker_Env.identifier_info =
-                   (uu___1587_12596.FStar_TypeChecker_Env.identifier_info);
+                   (uu___1591_12608.FStar_TypeChecker_Env.identifier_info);
                  FStar_TypeChecker_Env.tc_hooks =
-                   (uu___1587_12596.FStar_TypeChecker_Env.tc_hooks);
+                   (uu___1591_12608.FStar_TypeChecker_Env.tc_hooks);
                  FStar_TypeChecker_Env.dsenv =
-                   (uu___1587_12596.FStar_TypeChecker_Env.dsenv);
+                   (uu___1591_12608.FStar_TypeChecker_Env.dsenv);
                  FStar_TypeChecker_Env.nbe =
-                   (uu___1587_12596.FStar_TypeChecker_Env.nbe);
+                   (uu___1591_12608.FStar_TypeChecker_Env.nbe);
                  FStar_TypeChecker_Env.strict_args_tab =
-                   (uu___1587_12596.FStar_TypeChecker_Env.strict_args_tab)
+                   (uu___1591_12608.FStar_TypeChecker_Env.strict_args_tab);
+                 FStar_TypeChecker_Env.erasable_types_tab =
+                   (uu___1591_12608.FStar_TypeChecker_Env.erasable_types_tab)
                }
              else env1  in
-           ((let uu____12601 =
+           ((let uu____12613 =
                FStar_TypeChecker_Env.debug env1 FStar_Options.Low  in
-             if uu____12601
+             if uu____12613
              then
-               let uu____12604 =
-                 let uu____12606 =
+               let uu____12616 =
+                 let uu____12618 =
                    FStar_List.map FStar_Util.string_of_int errnos  in
-                 FStar_All.pipe_left (FStar_String.concat "; ") uu____12606
+                 FStar_All.pipe_left (FStar_String.concat "; ") uu____12618
                   in
-               FStar_Util.print1 ">> Expecting errors: [%s]\n" uu____12604
+               FStar_Util.print1 ">> Expecting errors: [%s]\n" uu____12616
              else ());
-            (let uu____12620 =
+            (let uu____12632 =
                FStar_Errors.catch_errors
-                 (fun uu____12650  ->
+                 (fun uu____12662  ->
                     FStar_Options.with_saved_options
-                      (fun uu____12662  -> tc_decl' env' se))
+                      (fun uu____12674  -> tc_decl' env' se))
                 in
-             match uu____12620 with
-             | (errs,uu____12674) ->
-                 ((let uu____12704 =
+             match uu____12632 with
+             | (errs,uu____12686) ->
+                 ((let uu____12716 =
                      FStar_TypeChecker_Env.debug env1 FStar_Options.Low  in
-                   if uu____12704
+                   if uu____12716
                    then
                      (FStar_Util.print_string ">> Got issues: [\n";
                       FStar_List.iter FStar_Errors.print_issue errs;
@@ -7038,66 +7086,66 @@ let (tc_decl :
                       in
                    let errnos1 = sort errnos  in
                    let actual =
-                     let uu____12739 =
+                     let uu____12751 =
                        FStar_List.concatMap
                          (fun i  ->
                             list_of_option i.FStar_Errors.issue_number) errs
                         in
-                     sort uu____12739  in
+                     sort uu____12751  in
                    (match errs with
                     | [] ->
                         (FStar_List.iter FStar_Errors.print_issue errs;
                          FStar_Errors.log_issue se.FStar_Syntax_Syntax.sigrng
                            (FStar_Errors.Error_DidNotFail,
                              "This top-level definition was expected to fail, but it succeeded"))
-                    | uu____12751 ->
+                    | uu____12763 ->
                         if (errnos1 <> []) && (errnos1 <> actual)
                         then
-                          let uu____12762 =
-                            let uu____12772 = check_multi_eq errnos1 actual
+                          let uu____12774 =
+                            let uu____12784 = check_multi_eq errnos1 actual
                                in
-                            match uu____12772 with
+                            match uu____12784 with
                             | FStar_Pervasives_Native.Some r -> r
                             | FStar_Pervasives_Native.None  ->
                                 ((~- Prims.int_one), (~- Prims.int_one),
                                   (~- Prims.int_one))
                              in
-                          (match uu____12762 with
+                          (match uu____12774 with
                            | (e,n1,n2) ->
                                (FStar_List.iter FStar_Errors.print_issue errs;
-                                (let uu____12837 =
-                                   let uu____12843 =
-                                     let uu____12845 =
+                                (let uu____12849 =
+                                   let uu____12855 =
+                                     let uu____12857 =
                                        FStar_Common.string_of_list
                                          FStar_Util.string_of_int errnos1
                                         in
-                                     let uu____12848 =
+                                     let uu____12860 =
                                        FStar_Common.string_of_list
                                          FStar_Util.string_of_int actual
                                         in
-                                     let uu____12851 =
+                                     let uu____12863 =
                                        FStar_Util.string_of_int e  in
-                                     let uu____12853 =
+                                     let uu____12865 =
                                        FStar_Util.string_of_int n2  in
-                                     let uu____12855 =
+                                     let uu____12867 =
                                        FStar_Util.string_of_int n1  in
                                      FStar_Util.format5
                                        "This top-level definition was expected to raise error codes %s, but it raised %s. Error #%s was raised %s times, instead of %s."
-                                       uu____12845 uu____12848 uu____12851
-                                       uu____12853 uu____12855
+                                       uu____12857 uu____12860 uu____12863
+                                       uu____12865 uu____12867
                                       in
                                    (FStar_Errors.Error_DidNotFail,
-                                     uu____12843)
+                                     uu____12855)
                                     in
                                  FStar_Errors.log_issue
-                                   se.FStar_Syntax_Syntax.sigrng uu____12837)))
+                                   se.FStar_Syntax_Syntax.sigrng uu____12849)))
                         else ());
                    ([], [], env1)))))
        | FStar_Pervasives_Native.None  -> tc_decl' env1 se)
   
 let for_export :
-  'Auu____12882 .
-    'Auu____12882 ->
+  'Auu____12894 .
+    'Auu____12894 ->
       FStar_Ident.lident Prims.list ->
         FStar_Syntax_Syntax.sigelt ->
           (FStar_Syntax_Syntax.sigelt Prims.list * FStar_Ident.lident
@@ -7109,151 +7157,151 @@ let for_export :
         let is_abstract quals =
           FStar_All.pipe_right quals
             (FStar_Util.for_some
-               (fun uu___3_12925  ->
-                  match uu___3_12925 with
+               (fun uu___3_12937  ->
+                  match uu___3_12937 with
                   | FStar_Syntax_Syntax.Abstract  -> true
-                  | uu____12928 -> false))
+                  | uu____12940 -> false))
            in
         let is_hidden_proj_or_disc q =
           match q with
-          | FStar_Syntax_Syntax.Projector (l,uu____12939) ->
+          | FStar_Syntax_Syntax.Projector (l,uu____12951) ->
               FStar_All.pipe_right hidden
                 (FStar_Util.for_some (FStar_Ident.lid_equals l))
           | FStar_Syntax_Syntax.Discriminator l ->
               FStar_All.pipe_right hidden
                 (FStar_Util.for_some (FStar_Ident.lid_equals l))
-          | uu____12947 -> false  in
+          | uu____12959 -> false  in
         match se.FStar_Syntax_Syntax.sigel with
-        | FStar_Syntax_Syntax.Sig_pragma uu____12957 -> ([], hidden)
-        | FStar_Syntax_Syntax.Sig_splice uu____12962 ->
+        | FStar_Syntax_Syntax.Sig_pragma uu____12969 -> ([], hidden)
+        | FStar_Syntax_Syntax.Sig_splice uu____12974 ->
             failwith "Impossible (Already handled)"
-        | FStar_Syntax_Syntax.Sig_inductive_typ uu____12978 ->
+        | FStar_Syntax_Syntax.Sig_inductive_typ uu____12990 ->
             failwith "Impossible (Already handled)"
-        | FStar_Syntax_Syntax.Sig_datacon uu____13004 ->
+        | FStar_Syntax_Syntax.Sig_datacon uu____13016 ->
             failwith "Impossible (Already handled)"
-        | FStar_Syntax_Syntax.Sig_bundle (ses,uu____13030) ->
-            let uu____13039 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
-            if uu____13039
+        | FStar_Syntax_Syntax.Sig_bundle (ses,uu____13042) ->
+            let uu____13051 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
+            if uu____13051
             then
-              let for_export_bundle se1 uu____13076 =
-                match uu____13076 with
+              let for_export_bundle se1 uu____13088 =
+                match uu____13088 with
                 | (out,hidden1) ->
                     (match se1.FStar_Syntax_Syntax.sigel with
                      | FStar_Syntax_Syntax.Sig_inductive_typ
-                         (l,us,bs,t,uu____13115,uu____13116) ->
+                         (l,us,bs,t,uu____13127,uu____13128) ->
                          let dec =
-                           let uu___1663_13126 = se1  in
-                           let uu____13127 =
-                             let uu____13128 =
-                               let uu____13135 =
-                                 let uu____13136 =
+                           let uu___1667_13138 = se1  in
+                           let uu____13139 =
+                             let uu____13140 =
+                               let uu____13147 =
+                                 let uu____13148 =
                                    FStar_Syntax_Syntax.mk_Total t  in
-                                 FStar_Syntax_Util.arrow bs uu____13136  in
-                               (l, us, uu____13135)  in
-                             FStar_Syntax_Syntax.Sig_declare_typ uu____13128
+                                 FStar_Syntax_Util.arrow bs uu____13148  in
+                               (l, us, uu____13147)  in
+                             FStar_Syntax_Syntax.Sig_declare_typ uu____13140
                               in
                            {
-                             FStar_Syntax_Syntax.sigel = uu____13127;
+                             FStar_Syntax_Syntax.sigel = uu____13139;
                              FStar_Syntax_Syntax.sigrng =
-                               (uu___1663_13126.FStar_Syntax_Syntax.sigrng);
+                               (uu___1667_13138.FStar_Syntax_Syntax.sigrng);
                              FStar_Syntax_Syntax.sigquals =
                                (FStar_Syntax_Syntax.Assumption ::
                                FStar_Syntax_Syntax.New ::
                                (se1.FStar_Syntax_Syntax.sigquals));
                              FStar_Syntax_Syntax.sigmeta =
-                               (uu___1663_13126.FStar_Syntax_Syntax.sigmeta);
+                               (uu___1667_13138.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs =
-                               (uu___1663_13126.FStar_Syntax_Syntax.sigattrs)
+                               (uu___1667_13138.FStar_Syntax_Syntax.sigattrs)
                            }  in
                          ((dec :: out), hidden1)
                      | FStar_Syntax_Syntax.Sig_datacon
-                         (l,us,t,uu____13146,uu____13147,uu____13148) ->
+                         (l,us,t,uu____13158,uu____13159,uu____13160) ->
                          let dec =
-                           let uu___1674_13156 = se1  in
+                           let uu___1678_13168 = se1  in
                            {
                              FStar_Syntax_Syntax.sigel =
                                (FStar_Syntax_Syntax.Sig_declare_typ
                                   (l, us, t));
                              FStar_Syntax_Syntax.sigrng =
-                               (uu___1674_13156.FStar_Syntax_Syntax.sigrng);
+                               (uu___1678_13168.FStar_Syntax_Syntax.sigrng);
                              FStar_Syntax_Syntax.sigquals =
                                [FStar_Syntax_Syntax.Assumption];
                              FStar_Syntax_Syntax.sigmeta =
-                               (uu___1674_13156.FStar_Syntax_Syntax.sigmeta);
+                               (uu___1678_13168.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs =
-                               (uu___1674_13156.FStar_Syntax_Syntax.sigattrs)
+                               (uu___1678_13168.FStar_Syntax_Syntax.sigattrs)
                            }  in
                          ((dec :: out), (l :: hidden1))
-                     | uu____13161 -> (out, hidden1))
+                     | uu____13173 -> (out, hidden1))
                  in
               FStar_List.fold_right for_export_bundle ses ([], hidden)
             else ([se], hidden)
         | FStar_Syntax_Syntax.Sig_assume
-            (uu____13184,uu____13185,uu____13186) ->
-            let uu____13187 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
-            if uu____13187 then ([], hidden) else ([se], hidden)
+            (uu____13196,uu____13197,uu____13198) ->
+            let uu____13199 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
+            if uu____13199 then ([], hidden) else ([se], hidden)
         | FStar_Syntax_Syntax.Sig_declare_typ (l,us,t) ->
-            let uu____13211 =
+            let uu____13223 =
               FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                 (FStar_Util.for_some is_hidden_proj_or_disc)
                in
-            if uu____13211
+            if uu____13223
             then
-              ([(let uu___1690_13230 = se  in
+              ([(let uu___1694_13242 = se  in
                  {
                    FStar_Syntax_Syntax.sigel =
                      (FStar_Syntax_Syntax.Sig_declare_typ (l, us, t));
                    FStar_Syntax_Syntax.sigrng =
-                     (uu___1690_13230.FStar_Syntax_Syntax.sigrng);
+                     (uu___1694_13242.FStar_Syntax_Syntax.sigrng);
                    FStar_Syntax_Syntax.sigquals =
                      [FStar_Syntax_Syntax.Assumption];
                    FStar_Syntax_Syntax.sigmeta =
-                     (uu___1690_13230.FStar_Syntax_Syntax.sigmeta);
+                     (uu___1694_13242.FStar_Syntax_Syntax.sigmeta);
                    FStar_Syntax_Syntax.sigattrs =
-                     (uu___1690_13230.FStar_Syntax_Syntax.sigattrs)
+                     (uu___1694_13242.FStar_Syntax_Syntax.sigattrs)
                  })], (l :: hidden))
             else
-              (let uu____13233 =
+              (let uu____13245 =
                  FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                    (FStar_Util.for_some
-                      (fun uu___4_13239  ->
-                         match uu___4_13239 with
+                      (fun uu___4_13251  ->
+                         match uu___4_13251 with
                          | FStar_Syntax_Syntax.Assumption  -> true
-                         | FStar_Syntax_Syntax.Projector uu____13242 -> true
-                         | FStar_Syntax_Syntax.Discriminator uu____13248 ->
+                         | FStar_Syntax_Syntax.Projector uu____13254 -> true
+                         | FStar_Syntax_Syntax.Discriminator uu____13260 ->
                              true
-                         | uu____13250 -> false))
+                         | uu____13262 -> false))
                   in
-               if uu____13233 then ([se], hidden) else ([], hidden))
-        | FStar_Syntax_Syntax.Sig_main uu____13271 -> ([], hidden)
-        | FStar_Syntax_Syntax.Sig_new_effect uu____13276 -> ([se], hidden)
-        | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____13281 ->
+               if uu____13245 then ([se], hidden) else ([], hidden))
+        | FStar_Syntax_Syntax.Sig_main uu____13283 -> ([], hidden)
+        | FStar_Syntax_Syntax.Sig_new_effect uu____13288 -> ([se], hidden)
+        | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____13293 ->
             ([se], hidden)
-        | FStar_Syntax_Syntax.Sig_sub_effect uu____13286 -> ([se], hidden)
-        | FStar_Syntax_Syntax.Sig_effect_abbrev uu____13291 -> ([se], hidden)
-        | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____13309) when
+        | FStar_Syntax_Syntax.Sig_sub_effect uu____13298 -> ([se], hidden)
+        | FStar_Syntax_Syntax.Sig_effect_abbrev uu____13303 -> ([se], hidden)
+        | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____13321) when
             FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
               (FStar_Util.for_some is_hidden_proj_or_disc)
             ->
             let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
             let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                in
-            let uu____13323 =
+            let uu____13335 =
               FStar_All.pipe_right hidden
                 (FStar_Util.for_some (FStar_Syntax_Syntax.fv_eq_lid fv))
                in
-            if uu____13323
+            if uu____13335
             then ([], hidden)
             else
               (let dec =
-                 let uu____13344 = FStar_Ident.range_of_lid lid  in
+                 let uu____13356 = FStar_Ident.range_of_lid lid  in
                  {
                    FStar_Syntax_Syntax.sigel =
                      (FStar_Syntax_Syntax.Sig_declare_typ
                         (((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v),
                           (lb.FStar_Syntax_Syntax.lbunivs),
                           (lb.FStar_Syntax_Syntax.lbtyp)));
-                   FStar_Syntax_Syntax.sigrng = uu____13344;
+                   FStar_Syntax_Syntax.sigrng = uu____13356;
                    FStar_Syntax_Syntax.sigquals =
                      [FStar_Syntax_Syntax.Assumption];
                    FStar_Syntax_Syntax.sigmeta =
@@ -7262,42 +7310,42 @@ let for_export :
                  }  in
                ([dec], (lid :: hidden)))
         | FStar_Syntax_Syntax.Sig_let (lbs,l) ->
-            let uu____13355 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
-            if uu____13355
+            let uu____13367 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
+            if uu____13367
             then
-              let uu____13366 =
+              let uu____13378 =
                 FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
                   (FStar_List.map
                      (fun lb  ->
-                        let uu___1727_13380 = se  in
-                        let uu____13381 =
-                          let uu____13382 =
-                            let uu____13389 =
-                              let uu____13390 =
-                                let uu____13393 =
+                        let uu___1731_13392 = se  in
+                        let uu____13393 =
+                          let uu____13394 =
+                            let uu____13401 =
+                              let uu____13402 =
+                                let uu____13405 =
                                   FStar_Util.right
                                     lb.FStar_Syntax_Syntax.lbname
                                    in
-                                uu____13393.FStar_Syntax_Syntax.fv_name  in
-                              uu____13390.FStar_Syntax_Syntax.v  in
-                            (uu____13389, (lb.FStar_Syntax_Syntax.lbunivs),
+                                uu____13405.FStar_Syntax_Syntax.fv_name  in
+                              uu____13402.FStar_Syntax_Syntax.v  in
+                            (uu____13401, (lb.FStar_Syntax_Syntax.lbunivs),
                               (lb.FStar_Syntax_Syntax.lbtyp))
                              in
-                          FStar_Syntax_Syntax.Sig_declare_typ uu____13382  in
+                          FStar_Syntax_Syntax.Sig_declare_typ uu____13394  in
                         {
-                          FStar_Syntax_Syntax.sigel = uu____13381;
+                          FStar_Syntax_Syntax.sigel = uu____13393;
                           FStar_Syntax_Syntax.sigrng =
-                            (uu___1727_13380.FStar_Syntax_Syntax.sigrng);
+                            (uu___1731_13392.FStar_Syntax_Syntax.sigrng);
                           FStar_Syntax_Syntax.sigquals =
                             (FStar_Syntax_Syntax.Assumption ::
                             (se.FStar_Syntax_Syntax.sigquals));
                           FStar_Syntax_Syntax.sigmeta =
-                            (uu___1727_13380.FStar_Syntax_Syntax.sigmeta);
+                            (uu___1731_13392.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (uu___1727_13380.FStar_Syntax_Syntax.sigattrs)
+                            (uu___1731_13392.FStar_Syntax_Syntax.sigattrs)
                         }))
                  in
-              (uu____13366, hidden)
+              (uu____13378, hidden)
             else ([se], hidden)
   
 let (add_sigelt_to_env :
@@ -7307,442 +7355,450 @@ let (add_sigelt_to_env :
   fun env  ->
     fun se  ->
       fun from_cache  ->
-        (let uu____13423 = FStar_TypeChecker_Env.debug env FStar_Options.Low
+        (let uu____13435 = FStar_TypeChecker_Env.debug env FStar_Options.Low
             in
-         if uu____13423
+         if uu____13435
          then
-           let uu____13426 = FStar_Syntax_Print.sigelt_to_string se  in
-           let uu____13428 = FStar_Util.string_of_bool from_cache  in
+           let uu____13438 = FStar_Syntax_Print.sigelt_to_string se  in
+           let uu____13440 = FStar_Util.string_of_bool from_cache  in
            FStar_Util.print2
              ">>>>>>>>>>>>>>Adding top-level decl to environment: %s (from_cache:%s)\n"
-             uu____13426 uu____13428
+             uu____13438 uu____13440
          else ());
         (match se.FStar_Syntax_Syntax.sigel with
-         | FStar_Syntax_Syntax.Sig_inductive_typ uu____13433 ->
-             let uu____13450 =
-               let uu____13456 =
-                 let uu____13458 = FStar_Syntax_Print.sigelt_to_string se  in
+         | FStar_Syntax_Syntax.Sig_inductive_typ uu____13445 ->
+             let uu____13462 =
+               let uu____13468 =
+                 let uu____13470 = FStar_Syntax_Print.sigelt_to_string se  in
                  FStar_Util.format1
                    "add_sigelt_to_env: unexpected bare type/data constructor: %s"
-                   uu____13458
+                   uu____13470
                   in
-               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____13456)  in
-             FStar_Errors.raise_error uu____13450
+               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____13468)  in
+             FStar_Errors.raise_error uu____13462
                se.FStar_Syntax_Syntax.sigrng
-         | FStar_Syntax_Syntax.Sig_datacon uu____13462 ->
-             let uu____13478 =
-               let uu____13484 =
-                 let uu____13486 = FStar_Syntax_Print.sigelt_to_string se  in
+         | FStar_Syntax_Syntax.Sig_datacon uu____13474 ->
+             let uu____13490 =
+               let uu____13496 =
+                 let uu____13498 = FStar_Syntax_Print.sigelt_to_string se  in
                  FStar_Util.format1
                    "add_sigelt_to_env: unexpected bare type/data constructor: %s"
-                   uu____13486
+                   uu____13498
                   in
-               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____13484)  in
-             FStar_Errors.raise_error uu____13478
+               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____13496)  in
+             FStar_Errors.raise_error uu____13490
                se.FStar_Syntax_Syntax.sigrng
          | FStar_Syntax_Syntax.Sig_declare_typ
-             (uu____13490,uu____13491,uu____13492) when
+             (uu____13502,uu____13503,uu____13504) when
              FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                (FStar_Util.for_some
-                  (fun uu___5_13497  ->
-                     match uu___5_13497 with
+                  (fun uu___5_13509  ->
+                     match uu___5_13509 with
                      | FStar_Syntax_Syntax.OnlyName  -> true
-                     | uu____13500 -> false))
+                     | uu____13512 -> false))
              -> env
-         | FStar_Syntax_Syntax.Sig_let (uu____13502,uu____13503) when
+         | FStar_Syntax_Syntax.Sig_let (uu____13514,uu____13515) when
              FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                (FStar_Util.for_some
-                  (fun uu___5_13512  ->
-                     match uu___5_13512 with
+                  (fun uu___5_13524  ->
+                     match uu___5_13524 with
                      | FStar_Syntax_Syntax.OnlyName  -> true
-                     | uu____13515 -> false))
+                     | uu____13527 -> false))
              -> env
-         | uu____13517 ->
+         | uu____13529 ->
              let env1 = FStar_TypeChecker_Env.push_sigelt env se  in
              (match se.FStar_Syntax_Syntax.sigel with
               | FStar_Syntax_Syntax.Sig_pragma
-                  (FStar_Syntax_Syntax.PushOptions uu____13519) ->
+                  (FStar_Syntax_Syntax.PushOptions uu____13531) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___1764_13526 = env1  in
-                     let uu____13527 = FStar_Options.using_facts_from ()  in
+                    (let uu___1768_13538 = env1  in
+                     let uu____13539 = FStar_Options.using_facts_from ()  in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___1764_13526.FStar_TypeChecker_Env.solver);
+                         (uu___1768_13538.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___1764_13526.FStar_TypeChecker_Env.range);
+                         (uu___1768_13538.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___1764_13526.FStar_TypeChecker_Env.curmodule);
+                         (uu___1768_13538.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___1764_13526.FStar_TypeChecker_Env.gamma);
+                         (uu___1768_13538.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___1764_13526.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___1768_13538.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___1764_13526.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___1768_13538.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___1764_13526.FStar_TypeChecker_Env.modules);
+                         (uu___1768_13538.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___1764_13526.FStar_TypeChecker_Env.expected_typ);
+                         (uu___1768_13538.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___1764_13526.FStar_TypeChecker_Env.sigtab);
+                         (uu___1768_13538.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___1764_13526.FStar_TypeChecker_Env.attrtab);
+                         (uu___1768_13538.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.is_pattern =
-                         (uu___1764_13526.FStar_TypeChecker_Env.is_pattern);
+                         (uu___1768_13538.FStar_TypeChecker_Env.is_pattern);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___1764_13526.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___1768_13538.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___1764_13526.FStar_TypeChecker_Env.effects);
+                         (uu___1768_13538.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___1764_13526.FStar_TypeChecker_Env.generalize);
+                         (uu___1768_13538.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___1764_13526.FStar_TypeChecker_Env.letrecs);
+                         (uu___1768_13538.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___1764_13526.FStar_TypeChecker_Env.top_level);
+                         (uu___1768_13538.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___1764_13526.FStar_TypeChecker_Env.check_uvars);
+                         (uu___1768_13538.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___1764_13526.FStar_TypeChecker_Env.use_eq);
+                         (uu___1768_13538.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___1764_13526.FStar_TypeChecker_Env.is_iface);
+                         (uu___1768_13538.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___1764_13526.FStar_TypeChecker_Env.admit);
+                         (uu___1768_13538.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___1764_13526.FStar_TypeChecker_Env.lax);
+                         (uu___1768_13538.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___1764_13526.FStar_TypeChecker_Env.lax_universes);
+                         (uu___1768_13538.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___1764_13526.FStar_TypeChecker_Env.phase1);
+                         (uu___1768_13538.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___1764_13526.FStar_TypeChecker_Env.failhard);
+                         (uu___1768_13538.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___1764_13526.FStar_TypeChecker_Env.nosynth);
+                         (uu___1768_13538.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___1764_13526.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___1768_13538.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___1764_13526.FStar_TypeChecker_Env.tc_term);
+                         (uu___1768_13538.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___1764_13526.FStar_TypeChecker_Env.type_of);
+                         (uu___1768_13538.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___1764_13526.FStar_TypeChecker_Env.universe_of);
+                         (uu___1768_13538.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___1764_13526.FStar_TypeChecker_Env.check_type_of);
+                         (uu___1768_13538.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___1764_13526.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___1768_13538.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___1764_13526.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___1768_13538.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___1764_13526.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___1768_13538.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___1764_13526.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____13527;
+                         (uu___1768_13538.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu____13539;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___1764_13526.FStar_TypeChecker_Env.synth_hook);
+                         (uu___1768_13538.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___1764_13526.FStar_TypeChecker_Env.splice);
+                         (uu___1768_13538.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___1764_13526.FStar_TypeChecker_Env.postprocess);
+                         (uu___1768_13538.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.is_native_tactic =
-                         (uu___1764_13526.FStar_TypeChecker_Env.is_native_tactic);
+                         (uu___1768_13538.FStar_TypeChecker_Env.is_native_tactic);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___1764_13526.FStar_TypeChecker_Env.identifier_info);
+                         (uu___1768_13538.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___1764_13526.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___1768_13538.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___1764_13526.FStar_TypeChecker_Env.dsenv);
+                         (uu___1768_13538.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___1764_13526.FStar_TypeChecker_Env.nbe);
+                         (uu___1768_13538.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___1764_13526.FStar_TypeChecker_Env.strict_args_tab)
+                         (uu___1768_13538.FStar_TypeChecker_Env.strict_args_tab);
+                       FStar_TypeChecker_Env.erasable_types_tab =
+                         (uu___1768_13538.FStar_TypeChecker_Env.erasable_types_tab)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
                   (FStar_Syntax_Syntax.PopOptions ) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___1764_13531 = env1  in
-                     let uu____13532 = FStar_Options.using_facts_from ()  in
+                    (let uu___1768_13543 = env1  in
+                     let uu____13544 = FStar_Options.using_facts_from ()  in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___1764_13531.FStar_TypeChecker_Env.solver);
+                         (uu___1768_13543.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___1764_13531.FStar_TypeChecker_Env.range);
+                         (uu___1768_13543.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___1764_13531.FStar_TypeChecker_Env.curmodule);
+                         (uu___1768_13543.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___1764_13531.FStar_TypeChecker_Env.gamma);
+                         (uu___1768_13543.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___1764_13531.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___1768_13543.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___1764_13531.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___1768_13543.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___1764_13531.FStar_TypeChecker_Env.modules);
+                         (uu___1768_13543.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___1764_13531.FStar_TypeChecker_Env.expected_typ);
+                         (uu___1768_13543.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___1764_13531.FStar_TypeChecker_Env.sigtab);
+                         (uu___1768_13543.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___1764_13531.FStar_TypeChecker_Env.attrtab);
+                         (uu___1768_13543.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.is_pattern =
-                         (uu___1764_13531.FStar_TypeChecker_Env.is_pattern);
+                         (uu___1768_13543.FStar_TypeChecker_Env.is_pattern);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___1764_13531.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___1768_13543.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___1764_13531.FStar_TypeChecker_Env.effects);
+                         (uu___1768_13543.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___1764_13531.FStar_TypeChecker_Env.generalize);
+                         (uu___1768_13543.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___1764_13531.FStar_TypeChecker_Env.letrecs);
+                         (uu___1768_13543.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___1764_13531.FStar_TypeChecker_Env.top_level);
+                         (uu___1768_13543.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___1764_13531.FStar_TypeChecker_Env.check_uvars);
+                         (uu___1768_13543.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___1764_13531.FStar_TypeChecker_Env.use_eq);
+                         (uu___1768_13543.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___1764_13531.FStar_TypeChecker_Env.is_iface);
+                         (uu___1768_13543.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___1764_13531.FStar_TypeChecker_Env.admit);
+                         (uu___1768_13543.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___1764_13531.FStar_TypeChecker_Env.lax);
+                         (uu___1768_13543.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___1764_13531.FStar_TypeChecker_Env.lax_universes);
+                         (uu___1768_13543.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___1764_13531.FStar_TypeChecker_Env.phase1);
+                         (uu___1768_13543.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___1764_13531.FStar_TypeChecker_Env.failhard);
+                         (uu___1768_13543.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___1764_13531.FStar_TypeChecker_Env.nosynth);
+                         (uu___1768_13543.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___1764_13531.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___1768_13543.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___1764_13531.FStar_TypeChecker_Env.tc_term);
+                         (uu___1768_13543.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___1764_13531.FStar_TypeChecker_Env.type_of);
+                         (uu___1768_13543.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___1764_13531.FStar_TypeChecker_Env.universe_of);
+                         (uu___1768_13543.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___1764_13531.FStar_TypeChecker_Env.check_type_of);
+                         (uu___1768_13543.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___1764_13531.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___1768_13543.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___1764_13531.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___1768_13543.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___1764_13531.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___1768_13543.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___1764_13531.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____13532;
+                         (uu___1768_13543.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu____13544;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___1764_13531.FStar_TypeChecker_Env.synth_hook);
+                         (uu___1768_13543.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___1764_13531.FStar_TypeChecker_Env.splice);
+                         (uu___1768_13543.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___1764_13531.FStar_TypeChecker_Env.postprocess);
+                         (uu___1768_13543.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.is_native_tactic =
-                         (uu___1764_13531.FStar_TypeChecker_Env.is_native_tactic);
+                         (uu___1768_13543.FStar_TypeChecker_Env.is_native_tactic);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___1764_13531.FStar_TypeChecker_Env.identifier_info);
+                         (uu___1768_13543.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___1764_13531.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___1768_13543.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___1764_13531.FStar_TypeChecker_Env.dsenv);
+                         (uu___1768_13543.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___1764_13531.FStar_TypeChecker_Env.nbe);
+                         (uu___1768_13543.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___1764_13531.FStar_TypeChecker_Env.strict_args_tab)
+                         (uu___1768_13543.FStar_TypeChecker_Env.strict_args_tab);
+                       FStar_TypeChecker_Env.erasable_types_tab =
+                         (uu___1768_13543.FStar_TypeChecker_Env.erasable_types_tab)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
-                  (FStar_Syntax_Syntax.SetOptions uu____13533) ->
+                  (FStar_Syntax_Syntax.SetOptions uu____13545) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___1764_13538 = env1  in
-                     let uu____13539 = FStar_Options.using_facts_from ()  in
+                    (let uu___1768_13550 = env1  in
+                     let uu____13551 = FStar_Options.using_facts_from ()  in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___1764_13538.FStar_TypeChecker_Env.solver);
+                         (uu___1768_13550.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___1764_13538.FStar_TypeChecker_Env.range);
+                         (uu___1768_13550.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___1764_13538.FStar_TypeChecker_Env.curmodule);
+                         (uu___1768_13550.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___1764_13538.FStar_TypeChecker_Env.gamma);
+                         (uu___1768_13550.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___1764_13538.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___1768_13550.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___1764_13538.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___1768_13550.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___1764_13538.FStar_TypeChecker_Env.modules);
+                         (uu___1768_13550.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___1764_13538.FStar_TypeChecker_Env.expected_typ);
+                         (uu___1768_13550.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___1764_13538.FStar_TypeChecker_Env.sigtab);
+                         (uu___1768_13550.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___1764_13538.FStar_TypeChecker_Env.attrtab);
+                         (uu___1768_13550.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.is_pattern =
-                         (uu___1764_13538.FStar_TypeChecker_Env.is_pattern);
+                         (uu___1768_13550.FStar_TypeChecker_Env.is_pattern);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___1764_13538.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___1768_13550.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___1764_13538.FStar_TypeChecker_Env.effects);
+                         (uu___1768_13550.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___1764_13538.FStar_TypeChecker_Env.generalize);
+                         (uu___1768_13550.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___1764_13538.FStar_TypeChecker_Env.letrecs);
+                         (uu___1768_13550.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___1764_13538.FStar_TypeChecker_Env.top_level);
+                         (uu___1768_13550.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___1764_13538.FStar_TypeChecker_Env.check_uvars);
+                         (uu___1768_13550.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___1764_13538.FStar_TypeChecker_Env.use_eq);
+                         (uu___1768_13550.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___1764_13538.FStar_TypeChecker_Env.is_iface);
+                         (uu___1768_13550.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___1764_13538.FStar_TypeChecker_Env.admit);
+                         (uu___1768_13550.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___1764_13538.FStar_TypeChecker_Env.lax);
+                         (uu___1768_13550.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___1764_13538.FStar_TypeChecker_Env.lax_universes);
+                         (uu___1768_13550.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___1764_13538.FStar_TypeChecker_Env.phase1);
+                         (uu___1768_13550.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___1764_13538.FStar_TypeChecker_Env.failhard);
+                         (uu___1768_13550.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___1764_13538.FStar_TypeChecker_Env.nosynth);
+                         (uu___1768_13550.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___1764_13538.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___1768_13550.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___1764_13538.FStar_TypeChecker_Env.tc_term);
+                         (uu___1768_13550.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___1764_13538.FStar_TypeChecker_Env.type_of);
+                         (uu___1768_13550.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___1764_13538.FStar_TypeChecker_Env.universe_of);
+                         (uu___1768_13550.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___1764_13538.FStar_TypeChecker_Env.check_type_of);
+                         (uu___1768_13550.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___1764_13538.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___1768_13550.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___1764_13538.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___1768_13550.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___1764_13538.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___1768_13550.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___1764_13538.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____13539;
+                         (uu___1768_13550.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu____13551;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___1764_13538.FStar_TypeChecker_Env.synth_hook);
+                         (uu___1768_13550.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___1764_13538.FStar_TypeChecker_Env.splice);
+                         (uu___1768_13550.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___1764_13538.FStar_TypeChecker_Env.postprocess);
+                         (uu___1768_13550.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.is_native_tactic =
-                         (uu___1764_13538.FStar_TypeChecker_Env.is_native_tactic);
+                         (uu___1768_13550.FStar_TypeChecker_Env.is_native_tactic);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___1764_13538.FStar_TypeChecker_Env.identifier_info);
+                         (uu___1768_13550.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___1764_13538.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___1768_13550.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___1764_13538.FStar_TypeChecker_Env.dsenv);
+                         (uu___1768_13550.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___1764_13538.FStar_TypeChecker_Env.nbe);
+                         (uu___1768_13550.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___1764_13538.FStar_TypeChecker_Env.strict_args_tab)
+                         (uu___1768_13550.FStar_TypeChecker_Env.strict_args_tab);
+                       FStar_TypeChecker_Env.erasable_types_tab =
+                         (uu___1768_13550.FStar_TypeChecker_Env.erasable_types_tab)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
-                  (FStar_Syntax_Syntax.ResetOptions uu____13540) ->
+                  (FStar_Syntax_Syntax.ResetOptions uu____13552) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___1764_13547 = env1  in
-                     let uu____13548 = FStar_Options.using_facts_from ()  in
+                    (let uu___1768_13559 = env1  in
+                     let uu____13560 = FStar_Options.using_facts_from ()  in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___1764_13547.FStar_TypeChecker_Env.solver);
+                         (uu___1768_13559.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___1764_13547.FStar_TypeChecker_Env.range);
+                         (uu___1768_13559.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___1764_13547.FStar_TypeChecker_Env.curmodule);
+                         (uu___1768_13559.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___1764_13547.FStar_TypeChecker_Env.gamma);
+                         (uu___1768_13559.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___1764_13547.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___1768_13559.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___1764_13547.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___1768_13559.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___1764_13547.FStar_TypeChecker_Env.modules);
+                         (uu___1768_13559.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___1764_13547.FStar_TypeChecker_Env.expected_typ);
+                         (uu___1768_13559.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___1764_13547.FStar_TypeChecker_Env.sigtab);
+                         (uu___1768_13559.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___1764_13547.FStar_TypeChecker_Env.attrtab);
+                         (uu___1768_13559.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.is_pattern =
-                         (uu___1764_13547.FStar_TypeChecker_Env.is_pattern);
+                         (uu___1768_13559.FStar_TypeChecker_Env.is_pattern);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___1764_13547.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___1768_13559.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___1764_13547.FStar_TypeChecker_Env.effects);
+                         (uu___1768_13559.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___1764_13547.FStar_TypeChecker_Env.generalize);
+                         (uu___1768_13559.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___1764_13547.FStar_TypeChecker_Env.letrecs);
+                         (uu___1768_13559.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___1764_13547.FStar_TypeChecker_Env.top_level);
+                         (uu___1768_13559.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___1764_13547.FStar_TypeChecker_Env.check_uvars);
+                         (uu___1768_13559.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___1764_13547.FStar_TypeChecker_Env.use_eq);
+                         (uu___1768_13559.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___1764_13547.FStar_TypeChecker_Env.is_iface);
+                         (uu___1768_13559.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___1764_13547.FStar_TypeChecker_Env.admit);
+                         (uu___1768_13559.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___1764_13547.FStar_TypeChecker_Env.lax);
+                         (uu___1768_13559.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___1764_13547.FStar_TypeChecker_Env.lax_universes);
+                         (uu___1768_13559.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___1764_13547.FStar_TypeChecker_Env.phase1);
+                         (uu___1768_13559.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___1764_13547.FStar_TypeChecker_Env.failhard);
+                         (uu___1768_13559.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___1764_13547.FStar_TypeChecker_Env.nosynth);
+                         (uu___1768_13559.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___1764_13547.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___1768_13559.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___1764_13547.FStar_TypeChecker_Env.tc_term);
+                         (uu___1768_13559.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___1764_13547.FStar_TypeChecker_Env.type_of);
+                         (uu___1768_13559.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___1764_13547.FStar_TypeChecker_Env.universe_of);
+                         (uu___1768_13559.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___1764_13547.FStar_TypeChecker_Env.check_type_of);
+                         (uu___1768_13559.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___1764_13547.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___1768_13559.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___1764_13547.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___1768_13559.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___1764_13547.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___1768_13559.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___1764_13547.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____13548;
+                         (uu___1768_13559.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu____13560;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___1764_13547.FStar_TypeChecker_Env.synth_hook);
+                         (uu___1768_13559.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___1764_13547.FStar_TypeChecker_Env.splice);
+                         (uu___1768_13559.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___1764_13547.FStar_TypeChecker_Env.postprocess);
+                         (uu___1768_13559.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.is_native_tactic =
-                         (uu___1764_13547.FStar_TypeChecker_Env.is_native_tactic);
+                         (uu___1768_13559.FStar_TypeChecker_Env.is_native_tactic);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___1764_13547.FStar_TypeChecker_Env.identifier_info);
+                         (uu___1768_13559.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___1764_13547.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___1768_13559.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___1764_13547.FStar_TypeChecker_Env.dsenv);
+                         (uu___1768_13559.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___1764_13547.FStar_TypeChecker_Env.nbe);
+                         (uu___1768_13559.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___1764_13547.FStar_TypeChecker_Env.strict_args_tab)
+                         (uu___1768_13559.FStar_TypeChecker_Env.strict_args_tab);
+                       FStar_TypeChecker_Env.erasable_types_tab =
+                         (uu___1768_13559.FStar_TypeChecker_Env.erasable_types_tab)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
                   (FStar_Syntax_Syntax.RestartSolver ) ->
@@ -7761,16 +7817,16 @@ let (add_sigelt_to_env :
                     (FStar_List.fold_left
                        (fun env3  ->
                           fun a  ->
-                            let uu____13564 =
+                            let uu____13576 =
                               FStar_Syntax_Util.action_as_lb
                                 ne.FStar_Syntax_Syntax.mname a
                                 (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
                                in
                             FStar_TypeChecker_Env.push_sigelt env3
-                              uu____13564) env2)
+                              uu____13576) env2)
               | FStar_Syntax_Syntax.Sig_sub_effect sub1 ->
                   FStar_TypeChecker_Env.update_effect_lattice env1 sub1
-              | uu____13566 -> env1))
+              | uu____13578 -> env1))
   
 let (tc_decls :
   FStar_TypeChecker_Env.env ->
@@ -7780,34 +7836,34 @@ let (tc_decls :
   =
   fun env  ->
     fun ses  ->
-      let rec process_one_decl uu____13635 se =
-        match uu____13635 with
+      let rec process_one_decl uu____13647 se =
+        match uu____13647 with
         | (ses1,exports,env1,hidden) ->
-            ((let uu____13688 =
+            ((let uu____13700 =
                 FStar_TypeChecker_Env.debug env1 FStar_Options.Low  in
-              if uu____13688
+              if uu____13700
               then
-                let uu____13691 = FStar_Syntax_Print.sigelt_to_string se  in
+                let uu____13703 = FStar_Syntax_Print.sigelt_to_string se  in
                 FStar_Util.print1
-                  ">>>>>>>>>>>>>>Checking top-level decl %s\n" uu____13691
+                  ">>>>>>>>>>>>>>Checking top-level decl %s\n" uu____13703
               else ());
-             (let uu____13696 = tc_decl env1 se  in
-              match uu____13696 with
+             (let uu____13708 = tc_decl env1 se  in
+              match uu____13708 with
               | (ses',ses_elaborated,env2) ->
                   let ses'1 =
                     FStar_All.pipe_right ses'
                       (FStar_List.map
                          (fun se1  ->
-                            (let uu____13749 =
+                            (let uu____13761 =
                                FStar_TypeChecker_Env.debug env2
                                  (FStar_Options.Other "UF")
                                 in
-                             if uu____13749
+                             if uu____13761
                              then
-                               let uu____13753 =
+                               let uu____13765 =
                                  FStar_Syntax_Print.sigelt_to_string se1  in
                                FStar_Util.print1
-                                 "About to elim vars from %s\n" uu____13753
+                                 "About to elim vars from %s\n" uu____13765
                              else ());
                             FStar_TypeChecker_Normalize.elim_uvars env2 se1))
                      in
@@ -7815,17 +7871,17 @@ let (tc_decls :
                     FStar_All.pipe_right ses_elaborated
                       (FStar_List.map
                          (fun se1  ->
-                            (let uu____13769 =
+                            (let uu____13781 =
                                FStar_TypeChecker_Env.debug env2
                                  (FStar_Options.Other "UF")
                                 in
-                             if uu____13769
+                             if uu____13781
                              then
-                               let uu____13773 =
+                               let uu____13785 =
                                  FStar_Syntax_Print.sigelt_to_string se1  in
                                FStar_Util.print1
                                  "About to elim vars from (elaborated) %s\\m"
-                                 uu____13773
+                                 uu____13785
                              else ());
                             FStar_TypeChecker_Normalize.elim_uvars env2 se1))
                      in
@@ -7850,43 +7906,43 @@ let (tc_decls :
                            env2)
                        in
                     FStar_Syntax_Unionfind.reset ();
-                    (let uu____13791 =
+                    (let uu____13803 =
                        (FStar_Options.log_types ()) ||
                          (FStar_All.pipe_left
                             (FStar_TypeChecker_Env.debug env3)
                             (FStar_Options.Other "LogTypes"))
                         in
-                     if uu____13791
+                     if uu____13803
                      then
-                       let uu____13796 =
+                       let uu____13808 =
                          FStar_List.fold_left
                            (fun s  ->
                               fun se1  ->
-                                let uu____13805 =
-                                  let uu____13807 =
+                                let uu____13817 =
+                                  let uu____13819 =
                                     FStar_Syntax_Print.sigelt_to_string se1
                                      in
-                                  Prims.op_Hat uu____13807 "\n"  in
-                                Prims.op_Hat s uu____13805) "" ses'1
+                                  Prims.op_Hat uu____13819 "\n"  in
+                                Prims.op_Hat s uu____13817) "" ses'1
                           in
-                       FStar_Util.print1 "Checked: %s\n" uu____13796
+                       FStar_Util.print1 "Checked: %s\n" uu____13808
                      else ());
                     FStar_List.iter
                       (fun se1  ->
                          (env3.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.encode_sig
                            env3 se1) ses'1;
-                    (let uu____13817 =
-                       let uu____13826 =
+                    (let uu____13829 =
+                       let uu____13838 =
                          FStar_Options.use_extracted_interfaces ()  in
-                       if uu____13826
+                       if uu____13838
                        then ((FStar_List.rev_append ses'1 exports), [])
                        else
-                         (let accum_exports_hidden uu____13868 se1 =
-                            match uu____13868 with
+                         (let accum_exports_hidden uu____13880 se1 =
+                            match uu____13880 with
                             | (exports1,hidden1) ->
-                                let uu____13896 = for_export env3 hidden1 se1
+                                let uu____13908 = for_export env3 hidden1 se1
                                    in
-                                (match uu____13896 with
+                                (match uu____13908 with
                                  | (se_exported,hidden2) ->
                                      ((FStar_List.rev_append se_exported
                                          exports1), hidden2))
@@ -7894,33 +7950,33 @@ let (tc_decls :
                           FStar_List.fold_left accum_exports_hidden
                             (exports, hidden) ses'1)
                         in
-                     match uu____13817 with
+                     match uu____13829 with
                      | (exports1,hidden1) ->
                          (((FStar_List.rev_append ses'1 ses1), exports1,
                             env3, hidden1), ses_elaborated1))))))
          in
       let process_one_decl_timed acc se =
-        let uu____14050 = acc  in
-        match uu____14050 with
-        | (uu____14085,uu____14086,env1,uu____14088) ->
+        let uu____14062 = acc  in
+        match uu____14062 with
+        | (uu____14097,uu____14098,env1,uu____14100) ->
             let r =
-              let uu____14122 =
-                let uu____14126 =
-                  let uu____14128 = FStar_TypeChecker_Env.current_module env1
+              let uu____14134 =
+                let uu____14138 =
+                  let uu____14140 = FStar_TypeChecker_Env.current_module env1
                      in
-                  FStar_Ident.string_of_lid uu____14128  in
-                FStar_Pervasives_Native.Some uu____14126  in
+                  FStar_Ident.string_of_lid uu____14140  in
+                FStar_Pervasives_Native.Some uu____14138  in
               FStar_Profiling.profile
-                (fun uu____14151  -> process_one_decl acc se) uu____14122
+                (fun uu____14163  -> process_one_decl acc se) uu____14134
                 "FStar.TypeChecker.Tc.process_one_decl"
                in
-            ((let uu____14154 = FStar_Options.profile_group_by_decls ()  in
-              if uu____14154
+            ((let uu____14166 = FStar_Options.profile_group_by_decls ()  in
+              if uu____14166
               then
                 let tag =
                   match FStar_Syntax_Util.lids_of_sigelt se with
-                  | hd1::uu____14161 -> FStar_Ident.string_of_lid hd1
-                  | uu____14164 ->
+                  | hd1::uu____14173 -> FStar_Ident.string_of_lid hd1
+                  | uu____14176 ->
                       FStar_Range.string_of_range
                         (FStar_Syntax_Util.range_of_sigelt se)
                    in
@@ -7928,11 +7984,11 @@ let (tc_decls :
               else ());
              r)
          in
-      let uu____14169 =
+      let uu____14181 =
         FStar_Util.fold_flatten process_one_decl_timed ([], [], env, []) ses
          in
-      match uu____14169 with
-      | (ses1,exports,env1,uu____14217) ->
+      match uu____14181 with
+      | (ses1,exports,env1,uu____14229) ->
           ((FStar_List.rev_append ses1 []),
             (FStar_List.rev_append exports []), env1)
   
@@ -7945,191 +8001,193 @@ let (check_exports :
     fun modul  ->
       fun exports  ->
         let env1 =
-          let uu___1850_14255 = env  in
+          let uu___1854_14267 = env  in
           {
             FStar_TypeChecker_Env.solver =
-              (uu___1850_14255.FStar_TypeChecker_Env.solver);
+              (uu___1854_14267.FStar_TypeChecker_Env.solver);
             FStar_TypeChecker_Env.range =
-              (uu___1850_14255.FStar_TypeChecker_Env.range);
+              (uu___1854_14267.FStar_TypeChecker_Env.range);
             FStar_TypeChecker_Env.curmodule =
-              (uu___1850_14255.FStar_TypeChecker_Env.curmodule);
+              (uu___1854_14267.FStar_TypeChecker_Env.curmodule);
             FStar_TypeChecker_Env.gamma =
-              (uu___1850_14255.FStar_TypeChecker_Env.gamma);
+              (uu___1854_14267.FStar_TypeChecker_Env.gamma);
             FStar_TypeChecker_Env.gamma_sig =
-              (uu___1850_14255.FStar_TypeChecker_Env.gamma_sig);
+              (uu___1854_14267.FStar_TypeChecker_Env.gamma_sig);
             FStar_TypeChecker_Env.gamma_cache =
-              (uu___1850_14255.FStar_TypeChecker_Env.gamma_cache);
+              (uu___1854_14267.FStar_TypeChecker_Env.gamma_cache);
             FStar_TypeChecker_Env.modules =
-              (uu___1850_14255.FStar_TypeChecker_Env.modules);
+              (uu___1854_14267.FStar_TypeChecker_Env.modules);
             FStar_TypeChecker_Env.expected_typ =
-              (uu___1850_14255.FStar_TypeChecker_Env.expected_typ);
+              (uu___1854_14267.FStar_TypeChecker_Env.expected_typ);
             FStar_TypeChecker_Env.sigtab =
-              (uu___1850_14255.FStar_TypeChecker_Env.sigtab);
+              (uu___1854_14267.FStar_TypeChecker_Env.sigtab);
             FStar_TypeChecker_Env.attrtab =
-              (uu___1850_14255.FStar_TypeChecker_Env.attrtab);
+              (uu___1854_14267.FStar_TypeChecker_Env.attrtab);
             FStar_TypeChecker_Env.is_pattern =
-              (uu___1850_14255.FStar_TypeChecker_Env.is_pattern);
+              (uu___1854_14267.FStar_TypeChecker_Env.is_pattern);
             FStar_TypeChecker_Env.instantiate_imp =
-              (uu___1850_14255.FStar_TypeChecker_Env.instantiate_imp);
+              (uu___1854_14267.FStar_TypeChecker_Env.instantiate_imp);
             FStar_TypeChecker_Env.effects =
-              (uu___1850_14255.FStar_TypeChecker_Env.effects);
+              (uu___1854_14267.FStar_TypeChecker_Env.effects);
             FStar_TypeChecker_Env.generalize =
-              (uu___1850_14255.FStar_TypeChecker_Env.generalize);
+              (uu___1854_14267.FStar_TypeChecker_Env.generalize);
             FStar_TypeChecker_Env.letrecs =
-              (uu___1850_14255.FStar_TypeChecker_Env.letrecs);
+              (uu___1854_14267.FStar_TypeChecker_Env.letrecs);
             FStar_TypeChecker_Env.top_level = true;
             FStar_TypeChecker_Env.check_uvars =
-              (uu___1850_14255.FStar_TypeChecker_Env.check_uvars);
+              (uu___1854_14267.FStar_TypeChecker_Env.check_uvars);
             FStar_TypeChecker_Env.use_eq =
-              (uu___1850_14255.FStar_TypeChecker_Env.use_eq);
+              (uu___1854_14267.FStar_TypeChecker_Env.use_eq);
             FStar_TypeChecker_Env.is_iface =
-              (uu___1850_14255.FStar_TypeChecker_Env.is_iface);
+              (uu___1854_14267.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit =
-              (uu___1850_14255.FStar_TypeChecker_Env.admit);
+              (uu___1854_14267.FStar_TypeChecker_Env.admit);
             FStar_TypeChecker_Env.lax = true;
             FStar_TypeChecker_Env.lax_universes = true;
             FStar_TypeChecker_Env.phase1 =
-              (uu___1850_14255.FStar_TypeChecker_Env.phase1);
+              (uu___1854_14267.FStar_TypeChecker_Env.phase1);
             FStar_TypeChecker_Env.failhard =
-              (uu___1850_14255.FStar_TypeChecker_Env.failhard);
+              (uu___1854_14267.FStar_TypeChecker_Env.failhard);
             FStar_TypeChecker_Env.nosynth =
-              (uu___1850_14255.FStar_TypeChecker_Env.nosynth);
+              (uu___1854_14267.FStar_TypeChecker_Env.nosynth);
             FStar_TypeChecker_Env.uvar_subtyping =
-              (uu___1850_14255.FStar_TypeChecker_Env.uvar_subtyping);
+              (uu___1854_14267.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.tc_term =
-              (uu___1850_14255.FStar_TypeChecker_Env.tc_term);
+              (uu___1854_14267.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.type_of =
-              (uu___1850_14255.FStar_TypeChecker_Env.type_of);
+              (uu___1854_14267.FStar_TypeChecker_Env.type_of);
             FStar_TypeChecker_Env.universe_of =
-              (uu___1850_14255.FStar_TypeChecker_Env.universe_of);
+              (uu___1854_14267.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.check_type_of =
-              (uu___1850_14255.FStar_TypeChecker_Env.check_type_of);
+              (uu___1854_14267.FStar_TypeChecker_Env.check_type_of);
             FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___1850_14255.FStar_TypeChecker_Env.use_bv_sorts);
+              (uu___1854_14267.FStar_TypeChecker_Env.use_bv_sorts);
             FStar_TypeChecker_Env.qtbl_name_and_index =
-              (uu___1850_14255.FStar_TypeChecker_Env.qtbl_name_and_index);
+              (uu___1854_14267.FStar_TypeChecker_Env.qtbl_name_and_index);
             FStar_TypeChecker_Env.normalized_eff_names =
-              (uu___1850_14255.FStar_TypeChecker_Env.normalized_eff_names);
+              (uu___1854_14267.FStar_TypeChecker_Env.normalized_eff_names);
             FStar_TypeChecker_Env.fv_delta_depths =
-              (uu___1850_14255.FStar_TypeChecker_Env.fv_delta_depths);
+              (uu___1854_14267.FStar_TypeChecker_Env.fv_delta_depths);
             FStar_TypeChecker_Env.proof_ns =
-              (uu___1850_14255.FStar_TypeChecker_Env.proof_ns);
+              (uu___1854_14267.FStar_TypeChecker_Env.proof_ns);
             FStar_TypeChecker_Env.synth_hook =
-              (uu___1850_14255.FStar_TypeChecker_Env.synth_hook);
+              (uu___1854_14267.FStar_TypeChecker_Env.synth_hook);
             FStar_TypeChecker_Env.splice =
-              (uu___1850_14255.FStar_TypeChecker_Env.splice);
+              (uu___1854_14267.FStar_TypeChecker_Env.splice);
             FStar_TypeChecker_Env.postprocess =
-              (uu___1850_14255.FStar_TypeChecker_Env.postprocess);
+              (uu___1854_14267.FStar_TypeChecker_Env.postprocess);
             FStar_TypeChecker_Env.is_native_tactic =
-              (uu___1850_14255.FStar_TypeChecker_Env.is_native_tactic);
+              (uu___1854_14267.FStar_TypeChecker_Env.is_native_tactic);
             FStar_TypeChecker_Env.identifier_info =
-              (uu___1850_14255.FStar_TypeChecker_Env.identifier_info);
+              (uu___1854_14267.FStar_TypeChecker_Env.identifier_info);
             FStar_TypeChecker_Env.tc_hooks =
-              (uu___1850_14255.FStar_TypeChecker_Env.tc_hooks);
+              (uu___1854_14267.FStar_TypeChecker_Env.tc_hooks);
             FStar_TypeChecker_Env.dsenv =
-              (uu___1850_14255.FStar_TypeChecker_Env.dsenv);
+              (uu___1854_14267.FStar_TypeChecker_Env.dsenv);
             FStar_TypeChecker_Env.nbe =
-              (uu___1850_14255.FStar_TypeChecker_Env.nbe);
+              (uu___1854_14267.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___1850_14255.FStar_TypeChecker_Env.strict_args_tab)
+              (uu___1854_14267.FStar_TypeChecker_Env.strict_args_tab);
+            FStar_TypeChecker_Env.erasable_types_tab =
+              (uu___1854_14267.FStar_TypeChecker_Env.erasable_types_tab)
           }  in
         let check_term lid univs1 t =
-          let uu____14275 = FStar_Syntax_Subst.open_univ_vars univs1 t  in
-          match uu____14275 with
+          let uu____14287 = FStar_Syntax_Subst.open_univ_vars univs1 t  in
+          match uu____14287 with
           | (univs2,t1) ->
-              ((let uu____14283 =
-                  let uu____14285 =
-                    let uu____14291 =
+              ((let uu____14295 =
+                  let uu____14297 =
+                    let uu____14303 =
                       FStar_TypeChecker_Env.set_current_module env1
                         modul.FStar_Syntax_Syntax.name
                        in
-                    FStar_TypeChecker_Env.debug uu____14291  in
-                  FStar_All.pipe_left uu____14285
+                    FStar_TypeChecker_Env.debug uu____14303  in
+                  FStar_All.pipe_left uu____14297
                     (FStar_Options.Other "Exports")
                    in
-                if uu____14283
+                if uu____14295
                 then
-                  let uu____14295 = FStar_Syntax_Print.lid_to_string lid  in
-                  let uu____14297 =
-                    let uu____14299 =
+                  let uu____14307 = FStar_Syntax_Print.lid_to_string lid  in
+                  let uu____14309 =
+                    let uu____14311 =
                       FStar_All.pipe_right univs2
                         (FStar_List.map
                            (fun x  ->
                               FStar_Syntax_Print.univ_to_string
                                 (FStar_Syntax_Syntax.U_name x)))
                        in
-                    FStar_All.pipe_right uu____14299
+                    FStar_All.pipe_right uu____14311
                       (FStar_String.concat ", ")
                      in
-                  let uu____14316 = FStar_Syntax_Print.term_to_string t1  in
+                  let uu____14328 = FStar_Syntax_Print.term_to_string t1  in
                   FStar_Util.print3 "Checking for export %s <%s> : %s\n"
-                    uu____14295 uu____14297 uu____14316
+                    uu____14307 uu____14309 uu____14328
                 else ());
                (let env2 = FStar_TypeChecker_Env.push_univ_vars env1 univs2
                    in
-                let uu____14322 =
+                let uu____14334 =
                   FStar_TypeChecker_TcTerm.tc_trivial_guard env2 t1  in
-                FStar_All.pipe_right uu____14322 (fun a2  -> ())))
+                FStar_All.pipe_right uu____14334 (fun a2  -> ())))
            in
         let check_term1 lid univs1 t =
-          (let uu____14348 =
-             let uu____14350 =
+          (let uu____14360 =
+             let uu____14362 =
                FStar_Syntax_Print.lid_to_string
                  modul.FStar_Syntax_Syntax.name
                 in
-             let uu____14352 = FStar_Syntax_Print.lid_to_string lid  in
+             let uu____14364 = FStar_Syntax_Print.lid_to_string lid  in
              FStar_Util.format2
                "Interface of %s violates its abstraction (add a 'private' qualifier to '%s'?)"
-               uu____14350 uu____14352
+               uu____14362 uu____14364
               in
-           FStar_Errors.message_prefix.FStar_Errors.set_prefix uu____14348);
+           FStar_Errors.message_prefix.FStar_Errors.set_prefix uu____14360);
           check_term lid univs1 t;
           FStar_Errors.message_prefix.FStar_Errors.clear_prefix ()  in
         let rec check_sigelt se =
           match se.FStar_Syntax_Syntax.sigel with
-          | FStar_Syntax_Syntax.Sig_bundle (ses,uu____14363) ->
-              let uu____14372 =
-                let uu____14374 =
+          | FStar_Syntax_Syntax.Sig_bundle (ses,uu____14375) ->
+              let uu____14384 =
+                let uu____14386 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                     (FStar_List.contains FStar_Syntax_Syntax.Private)
                    in
-                Prims.op_Negation uu____14374  in
-              if uu____14372
+                Prims.op_Negation uu____14386  in
+              if uu____14384
               then FStar_All.pipe_right ses (FStar_List.iter check_sigelt)
               else ()
           | FStar_Syntax_Syntax.Sig_inductive_typ
-              (l,univs1,binders,typ,uu____14388,uu____14389) ->
+              (l,univs1,binders,typ,uu____14400,uu____14401) ->
               let t =
-                let uu____14401 =
-                  let uu____14408 =
-                    let uu____14409 =
-                      let uu____14424 = FStar_Syntax_Syntax.mk_Total typ  in
-                      (binders, uu____14424)  in
-                    FStar_Syntax_Syntax.Tm_arrow uu____14409  in
-                  FStar_Syntax_Syntax.mk uu____14408  in
-                uu____14401 FStar_Pervasives_Native.None
+                let uu____14413 =
+                  let uu____14420 =
+                    let uu____14421 =
+                      let uu____14436 = FStar_Syntax_Syntax.mk_Total typ  in
+                      (binders, uu____14436)  in
+                    FStar_Syntax_Syntax.Tm_arrow uu____14421  in
+                  FStar_Syntax_Syntax.mk uu____14420  in
+                uu____14413 FStar_Pervasives_Native.None
                   se.FStar_Syntax_Syntax.sigrng
                  in
               check_term1 l univs1 t
           | FStar_Syntax_Syntax.Sig_datacon
-              (l,univs1,t,uu____14440,uu____14441,uu____14442) ->
+              (l,univs1,t,uu____14452,uu____14453,uu____14454) ->
               check_term1 l univs1 t
           | FStar_Syntax_Syntax.Sig_declare_typ (l,univs1,t) ->
-              let uu____14452 =
-                let uu____14454 =
+              let uu____14464 =
+                let uu____14466 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                     (FStar_List.contains FStar_Syntax_Syntax.Private)
                    in
-                Prims.op_Negation uu____14454  in
-              if uu____14452 then check_term1 l univs1 t else ()
-          | FStar_Syntax_Syntax.Sig_let ((uu____14462,lbs),uu____14464) ->
-              let uu____14475 =
-                let uu____14477 =
+                Prims.op_Negation uu____14466  in
+              if uu____14464 then check_term1 l univs1 t else ()
+          | FStar_Syntax_Syntax.Sig_let ((uu____14474,lbs),uu____14476) ->
+              let uu____14487 =
+                let uu____14489 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                     (FStar_List.contains FStar_Syntax_Syntax.Private)
                    in
-                Prims.op_Negation uu____14477  in
-              if uu____14475
+                Prims.op_Negation uu____14489  in
+              if uu____14487
               then
                 FStar_All.pipe_right lbs
                   (FStar_List.iter
@@ -8143,13 +8201,13 @@ let (check_exports :
               else ()
           | FStar_Syntax_Syntax.Sig_effect_abbrev
               (l,univs1,binders,comp,flags) ->
-              let uu____14500 =
-                let uu____14502 =
+              let uu____14512 =
+                let uu____14514 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                     (FStar_List.contains FStar_Syntax_Syntax.Private)
                    in
-                Prims.op_Negation uu____14502  in
-              if uu____14500
+                Prims.op_Negation uu____14514  in
+              if uu____14512
               then
                 let arrow1 =
                   FStar_Syntax_Syntax.mk
@@ -8159,18 +8217,18 @@ let (check_exports :
                    in
                 check_term1 l univs1 arrow1
               else ()
-          | FStar_Syntax_Syntax.Sig_main uu____14523 -> ()
-          | FStar_Syntax_Syntax.Sig_assume uu____14524 -> ()
-          | FStar_Syntax_Syntax.Sig_new_effect uu____14531 -> ()
-          | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____14532 -> ()
-          | FStar_Syntax_Syntax.Sig_sub_effect uu____14533 -> ()
-          | FStar_Syntax_Syntax.Sig_splice uu____14534 -> ()
-          | FStar_Syntax_Syntax.Sig_pragma uu____14541 -> ()  in
-        let uu____14542 =
+          | FStar_Syntax_Syntax.Sig_main uu____14535 -> ()
+          | FStar_Syntax_Syntax.Sig_assume uu____14536 -> ()
+          | FStar_Syntax_Syntax.Sig_new_effect uu____14543 -> ()
+          | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____14544 -> ()
+          | FStar_Syntax_Syntax.Sig_sub_effect uu____14545 -> ()
+          | FStar_Syntax_Syntax.Sig_splice uu____14546 -> ()
+          | FStar_Syntax_Syntax.Sig_pragma uu____14553 -> ()  in
+        let uu____14554 =
           FStar_Ident.lid_equals modul.FStar_Syntax_Syntax.name
             FStar_Parser_Const.prims_lid
            in
-        if uu____14542 then () else FStar_List.iter check_sigelt exports
+        if uu____14554 then () else FStar_List.iter check_sigelt exports
   
 let (extract_interface :
   FStar_TypeChecker_Env.env ->
@@ -8218,97 +8276,97 @@ let (extract_interface :
           (fun q  ->
              match q with
              | FStar_Syntax_Syntax.Discriminator l -> true
-             | FStar_Syntax_Syntax.Projector (l,uu____14648) -> true
-             | uu____14650 -> false) quals
+             | FStar_Syntax_Syntax.Projector (l,uu____14660) -> true
+             | uu____14662 -> false) quals
          in
       let vals_of_abstract_inductive s =
         let mk_typ_for_abstract_inductive bs t r =
           match bs with
           | [] -> t
-          | uu____14680 ->
+          | uu____14692 ->
               (match t.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_arrow (bs',c) ->
                    FStar_Syntax_Syntax.mk
                      (FStar_Syntax_Syntax.Tm_arrow
                         ((FStar_List.append bs bs'), c))
                      FStar_Pervasives_Native.None r
-               | uu____14719 ->
-                   let uu____14720 =
-                     let uu____14727 =
-                       let uu____14728 =
-                         let uu____14743 = FStar_Syntax_Syntax.mk_Total t  in
-                         (bs, uu____14743)  in
-                       FStar_Syntax_Syntax.Tm_arrow uu____14728  in
-                     FStar_Syntax_Syntax.mk uu____14727  in
-                   uu____14720 FStar_Pervasives_Native.None r)
+               | uu____14731 ->
+                   let uu____14732 =
+                     let uu____14739 =
+                       let uu____14740 =
+                         let uu____14755 = FStar_Syntax_Syntax.mk_Total t  in
+                         (bs, uu____14755)  in
+                       FStar_Syntax_Syntax.Tm_arrow uu____14740  in
+                     FStar_Syntax_Syntax.mk uu____14739  in
+                   uu____14732 FStar_Pervasives_Native.None r)
            in
         match s.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_inductive_typ
-            (lid,uvs,bs,t,uu____14760,uu____14761) ->
+            (lid,uvs,bs,t,uu____14772,uu____14773) ->
             let s1 =
-              let uu___1976_14771 = s  in
-              let uu____14772 =
-                let uu____14773 =
-                  let uu____14780 =
+              let uu___1980_14783 = s  in
+              let uu____14784 =
+                let uu____14785 =
+                  let uu____14792 =
                     mk_typ_for_abstract_inductive bs t
                       s.FStar_Syntax_Syntax.sigrng
                      in
-                  (lid, uvs, uu____14780)  in
-                FStar_Syntax_Syntax.Sig_declare_typ uu____14773  in
-              let uu____14781 =
-                let uu____14784 =
-                  let uu____14787 =
+                  (lid, uvs, uu____14792)  in
+                FStar_Syntax_Syntax.Sig_declare_typ uu____14785  in
+              let uu____14793 =
+                let uu____14796 =
+                  let uu____14799 =
                     filter_out_abstract_and_noeq
                       s.FStar_Syntax_Syntax.sigquals
                      in
-                  FStar_Syntax_Syntax.New :: uu____14787  in
-                FStar_Syntax_Syntax.Assumption :: uu____14784  in
+                  FStar_Syntax_Syntax.New :: uu____14799  in
+                FStar_Syntax_Syntax.Assumption :: uu____14796  in
               {
-                FStar_Syntax_Syntax.sigel = uu____14772;
+                FStar_Syntax_Syntax.sigel = uu____14784;
                 FStar_Syntax_Syntax.sigrng =
-                  (uu___1976_14771.FStar_Syntax_Syntax.sigrng);
-                FStar_Syntax_Syntax.sigquals = uu____14781;
+                  (uu___1980_14783.FStar_Syntax_Syntax.sigrng);
+                FStar_Syntax_Syntax.sigquals = uu____14793;
                 FStar_Syntax_Syntax.sigmeta =
-                  (uu___1976_14771.FStar_Syntax_Syntax.sigmeta);
+                  (uu___1980_14783.FStar_Syntax_Syntax.sigmeta);
                 FStar_Syntax_Syntax.sigattrs =
-                  (uu___1976_14771.FStar_Syntax_Syntax.sigattrs)
+                  (uu___1980_14783.FStar_Syntax_Syntax.sigattrs)
               }  in
             [s1]
-        | uu____14790 -> failwith "Impossible!"  in
-      let val_of_lb s lid uu____14815 lbdef =
-        match uu____14815 with
+        | uu____14802 -> failwith "Impossible!"  in
+      let val_of_lb s lid uu____14827 lbdef =
+        match uu____14827 with
         | (uvs,t) ->
             let attrs =
-              let uu____14826 =
+              let uu____14838 =
                 FStar_TypeChecker_Util.must_erase_for_extraction en lbdef  in
-              if uu____14826
+              if uu____14838
               then
-                let uu____14831 =
-                  let uu____14832 =
+                let uu____14843 =
+                  let uu____14844 =
                     FStar_Syntax_Syntax.lid_as_fv
                       FStar_Parser_Const.must_erase_for_extraction_attr
                       FStar_Syntax_Syntax.delta_constant
                       FStar_Pervasives_Native.None
                      in
-                  FStar_All.pipe_right uu____14832
+                  FStar_All.pipe_right uu____14844
                     FStar_Syntax_Syntax.fv_to_tm
                    in
-                uu____14831 :: (s.FStar_Syntax_Syntax.sigattrs)
+                uu____14843 :: (s.FStar_Syntax_Syntax.sigattrs)
               else s.FStar_Syntax_Syntax.sigattrs  in
-            let uu___1989_14835 = s  in
-            let uu____14836 =
-              let uu____14839 =
+            let uu___1993_14847 = s  in
+            let uu____14848 =
+              let uu____14851 =
                 filter_out_abstract_and_inline s.FStar_Syntax_Syntax.sigquals
                  in
-              FStar_Syntax_Syntax.Assumption :: uu____14839  in
+              FStar_Syntax_Syntax.Assumption :: uu____14851  in
             {
               FStar_Syntax_Syntax.sigel =
                 (FStar_Syntax_Syntax.Sig_declare_typ (lid, uvs, t));
               FStar_Syntax_Syntax.sigrng =
-                (uu___1989_14835.FStar_Syntax_Syntax.sigrng);
-              FStar_Syntax_Syntax.sigquals = uu____14836;
+                (uu___1993_14847.FStar_Syntax_Syntax.sigrng);
+              FStar_Syntax_Syntax.sigquals = uu____14848;
               FStar_Syntax_Syntax.sigmeta =
-                (uu___1989_14835.FStar_Syntax_Syntax.sigmeta);
+                (uu___1993_14847.FStar_Syntax_Syntax.sigmeta);
               FStar_Syntax_Syntax.sigattrs = attrs
             }
          in
@@ -8316,51 +8374,51 @@ let (extract_interface :
         let comp_effect_name1 c =
           match c.FStar_Syntax_Syntax.n with
           | FStar_Syntax_Syntax.Comp c1 -> c1.FStar_Syntax_Syntax.effect_name
-          | uu____14857 -> failwith "Impossible!"  in
+          | uu____14869 -> failwith "Impossible!"  in
         let c_opt =
-          let uu____14864 = FStar_Syntax_Util.is_unit t  in
-          if uu____14864
+          let uu____14876 = FStar_Syntax_Util.is_unit t  in
+          if uu____14876
           then
-            let uu____14871 = FStar_Syntax_Syntax.mk_Total t  in
-            FStar_Pervasives_Native.Some uu____14871
+            let uu____14883 = FStar_Syntax_Syntax.mk_Total t  in
+            FStar_Pervasives_Native.Some uu____14883
           else
-            (let uu____14878 =
-               let uu____14879 = FStar_Syntax_Subst.compress t  in
-               uu____14879.FStar_Syntax_Syntax.n  in
-             match uu____14878 with
-             | FStar_Syntax_Syntax.Tm_arrow (uu____14886,c) ->
+            (let uu____14890 =
+               let uu____14891 = FStar_Syntax_Subst.compress t  in
+               uu____14891.FStar_Syntax_Syntax.n  in
+             match uu____14890 with
+             | FStar_Syntax_Syntax.Tm_arrow (uu____14898,c) ->
                  FStar_Pervasives_Native.Some c
-             | uu____14910 -> FStar_Pervasives_Native.None)
+             | uu____14922 -> FStar_Pervasives_Native.None)
            in
         match c_opt with
         | FStar_Pervasives_Native.None  -> true
         | FStar_Pervasives_Native.Some c ->
-            let uu____14922 = FStar_Syntax_Util.is_lemma_comp c  in
-            if uu____14922
+            let uu____14934 = FStar_Syntax_Util.is_lemma_comp c  in
+            if uu____14934
             then false
             else
-              (let uu____14929 = FStar_Syntax_Util.is_pure_or_ghost_comp c
+              (let uu____14941 = FStar_Syntax_Util.is_pure_or_ghost_comp c
                   in
-               if uu____14929
+               if uu____14941
                then true
                else
-                 (let uu____14936 = comp_effect_name1 c  in
-                  FStar_TypeChecker_Env.is_reifiable_effect en uu____14936))
+                 (let uu____14948 = comp_effect_name1 c  in
+                  FStar_TypeChecker_Env.is_reifiable_effect en uu____14948))
          in
       let extract_sigelt s =
-        (let uu____14948 =
+        (let uu____14960 =
            FStar_TypeChecker_Env.debug en FStar_Options.Extreme  in
-         if uu____14948
+         if uu____14960
          then
-           let uu____14951 = FStar_Syntax_Print.sigelt_to_string s  in
-           FStar_Util.print1 "Extracting interface for %s\n" uu____14951
+           let uu____14963 = FStar_Syntax_Print.sigelt_to_string s  in
+           FStar_Util.print1 "Extracting interface for %s\n" uu____14963
          else ());
         (match s.FStar_Syntax_Syntax.sigel with
-         | FStar_Syntax_Syntax.Sig_inductive_typ uu____14958 ->
+         | FStar_Syntax_Syntax.Sig_inductive_typ uu____14970 ->
              failwith "Impossible! extract_interface: bare data constructor"
-         | FStar_Syntax_Syntax.Sig_datacon uu____14978 ->
+         | FStar_Syntax_Syntax.Sig_datacon uu____14990 ->
              failwith "Impossible! extract_interface: bare data constructor"
-         | FStar_Syntax_Syntax.Sig_splice uu____14997 ->
+         | FStar_Syntax_Syntax.Sig_splice uu____15009 ->
              failwith
                "Impossible! extract_interface: trying to extract splice"
          | FStar_Syntax_Syntax.Sig_bundle (sigelts,lidents1) ->
@@ -8372,72 +8430,72 @@ let (extract_interface :
                        fun s1  ->
                          match s1.FStar_Syntax_Syntax.sigel with
                          | FStar_Syntax_Syntax.Sig_inductive_typ
-                             (lid,uu____15043,uu____15044,uu____15045,uu____15046,uu____15047)
+                             (lid,uu____15055,uu____15056,uu____15057,uu____15058,uu____15059)
                              ->
-                             ((let uu____15057 =
-                                 let uu____15060 =
+                             ((let uu____15069 =
+                                 let uu____15072 =
                                    FStar_ST.op_Bang abstract_inductive_tycons
                                     in
-                                 lid :: uu____15060  in
+                                 lid :: uu____15072  in
                                FStar_ST.op_Colon_Equals
-                                 abstract_inductive_tycons uu____15057);
-                              (let uu____15109 =
+                                 abstract_inductive_tycons uu____15069);
+                              (let uu____15121 =
                                  vals_of_abstract_inductive s1  in
-                               FStar_List.append uu____15109 sigelts1))
+                               FStar_List.append uu____15121 sigelts1))
                          | FStar_Syntax_Syntax.Sig_datacon
-                             (lid,uu____15113,uu____15114,uu____15115,uu____15116,uu____15117)
+                             (lid,uu____15125,uu____15126,uu____15127,uu____15128,uu____15129)
                              ->
-                             ((let uu____15125 =
-                                 let uu____15128 =
+                             ((let uu____15137 =
+                                 let uu____15140 =
                                    FStar_ST.op_Bang
                                      abstract_inductive_datacons
                                     in
-                                 lid :: uu____15128  in
+                                 lid :: uu____15140  in
                                FStar_ST.op_Colon_Equals
-                                 abstract_inductive_datacons uu____15125);
+                                 abstract_inductive_datacons uu____15137);
                               sigelts1)
-                         | uu____15177 ->
+                         | uu____15189 ->
                              failwith
                                "Impossible! extract_interface: Sig_bundle can't have anything other than Sig_inductive_typ and Sig_datacon")
                     [])
              else [s]
          | FStar_Syntax_Syntax.Sig_declare_typ (lid,uvs,t) ->
-             let uu____15186 =
+             let uu____15198 =
                is_projector_or_discriminator_of_an_abstract_inductive
                  s.FStar_Syntax_Syntax.sigquals
                 in
-             if uu____15186
+             if uu____15198
              then []
              else
                if is_assume s.FStar_Syntax_Syntax.sigquals
                then
-                 (let uu____15196 =
-                    let uu___2053_15197 = s  in
-                    let uu____15198 =
+                 (let uu____15208 =
+                    let uu___2057_15209 = s  in
+                    let uu____15210 =
                       filter_out_abstract s.FStar_Syntax_Syntax.sigquals  in
                     {
                       FStar_Syntax_Syntax.sigel =
-                        (uu___2053_15197.FStar_Syntax_Syntax.sigel);
+                        (uu___2057_15209.FStar_Syntax_Syntax.sigel);
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___2053_15197.FStar_Syntax_Syntax.sigrng);
-                      FStar_Syntax_Syntax.sigquals = uu____15198;
+                        (uu___2057_15209.FStar_Syntax_Syntax.sigrng);
+                      FStar_Syntax_Syntax.sigquals = uu____15210;
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___2053_15197.FStar_Syntax_Syntax.sigmeta);
+                        (uu___2057_15209.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___2053_15197.FStar_Syntax_Syntax.sigattrs)
+                        (uu___2057_15209.FStar_Syntax_Syntax.sigattrs)
                     }  in
-                  [uu____15196])
+                  [uu____15208])
                else []
          | FStar_Syntax_Syntax.Sig_let (lbs,lids) ->
-             let uu____15209 =
+             let uu____15221 =
                is_projector_or_discriminator_of_an_abstract_inductive
                  s.FStar_Syntax_Syntax.sigquals
                 in
-             if uu____15209
+             if uu____15221
              then []
              else
-               (let uu____15216 = lbs  in
-                match uu____15216 with
+               (let uu____15228 = lbs  in
+                match uu____15228 with
                 | (flbs,slbs) ->
                     let typs_and_defs =
                       FStar_All.pipe_right slbs
@@ -8449,17 +8507,17 @@ let (extract_interface :
                        in
                     let is_lemma1 =
                       FStar_List.existsML
-                        (fun uu____15278  ->
-                           match uu____15278 with
-                           | (uu____15286,t,uu____15288) ->
+                        (fun uu____15290  ->
+                           match uu____15290 with
+                           | (uu____15298,t,uu____15300) ->
                                FStar_All.pipe_right t
                                  FStar_Syntax_Util.is_lemma) typs_and_defs
                        in
                     let vals =
                       FStar_List.map2
                         (fun lid  ->
-                           fun uu____15305  ->
-                             match uu____15305 with
+                           fun uu____15317  ->
+                             match uu____15317 with
                              | (u,t,d) -> val_of_lb s lid (u, t) d) lids
                         typs_and_defs
                        in
@@ -8471,9 +8529,9 @@ let (extract_interface :
                     else
                       (let should_keep_defs =
                          FStar_List.existsML
-                           (fun uu____15332  ->
-                              match uu____15332 with
-                              | (uu____15340,t,uu____15342) ->
+                           (fun uu____15344  ->
+                              match uu____15344 with
+                              | (uu____15352,t,uu____15354) ->
                                   FStar_All.pipe_right t should_keep_lbdef)
                            typs_and_defs
                           in
@@ -8481,75 +8539,75 @@ let (extract_interface :
          | FStar_Syntax_Syntax.Sig_main t ->
              failwith
                "Did not anticipate main would arise when extracting interfaces!"
-         | FStar_Syntax_Syntax.Sig_assume (lid,uu____15354,uu____15355) ->
+         | FStar_Syntax_Syntax.Sig_assume (lid,uu____15366,uu____15367) ->
              let is_haseq = FStar_TypeChecker_TcInductive.is_haseq_lid lid
                 in
              if is_haseq
              then
                let is_haseq_of_abstract_inductive =
-                 let uu____15363 = FStar_ST.op_Bang abstract_inductive_tycons
+                 let uu____15375 = FStar_ST.op_Bang abstract_inductive_tycons
                     in
                  FStar_List.existsML
                    (fun l  ->
-                      let uu____15392 =
+                      let uu____15404 =
                         FStar_TypeChecker_TcInductive.get_haseq_axiom_lid l
                          in
-                      FStar_Ident.lid_equals lid uu____15392) uu____15363
+                      FStar_Ident.lid_equals lid uu____15404) uu____15375
                   in
                (if is_haseq_of_abstract_inductive
                 then
-                  let uu____15396 =
-                    let uu___2095_15397 = s  in
-                    let uu____15398 =
+                  let uu____15408 =
+                    let uu___2099_15409 = s  in
+                    let uu____15410 =
                       filter_out_abstract s.FStar_Syntax_Syntax.sigquals  in
                     {
                       FStar_Syntax_Syntax.sigel =
-                        (uu___2095_15397.FStar_Syntax_Syntax.sigel);
+                        (uu___2099_15409.FStar_Syntax_Syntax.sigel);
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___2095_15397.FStar_Syntax_Syntax.sigrng);
-                      FStar_Syntax_Syntax.sigquals = uu____15398;
+                        (uu___2099_15409.FStar_Syntax_Syntax.sigrng);
+                      FStar_Syntax_Syntax.sigquals = uu____15410;
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___2095_15397.FStar_Syntax_Syntax.sigmeta);
+                        (uu___2099_15409.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___2095_15397.FStar_Syntax_Syntax.sigattrs)
+                        (uu___2099_15409.FStar_Syntax_Syntax.sigattrs)
                     }  in
-                  [uu____15396]
+                  [uu____15408]
                 else [])
              else
-               (let uu____15405 =
-                  let uu___2097_15406 = s  in
-                  let uu____15407 =
+               (let uu____15417 =
+                  let uu___2101_15418 = s  in
+                  let uu____15419 =
                     filter_out_abstract s.FStar_Syntax_Syntax.sigquals  in
                   {
                     FStar_Syntax_Syntax.sigel =
-                      (uu___2097_15406.FStar_Syntax_Syntax.sigel);
+                      (uu___2101_15418.FStar_Syntax_Syntax.sigel);
                     FStar_Syntax_Syntax.sigrng =
-                      (uu___2097_15406.FStar_Syntax_Syntax.sigrng);
-                    FStar_Syntax_Syntax.sigquals = uu____15407;
+                      (uu___2101_15418.FStar_Syntax_Syntax.sigrng);
+                    FStar_Syntax_Syntax.sigquals = uu____15419;
                     FStar_Syntax_Syntax.sigmeta =
-                      (uu___2097_15406.FStar_Syntax_Syntax.sigmeta);
+                      (uu___2101_15418.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
-                      (uu___2097_15406.FStar_Syntax_Syntax.sigattrs)
+                      (uu___2101_15418.FStar_Syntax_Syntax.sigattrs)
                   }  in
-                [uu____15405])
-         | FStar_Syntax_Syntax.Sig_new_effect uu____15410 -> [s]
-         | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____15411 -> [s]
-         | FStar_Syntax_Syntax.Sig_sub_effect uu____15412 -> [s]
-         | FStar_Syntax_Syntax.Sig_effect_abbrev uu____15413 -> [s]
-         | FStar_Syntax_Syntax.Sig_pragma uu____15426 -> [s])
+                [uu____15417])
+         | FStar_Syntax_Syntax.Sig_new_effect uu____15422 -> [s]
+         | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____15423 -> [s]
+         | FStar_Syntax_Syntax.Sig_sub_effect uu____15424 -> [s]
+         | FStar_Syntax_Syntax.Sig_effect_abbrev uu____15425 -> [s]
+         | FStar_Syntax_Syntax.Sig_pragma uu____15438 -> [s])
          in
-      let uu___2109_15427 = m  in
-      let uu____15428 =
-        let uu____15429 =
+      let uu___2113_15439 = m  in
+      let uu____15440 =
+        let uu____15441 =
           FStar_All.pipe_right m.FStar_Syntax_Syntax.declarations
             (FStar_List.map extract_sigelt)
            in
-        FStar_All.pipe_right uu____15429 FStar_List.flatten  in
+        FStar_All.pipe_right uu____15441 FStar_List.flatten  in
       {
-        FStar_Syntax_Syntax.name = (uu___2109_15427.FStar_Syntax_Syntax.name);
-        FStar_Syntax_Syntax.declarations = uu____15428;
+        FStar_Syntax_Syntax.name = (uu___2113_15439.FStar_Syntax_Syntax.name);
+        FStar_Syntax_Syntax.declarations = uu____15440;
         FStar_Syntax_Syntax.exports =
-          (uu___2109_15427.FStar_Syntax_Syntax.exports);
+          (uu___2113_15439.FStar_Syntax_Syntax.exports);
         FStar_Syntax_Syntax.is_interface = true
       }
   
@@ -8562,7 +8620,7 @@ let (snapshot_context :
   fun env  ->
     fun msg  ->
       FStar_Util.atomically
-        (fun uu____15480  -> FStar_TypeChecker_Env.snapshot env msg)
+        (fun uu____15492  -> FStar_TypeChecker_Env.snapshot env msg)
   
 let (rollback_context :
   FStar_TypeChecker_Env.solver_t ->
@@ -8575,7 +8633,7 @@ let (rollback_context :
     fun msg  ->
       fun depth  ->
         FStar_Util.atomically
-          (fun uu____15527  ->
+          (fun uu____15539  ->
              let env = FStar_TypeChecker_Env.rollback solver msg depth  in
              env)
   
@@ -8583,8 +8641,8 @@ let (push_context :
   FStar_TypeChecker_Env.env -> Prims.string -> FStar_TypeChecker_Env.env) =
   fun env  ->
     fun msg  ->
-      let uu____15542 = snapshot_context env msg  in
-      FStar_Pervasives_Native.snd uu____15542
+      let uu____15554 = snapshot_context env msg  in
+      FStar_Pervasives_Native.snd uu____15554
   
 let (pop_context :
   FStar_TypeChecker_Env.env -> Prims.string -> FStar_TypeChecker_Env.env) =
@@ -8610,8 +8668,8 @@ let (tc_partial_modul :
         if modul.FStar_Syntax_Syntax.is_interface
         then "interface"
         else "implementation"  in
-      (let uu____15631 = FStar_Options.debug_any ()  in
-       if uu____15631
+      (let uu____15643 = FStar_Options.debug_any ()  in
+       if uu____15643
        then
          FStar_Util.print3 "%s %s of %s\n" action label1
            (modul.FStar_Syntax_Syntax.name).FStar_Ident.str
@@ -8623,113 +8681,115 @@ let (tc_partial_modul :
             else "module") (modul.FStar_Syntax_Syntax.name).FStar_Ident.str
           in
        let env1 =
-         let uu___2134_15647 = env  in
+         let uu___2138_15659 = env  in
          {
            FStar_TypeChecker_Env.solver =
-             (uu___2134_15647.FStar_TypeChecker_Env.solver);
+             (uu___2138_15659.FStar_TypeChecker_Env.solver);
            FStar_TypeChecker_Env.range =
-             (uu___2134_15647.FStar_TypeChecker_Env.range);
+             (uu___2138_15659.FStar_TypeChecker_Env.range);
            FStar_TypeChecker_Env.curmodule =
-             (uu___2134_15647.FStar_TypeChecker_Env.curmodule);
+             (uu___2138_15659.FStar_TypeChecker_Env.curmodule);
            FStar_TypeChecker_Env.gamma =
-             (uu___2134_15647.FStar_TypeChecker_Env.gamma);
+             (uu___2138_15659.FStar_TypeChecker_Env.gamma);
            FStar_TypeChecker_Env.gamma_sig =
-             (uu___2134_15647.FStar_TypeChecker_Env.gamma_sig);
+             (uu___2138_15659.FStar_TypeChecker_Env.gamma_sig);
            FStar_TypeChecker_Env.gamma_cache =
-             (uu___2134_15647.FStar_TypeChecker_Env.gamma_cache);
+             (uu___2138_15659.FStar_TypeChecker_Env.gamma_cache);
            FStar_TypeChecker_Env.modules =
-             (uu___2134_15647.FStar_TypeChecker_Env.modules);
+             (uu___2138_15659.FStar_TypeChecker_Env.modules);
            FStar_TypeChecker_Env.expected_typ =
-             (uu___2134_15647.FStar_TypeChecker_Env.expected_typ);
+             (uu___2138_15659.FStar_TypeChecker_Env.expected_typ);
            FStar_TypeChecker_Env.sigtab =
-             (uu___2134_15647.FStar_TypeChecker_Env.sigtab);
+             (uu___2138_15659.FStar_TypeChecker_Env.sigtab);
            FStar_TypeChecker_Env.attrtab =
-             (uu___2134_15647.FStar_TypeChecker_Env.attrtab);
+             (uu___2138_15659.FStar_TypeChecker_Env.attrtab);
            FStar_TypeChecker_Env.is_pattern =
-             (uu___2134_15647.FStar_TypeChecker_Env.is_pattern);
+             (uu___2138_15659.FStar_TypeChecker_Env.is_pattern);
            FStar_TypeChecker_Env.instantiate_imp =
-             (uu___2134_15647.FStar_TypeChecker_Env.instantiate_imp);
+             (uu___2138_15659.FStar_TypeChecker_Env.instantiate_imp);
            FStar_TypeChecker_Env.effects =
-             (uu___2134_15647.FStar_TypeChecker_Env.effects);
+             (uu___2138_15659.FStar_TypeChecker_Env.effects);
            FStar_TypeChecker_Env.generalize =
-             (uu___2134_15647.FStar_TypeChecker_Env.generalize);
+             (uu___2138_15659.FStar_TypeChecker_Env.generalize);
            FStar_TypeChecker_Env.letrecs =
-             (uu___2134_15647.FStar_TypeChecker_Env.letrecs);
+             (uu___2138_15659.FStar_TypeChecker_Env.letrecs);
            FStar_TypeChecker_Env.top_level =
-             (uu___2134_15647.FStar_TypeChecker_Env.top_level);
+             (uu___2138_15659.FStar_TypeChecker_Env.top_level);
            FStar_TypeChecker_Env.check_uvars =
-             (uu___2134_15647.FStar_TypeChecker_Env.check_uvars);
+             (uu___2138_15659.FStar_TypeChecker_Env.check_uvars);
            FStar_TypeChecker_Env.use_eq =
-             (uu___2134_15647.FStar_TypeChecker_Env.use_eq);
+             (uu___2138_15659.FStar_TypeChecker_Env.use_eq);
            FStar_TypeChecker_Env.is_iface =
              (modul.FStar_Syntax_Syntax.is_interface);
            FStar_TypeChecker_Env.admit = (Prims.op_Negation verify);
            FStar_TypeChecker_Env.lax =
-             (uu___2134_15647.FStar_TypeChecker_Env.lax);
+             (uu___2138_15659.FStar_TypeChecker_Env.lax);
            FStar_TypeChecker_Env.lax_universes =
-             (uu___2134_15647.FStar_TypeChecker_Env.lax_universes);
+             (uu___2138_15659.FStar_TypeChecker_Env.lax_universes);
            FStar_TypeChecker_Env.phase1 =
-             (uu___2134_15647.FStar_TypeChecker_Env.phase1);
+             (uu___2138_15659.FStar_TypeChecker_Env.phase1);
            FStar_TypeChecker_Env.failhard =
-             (uu___2134_15647.FStar_TypeChecker_Env.failhard);
+             (uu___2138_15659.FStar_TypeChecker_Env.failhard);
            FStar_TypeChecker_Env.nosynth =
-             (uu___2134_15647.FStar_TypeChecker_Env.nosynth);
+             (uu___2138_15659.FStar_TypeChecker_Env.nosynth);
            FStar_TypeChecker_Env.uvar_subtyping =
-             (uu___2134_15647.FStar_TypeChecker_Env.uvar_subtyping);
+             (uu___2138_15659.FStar_TypeChecker_Env.uvar_subtyping);
            FStar_TypeChecker_Env.tc_term =
-             (uu___2134_15647.FStar_TypeChecker_Env.tc_term);
+             (uu___2138_15659.FStar_TypeChecker_Env.tc_term);
            FStar_TypeChecker_Env.type_of =
-             (uu___2134_15647.FStar_TypeChecker_Env.type_of);
+             (uu___2138_15659.FStar_TypeChecker_Env.type_of);
            FStar_TypeChecker_Env.universe_of =
-             (uu___2134_15647.FStar_TypeChecker_Env.universe_of);
+             (uu___2138_15659.FStar_TypeChecker_Env.universe_of);
            FStar_TypeChecker_Env.check_type_of =
-             (uu___2134_15647.FStar_TypeChecker_Env.check_type_of);
+             (uu___2138_15659.FStar_TypeChecker_Env.check_type_of);
            FStar_TypeChecker_Env.use_bv_sorts =
-             (uu___2134_15647.FStar_TypeChecker_Env.use_bv_sorts);
+             (uu___2138_15659.FStar_TypeChecker_Env.use_bv_sorts);
            FStar_TypeChecker_Env.qtbl_name_and_index =
-             (uu___2134_15647.FStar_TypeChecker_Env.qtbl_name_and_index);
+             (uu___2138_15659.FStar_TypeChecker_Env.qtbl_name_and_index);
            FStar_TypeChecker_Env.normalized_eff_names =
-             (uu___2134_15647.FStar_TypeChecker_Env.normalized_eff_names);
+             (uu___2138_15659.FStar_TypeChecker_Env.normalized_eff_names);
            FStar_TypeChecker_Env.fv_delta_depths =
-             (uu___2134_15647.FStar_TypeChecker_Env.fv_delta_depths);
+             (uu___2138_15659.FStar_TypeChecker_Env.fv_delta_depths);
            FStar_TypeChecker_Env.proof_ns =
-             (uu___2134_15647.FStar_TypeChecker_Env.proof_ns);
+             (uu___2138_15659.FStar_TypeChecker_Env.proof_ns);
            FStar_TypeChecker_Env.synth_hook =
-             (uu___2134_15647.FStar_TypeChecker_Env.synth_hook);
+             (uu___2138_15659.FStar_TypeChecker_Env.synth_hook);
            FStar_TypeChecker_Env.splice =
-             (uu___2134_15647.FStar_TypeChecker_Env.splice);
+             (uu___2138_15659.FStar_TypeChecker_Env.splice);
            FStar_TypeChecker_Env.postprocess =
-             (uu___2134_15647.FStar_TypeChecker_Env.postprocess);
+             (uu___2138_15659.FStar_TypeChecker_Env.postprocess);
            FStar_TypeChecker_Env.is_native_tactic =
-             (uu___2134_15647.FStar_TypeChecker_Env.is_native_tactic);
+             (uu___2138_15659.FStar_TypeChecker_Env.is_native_tactic);
            FStar_TypeChecker_Env.identifier_info =
-             (uu___2134_15647.FStar_TypeChecker_Env.identifier_info);
+             (uu___2138_15659.FStar_TypeChecker_Env.identifier_info);
            FStar_TypeChecker_Env.tc_hooks =
-             (uu___2134_15647.FStar_TypeChecker_Env.tc_hooks);
+             (uu___2138_15659.FStar_TypeChecker_Env.tc_hooks);
            FStar_TypeChecker_Env.dsenv =
-             (uu___2134_15647.FStar_TypeChecker_Env.dsenv);
+             (uu___2138_15659.FStar_TypeChecker_Env.dsenv);
            FStar_TypeChecker_Env.nbe =
-             (uu___2134_15647.FStar_TypeChecker_Env.nbe);
+             (uu___2138_15659.FStar_TypeChecker_Env.nbe);
            FStar_TypeChecker_Env.strict_args_tab =
-             (uu___2134_15647.FStar_TypeChecker_Env.strict_args_tab)
+             (uu___2138_15659.FStar_TypeChecker_Env.strict_args_tab);
+           FStar_TypeChecker_Env.erasable_types_tab =
+             (uu___2138_15659.FStar_TypeChecker_Env.erasable_types_tab)
          }  in
        let env2 =
          FStar_TypeChecker_Env.set_current_module env1
            modul.FStar_Syntax_Syntax.name
           in
-       let uu____15649 = tc_decls env2 modul.FStar_Syntax_Syntax.declarations
+       let uu____15661 = tc_decls env2 modul.FStar_Syntax_Syntax.declarations
           in
-       match uu____15649 with
+       match uu____15661 with
        | (ses,exports,env3) ->
-           ((let uu___2142_15682 = modul  in
+           ((let uu___2146_15694 = modul  in
              {
                FStar_Syntax_Syntax.name =
-                 (uu___2142_15682.FStar_Syntax_Syntax.name);
+                 (uu___2146_15694.FStar_Syntax_Syntax.name);
                FStar_Syntax_Syntax.declarations = ses;
                FStar_Syntax_Syntax.exports =
-                 (uu___2142_15682.FStar_Syntax_Syntax.exports);
+                 (uu___2146_15694.FStar_Syntax_Syntax.exports);
                FStar_Syntax_Syntax.is_interface =
-                 (uu___2142_15682.FStar_Syntax_Syntax.is_interface)
+                 (uu___2146_15694.FStar_Syntax_Syntax.is_interface)
              }), exports, env3))
   
 let (tc_more_partial_modul :
@@ -8742,21 +8802,21 @@ let (tc_more_partial_modul :
   fun env  ->
     fun modul  ->
       fun decls  ->
-        let uu____15711 = tc_decls env decls  in
-        match uu____15711 with
+        let uu____15723 = tc_decls env decls  in
+        match uu____15723 with
         | (ses,exports,env1) ->
             let modul1 =
-              let uu___2151_15742 = modul  in
+              let uu___2155_15754 = modul  in
               {
                 FStar_Syntax_Syntax.name =
-                  (uu___2151_15742.FStar_Syntax_Syntax.name);
+                  (uu___2155_15754.FStar_Syntax_Syntax.name);
                 FStar_Syntax_Syntax.declarations =
                   (FStar_List.append modul.FStar_Syntax_Syntax.declarations
                      ses);
                 FStar_Syntax_Syntax.exports =
-                  (uu___2151_15742.FStar_Syntax_Syntax.exports);
+                  (uu___2155_15754.FStar_Syntax_Syntax.exports);
                 FStar_Syntax_Syntax.is_interface =
-                  (uu___2151_15742.FStar_Syntax_Syntax.is_interface)
+                  (uu___2155_15754.FStar_Syntax_Syntax.is_interface)
               }  in
             (modul1, exports, env1)
   
@@ -8773,8 +8833,8 @@ let rec (tc_modul :
             (m.FStar_Syntax_Syntax.name).FStar_Ident.str
            in
         let env01 = push_context env0 msg  in
-        let uu____15803 = tc_partial_modul env01 m  in
-        match uu____15803 with
+        let uu____15815 = tc_partial_modul env01 m  in
+        match uu____15815 with
         | (modul,non_private_decls,env) ->
             finish_partial_modul false iface_exists env modul
               non_private_decls
@@ -8798,54 +8858,54 @@ and (finish_partial_modul :
                   && (FStar_Options.use_extracted_interfaces ()))
                  && (Prims.op_Negation m.FStar_Syntax_Syntax.is_interface))
                 &&
-                (let uu____15840 = FStar_Errors.get_err_count ()  in
-                 uu____15840 = Prims.int_zero)
+                (let uu____15852 = FStar_Errors.get_err_count ()  in
+                 uu____15852 = Prims.int_zero)
                in
             if should_extract_interface
             then
               let modul_iface = extract_interface en m  in
-              ((let uu____15851 =
+              ((let uu____15863 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug en)
                     FStar_Options.Low
                    in
-                if uu____15851
+                if uu____15863
                 then
-                  let uu____15855 =
-                    let uu____15857 =
+                  let uu____15867 =
+                    let uu____15869 =
                       FStar_Options.should_verify
                         (m.FStar_Syntax_Syntax.name).FStar_Ident.str
                        in
-                    if uu____15857 then "" else " (in lax mode) "  in
-                  let uu____15865 =
-                    let uu____15867 =
+                    if uu____15869 then "" else " (in lax mode) "  in
+                  let uu____15877 =
+                    let uu____15879 =
                       FStar_Options.dump_module
                         (m.FStar_Syntax_Syntax.name).FStar_Ident.str
                        in
-                    if uu____15867
+                    if uu____15879
                     then
-                      let uu____15871 =
-                        let uu____15873 =
+                      let uu____15883 =
+                        let uu____15885 =
                           FStar_Syntax_Print.modul_to_string m  in
-                        Prims.op_Hat uu____15873 "\n"  in
-                      Prims.op_Hat "\nfrom: " uu____15871
+                        Prims.op_Hat uu____15885 "\n"  in
+                      Prims.op_Hat "\nfrom: " uu____15883
                     else ""  in
-                  let uu____15880 =
-                    let uu____15882 =
+                  let uu____15892 =
+                    let uu____15894 =
                       FStar_Options.dump_module
                         (m.FStar_Syntax_Syntax.name).FStar_Ident.str
                        in
-                    if uu____15882
+                    if uu____15894
                     then
-                      let uu____15886 =
-                        let uu____15888 =
+                      let uu____15898 =
+                        let uu____15900 =
                           FStar_Syntax_Print.modul_to_string modul_iface  in
-                        Prims.op_Hat uu____15888 "\n"  in
-                      Prims.op_Hat "\nto: " uu____15886
+                        Prims.op_Hat uu____15900 "\n"  in
+                      Prims.op_Hat "\nto: " uu____15898
                     else ""  in
                   FStar_Util.print4
                     "Extracting and type checking module %s interface%s%s%s\n"
-                    (m.FStar_Syntax_Syntax.name).FStar_Ident.str uu____15855
-                    uu____15865 uu____15880
+                    (m.FStar_Syntax_Syntax.name).FStar_Ident.str uu____15867
+                    uu____15877 uu____15892
                 else ());
                (let en0 =
                   let en0 =
@@ -8854,254 +8914,258 @@ and (finish_partial_modul :
                          (m.FStar_Syntax_Syntax.name).FStar_Ident.str)
                      in
                   let en01 =
-                    let uu___2177_15902 = en0  in
+                    let uu___2181_15914 = en0  in
                     {
                       FStar_TypeChecker_Env.solver =
-                        (uu___2177_15902.FStar_TypeChecker_Env.solver);
+                        (uu___2181_15914.FStar_TypeChecker_Env.solver);
                       FStar_TypeChecker_Env.range =
-                        (uu___2177_15902.FStar_TypeChecker_Env.range);
+                        (uu___2181_15914.FStar_TypeChecker_Env.range);
                       FStar_TypeChecker_Env.curmodule =
-                        (uu___2177_15902.FStar_TypeChecker_Env.curmodule);
+                        (uu___2181_15914.FStar_TypeChecker_Env.curmodule);
                       FStar_TypeChecker_Env.gamma =
-                        (uu___2177_15902.FStar_TypeChecker_Env.gamma);
+                        (uu___2181_15914.FStar_TypeChecker_Env.gamma);
                       FStar_TypeChecker_Env.gamma_sig =
-                        (uu___2177_15902.FStar_TypeChecker_Env.gamma_sig);
+                        (uu___2181_15914.FStar_TypeChecker_Env.gamma_sig);
                       FStar_TypeChecker_Env.gamma_cache =
-                        (uu___2177_15902.FStar_TypeChecker_Env.gamma_cache);
+                        (uu___2181_15914.FStar_TypeChecker_Env.gamma_cache);
                       FStar_TypeChecker_Env.modules =
-                        (uu___2177_15902.FStar_TypeChecker_Env.modules);
+                        (uu___2181_15914.FStar_TypeChecker_Env.modules);
                       FStar_TypeChecker_Env.expected_typ =
-                        (uu___2177_15902.FStar_TypeChecker_Env.expected_typ);
+                        (uu___2181_15914.FStar_TypeChecker_Env.expected_typ);
                       FStar_TypeChecker_Env.sigtab =
-                        (uu___2177_15902.FStar_TypeChecker_Env.sigtab);
+                        (uu___2181_15914.FStar_TypeChecker_Env.sigtab);
                       FStar_TypeChecker_Env.attrtab =
-                        (uu___2177_15902.FStar_TypeChecker_Env.attrtab);
+                        (uu___2181_15914.FStar_TypeChecker_Env.attrtab);
                       FStar_TypeChecker_Env.is_pattern =
-                        (uu___2177_15902.FStar_TypeChecker_Env.is_pattern);
+                        (uu___2181_15914.FStar_TypeChecker_Env.is_pattern);
                       FStar_TypeChecker_Env.instantiate_imp =
-                        (uu___2177_15902.FStar_TypeChecker_Env.instantiate_imp);
+                        (uu___2181_15914.FStar_TypeChecker_Env.instantiate_imp);
                       FStar_TypeChecker_Env.effects =
-                        (uu___2177_15902.FStar_TypeChecker_Env.effects);
+                        (uu___2181_15914.FStar_TypeChecker_Env.effects);
                       FStar_TypeChecker_Env.generalize =
-                        (uu___2177_15902.FStar_TypeChecker_Env.generalize);
+                        (uu___2181_15914.FStar_TypeChecker_Env.generalize);
                       FStar_TypeChecker_Env.letrecs =
-                        (uu___2177_15902.FStar_TypeChecker_Env.letrecs);
+                        (uu___2181_15914.FStar_TypeChecker_Env.letrecs);
                       FStar_TypeChecker_Env.top_level =
-                        (uu___2177_15902.FStar_TypeChecker_Env.top_level);
+                        (uu___2181_15914.FStar_TypeChecker_Env.top_level);
                       FStar_TypeChecker_Env.check_uvars =
-                        (uu___2177_15902.FStar_TypeChecker_Env.check_uvars);
+                        (uu___2181_15914.FStar_TypeChecker_Env.check_uvars);
                       FStar_TypeChecker_Env.use_eq =
-                        (uu___2177_15902.FStar_TypeChecker_Env.use_eq);
+                        (uu___2181_15914.FStar_TypeChecker_Env.use_eq);
                       FStar_TypeChecker_Env.is_iface =
-                        (uu___2177_15902.FStar_TypeChecker_Env.is_iface);
+                        (uu___2181_15914.FStar_TypeChecker_Env.is_iface);
                       FStar_TypeChecker_Env.admit =
-                        (uu___2177_15902.FStar_TypeChecker_Env.admit);
+                        (uu___2181_15914.FStar_TypeChecker_Env.admit);
                       FStar_TypeChecker_Env.lax =
-                        (uu___2177_15902.FStar_TypeChecker_Env.lax);
+                        (uu___2181_15914.FStar_TypeChecker_Env.lax);
                       FStar_TypeChecker_Env.lax_universes =
-                        (uu___2177_15902.FStar_TypeChecker_Env.lax_universes);
+                        (uu___2181_15914.FStar_TypeChecker_Env.lax_universes);
                       FStar_TypeChecker_Env.phase1 =
-                        (uu___2177_15902.FStar_TypeChecker_Env.phase1);
+                        (uu___2181_15914.FStar_TypeChecker_Env.phase1);
                       FStar_TypeChecker_Env.failhard =
-                        (uu___2177_15902.FStar_TypeChecker_Env.failhard);
+                        (uu___2181_15914.FStar_TypeChecker_Env.failhard);
                       FStar_TypeChecker_Env.nosynth =
-                        (uu___2177_15902.FStar_TypeChecker_Env.nosynth);
+                        (uu___2181_15914.FStar_TypeChecker_Env.nosynth);
                       FStar_TypeChecker_Env.uvar_subtyping =
-                        (uu___2177_15902.FStar_TypeChecker_Env.uvar_subtyping);
+                        (uu___2181_15914.FStar_TypeChecker_Env.uvar_subtyping);
                       FStar_TypeChecker_Env.tc_term =
-                        (uu___2177_15902.FStar_TypeChecker_Env.tc_term);
+                        (uu___2181_15914.FStar_TypeChecker_Env.tc_term);
                       FStar_TypeChecker_Env.type_of =
-                        (uu___2177_15902.FStar_TypeChecker_Env.type_of);
+                        (uu___2181_15914.FStar_TypeChecker_Env.type_of);
                       FStar_TypeChecker_Env.universe_of =
-                        (uu___2177_15902.FStar_TypeChecker_Env.universe_of);
+                        (uu___2181_15914.FStar_TypeChecker_Env.universe_of);
                       FStar_TypeChecker_Env.check_type_of =
-                        (uu___2177_15902.FStar_TypeChecker_Env.check_type_of);
+                        (uu___2181_15914.FStar_TypeChecker_Env.check_type_of);
                       FStar_TypeChecker_Env.use_bv_sorts =
-                        (uu___2177_15902.FStar_TypeChecker_Env.use_bv_sorts);
+                        (uu___2181_15914.FStar_TypeChecker_Env.use_bv_sorts);
                       FStar_TypeChecker_Env.qtbl_name_and_index =
-                        (uu___2177_15902.FStar_TypeChecker_Env.qtbl_name_and_index);
+                        (uu___2181_15914.FStar_TypeChecker_Env.qtbl_name_and_index);
                       FStar_TypeChecker_Env.normalized_eff_names =
-                        (uu___2177_15902.FStar_TypeChecker_Env.normalized_eff_names);
+                        (uu___2181_15914.FStar_TypeChecker_Env.normalized_eff_names);
                       FStar_TypeChecker_Env.fv_delta_depths =
-                        (uu___2177_15902.FStar_TypeChecker_Env.fv_delta_depths);
+                        (uu___2181_15914.FStar_TypeChecker_Env.fv_delta_depths);
                       FStar_TypeChecker_Env.proof_ns =
-                        (uu___2177_15902.FStar_TypeChecker_Env.proof_ns);
+                        (uu___2181_15914.FStar_TypeChecker_Env.proof_ns);
                       FStar_TypeChecker_Env.synth_hook =
-                        (uu___2177_15902.FStar_TypeChecker_Env.synth_hook);
+                        (uu___2181_15914.FStar_TypeChecker_Env.synth_hook);
                       FStar_TypeChecker_Env.splice =
-                        (uu___2177_15902.FStar_TypeChecker_Env.splice);
+                        (uu___2181_15914.FStar_TypeChecker_Env.splice);
                       FStar_TypeChecker_Env.postprocess =
-                        (uu___2177_15902.FStar_TypeChecker_Env.postprocess);
+                        (uu___2181_15914.FStar_TypeChecker_Env.postprocess);
                       FStar_TypeChecker_Env.is_native_tactic =
-                        (uu___2177_15902.FStar_TypeChecker_Env.is_native_tactic);
+                        (uu___2181_15914.FStar_TypeChecker_Env.is_native_tactic);
                       FStar_TypeChecker_Env.identifier_info =
-                        (uu___2177_15902.FStar_TypeChecker_Env.identifier_info);
+                        (uu___2181_15914.FStar_TypeChecker_Env.identifier_info);
                       FStar_TypeChecker_Env.tc_hooks =
-                        (uu___2177_15902.FStar_TypeChecker_Env.tc_hooks);
+                        (uu___2181_15914.FStar_TypeChecker_Env.tc_hooks);
                       FStar_TypeChecker_Env.dsenv =
                         (en.FStar_TypeChecker_Env.dsenv);
                       FStar_TypeChecker_Env.nbe =
-                        (uu___2177_15902.FStar_TypeChecker_Env.nbe);
+                        (uu___2181_15914.FStar_TypeChecker_Env.nbe);
                       FStar_TypeChecker_Env.strict_args_tab =
-                        (uu___2177_15902.FStar_TypeChecker_Env.strict_args_tab)
+                        (uu___2181_15914.FStar_TypeChecker_Env.strict_args_tab);
+                      FStar_TypeChecker_Env.erasable_types_tab =
+                        (uu___2181_15914.FStar_TypeChecker_Env.erasable_types_tab)
                     }  in
                   let en02 =
-                    let uu___2180_15904 = en01  in
-                    let uu____15905 =
-                      let uu____15920 =
+                    let uu___2184_15916 = en01  in
+                    let uu____15917 =
+                      let uu____15932 =
                         FStar_All.pipe_right
                           en.FStar_TypeChecker_Env.qtbl_name_and_index
                           FStar_Pervasives_Native.fst
                          in
-                      (uu____15920, FStar_Pervasives_Native.None)  in
+                      (uu____15932, FStar_Pervasives_Native.None)  in
                     {
                       FStar_TypeChecker_Env.solver =
-                        (uu___2180_15904.FStar_TypeChecker_Env.solver);
+                        (uu___2184_15916.FStar_TypeChecker_Env.solver);
                       FStar_TypeChecker_Env.range =
-                        (uu___2180_15904.FStar_TypeChecker_Env.range);
+                        (uu___2184_15916.FStar_TypeChecker_Env.range);
                       FStar_TypeChecker_Env.curmodule =
-                        (uu___2180_15904.FStar_TypeChecker_Env.curmodule);
+                        (uu___2184_15916.FStar_TypeChecker_Env.curmodule);
                       FStar_TypeChecker_Env.gamma =
-                        (uu___2180_15904.FStar_TypeChecker_Env.gamma);
+                        (uu___2184_15916.FStar_TypeChecker_Env.gamma);
                       FStar_TypeChecker_Env.gamma_sig =
-                        (uu___2180_15904.FStar_TypeChecker_Env.gamma_sig);
+                        (uu___2184_15916.FStar_TypeChecker_Env.gamma_sig);
                       FStar_TypeChecker_Env.gamma_cache =
-                        (uu___2180_15904.FStar_TypeChecker_Env.gamma_cache);
+                        (uu___2184_15916.FStar_TypeChecker_Env.gamma_cache);
                       FStar_TypeChecker_Env.modules =
-                        (uu___2180_15904.FStar_TypeChecker_Env.modules);
+                        (uu___2184_15916.FStar_TypeChecker_Env.modules);
                       FStar_TypeChecker_Env.expected_typ =
-                        (uu___2180_15904.FStar_TypeChecker_Env.expected_typ);
+                        (uu___2184_15916.FStar_TypeChecker_Env.expected_typ);
                       FStar_TypeChecker_Env.sigtab =
-                        (uu___2180_15904.FStar_TypeChecker_Env.sigtab);
+                        (uu___2184_15916.FStar_TypeChecker_Env.sigtab);
                       FStar_TypeChecker_Env.attrtab =
-                        (uu___2180_15904.FStar_TypeChecker_Env.attrtab);
+                        (uu___2184_15916.FStar_TypeChecker_Env.attrtab);
                       FStar_TypeChecker_Env.is_pattern =
-                        (uu___2180_15904.FStar_TypeChecker_Env.is_pattern);
+                        (uu___2184_15916.FStar_TypeChecker_Env.is_pattern);
                       FStar_TypeChecker_Env.instantiate_imp =
-                        (uu___2180_15904.FStar_TypeChecker_Env.instantiate_imp);
+                        (uu___2184_15916.FStar_TypeChecker_Env.instantiate_imp);
                       FStar_TypeChecker_Env.effects =
-                        (uu___2180_15904.FStar_TypeChecker_Env.effects);
+                        (uu___2184_15916.FStar_TypeChecker_Env.effects);
                       FStar_TypeChecker_Env.generalize =
-                        (uu___2180_15904.FStar_TypeChecker_Env.generalize);
+                        (uu___2184_15916.FStar_TypeChecker_Env.generalize);
                       FStar_TypeChecker_Env.letrecs =
-                        (uu___2180_15904.FStar_TypeChecker_Env.letrecs);
+                        (uu___2184_15916.FStar_TypeChecker_Env.letrecs);
                       FStar_TypeChecker_Env.top_level =
-                        (uu___2180_15904.FStar_TypeChecker_Env.top_level);
+                        (uu___2184_15916.FStar_TypeChecker_Env.top_level);
                       FStar_TypeChecker_Env.check_uvars =
-                        (uu___2180_15904.FStar_TypeChecker_Env.check_uvars);
+                        (uu___2184_15916.FStar_TypeChecker_Env.check_uvars);
                       FStar_TypeChecker_Env.use_eq =
-                        (uu___2180_15904.FStar_TypeChecker_Env.use_eq);
+                        (uu___2184_15916.FStar_TypeChecker_Env.use_eq);
                       FStar_TypeChecker_Env.is_iface =
-                        (uu___2180_15904.FStar_TypeChecker_Env.is_iface);
+                        (uu___2184_15916.FStar_TypeChecker_Env.is_iface);
                       FStar_TypeChecker_Env.admit =
-                        (uu___2180_15904.FStar_TypeChecker_Env.admit);
+                        (uu___2184_15916.FStar_TypeChecker_Env.admit);
                       FStar_TypeChecker_Env.lax =
-                        (uu___2180_15904.FStar_TypeChecker_Env.lax);
+                        (uu___2184_15916.FStar_TypeChecker_Env.lax);
                       FStar_TypeChecker_Env.lax_universes =
-                        (uu___2180_15904.FStar_TypeChecker_Env.lax_universes);
+                        (uu___2184_15916.FStar_TypeChecker_Env.lax_universes);
                       FStar_TypeChecker_Env.phase1 =
-                        (uu___2180_15904.FStar_TypeChecker_Env.phase1);
+                        (uu___2184_15916.FStar_TypeChecker_Env.phase1);
                       FStar_TypeChecker_Env.failhard =
-                        (uu___2180_15904.FStar_TypeChecker_Env.failhard);
+                        (uu___2184_15916.FStar_TypeChecker_Env.failhard);
                       FStar_TypeChecker_Env.nosynth =
-                        (uu___2180_15904.FStar_TypeChecker_Env.nosynth);
+                        (uu___2184_15916.FStar_TypeChecker_Env.nosynth);
                       FStar_TypeChecker_Env.uvar_subtyping =
-                        (uu___2180_15904.FStar_TypeChecker_Env.uvar_subtyping);
+                        (uu___2184_15916.FStar_TypeChecker_Env.uvar_subtyping);
                       FStar_TypeChecker_Env.tc_term =
-                        (uu___2180_15904.FStar_TypeChecker_Env.tc_term);
+                        (uu___2184_15916.FStar_TypeChecker_Env.tc_term);
                       FStar_TypeChecker_Env.type_of =
-                        (uu___2180_15904.FStar_TypeChecker_Env.type_of);
+                        (uu___2184_15916.FStar_TypeChecker_Env.type_of);
                       FStar_TypeChecker_Env.universe_of =
-                        (uu___2180_15904.FStar_TypeChecker_Env.universe_of);
+                        (uu___2184_15916.FStar_TypeChecker_Env.universe_of);
                       FStar_TypeChecker_Env.check_type_of =
-                        (uu___2180_15904.FStar_TypeChecker_Env.check_type_of);
+                        (uu___2184_15916.FStar_TypeChecker_Env.check_type_of);
                       FStar_TypeChecker_Env.use_bv_sorts =
-                        (uu___2180_15904.FStar_TypeChecker_Env.use_bv_sorts);
-                      FStar_TypeChecker_Env.qtbl_name_and_index = uu____15905;
+                        (uu___2184_15916.FStar_TypeChecker_Env.use_bv_sorts);
+                      FStar_TypeChecker_Env.qtbl_name_and_index = uu____15917;
                       FStar_TypeChecker_Env.normalized_eff_names =
-                        (uu___2180_15904.FStar_TypeChecker_Env.normalized_eff_names);
+                        (uu___2184_15916.FStar_TypeChecker_Env.normalized_eff_names);
                       FStar_TypeChecker_Env.fv_delta_depths =
-                        (uu___2180_15904.FStar_TypeChecker_Env.fv_delta_depths);
+                        (uu___2184_15916.FStar_TypeChecker_Env.fv_delta_depths);
                       FStar_TypeChecker_Env.proof_ns =
-                        (uu___2180_15904.FStar_TypeChecker_Env.proof_ns);
+                        (uu___2184_15916.FStar_TypeChecker_Env.proof_ns);
                       FStar_TypeChecker_Env.synth_hook =
-                        (uu___2180_15904.FStar_TypeChecker_Env.synth_hook);
+                        (uu___2184_15916.FStar_TypeChecker_Env.synth_hook);
                       FStar_TypeChecker_Env.splice =
-                        (uu___2180_15904.FStar_TypeChecker_Env.splice);
+                        (uu___2184_15916.FStar_TypeChecker_Env.splice);
                       FStar_TypeChecker_Env.postprocess =
-                        (uu___2180_15904.FStar_TypeChecker_Env.postprocess);
+                        (uu___2184_15916.FStar_TypeChecker_Env.postprocess);
                       FStar_TypeChecker_Env.is_native_tactic =
-                        (uu___2180_15904.FStar_TypeChecker_Env.is_native_tactic);
+                        (uu___2184_15916.FStar_TypeChecker_Env.is_native_tactic);
                       FStar_TypeChecker_Env.identifier_info =
-                        (uu___2180_15904.FStar_TypeChecker_Env.identifier_info);
+                        (uu___2184_15916.FStar_TypeChecker_Env.identifier_info);
                       FStar_TypeChecker_Env.tc_hooks =
-                        (uu___2180_15904.FStar_TypeChecker_Env.tc_hooks);
+                        (uu___2184_15916.FStar_TypeChecker_Env.tc_hooks);
                       FStar_TypeChecker_Env.dsenv =
-                        (uu___2180_15904.FStar_TypeChecker_Env.dsenv);
+                        (uu___2184_15916.FStar_TypeChecker_Env.dsenv);
                       FStar_TypeChecker_Env.nbe =
-                        (uu___2180_15904.FStar_TypeChecker_Env.nbe);
+                        (uu___2184_15916.FStar_TypeChecker_Env.nbe);
                       FStar_TypeChecker_Env.strict_args_tab =
-                        (uu___2180_15904.FStar_TypeChecker_Env.strict_args_tab)
+                        (uu___2184_15916.FStar_TypeChecker_Env.strict_args_tab);
+                      FStar_TypeChecker_Env.erasable_types_tab =
+                        (uu___2184_15916.FStar_TypeChecker_Env.erasable_types_tab)
                     }  in
-                  let uu____15966 =
-                    let uu____15968 = FStar_Options.interactive ()  in
-                    Prims.op_Negation uu____15968  in
-                  if uu____15966
+                  let uu____15978 =
+                    let uu____15980 = FStar_Options.interactive ()  in
+                    Prims.op_Negation uu____15980  in
+                  if uu____15978
                   then
-                    ((let uu____15972 =
+                    ((let uu____15984 =
                         FStar_Options.restore_cmd_line_options true  in
-                      FStar_All.pipe_right uu____15972 (fun a3  -> ()));
+                      FStar_All.pipe_right uu____15984 (fun a3  -> ()));
                      en02)
                   else en02  in
-                let uu____15976 = tc_modul en0 modul_iface true  in
-                match uu____15976 with
+                let uu____15988 = tc_modul en0 modul_iface true  in
+                match uu____15988 with
                 | (modul_iface1,env) ->
-                    ((let uu___2189_15989 = m  in
+                    ((let uu___2193_16001 = m  in
                       {
                         FStar_Syntax_Syntax.name =
-                          (uu___2189_15989.FStar_Syntax_Syntax.name);
+                          (uu___2193_16001.FStar_Syntax_Syntax.name);
                         FStar_Syntax_Syntax.declarations =
-                          (uu___2189_15989.FStar_Syntax_Syntax.declarations);
+                          (uu___2193_16001.FStar_Syntax_Syntax.declarations);
                         FStar_Syntax_Syntax.exports =
                           (modul_iface1.FStar_Syntax_Syntax.exports);
                         FStar_Syntax_Syntax.is_interface =
-                          (uu___2189_15989.FStar_Syntax_Syntax.is_interface)
+                          (uu___2193_16001.FStar_Syntax_Syntax.is_interface)
                       }), env)))
             else
               (let modul =
-                 let uu___2191_15993 = m  in
+                 let uu___2195_16005 = m  in
                  {
                    FStar_Syntax_Syntax.name =
-                     (uu___2191_15993.FStar_Syntax_Syntax.name);
+                     (uu___2195_16005.FStar_Syntax_Syntax.name);
                    FStar_Syntax_Syntax.declarations =
-                     (uu___2191_15993.FStar_Syntax_Syntax.declarations);
+                     (uu___2195_16005.FStar_Syntax_Syntax.declarations);
                    FStar_Syntax_Syntax.exports = exports;
                    FStar_Syntax_Syntax.is_interface =
-                     (uu___2191_15993.FStar_Syntax_Syntax.is_interface)
+                     (uu___2195_16005.FStar_Syntax_Syntax.is_interface)
                  }  in
                let env = FStar_TypeChecker_Env.finish_module en modul  in
-               (let uu____15996 =
+               (let uu____16008 =
                   FStar_All.pipe_right
                     env.FStar_TypeChecker_Env.qtbl_name_and_index
                     FStar_Pervasives_Native.fst
                    in
-                FStar_All.pipe_right uu____15996 FStar_Util.smap_clear);
-               (let uu____16032 =
-                  ((let uu____16036 = FStar_Options.lax ()  in
-                    Prims.op_Negation uu____16036) &&
+                FStar_All.pipe_right uu____16008 FStar_Util.smap_clear);
+               (let uu____16044 =
+                  ((let uu____16048 = FStar_Options.lax ()  in
+                    Prims.op_Negation uu____16048) &&
                      (Prims.op_Negation loading_from_cache))
                     &&
-                    (let uu____16039 =
+                    (let uu____16051 =
                        FStar_Options.use_extracted_interfaces ()  in
-                     Prims.op_Negation uu____16039)
+                     Prims.op_Negation uu____16051)
                    in
-                if uu____16032 then check_exports env modul exports else ());
-               (let uu____16045 =
+                if uu____16044 then check_exports env modul exports else ());
+               (let uu____16057 =
                   pop_context env
                     (Prims.op_Hat "Ending modul "
                        (modul.FStar_Syntax_Syntax.name).FStar_Ident.str)
                    in
-                FStar_All.pipe_right uu____16045 (fun a4  -> ()));
+                FStar_All.pipe_right uu____16057 (fun a4  -> ()));
                (modul, env))
 
 let (load_checked_module :
@@ -9115,11 +9179,11 @@ let (load_checked_module :
           m.FStar_Syntax_Syntax.name
          in
       let env1 =
-        let uu____16060 =
-          let uu____16062 =
+        let uu____16072 =
+          let uu____16074 =
             FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
-          Prims.op_Hat "Internals for " uu____16062  in
-        push_context env uu____16060  in
+          Prims.op_Hat "Internals for " uu____16074  in
+        push_context env uu____16072  in
       let env2 =
         FStar_List.fold_left
           (fun env2  ->
@@ -9129,15 +9193,15 @@ let (load_checked_module :
                FStar_All.pipe_right lids
                  (FStar_List.iter
                     (fun lid  ->
-                       let uu____16084 =
+                       let uu____16096 =
                          FStar_TypeChecker_Env.lookup_sigelt env3 lid  in
                        ()));
                env3) env1 m.FStar_Syntax_Syntax.declarations
          in
-      let uu____16087 =
+      let uu____16099 =
         finish_partial_modul true true env2 m m.FStar_Syntax_Syntax.exports
          in
-      match uu____16087 with | (uu____16094,env3) -> env3
+      match uu____16099 with | (uu____16106,env3) -> env3
   
 let (check_module :
   FStar_TypeChecker_Env.env ->
@@ -9147,136 +9211,138 @@ let (check_module :
   fun env  ->
     fun m  ->
       fun b  ->
-        (let uu____16119 = FStar_Options.debug_any ()  in
-         if uu____16119
+        (let uu____16131 = FStar_Options.debug_any ()  in
+         if uu____16131
          then
-           let uu____16122 =
+           let uu____16134 =
              FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name  in
            FStar_Util.print2 "Checking %s: %s\n"
              (if m.FStar_Syntax_Syntax.is_interface
               then "i'face"
-              else "module") uu____16122
+              else "module") uu____16134
          else ());
-        (let uu____16134 =
+        (let uu____16146 =
            FStar_Options.dump_module
              (m.FStar_Syntax_Syntax.name).FStar_Ident.str
             in
-         if uu____16134
+         if uu____16146
          then
-           let uu____16137 = FStar_Syntax_Print.modul_to_string m  in
-           FStar_Util.print1 "Module before type checking:\n%s\n" uu____16137
+           let uu____16149 = FStar_Syntax_Print.modul_to_string m  in
+           FStar_Util.print1 "Module before type checking:\n%s\n" uu____16149
          else ());
         (let env1 =
-           let uu___2221_16143 = env  in
-           let uu____16144 =
-             let uu____16146 =
+           let uu___2225_16155 = env  in
+           let uu____16156 =
+             let uu____16158 =
                FStar_Options.should_verify
                  (m.FStar_Syntax_Syntax.name).FStar_Ident.str
                 in
-             Prims.op_Negation uu____16146  in
+             Prims.op_Negation uu____16158  in
            {
              FStar_TypeChecker_Env.solver =
-               (uu___2221_16143.FStar_TypeChecker_Env.solver);
+               (uu___2225_16155.FStar_TypeChecker_Env.solver);
              FStar_TypeChecker_Env.range =
-               (uu___2221_16143.FStar_TypeChecker_Env.range);
+               (uu___2225_16155.FStar_TypeChecker_Env.range);
              FStar_TypeChecker_Env.curmodule =
-               (uu___2221_16143.FStar_TypeChecker_Env.curmodule);
+               (uu___2225_16155.FStar_TypeChecker_Env.curmodule);
              FStar_TypeChecker_Env.gamma =
-               (uu___2221_16143.FStar_TypeChecker_Env.gamma);
+               (uu___2225_16155.FStar_TypeChecker_Env.gamma);
              FStar_TypeChecker_Env.gamma_sig =
-               (uu___2221_16143.FStar_TypeChecker_Env.gamma_sig);
+               (uu___2225_16155.FStar_TypeChecker_Env.gamma_sig);
              FStar_TypeChecker_Env.gamma_cache =
-               (uu___2221_16143.FStar_TypeChecker_Env.gamma_cache);
+               (uu___2225_16155.FStar_TypeChecker_Env.gamma_cache);
              FStar_TypeChecker_Env.modules =
-               (uu___2221_16143.FStar_TypeChecker_Env.modules);
+               (uu___2225_16155.FStar_TypeChecker_Env.modules);
              FStar_TypeChecker_Env.expected_typ =
-               (uu___2221_16143.FStar_TypeChecker_Env.expected_typ);
+               (uu___2225_16155.FStar_TypeChecker_Env.expected_typ);
              FStar_TypeChecker_Env.sigtab =
-               (uu___2221_16143.FStar_TypeChecker_Env.sigtab);
+               (uu___2225_16155.FStar_TypeChecker_Env.sigtab);
              FStar_TypeChecker_Env.attrtab =
-               (uu___2221_16143.FStar_TypeChecker_Env.attrtab);
+               (uu___2225_16155.FStar_TypeChecker_Env.attrtab);
              FStar_TypeChecker_Env.is_pattern =
-               (uu___2221_16143.FStar_TypeChecker_Env.is_pattern);
+               (uu___2225_16155.FStar_TypeChecker_Env.is_pattern);
              FStar_TypeChecker_Env.instantiate_imp =
-               (uu___2221_16143.FStar_TypeChecker_Env.instantiate_imp);
+               (uu___2225_16155.FStar_TypeChecker_Env.instantiate_imp);
              FStar_TypeChecker_Env.effects =
-               (uu___2221_16143.FStar_TypeChecker_Env.effects);
+               (uu___2225_16155.FStar_TypeChecker_Env.effects);
              FStar_TypeChecker_Env.generalize =
-               (uu___2221_16143.FStar_TypeChecker_Env.generalize);
+               (uu___2225_16155.FStar_TypeChecker_Env.generalize);
              FStar_TypeChecker_Env.letrecs =
-               (uu___2221_16143.FStar_TypeChecker_Env.letrecs);
+               (uu___2225_16155.FStar_TypeChecker_Env.letrecs);
              FStar_TypeChecker_Env.top_level =
-               (uu___2221_16143.FStar_TypeChecker_Env.top_level);
+               (uu___2225_16155.FStar_TypeChecker_Env.top_level);
              FStar_TypeChecker_Env.check_uvars =
-               (uu___2221_16143.FStar_TypeChecker_Env.check_uvars);
+               (uu___2225_16155.FStar_TypeChecker_Env.check_uvars);
              FStar_TypeChecker_Env.use_eq =
-               (uu___2221_16143.FStar_TypeChecker_Env.use_eq);
+               (uu___2225_16155.FStar_TypeChecker_Env.use_eq);
              FStar_TypeChecker_Env.is_iface =
-               (uu___2221_16143.FStar_TypeChecker_Env.is_iface);
+               (uu___2225_16155.FStar_TypeChecker_Env.is_iface);
              FStar_TypeChecker_Env.admit =
-               (uu___2221_16143.FStar_TypeChecker_Env.admit);
-             FStar_TypeChecker_Env.lax = uu____16144;
+               (uu___2225_16155.FStar_TypeChecker_Env.admit);
+             FStar_TypeChecker_Env.lax = uu____16156;
              FStar_TypeChecker_Env.lax_universes =
-               (uu___2221_16143.FStar_TypeChecker_Env.lax_universes);
+               (uu___2225_16155.FStar_TypeChecker_Env.lax_universes);
              FStar_TypeChecker_Env.phase1 =
-               (uu___2221_16143.FStar_TypeChecker_Env.phase1);
+               (uu___2225_16155.FStar_TypeChecker_Env.phase1);
              FStar_TypeChecker_Env.failhard =
-               (uu___2221_16143.FStar_TypeChecker_Env.failhard);
+               (uu___2225_16155.FStar_TypeChecker_Env.failhard);
              FStar_TypeChecker_Env.nosynth =
-               (uu___2221_16143.FStar_TypeChecker_Env.nosynth);
+               (uu___2225_16155.FStar_TypeChecker_Env.nosynth);
              FStar_TypeChecker_Env.uvar_subtyping =
-               (uu___2221_16143.FStar_TypeChecker_Env.uvar_subtyping);
+               (uu___2225_16155.FStar_TypeChecker_Env.uvar_subtyping);
              FStar_TypeChecker_Env.tc_term =
-               (uu___2221_16143.FStar_TypeChecker_Env.tc_term);
+               (uu___2225_16155.FStar_TypeChecker_Env.tc_term);
              FStar_TypeChecker_Env.type_of =
-               (uu___2221_16143.FStar_TypeChecker_Env.type_of);
+               (uu___2225_16155.FStar_TypeChecker_Env.type_of);
              FStar_TypeChecker_Env.universe_of =
-               (uu___2221_16143.FStar_TypeChecker_Env.universe_of);
+               (uu___2225_16155.FStar_TypeChecker_Env.universe_of);
              FStar_TypeChecker_Env.check_type_of =
-               (uu___2221_16143.FStar_TypeChecker_Env.check_type_of);
+               (uu___2225_16155.FStar_TypeChecker_Env.check_type_of);
              FStar_TypeChecker_Env.use_bv_sorts =
-               (uu___2221_16143.FStar_TypeChecker_Env.use_bv_sorts);
+               (uu___2225_16155.FStar_TypeChecker_Env.use_bv_sorts);
              FStar_TypeChecker_Env.qtbl_name_and_index =
-               (uu___2221_16143.FStar_TypeChecker_Env.qtbl_name_and_index);
+               (uu___2225_16155.FStar_TypeChecker_Env.qtbl_name_and_index);
              FStar_TypeChecker_Env.normalized_eff_names =
-               (uu___2221_16143.FStar_TypeChecker_Env.normalized_eff_names);
+               (uu___2225_16155.FStar_TypeChecker_Env.normalized_eff_names);
              FStar_TypeChecker_Env.fv_delta_depths =
-               (uu___2221_16143.FStar_TypeChecker_Env.fv_delta_depths);
+               (uu___2225_16155.FStar_TypeChecker_Env.fv_delta_depths);
              FStar_TypeChecker_Env.proof_ns =
-               (uu___2221_16143.FStar_TypeChecker_Env.proof_ns);
+               (uu___2225_16155.FStar_TypeChecker_Env.proof_ns);
              FStar_TypeChecker_Env.synth_hook =
-               (uu___2221_16143.FStar_TypeChecker_Env.synth_hook);
+               (uu___2225_16155.FStar_TypeChecker_Env.synth_hook);
              FStar_TypeChecker_Env.splice =
-               (uu___2221_16143.FStar_TypeChecker_Env.splice);
+               (uu___2225_16155.FStar_TypeChecker_Env.splice);
              FStar_TypeChecker_Env.postprocess =
-               (uu___2221_16143.FStar_TypeChecker_Env.postprocess);
+               (uu___2225_16155.FStar_TypeChecker_Env.postprocess);
              FStar_TypeChecker_Env.is_native_tactic =
-               (uu___2221_16143.FStar_TypeChecker_Env.is_native_tactic);
+               (uu___2225_16155.FStar_TypeChecker_Env.is_native_tactic);
              FStar_TypeChecker_Env.identifier_info =
-               (uu___2221_16143.FStar_TypeChecker_Env.identifier_info);
+               (uu___2225_16155.FStar_TypeChecker_Env.identifier_info);
              FStar_TypeChecker_Env.tc_hooks =
-               (uu___2221_16143.FStar_TypeChecker_Env.tc_hooks);
+               (uu___2225_16155.FStar_TypeChecker_Env.tc_hooks);
              FStar_TypeChecker_Env.dsenv =
-               (uu___2221_16143.FStar_TypeChecker_Env.dsenv);
+               (uu___2225_16155.FStar_TypeChecker_Env.dsenv);
              FStar_TypeChecker_Env.nbe =
-               (uu___2221_16143.FStar_TypeChecker_Env.nbe);
+               (uu___2225_16155.FStar_TypeChecker_Env.nbe);
              FStar_TypeChecker_Env.strict_args_tab =
-               (uu___2221_16143.FStar_TypeChecker_Env.strict_args_tab)
+               (uu___2225_16155.FStar_TypeChecker_Env.strict_args_tab);
+             FStar_TypeChecker_Env.erasable_types_tab =
+               (uu___2225_16155.FStar_TypeChecker_Env.erasable_types_tab)
            }  in
-         let uu____16148 = tc_modul env1 m b  in
-         match uu____16148 with
+         let uu____16160 = tc_modul env1 m b  in
+         match uu____16160 with
          | (m1,env2) ->
-             ((let uu____16160 =
+             ((let uu____16172 =
                  FStar_Options.dump_module
                    (m1.FStar_Syntax_Syntax.name).FStar_Ident.str
                   in
-               if uu____16160
+               if uu____16172
                then
-                 let uu____16163 = FStar_Syntax_Print.modul_to_string m1  in
+                 let uu____16175 = FStar_Syntax_Print.modul_to_string m1  in
                  FStar_Util.print1 "Module after type checking:\n%s\n"
-                   uu____16163
+                   uu____16175
                else ());
-              (let uu____16169 =
+              (let uu____16181 =
                  (FStar_Options.dump_module
                     (m1.FStar_Syntax_Syntax.name).FStar_Ident.str)
                    &&
@@ -9284,7 +9350,7 @@ let (check_module :
                       (m1.FStar_Syntax_Syntax.name).FStar_Ident.str
                       (FStar_Options.Other "Normalize"))
                   in
-               if uu____16169
+               if uu____16181
                then
                  let normalize_toplevel_lets se =
                    match se.FStar_Syntax_Syntax.sigel with
@@ -9301,74 +9367,74 @@ let (check_module :
                            FStar_TypeChecker_Env.AllowUnboundUniverses]
                           in
                        let update lb =
-                         let uu____16207 =
+                         let uu____16219 =
                            FStar_Syntax_Subst.open_univ_vars
                              lb.FStar_Syntax_Syntax.lbunivs
                              lb.FStar_Syntax_Syntax.lbdef
                             in
-                         match uu____16207 with
+                         match uu____16219 with
                          | (univnames1,e) ->
-                             let uu___2243_16214 = lb  in
-                             let uu____16215 =
-                               let uu____16218 =
+                             let uu___2247_16226 = lb  in
+                             let uu____16227 =
+                               let uu____16230 =
                                  FStar_TypeChecker_Env.push_univ_vars env2
                                    univnames1
                                   in
-                               n1 uu____16218 e  in
+                               n1 uu____16230 e  in
                              {
                                FStar_Syntax_Syntax.lbname =
-                                 (uu___2243_16214.FStar_Syntax_Syntax.lbname);
+                                 (uu___2247_16226.FStar_Syntax_Syntax.lbname);
                                FStar_Syntax_Syntax.lbunivs =
-                                 (uu___2243_16214.FStar_Syntax_Syntax.lbunivs);
+                                 (uu___2247_16226.FStar_Syntax_Syntax.lbunivs);
                                FStar_Syntax_Syntax.lbtyp =
-                                 (uu___2243_16214.FStar_Syntax_Syntax.lbtyp);
+                                 (uu___2247_16226.FStar_Syntax_Syntax.lbtyp);
                                FStar_Syntax_Syntax.lbeff =
-                                 (uu___2243_16214.FStar_Syntax_Syntax.lbeff);
-                               FStar_Syntax_Syntax.lbdef = uu____16215;
+                                 (uu___2247_16226.FStar_Syntax_Syntax.lbeff);
+                               FStar_Syntax_Syntax.lbdef = uu____16227;
                                FStar_Syntax_Syntax.lbattrs =
-                                 (uu___2243_16214.FStar_Syntax_Syntax.lbattrs);
+                                 (uu___2247_16226.FStar_Syntax_Syntax.lbattrs);
                                FStar_Syntax_Syntax.lbpos =
-                                 (uu___2243_16214.FStar_Syntax_Syntax.lbpos)
+                                 (uu___2247_16226.FStar_Syntax_Syntax.lbpos)
                              }
                           in
-                       let uu___2245_16219 = se  in
-                       let uu____16220 =
-                         let uu____16221 =
-                           let uu____16228 =
-                             let uu____16229 = FStar_List.map update lbs  in
-                             (b1, uu____16229)  in
-                           (uu____16228, ids)  in
-                         FStar_Syntax_Syntax.Sig_let uu____16221  in
+                       let uu___2249_16231 = se  in
+                       let uu____16232 =
+                         let uu____16233 =
+                           let uu____16240 =
+                             let uu____16241 = FStar_List.map update lbs  in
+                             (b1, uu____16241)  in
+                           (uu____16240, ids)  in
+                         FStar_Syntax_Syntax.Sig_let uu____16233  in
                        {
-                         FStar_Syntax_Syntax.sigel = uu____16220;
+                         FStar_Syntax_Syntax.sigel = uu____16232;
                          FStar_Syntax_Syntax.sigrng =
-                           (uu___2245_16219.FStar_Syntax_Syntax.sigrng);
+                           (uu___2249_16231.FStar_Syntax_Syntax.sigrng);
                          FStar_Syntax_Syntax.sigquals =
-                           (uu___2245_16219.FStar_Syntax_Syntax.sigquals);
+                           (uu___2249_16231.FStar_Syntax_Syntax.sigquals);
                          FStar_Syntax_Syntax.sigmeta =
-                           (uu___2245_16219.FStar_Syntax_Syntax.sigmeta);
+                           (uu___2249_16231.FStar_Syntax_Syntax.sigmeta);
                          FStar_Syntax_Syntax.sigattrs =
-                           (uu___2245_16219.FStar_Syntax_Syntax.sigattrs)
+                           (uu___2249_16231.FStar_Syntax_Syntax.sigattrs)
                        }
-                   | uu____16237 -> se  in
+                   | uu____16249 -> se  in
                  let normalized_module =
-                   let uu___2249_16239 = m1  in
-                   let uu____16240 =
+                   let uu___2253_16251 = m1  in
+                   let uu____16252 =
                      FStar_List.map normalize_toplevel_lets
                        m1.FStar_Syntax_Syntax.declarations
                       in
                    {
                      FStar_Syntax_Syntax.name =
-                       (uu___2249_16239.FStar_Syntax_Syntax.name);
-                     FStar_Syntax_Syntax.declarations = uu____16240;
+                       (uu___2253_16251.FStar_Syntax_Syntax.name);
+                     FStar_Syntax_Syntax.declarations = uu____16252;
                      FStar_Syntax_Syntax.exports =
-                       (uu___2249_16239.FStar_Syntax_Syntax.exports);
+                       (uu___2253_16251.FStar_Syntax_Syntax.exports);
                      FStar_Syntax_Syntax.is_interface =
-                       (uu___2249_16239.FStar_Syntax_Syntax.is_interface)
+                       (uu___2253_16251.FStar_Syntax_Syntax.is_interface)
                    }  in
-                 let uu____16241 =
+                 let uu____16253 =
                    FStar_Syntax_Print.modul_to_string normalized_module  in
-                 FStar_Util.print1 "%s\n" uu____16241
+                 FStar_Util.print1 "%s\n" uu____16253
                else ());
               (m1, env2)))
   

--- a/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
@@ -2780,7 +2780,7 @@ let (mk_discriminator_and_indexed_projectors :
                 FStar_Syntax_Syntax.binders ->
                   FStar_Syntax_Syntax.binders ->
                     FStar_Syntax_Syntax.binders ->
-                      FStar_Syntax_Syntax.sigelt Prims.list)
+                      Prims.bool -> FStar_Syntax_Syntax.sigelt Prims.list)
   =
   fun iquals  ->
     fun fvq  ->
@@ -2792,655 +2792,676 @@ let (mk_discriminator_and_indexed_projectors :
                 fun inductive_tps  ->
                   fun indices  ->
                     fun fields  ->
-                      let p = FStar_Ident.range_of_lid lid  in
-                      let pos q = FStar_Syntax_Syntax.withinfo q p  in
-                      let projectee ptyp =
-                        FStar_Syntax_Syntax.gen_bv "projectee"
-                          (FStar_Pervasives_Native.Some p) ptyp
-                         in
-                      let inst_univs =
-                        FStar_List.map
-                          (fun u  -> FStar_Syntax_Syntax.U_name u) uvs
-                         in
-                      let tps = inductive_tps  in
-                      let arg_typ =
-                        let inst_tc =
-                          let uu____7531 =
+                      fun erasable1  ->
+                        let p = FStar_Ident.range_of_lid lid  in
+                        let pos q = FStar_Syntax_Syntax.withinfo q p  in
+                        let projectee ptyp =
+                          FStar_Syntax_Syntax.gen_bv "projectee"
+                            (FStar_Pervasives_Native.Some p) ptyp
+                           in
+                        let inst_univs =
+                          FStar_List.map
+                            (fun u  -> FStar_Syntax_Syntax.U_name u) uvs
+                           in
+                        let tps = inductive_tps  in
+                        let arg_typ =
+                          let inst_tc =
                             let uu____7538 =
-                              let uu____7539 =
+                              let uu____7545 =
                                 let uu____7546 =
-                                  let uu____7549 =
-                                    FStar_Syntax_Syntax.lid_as_fv tc
-                                      FStar_Syntax_Syntax.delta_constant
-                                      FStar_Pervasives_Native.None
+                                  let uu____7553 =
+                                    let uu____7556 =
+                                      FStar_Syntax_Syntax.lid_as_fv tc
+                                        FStar_Syntax_Syntax.delta_constant
+                                        FStar_Pervasives_Native.None
+                                       in
+                                    FStar_Syntax_Syntax.fv_to_tm uu____7556
                                      in
-                                  FStar_Syntax_Syntax.fv_to_tm uu____7549  in
-                                (uu____7546, inst_univs)  in
-                              FStar_Syntax_Syntax.Tm_uinst uu____7539  in
-                            FStar_Syntax_Syntax.mk uu____7538  in
-                          uu____7531 FStar_Pervasives_Native.None p  in
-                        let args =
+                                  (uu____7553, inst_univs)  in
+                                FStar_Syntax_Syntax.Tm_uinst uu____7546  in
+                              FStar_Syntax_Syntax.mk uu____7545  in
+                            uu____7538 FStar_Pervasives_Native.None p  in
+                          let args =
+                            FStar_All.pipe_right
+                              (FStar_List.append tps indices)
+                              (FStar_List.map
+                                 (fun uu____7590  ->
+                                    match uu____7590 with
+                                    | (x,imp) ->
+                                        let uu____7609 =
+                                          FStar_Syntax_Syntax.bv_to_name x
+                                           in
+                                        (uu____7609, imp)))
+                             in
+                          FStar_Syntax_Syntax.mk_Tm_app inst_tc args
+                            FStar_Pervasives_Native.None p
+                           in
+                        let unrefined_arg_binder =
+                          let uu____7613 = projectee arg_typ  in
+                          FStar_Syntax_Syntax.mk_binder uu____7613  in
+                        let arg_binder =
+                          if Prims.op_Negation refine_domain
+                          then unrefined_arg_binder
+                          else
+                            (let disc_name =
+                               FStar_Syntax_Util.mk_discriminator lid  in
+                             let x =
+                               FStar_Syntax_Syntax.new_bv
+                                 (FStar_Pervasives_Native.Some p) arg_typ
+                                in
+                             let sort =
+                               let disc_fvar =
+                                 let uu____7636 =
+                                   FStar_Ident.set_lid_range disc_name p  in
+                                 FStar_Syntax_Syntax.fvar uu____7636
+                                   (FStar_Syntax_Syntax.Delta_equational_at_level
+                                      Prims.int_one)
+                                   FStar_Pervasives_Native.None
+                                  in
+                               let uu____7638 =
+                                 let uu____7641 =
+                                   let uu____7644 =
+                                     let uu____7649 =
+                                       FStar_Syntax_Syntax.mk_Tm_uinst
+                                         disc_fvar inst_univs
+                                        in
+                                     let uu____7650 =
+                                       let uu____7651 =
+                                         let uu____7660 =
+                                           FStar_Syntax_Syntax.bv_to_name x
+                                            in
+                                         FStar_All.pipe_left
+                                           FStar_Syntax_Syntax.as_arg
+                                           uu____7660
+                                          in
+                                       [uu____7651]  in
+                                     FStar_Syntax_Syntax.mk_Tm_app uu____7649
+                                       uu____7650
+                                      in
+                                   uu____7644 FStar_Pervasives_Native.None p
+                                    in
+                                 FStar_Syntax_Util.b2t uu____7641  in
+                               FStar_Syntax_Util.refine x uu____7638  in
+                             let uu____7685 =
+                               let uu___1050_7686 = projectee arg_typ  in
+                               {
+                                 FStar_Syntax_Syntax.ppname =
+                                   (uu___1050_7686.FStar_Syntax_Syntax.ppname);
+                                 FStar_Syntax_Syntax.index =
+                                   (uu___1050_7686.FStar_Syntax_Syntax.index);
+                                 FStar_Syntax_Syntax.sort = sort
+                               }  in
+                             FStar_Syntax_Syntax.mk_binder uu____7685)
+                           in
+                        let ntps = FStar_List.length tps  in
+                        let all_params =
+                          let uu____7703 =
+                            FStar_List.map
+                              (fun uu____7727  ->
+                                 match uu____7727 with
+                                 | (x,uu____7741) ->
+                                     (x,
+                                       (FStar_Pervasives_Native.Some
+                                          FStar_Syntax_Syntax.imp_tag))) tps
+                             in
+                          FStar_List.append uu____7703 fields  in
+                        let imp_binders =
                           FStar_All.pipe_right
                             (FStar_List.append tps indices)
                             (FStar_List.map
-                               (fun uu____7583  ->
-                                  match uu____7583 with
-                                  | (x,imp) ->
-                                      let uu____7602 =
-                                        FStar_Syntax_Syntax.bv_to_name x  in
-                                      (uu____7602, imp)))
+                               (fun uu____7800  ->
+                                  match uu____7800 with
+                                  | (x,uu____7814) ->
+                                      (x,
+                                        (FStar_Pervasives_Native.Some
+                                           FStar_Syntax_Syntax.imp_tag))))
                            in
-                        FStar_Syntax_Syntax.mk_Tm_app inst_tc args
-                          FStar_Pervasives_Native.None p
-                         in
-                      let unrefined_arg_binder =
-                        let uu____7606 = projectee arg_typ  in
-                        FStar_Syntax_Syntax.mk_binder uu____7606  in
-                      let arg_binder =
-                        if Prims.op_Negation refine_domain
-                        then unrefined_arg_binder
-                        else
-                          (let disc_name =
-                             FStar_Syntax_Util.mk_discriminator lid  in
-                           let x =
-                             FStar_Syntax_Syntax.new_bv
-                               (FStar_Pervasives_Native.Some p) arg_typ
-                              in
-                           let sort =
-                             let disc_fvar =
-                               let uu____7629 =
-                                 FStar_Ident.set_lid_range disc_name p  in
-                               FStar_Syntax_Syntax.fvar uu____7629
-                                 (FStar_Syntax_Syntax.Delta_equational_at_level
-                                    Prims.int_one)
-                                 FStar_Pervasives_Native.None
+                        let early_prims_inductive =
+                          (let uu____7825 =
+                             FStar_TypeChecker_Env.current_module env  in
+                           FStar_Ident.lid_equals
+                             FStar_Parser_Const.prims_lid uu____7825)
+                            &&
+                            (FStar_List.existsb
+                               (fun s  ->
+                                  s =
+                                    (tc.FStar_Ident.ident).FStar_Ident.idText)
+                               early_prims_inductives)
+                           in
+                        let discriminator_ses =
+                          if fvq <> FStar_Syntax_Syntax.Data_ctor
+                          then []
+                          else
+                            (let discriminator_name =
+                               FStar_Syntax_Util.mk_discriminator lid  in
+                             let no_decl = false  in
+                             let only_decl =
+                               early_prims_inductive ||
+                                 (let uu____7846 =
+                                    let uu____7848 =
+                                      FStar_TypeChecker_Env.current_module
+                                        env
+                                       in
+                                    uu____7848.FStar_Ident.str  in
+                                  FStar_Options.dont_gen_projectors
+                                    uu____7846)
                                 in
-                             let uu____7631 =
-                               let uu____7634 =
-                                 let uu____7637 =
-                                   let uu____7642 =
-                                     FStar_Syntax_Syntax.mk_Tm_uinst
-                                       disc_fvar inst_univs
-                                      in
-                                   let uu____7643 =
-                                     let uu____7644 =
-                                       let uu____7653 =
-                                         FStar_Syntax_Syntax.bv_to_name x  in
-                                       FStar_All.pipe_left
-                                         FStar_Syntax_Syntax.as_arg
-                                         uu____7653
-                                        in
-                                     [uu____7644]  in
-                                   FStar_Syntax_Syntax.mk_Tm_app uu____7642
-                                     uu____7643
-                                    in
-                                 uu____7637 FStar_Pervasives_Native.None p
+                             let quals =
+                               let uu____7852 =
+                                 FStar_List.filter
+                                   (fun uu___4_7856  ->
+                                      match uu___4_7856 with
+                                      | FStar_Syntax_Syntax.Abstract  ->
+                                          Prims.op_Negation only_decl
+                                      | FStar_Syntax_Syntax.Inline_for_extraction
+                                           -> true
+                                      | FStar_Syntax_Syntax.NoExtract  ->
+                                          true
+                                      | FStar_Syntax_Syntax.Private  -> true
+                                      | uu____7861 -> false) iquals
                                   in
-                               FStar_Syntax_Util.b2t uu____7634  in
-                             FStar_Syntax_Util.refine x uu____7631  in
-                           let uu____7678 =
-                             let uu___1049_7679 = projectee arg_typ  in
-                             {
-                               FStar_Syntax_Syntax.ppname =
-                                 (uu___1049_7679.FStar_Syntax_Syntax.ppname);
-                               FStar_Syntax_Syntax.index =
-                                 (uu___1049_7679.FStar_Syntax_Syntax.index);
-                               FStar_Syntax_Syntax.sort = sort
-                             }  in
-                           FStar_Syntax_Syntax.mk_binder uu____7678)
-                         in
-                      let ntps = FStar_List.length tps  in
-                      let all_params =
-                        let uu____7696 =
-                          FStar_List.map
-                            (fun uu____7720  ->
-                               match uu____7720 with
-                               | (x,uu____7734) ->
-                                   (x,
-                                     (FStar_Pervasives_Native.Some
-                                        FStar_Syntax_Syntax.imp_tag))) tps
-                           in
-                        FStar_List.append uu____7696 fields  in
-                      let imp_binders =
-                        FStar_All.pipe_right (FStar_List.append tps indices)
-                          (FStar_List.map
-                             (fun uu____7793  ->
-                                match uu____7793 with
-                                | (x,uu____7807) ->
-                                    (x,
-                                      (FStar_Pervasives_Native.Some
-                                         FStar_Syntax_Syntax.imp_tag))))
-                         in
-                      let early_prims_inductive =
-                        (let uu____7818 =
-                           FStar_TypeChecker_Env.current_module env  in
-                         FStar_Ident.lid_equals FStar_Parser_Const.prims_lid
-                           uu____7818)
-                          &&
-                          (FStar_List.existsb
-                             (fun s  ->
-                                s = (tc.FStar_Ident.ident).FStar_Ident.idText)
-                             early_prims_inductives)
-                         in
-                      let discriminator_ses =
-                        if fvq <> FStar_Syntax_Syntax.Data_ctor
-                        then []
-                        else
-                          (let discriminator_name =
-                             FStar_Syntax_Util.mk_discriminator lid  in
-                           let no_decl = false  in
-                           let only_decl =
-                             early_prims_inductive ||
-                               (let uu____7839 =
-                                  let uu____7841 =
-                                    FStar_TypeChecker_Env.current_module env
-                                     in
-                                  uu____7841.FStar_Ident.str  in
-                                FStar_Options.dont_gen_projectors uu____7839)
-                              in
-                           let quals =
-                             let uu____7845 =
-                               FStar_List.filter
-                                 (fun uu___4_7849  ->
-                                    match uu___4_7849 with
-                                    | FStar_Syntax_Syntax.Abstract  ->
-                                        Prims.op_Negation only_decl
-                                    | FStar_Syntax_Syntax.Inline_for_extraction
-                                         -> true
-                                    | FStar_Syntax_Syntax.NoExtract  -> true
-                                    | FStar_Syntax_Syntax.Private  -> true
-                                    | uu____7854 -> false) iquals
+                               FStar_List.append
+                                 ((FStar_Syntax_Syntax.Discriminator lid) ::
+                                 (if only_decl
+                                  then
+                                    [FStar_Syntax_Syntax.Logic;
+                                    FStar_Syntax_Syntax.Assumption]
+                                  else [])) uu____7852
                                 in
-                             FStar_List.append
-                               ((FStar_Syntax_Syntax.Discriminator lid) ::
-                               (if only_decl
-                                then
-                                  [FStar_Syntax_Syntax.Logic;
-                                  FStar_Syntax_Syntax.Assumption]
-                                else [])) uu____7845
-                              in
-                           let binders =
-                             FStar_List.append imp_binders
-                               [unrefined_arg_binder]
-                              in
-                           let t =
-                             let bool_typ =
-                               let uu____7892 =
-                                 let uu____7893 =
-                                   FStar_Syntax_Syntax.lid_as_fv
-                                     FStar_Parser_Const.bool_lid
-                                     FStar_Syntax_Syntax.delta_constant
-                                     FStar_Pervasives_Native.None
-                                    in
-                                 FStar_Syntax_Syntax.fv_to_tm uu____7893  in
-                               FStar_Syntax_Syntax.mk_Total uu____7892  in
-                             let uu____7894 =
-                               FStar_Syntax_Util.arrow binders bool_typ  in
-                             FStar_All.pipe_left
-                               (FStar_Syntax_Subst.close_univ_vars uvs)
-                               uu____7894
-                              in
-                           let decl =
-                             let uu____7898 =
-                               FStar_Ident.range_of_lid discriminator_name
+                             let binders =
+                               FStar_List.append imp_binders
+                                 [unrefined_arg_binder]
                                 in
-                             {
-                               FStar_Syntax_Syntax.sigel =
-                                 (FStar_Syntax_Syntax.Sig_declare_typ
-                                    (discriminator_name, uvs, t));
-                               FStar_Syntax_Syntax.sigrng = uu____7898;
-                               FStar_Syntax_Syntax.sigquals = quals;
-                               FStar_Syntax_Syntax.sigmeta =
-                                 FStar_Syntax_Syntax.default_sigmeta;
-                               FStar_Syntax_Syntax.sigattrs = []
-                             }  in
-                           (let uu____7900 =
-                              FStar_TypeChecker_Env.debug env
-                                (FStar_Options.Other "LogTypes")
-                               in
-                            if uu____7900
-                            then
-                              let uu____7904 =
-                                FStar_Syntax_Print.sigelt_to_string decl  in
-                              FStar_Util.print1
-                                "Declaration of a discriminator %s\n"
-                                uu____7904
-                            else ());
-                           if only_decl
-                           then [decl]
-                           else
-                             (let body =
-                                if Prims.op_Negation refine_domain
-                                then FStar_Syntax_Util.exp_true_bool
-                                else
-                                  (let arg_pats =
-                                     FStar_All.pipe_right all_params
-                                       (FStar_List.mapi
-                                          (fun j  ->
-                                             fun uu____7965  ->
-                                               match uu____7965 with
-                                               | (x,imp) ->
-                                                   let b =
-                                                     FStar_Syntax_Syntax.is_implicit
-                                                       imp
-                                                      in
-                                                   if b && (j < ntps)
-                                                   then
-                                                     let uu____7990 =
-                                                       let uu____7993 =
-                                                         let uu____7994 =
-                                                           let uu____8001 =
-                                                             FStar_Syntax_Syntax.gen_bv
-                                                               (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                                                               FStar_Pervasives_Native.None
-                                                               FStar_Syntax_Syntax.tun
+                             let t =
+                               let bool_typ =
+                                 if erasable1
+                                 then
+                                   FStar_Syntax_Syntax.mk_GTotal
+                                     FStar_Syntax_Util.t_bool
+                                 else
+                                   FStar_Syntax_Syntax.mk_Total
+                                     FStar_Syntax_Util.t_bool
+                                  in
+                               let uu____7906 =
+                                 FStar_Syntax_Util.arrow binders bool_typ  in
+                               FStar_All.pipe_left
+                                 (FStar_Syntax_Subst.close_univ_vars uvs)
+                                 uu____7906
+                                in
+                             let decl =
+                               let uu____7910 =
+                                 FStar_Ident.range_of_lid discriminator_name
+                                  in
+                               {
+                                 FStar_Syntax_Syntax.sigel =
+                                   (FStar_Syntax_Syntax.Sig_declare_typ
+                                      (discriminator_name, uvs, t));
+                                 FStar_Syntax_Syntax.sigrng = uu____7910;
+                                 FStar_Syntax_Syntax.sigquals = quals;
+                                 FStar_Syntax_Syntax.sigmeta =
+                                   FStar_Syntax_Syntax.default_sigmeta;
+                                 FStar_Syntax_Syntax.sigattrs = []
+                               }  in
+                             (let uu____7912 =
+                                FStar_TypeChecker_Env.debug env
+                                  (FStar_Options.Other "LogTypes")
+                                 in
+                              if uu____7912
+                              then
+                                let uu____7916 =
+                                  FStar_Syntax_Print.sigelt_to_string decl
+                                   in
+                                FStar_Util.print1
+                                  "Declaration of a discriminator %s\n"
+                                  uu____7916
+                              else ());
+                             if only_decl
+                             then [decl]
+                             else
+                               (let body =
+                                  if Prims.op_Negation refine_domain
+                                  then FStar_Syntax_Util.exp_true_bool
+                                  else
+                                    (let arg_pats =
+                                       FStar_All.pipe_right all_params
+                                         (FStar_List.mapi
+                                            (fun j  ->
+                                               fun uu____7977  ->
+                                                 match uu____7977 with
+                                                 | (x,imp) ->
+                                                     let b =
+                                                       FStar_Syntax_Syntax.is_implicit
+                                                         imp
+                                                        in
+                                                     if b && (j < ntps)
+                                                     then
+                                                       let uu____8002 =
+                                                         let uu____8005 =
+                                                           let uu____8006 =
+                                                             let uu____8013 =
+                                                               FStar_Syntax_Syntax.gen_bv
+                                                                 (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
+                                                                 FStar_Pervasives_Native.None
+                                                                 FStar_Syntax_Syntax.tun
+                                                                in
+                                                             (uu____8013,
+                                                               FStar_Syntax_Syntax.tun)
                                                               in
-                                                           (uu____8001,
-                                                             FStar_Syntax_Syntax.tun)
+                                                           FStar_Syntax_Syntax.Pat_dot_term
+                                                             uu____8006
                                                             in
-                                                         FStar_Syntax_Syntax.Pat_dot_term
-                                                           uu____7994
-                                                          in
-                                                       pos uu____7993  in
-                                                     (uu____7990, b)
-                                                   else
-                                                     (let uu____8009 =
-                                                        let uu____8012 =
-                                                          let uu____8013 =
-                                                            FStar_Syntax_Syntax.gen_bv
-                                                              (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                                                              FStar_Pervasives_Native.None
-                                                              FStar_Syntax_Syntax.tun
+                                                         pos uu____8005  in
+                                                       (uu____8002, b)
+                                                     else
+                                                       (let uu____8021 =
+                                                          let uu____8024 =
+                                                            let uu____8025 =
+                                                              FStar_Syntax_Syntax.gen_bv
+                                                                (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
+                                                                FStar_Pervasives_Native.None
+                                                                FStar_Syntax_Syntax.tun
+                                                               in
+                                                            FStar_Syntax_Syntax.Pat_wild
+                                                              uu____8025
                                                              in
-                                                          FStar_Syntax_Syntax.Pat_wild
-                                                            uu____8013
-                                                           in
-                                                        pos uu____8012  in
-                                                      (uu____8009, b))))
-                                      in
-                                   let pat_true =
-                                     let uu____8032 =
-                                       let uu____8035 =
-                                         let uu____8036 =
-                                           let uu____8050 =
-                                             FStar_Syntax_Syntax.lid_as_fv
-                                               lid
-                                               FStar_Syntax_Syntax.delta_constant
-                                               (FStar_Pervasives_Native.Some
-                                                  fvq)
-                                              in
-                                           (uu____8050, arg_pats)  in
-                                         FStar_Syntax_Syntax.Pat_cons
-                                           uu____8036
-                                          in
-                                       pos uu____8035  in
-                                     (uu____8032,
-                                       FStar_Pervasives_Native.None,
-                                       FStar_Syntax_Util.exp_true_bool)
-                                      in
-                                   let pat_false =
-                                     let uu____8085 =
-                                       let uu____8088 =
-                                         let uu____8089 =
-                                           FStar_Syntax_Syntax.new_bv
-                                             FStar_Pervasives_Native.None
-                                             FStar_Syntax_Syntax.tun
-                                            in
-                                         FStar_Syntax_Syntax.Pat_wild
-                                           uu____8089
-                                          in
-                                       pos uu____8088  in
-                                     (uu____8085,
-                                       FStar_Pervasives_Native.None,
-                                       FStar_Syntax_Util.exp_false_bool)
-                                      in
-                                   let arg_exp =
-                                     FStar_Syntax_Syntax.bv_to_name
-                                       (FStar_Pervasives_Native.fst
-                                          unrefined_arg_binder)
-                                      in
-                                   let uu____8103 =
-                                     let uu____8110 =
-                                       let uu____8111 =
-                                         let uu____8134 =
-                                           let uu____8151 =
-                                             FStar_Syntax_Util.branch
-                                               pat_true
-                                              in
-                                           let uu____8166 =
-                                             let uu____8183 =
-                                               FStar_Syntax_Util.branch
-                                                 pat_false
-                                                in
-                                             [uu____8183]  in
-                                           uu____8151 :: uu____8166  in
-                                         (arg_exp, uu____8134)  in
-                                       FStar_Syntax_Syntax.Tm_match
-                                         uu____8111
+                                                          pos uu____8024  in
+                                                        (uu____8021, b))))
                                         in
-                                     FStar_Syntax_Syntax.mk uu____8110  in
-                                   uu____8103 FStar_Pervasives_Native.None p)
-                                 in
-                              let dd =
-                                let uu____8259 =
-                                  FStar_All.pipe_right quals
-                                    (FStar_List.contains
-                                       FStar_Syntax_Syntax.Abstract)
-                                   in
-                                if uu____8259
-                                then
-                                  FStar_Syntax_Syntax.Delta_abstract
-                                    (FStar_Syntax_Syntax.Delta_equational_at_level
-                                       Prims.int_one)
-                                else
-                                  FStar_Syntax_Syntax.Delta_equational_at_level
-                                    Prims.int_one
-                                 in
-                              let imp =
-                                FStar_Syntax_Util.abs binders body
-                                  FStar_Pervasives_Native.None
-                                 in
-                              let lbtyp =
-                                if no_decl
-                                then t
-                                else FStar_Syntax_Syntax.tun  in
-                              let lb =
-                                let uu____8281 =
-                                  let uu____8286 =
-                                    FStar_Syntax_Syntax.lid_as_fv
-                                      discriminator_name dd
-                                      FStar_Pervasives_Native.None
-                                     in
-                                  FStar_Util.Inr uu____8286  in
-                                let uu____8287 =
-                                  FStar_Syntax_Subst.close_univ_vars uvs imp
-                                   in
-                                FStar_Syntax_Util.mk_letbinding uu____8281
-                                  uvs lbtyp FStar_Parser_Const.effect_Tot_lid
-                                  uu____8287 [] FStar_Range.dummyRange
-                                 in
-                              let impl =
-                                let uu____8293 =
-                                  let uu____8294 =
-                                    let uu____8301 =
-                                      let uu____8304 =
-                                        let uu____8305 =
-                                          FStar_All.pipe_right
-                                            lb.FStar_Syntax_Syntax.lbname
-                                            FStar_Util.right
-                                           in
-                                        FStar_All.pipe_right uu____8305
-                                          (fun fv  ->
-                                             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-                                         in
-                                      [uu____8304]  in
-                                    ((false, [lb]), uu____8301)  in
-                                  FStar_Syntax_Syntax.Sig_let uu____8294  in
-                                {
-                                  FStar_Syntax_Syntax.sigel = uu____8293;
-                                  FStar_Syntax_Syntax.sigrng = p;
-                                  FStar_Syntax_Syntax.sigquals = quals;
-                                  FStar_Syntax_Syntax.sigmeta =
-                                    FStar_Syntax_Syntax.default_sigmeta;
-                                  FStar_Syntax_Syntax.sigattrs = []
-                                }  in
-                              (let uu____8319 =
-                                 FStar_TypeChecker_Env.debug env
-                                   (FStar_Options.Other "LogTypes")
-                                  in
-                               if uu____8319
-                               then
-                                 let uu____8323 =
-                                   FStar_Syntax_Print.sigelt_to_string impl
-                                    in
-                                 FStar_Util.print1
-                                   "Implementation of a discriminator %s\n"
-                                   uu____8323
-                               else ());
-                              [decl; impl]))
-                         in
-                      let arg_exp =
-                        FStar_Syntax_Syntax.bv_to_name
-                          (FStar_Pervasives_Native.fst arg_binder)
-                         in
-                      let binders =
-                        FStar_List.append imp_binders [arg_binder]  in
-                      let arg =
-                        FStar_Syntax_Util.arg_of_non_null_binder arg_binder
-                         in
-                      let subst1 =
-                        FStar_All.pipe_right fields
-                          (FStar_List.mapi
-                             (fun i  ->
-                                fun uu____8396  ->
-                                  match uu____8396 with
-                                  | (a,uu____8405) ->
-                                      let uu____8410 =
-                                        FStar_Syntax_Util.mk_field_projector_name
-                                          lid a i
-                                         in
-                                      (match uu____8410 with
-                                       | (field_name,uu____8416) ->
-                                           let field_proj_tm =
-                                             let uu____8418 =
-                                               let uu____8419 =
-                                                 FStar_Syntax_Syntax.lid_as_fv
-                                                   field_name
-                                                   (FStar_Syntax_Syntax.Delta_equational_at_level
-                                                      Prims.int_one)
-                                                   FStar_Pervasives_Native.None
-                                                  in
-                                               FStar_Syntax_Syntax.fv_to_tm
-                                                 uu____8419
+                                     let pat_true =
+                                       let uu____8044 =
+                                         let uu____8047 =
+                                           let uu____8048 =
+                                             let uu____8062 =
+                                               FStar_Syntax_Syntax.lid_as_fv
+                                                 lid
+                                                 FStar_Syntax_Syntax.delta_constant
+                                                 (FStar_Pervasives_Native.Some
+                                                    fvq)
                                                 in
-                                             FStar_Syntax_Syntax.mk_Tm_uinst
-                                               uu____8418 inst_univs
+                                             (uu____8062, arg_pats)  in
+                                           FStar_Syntax_Syntax.Pat_cons
+                                             uu____8048
+                                            in
+                                         pos uu____8047  in
+                                       (uu____8044,
+                                         FStar_Pervasives_Native.None,
+                                         FStar_Syntax_Util.exp_true_bool)
+                                        in
+                                     let pat_false =
+                                       let uu____8097 =
+                                         let uu____8100 =
+                                           let uu____8101 =
+                                             FStar_Syntax_Syntax.new_bv
+                                               FStar_Pervasives_Native.None
+                                               FStar_Syntax_Syntax.tun
                                               in
-                                           let proj =
-                                             FStar_Syntax_Syntax.mk_Tm_app
-                                               field_proj_tm [arg]
-                                               FStar_Pervasives_Native.None p
-                                              in
-                                           FStar_Syntax_Syntax.NT (a, proj))))
-                         in
-                      let projectors_ses =
-                        let uu____8445 =
+                                           FStar_Syntax_Syntax.Pat_wild
+                                             uu____8101
+                                            in
+                                         pos uu____8100  in
+                                       (uu____8097,
+                                         FStar_Pervasives_Native.None,
+                                         FStar_Syntax_Util.exp_false_bool)
+                                        in
+                                     let arg_exp =
+                                       FStar_Syntax_Syntax.bv_to_name
+                                         (FStar_Pervasives_Native.fst
+                                            unrefined_arg_binder)
+                                        in
+                                     let uu____8115 =
+                                       let uu____8122 =
+                                         let uu____8123 =
+                                           let uu____8146 =
+                                             let uu____8163 =
+                                               FStar_Syntax_Util.branch
+                                                 pat_true
+                                                in
+                                             let uu____8178 =
+                                               let uu____8195 =
+                                                 FStar_Syntax_Util.branch
+                                                   pat_false
+                                                  in
+                                               [uu____8195]  in
+                                             uu____8163 :: uu____8178  in
+                                           (arg_exp, uu____8146)  in
+                                         FStar_Syntax_Syntax.Tm_match
+                                           uu____8123
+                                          in
+                                       FStar_Syntax_Syntax.mk uu____8122  in
+                                     uu____8115 FStar_Pervasives_Native.None
+                                       p)
+                                   in
+                                let dd =
+                                  let uu____8271 =
+                                    FStar_All.pipe_right quals
+                                      (FStar_List.contains
+                                         FStar_Syntax_Syntax.Abstract)
+                                     in
+                                  if uu____8271
+                                  then
+                                    FStar_Syntax_Syntax.Delta_abstract
+                                      (FStar_Syntax_Syntax.Delta_equational_at_level
+                                         Prims.int_one)
+                                  else
+                                    FStar_Syntax_Syntax.Delta_equational_at_level
+                                      Prims.int_one
+                                   in
+                                let imp =
+                                  FStar_Syntax_Util.abs binders body
+                                    FStar_Pervasives_Native.None
+                                   in
+                                let lbtyp =
+                                  if no_decl
+                                  then t
+                                  else FStar_Syntax_Syntax.tun  in
+                                let lb =
+                                  let uu____8293 =
+                                    let uu____8298 =
+                                      FStar_Syntax_Syntax.lid_as_fv
+                                        discriminator_name dd
+                                        FStar_Pervasives_Native.None
+                                       in
+                                    FStar_Util.Inr uu____8298  in
+                                  let uu____8299 =
+                                    FStar_Syntax_Subst.close_univ_vars uvs
+                                      imp
+                                     in
+                                  FStar_Syntax_Util.mk_letbinding uu____8293
+                                    uvs lbtyp
+                                    FStar_Parser_Const.effect_Tot_lid
+                                    uu____8299 [] FStar_Range.dummyRange
+                                   in
+                                let impl =
+                                  let uu____8305 =
+                                    let uu____8306 =
+                                      let uu____8313 =
+                                        let uu____8316 =
+                                          let uu____8317 =
+                                            FStar_All.pipe_right
+                                              lb.FStar_Syntax_Syntax.lbname
+                                              FStar_Util.right
+                                             in
+                                          FStar_All.pipe_right uu____8317
+                                            (fun fv  ->
+                                               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
+                                           in
+                                        [uu____8316]  in
+                                      ((false, [lb]), uu____8313)  in
+                                    FStar_Syntax_Syntax.Sig_let uu____8306
+                                     in
+                                  {
+                                    FStar_Syntax_Syntax.sigel = uu____8305;
+                                    FStar_Syntax_Syntax.sigrng = p;
+                                    FStar_Syntax_Syntax.sigquals = quals;
+                                    FStar_Syntax_Syntax.sigmeta =
+                                      FStar_Syntax_Syntax.default_sigmeta;
+                                    FStar_Syntax_Syntax.sigattrs = []
+                                  }  in
+                                (let uu____8331 =
+                                   FStar_TypeChecker_Env.debug env
+                                     (FStar_Options.Other "LogTypes")
+                                    in
+                                 if uu____8331
+                                 then
+                                   let uu____8335 =
+                                     FStar_Syntax_Print.sigelt_to_string impl
+                                      in
+                                   FStar_Util.print1
+                                     "Implementation of a discriminator %s\n"
+                                     uu____8335
+                                 else ());
+                                [decl; impl]))
+                           in
+                        let arg_exp =
+                          FStar_Syntax_Syntax.bv_to_name
+                            (FStar_Pervasives_Native.fst arg_binder)
+                           in
+                        let binders =
+                          FStar_List.append imp_binders [arg_binder]  in
+                        let arg =
+                          FStar_Syntax_Util.arg_of_non_null_binder arg_binder
+                           in
+                        let subst1 =
                           FStar_All.pipe_right fields
                             (FStar_List.mapi
                                (fun i  ->
-                                  fun uu____8487  ->
-                                    match uu____8487 with
-                                    | (x,uu____8498) ->
-                                        let p1 =
-                                          FStar_Syntax_Syntax.range_of_bv x
-                                           in
-                                        let uu____8504 =
+                                  fun uu____8408  ->
+                                    match uu____8408 with
+                                    | (a,uu____8417) ->
+                                        let uu____8422 =
                                           FStar_Syntax_Util.mk_field_projector_name
-                                            lid x i
+                                            lid a i
                                            in
-                                        (match uu____8504 with
-                                         | (field_name,uu____8512) ->
-                                             let t =
-                                               let uu____8516 =
-                                                 let uu____8517 =
-                                                   let uu____8520 =
+                                        (match uu____8422 with
+                                         | (field_name,uu____8428) ->
+                                             let field_proj_tm =
+                                               let uu____8430 =
+                                                 let uu____8431 =
+                                                   FStar_Syntax_Syntax.lid_as_fv
+                                                     field_name
+                                                     (FStar_Syntax_Syntax.Delta_equational_at_level
+                                                        Prims.int_one)
+                                                     FStar_Pervasives_Native.None
+                                                    in
+                                                 FStar_Syntax_Syntax.fv_to_tm
+                                                   uu____8431
+                                                  in
+                                               FStar_Syntax_Syntax.mk_Tm_uinst
+                                                 uu____8430 inst_univs
+                                                in
+                                             let proj =
+                                               FStar_Syntax_Syntax.mk_Tm_app
+                                                 field_proj_tm [arg]
+                                                 FStar_Pervasives_Native.None
+                                                 p
+                                                in
+                                             FStar_Syntax_Syntax.NT (a, proj))))
+                           in
+                        let projectors_ses =
+                          let uu____8457 =
+                            FStar_All.pipe_right fields
+                              (FStar_List.mapi
+                                 (fun i  ->
+                                    fun uu____8499  ->
+                                      match uu____8499 with
+                                      | (x,uu____8510) ->
+                                          let p1 =
+                                            FStar_Syntax_Syntax.range_of_bv x
+                                             in
+                                          let uu____8516 =
+                                            FStar_Syntax_Util.mk_field_projector_name
+                                              lid x i
+                                             in
+                                          (match uu____8516 with
+                                           | (field_name,uu____8524) ->
+                                               let t =
+                                                 let result_comp =
+                                                   let t =
                                                      FStar_Syntax_Subst.subst
                                                        subst1
                                                        x.FStar_Syntax_Syntax.sort
                                                       in
-                                                   FStar_Syntax_Syntax.mk_Total
-                                                     uu____8520
+                                                   if erasable1
+                                                   then
+                                                     FStar_Syntax_Syntax.mk_GTotal
+                                                       t
+                                                   else
+                                                     FStar_Syntax_Syntax.mk_Total
+                                                       t
                                                     in
-                                                 FStar_Syntax_Util.arrow
-                                                   binders uu____8517
+                                                 let uu____8537 =
+                                                   FStar_Syntax_Util.arrow
+                                                     binders result_comp
+                                                    in
+                                                 FStar_All.pipe_left
+                                                   (FStar_Syntax_Subst.close_univ_vars
+                                                      uvs) uu____8537
                                                   in
-                                               FStar_All.pipe_left
-                                                 (FStar_Syntax_Subst.close_univ_vars
-                                                    uvs) uu____8516
-                                                in
-                                             let only_decl =
-                                               early_prims_inductive ||
-                                                 (let uu____8526 =
-                                                    let uu____8528 =
-                                                      FStar_TypeChecker_Env.current_module
-                                                        env
+                                               let only_decl =
+                                                 early_prims_inductive ||
+                                                   (let uu____8543 =
+                                                      let uu____8545 =
+                                                        FStar_TypeChecker_Env.current_module
+                                                          env
+                                                         in
+                                                      uu____8545.FStar_Ident.str
                                                        in
-                                                    uu____8528.FStar_Ident.str
-                                                     in
-                                                  FStar_Options.dont_gen_projectors
-                                                    uu____8526)
-                                                in
-                                             let no_decl = false  in
-                                             let quals q =
-                                               if only_decl
-                                               then
-                                                 let uu____8547 =
-                                                   FStar_List.filter
-                                                     (fun uu___5_8551  ->
-                                                        match uu___5_8551
-                                                        with
-                                                        | FStar_Syntax_Syntax.Abstract
-                                                             -> false
-                                                        | uu____8554 -> true)
-                                                     q
-                                                    in
-                                                 FStar_Syntax_Syntax.Assumption
-                                                   :: uu____8547
-                                               else q  in
-                                             let quals1 =
-                                               let iquals1 =
-                                                 FStar_All.pipe_right iquals
-                                                   (FStar_List.filter
-                                                      (fun uu___6_8569  ->
-                                                         match uu___6_8569
-                                                         with
-                                                         | FStar_Syntax_Syntax.Inline_for_extraction
-                                                              -> true
-                                                         | FStar_Syntax_Syntax.NoExtract
-                                                              -> true
-                                                         | FStar_Syntax_Syntax.Abstract
-                                                              -> true
-                                                         | FStar_Syntax_Syntax.Private
-                                                              -> true
-                                                         | uu____8575 ->
-                                                             false))
+                                                    FStar_Options.dont_gen_projectors
+                                                      uu____8543)
                                                   in
-                                               quals
-                                                 ((FStar_Syntax_Syntax.Projector
-                                                     (lid,
-                                                       (x.FStar_Syntax_Syntax.ppname)))
-                                                 :: iquals1)
-                                                in
-                                             let attrs =
-                                               if only_decl
-                                               then []
-                                               else
-                                                 [FStar_Syntax_Util.attr_substitute]
-                                                in
-                                             let decl =
-                                               let uu____8586 =
-                                                 FStar_Ident.range_of_lid
-                                                   field_name
-                                                  in
-                                               {
-                                                 FStar_Syntax_Syntax.sigel =
-                                                   (FStar_Syntax_Syntax.Sig_declare_typ
-                                                      (field_name, uvs, t));
-                                                 FStar_Syntax_Syntax.sigrng =
-                                                   uu____8586;
-                                                 FStar_Syntax_Syntax.sigquals
-                                                   = quals1;
-                                                 FStar_Syntax_Syntax.sigmeta
-                                                   =
-                                                   FStar_Syntax_Syntax.default_sigmeta;
-                                                 FStar_Syntax_Syntax.sigattrs
-                                                   = attrs
-                                               }  in
-                                             ((let uu____8588 =
-                                                 FStar_TypeChecker_Env.debug
-                                                   env
-                                                   (FStar_Options.Other
-                                                      "LogTypes")
-                                                  in
-                                               if uu____8588
-                                               then
-                                                 let uu____8592 =
-                                                   FStar_Syntax_Print.sigelt_to_string
-                                                     decl
-                                                    in
-                                                 FStar_Util.print1
-                                                   "Declaration of a projector %s\n"
-                                                   uu____8592
-                                               else ());
-                                              if only_decl
-                                              then [decl]
-                                              else
-                                                (let projection =
-                                                   FStar_Syntax_Syntax.gen_bv
-                                                     (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                                                     FStar_Pervasives_Native.None
-                                                     FStar_Syntax_Syntax.tun
-                                                    in
-                                                 let arg_pats =
+                                               let no_decl = false  in
+                                               let quals q =
+                                                 if only_decl
+                                                 then
+                                                   let uu____8564 =
+                                                     FStar_List.filter
+                                                       (fun uu___5_8568  ->
+                                                          match uu___5_8568
+                                                          with
+                                                          | FStar_Syntax_Syntax.Abstract
+                                                               -> false
+                                                          | uu____8571 ->
+                                                              true) q
+                                                      in
+                                                   FStar_Syntax_Syntax.Assumption
+                                                     :: uu____8564
+                                                 else q  in
+                                               let quals1 =
+                                                 let iquals1 =
                                                    FStar_All.pipe_right
-                                                     all_params
-                                                     (FStar_List.mapi
-                                                        (fun j  ->
-                                                           fun uu____8646  ->
-                                                             match uu____8646
-                                                             with
-                                                             | (x1,imp) ->
-                                                                 let b =
-                                                                   FStar_Syntax_Syntax.is_implicit
-                                                                    imp
-                                                                    in
-                                                                 if
-                                                                   (i + ntps)
+                                                     iquals
+                                                     (FStar_List.filter
+                                                        (fun uu___6_8586  ->
+                                                           match uu___6_8586
+                                                           with
+                                                           | FStar_Syntax_Syntax.Inline_for_extraction
+                                                                -> true
+                                                           | FStar_Syntax_Syntax.NoExtract
+                                                                -> true
+                                                           | FStar_Syntax_Syntax.Abstract
+                                                                -> true
+                                                           | FStar_Syntax_Syntax.Private
+                                                                -> true
+                                                           | uu____8592 ->
+                                                               false))
+                                                    in
+                                                 quals
+                                                   ((FStar_Syntax_Syntax.Projector
+                                                       (lid,
+                                                         (x.FStar_Syntax_Syntax.ppname)))
+                                                   :: iquals1)
+                                                  in
+                                               let attrs =
+                                                 if only_decl
+                                                 then []
+                                                 else
+                                                   [FStar_Syntax_Util.attr_substitute]
+                                                  in
+                                               let decl =
+                                                 let uu____8603 =
+                                                   FStar_Ident.range_of_lid
+                                                     field_name
+                                                    in
+                                                 {
+                                                   FStar_Syntax_Syntax.sigel
+                                                     =
+                                                     (FStar_Syntax_Syntax.Sig_declare_typ
+                                                        (field_name, uvs, t));
+                                                   FStar_Syntax_Syntax.sigrng
+                                                     = uu____8603;
+                                                   FStar_Syntax_Syntax.sigquals
+                                                     = quals1;
+                                                   FStar_Syntax_Syntax.sigmeta
+                                                     =
+                                                     FStar_Syntax_Syntax.default_sigmeta;
+                                                   FStar_Syntax_Syntax.sigattrs
+                                                     = attrs
+                                                 }  in
+                                               ((let uu____8605 =
+                                                   FStar_TypeChecker_Env.debug
+                                                     env
+                                                     (FStar_Options.Other
+                                                        "LogTypes")
+                                                    in
+                                                 if uu____8605
+                                                 then
+                                                   let uu____8609 =
+                                                     FStar_Syntax_Print.sigelt_to_string
+                                                       decl
+                                                      in
+                                                   FStar_Util.print1
+                                                     "Declaration of a projector %s\n"
+                                                     uu____8609
+                                                 else ());
+                                                if only_decl
+                                                then [decl]
+                                                else
+                                                  (let projection =
+                                                     FStar_Syntax_Syntax.gen_bv
+                                                       (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
+                                                       FStar_Pervasives_Native.None
+                                                       FStar_Syntax_Syntax.tun
+                                                      in
+                                                   let arg_pats =
+                                                     FStar_All.pipe_right
+                                                       all_params
+                                                       (FStar_List.mapi
+                                                          (fun j  ->
+                                                             fun uu____8663 
+                                                               ->
+                                                               match uu____8663
+                                                               with
+                                                               | (x1,imp) ->
+                                                                   let b =
+                                                                    FStar_Syntax_Syntax.is_implicit
+                                                                    imp  in
+                                                                   if
+                                                                    (i + ntps)
                                                                     = j
-                                                                 then
-                                                                   let uu____8672
+                                                                   then
+                                                                    let uu____8689
                                                                     =
                                                                     pos
                                                                     (FStar_Syntax_Syntax.Pat_var
                                                                     projection)
                                                                      in
-                                                                   (uu____8672,
+                                                                    (uu____8689,
                                                                     b)
-                                                                 else
-                                                                   if
+                                                                   else
+                                                                    if
                                                                     b &&
                                                                     (j < ntps)
-                                                                   then
-                                                                    (let uu____8688
+                                                                    then
+                                                                    (let uu____8705
                                                                     =
-                                                                    let uu____8691
+                                                                    let uu____8708
                                                                     =
-                                                                    let uu____8692
+                                                                    let uu____8709
                                                                     =
-                                                                    let uu____8699
+                                                                    let uu____8716
                                                                     =
                                                                     FStar_Syntax_Syntax.gen_bv
                                                                     (x1.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
                                                                     FStar_Pervasives_Native.None
                                                                     FStar_Syntax_Syntax.tun
                                                                      in
-                                                                    (uu____8699,
+                                                                    (uu____8716,
                                                                     FStar_Syntax_Syntax.tun)
                                                                      in
                                                                     FStar_Syntax_Syntax.Pat_dot_term
-                                                                    uu____8692
+                                                                    uu____8709
                                                                      in
                                                                     pos
-                                                                    uu____8691
+                                                                    uu____8708
                                                                      in
-                                                                    (uu____8688,
+                                                                    (uu____8705,
                                                                     b))
-                                                                   else
-                                                                    (let uu____8707
+                                                                    else
+                                                                    (let uu____8724
                                                                     =
-                                                                    let uu____8710
+                                                                    let uu____8727
                                                                     =
-                                                                    let uu____8711
+                                                                    let uu____8728
                                                                     =
                                                                     FStar_Syntax_Syntax.gen_bv
                                                                     (x1.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
@@ -3448,180 +3469,180 @@ let (mk_discriminator_and_indexed_projectors :
                                                                     FStar_Syntax_Syntax.tun
                                                                      in
                                                                     FStar_Syntax_Syntax.Pat_wild
-                                                                    uu____8711
+                                                                    uu____8728
                                                                      in
                                                                     pos
-                                                                    uu____8710
+                                                                    uu____8727
                                                                      in
-                                                                    (uu____8707,
+                                                                    (uu____8724,
                                                                     b))))
-                                                    in
-                                                 let pat =
-                                                   let uu____8730 =
-                                                     let uu____8733 =
-                                                       let uu____8734 =
-                                                         let uu____8748 =
-                                                           FStar_Syntax_Syntax.lid_as_fv
-                                                             lid
-                                                             FStar_Syntax_Syntax.delta_constant
-                                                             (FStar_Pervasives_Native.Some
-                                                                fvq)
-                                                            in
-                                                         (uu____8748,
-                                                           arg_pats)
-                                                          in
-                                                       FStar_Syntax_Syntax.Pat_cons
-                                                         uu____8734
-                                                        in
-                                                     pos uu____8733  in
-                                                   let uu____8758 =
-                                                     FStar_Syntax_Syntax.bv_to_name
-                                                       projection
                                                       in
-                                                   (uu____8730,
-                                                     FStar_Pervasives_Native.None,
-                                                     uu____8758)
-                                                    in
-                                                 let body =
-                                                   let uu____8774 =
-                                                     let uu____8781 =
-                                                       let uu____8782 =
-                                                         let uu____8805 =
+                                                   let pat =
+                                                     let uu____8747 =
+                                                       let uu____8750 =
+                                                         let uu____8751 =
+                                                           let uu____8765 =
+                                                             FStar_Syntax_Syntax.lid_as_fv
+                                                               lid
+                                                               FStar_Syntax_Syntax.delta_constant
+                                                               (FStar_Pervasives_Native.Some
+                                                                  fvq)
+                                                              in
+                                                           (uu____8765,
+                                                             arg_pats)
+                                                            in
+                                                         FStar_Syntax_Syntax.Pat_cons
+                                                           uu____8751
+                                                          in
+                                                       pos uu____8750  in
+                                                     let uu____8775 =
+                                                       FStar_Syntax_Syntax.bv_to_name
+                                                         projection
+                                                        in
+                                                     (uu____8747,
+                                                       FStar_Pervasives_Native.None,
+                                                       uu____8775)
+                                                      in
+                                                   let body =
+                                                     let uu____8791 =
+                                                       let uu____8798 =
+                                                         let uu____8799 =
                                                            let uu____8822 =
-                                                             FStar_Syntax_Util.branch
-                                                               pat
-                                                              in
-                                                           [uu____8822]  in
-                                                         (arg_exp,
-                                                           uu____8805)
-                                                          in
-                                                       FStar_Syntax_Syntax.Tm_match
-                                                         uu____8782
-                                                        in
-                                                     FStar_Syntax_Syntax.mk
-                                                       uu____8781
-                                                      in
-                                                   uu____8774
-                                                     FStar_Pervasives_Native.None
-                                                     p1
-                                                    in
-                                                 let imp =
-                                                   FStar_Syntax_Util.abs
-                                                     binders body
-                                                     FStar_Pervasives_Native.None
-                                                    in
-                                                 let dd =
-                                                   let uu____8887 =
-                                                     FStar_All.pipe_right
-                                                       quals1
-                                                       (FStar_List.contains
-                                                          FStar_Syntax_Syntax.Abstract)
-                                                      in
-                                                   if uu____8887
-                                                   then
-                                                     FStar_Syntax_Syntax.Delta_abstract
-                                                       (FStar_Syntax_Syntax.Delta_equational_at_level
-                                                          Prims.int_one)
-                                                   else
-                                                     FStar_Syntax_Syntax.Delta_equational_at_level
-                                                       Prims.int_one
-                                                    in
-                                                 let lbtyp =
-                                                   if no_decl
-                                                   then t
-                                                   else
-                                                     FStar_Syntax_Syntax.tun
-                                                    in
-                                                 let lb =
-                                                   let uu____8906 =
-                                                     let uu____8911 =
-                                                       FStar_Syntax_Syntax.lid_as_fv
-                                                         field_name dd
-                                                         FStar_Pervasives_Native.None
-                                                        in
-                                                     FStar_Util.Inr
-                                                       uu____8911
-                                                      in
-                                                   let uu____8912 =
-                                                     FStar_Syntax_Subst.close_univ_vars
-                                                       uvs imp
-                                                      in
-                                                   {
-                                                     FStar_Syntax_Syntax.lbname
-                                                       = uu____8906;
-                                                     FStar_Syntax_Syntax.lbunivs
-                                                       = uvs;
-                                                     FStar_Syntax_Syntax.lbtyp
-                                                       = lbtyp;
-                                                     FStar_Syntax_Syntax.lbeff
-                                                       =
-                                                       FStar_Parser_Const.effect_Tot_lid;
-                                                     FStar_Syntax_Syntax.lbdef
-                                                       = uu____8912;
-                                                     FStar_Syntax_Syntax.lbattrs
-                                                       = [];
-                                                     FStar_Syntax_Syntax.lbpos
-                                                       =
-                                                       FStar_Range.dummyRange
-                                                   }  in
-                                                 let impl =
-                                                   let uu____8918 =
-                                                     let uu____8919 =
-                                                       let uu____8926 =
-                                                         let uu____8929 =
-                                                           let uu____8930 =
-                                                             FStar_All.pipe_right
-                                                               lb.FStar_Syntax_Syntax.lbname
-                                                               FStar_Util.right
-                                                              in
-                                                           FStar_All.pipe_right
-                                                             uu____8930
-                                                             (fun fv  ->
-                                                                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
+                                                             let uu____8839 =
+                                                               FStar_Syntax_Util.branch
+                                                                 pat
+                                                                in
+                                                             [uu____8839]  in
+                                                           (arg_exp,
+                                                             uu____8822)
                                                             in
-                                                         [uu____8929]  in
-                                                       ((false, [lb]),
-                                                         uu____8926)
+                                                         FStar_Syntax_Syntax.Tm_match
+                                                           uu____8799
+                                                          in
+                                                       FStar_Syntax_Syntax.mk
+                                                         uu____8798
                                                         in
-                                                     FStar_Syntax_Syntax.Sig_let
-                                                       uu____8919
+                                                     uu____8791
+                                                       FStar_Pervasives_Native.None
+                                                       p1
                                                       in
-                                                   {
-                                                     FStar_Syntax_Syntax.sigel
-                                                       = uu____8918;
-                                                     FStar_Syntax_Syntax.sigrng
-                                                       = p1;
-                                                     FStar_Syntax_Syntax.sigquals
-                                                       = quals1;
-                                                     FStar_Syntax_Syntax.sigmeta
-                                                       =
-                                                       FStar_Syntax_Syntax.default_sigmeta;
-                                                     FStar_Syntax_Syntax.sigattrs
-                                                       = attrs
-                                                   }  in
-                                                 (let uu____8944 =
-                                                    FStar_TypeChecker_Env.debug
-                                                      env
-                                                      (FStar_Options.Other
-                                                         "LogTypes")
-                                                     in
-                                                  if uu____8944
-                                                  then
-                                                    let uu____8948 =
-                                                      FStar_Syntax_Print.sigelt_to_string
-                                                        impl
+                                                   let imp =
+                                                     FStar_Syntax_Util.abs
+                                                       binders body
+                                                       FStar_Pervasives_Native.None
+                                                      in
+                                                   let dd =
+                                                     let uu____8904 =
+                                                       FStar_All.pipe_right
+                                                         quals1
+                                                         (FStar_List.contains
+                                                            FStar_Syntax_Syntax.Abstract)
+                                                        in
+                                                     if uu____8904
+                                                     then
+                                                       FStar_Syntax_Syntax.Delta_abstract
+                                                         (FStar_Syntax_Syntax.Delta_equational_at_level
+                                                            Prims.int_one)
+                                                     else
+                                                       FStar_Syntax_Syntax.Delta_equational_at_level
+                                                         Prims.int_one
+                                                      in
+                                                   let lbtyp =
+                                                     if no_decl
+                                                     then t
+                                                     else
+                                                       FStar_Syntax_Syntax.tun
+                                                      in
+                                                   let lb =
+                                                     let uu____8923 =
+                                                       let uu____8928 =
+                                                         FStar_Syntax_Syntax.lid_as_fv
+                                                           field_name dd
+                                                           FStar_Pervasives_Native.None
+                                                          in
+                                                       FStar_Util.Inr
+                                                         uu____8928
+                                                        in
+                                                     let uu____8929 =
+                                                       FStar_Syntax_Subst.close_univ_vars
+                                                         uvs imp
+                                                        in
+                                                     {
+                                                       FStar_Syntax_Syntax.lbname
+                                                         = uu____8923;
+                                                       FStar_Syntax_Syntax.lbunivs
+                                                         = uvs;
+                                                       FStar_Syntax_Syntax.lbtyp
+                                                         = lbtyp;
+                                                       FStar_Syntax_Syntax.lbeff
+                                                         =
+                                                         FStar_Parser_Const.effect_Tot_lid;
+                                                       FStar_Syntax_Syntax.lbdef
+                                                         = uu____8929;
+                                                       FStar_Syntax_Syntax.lbattrs
+                                                         = [];
+                                                       FStar_Syntax_Syntax.lbpos
+                                                         =
+                                                         FStar_Range.dummyRange
+                                                     }  in
+                                                   let impl =
+                                                     let uu____8935 =
+                                                       let uu____8936 =
+                                                         let uu____8943 =
+                                                           let uu____8946 =
+                                                             let uu____8947 =
+                                                               FStar_All.pipe_right
+                                                                 lb.FStar_Syntax_Syntax.lbname
+                                                                 FStar_Util.right
+                                                                in
+                                                             FStar_All.pipe_right
+                                                               uu____8947
+                                                               (fun fv  ->
+                                                                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
+                                                              in
+                                                           [uu____8946]  in
+                                                         ((false, [lb]),
+                                                           uu____8943)
+                                                          in
+                                                       FStar_Syntax_Syntax.Sig_let
+                                                         uu____8936
+                                                        in
+                                                     {
+                                                       FStar_Syntax_Syntax.sigel
+                                                         = uu____8935;
+                                                       FStar_Syntax_Syntax.sigrng
+                                                         = p1;
+                                                       FStar_Syntax_Syntax.sigquals
+                                                         = quals1;
+                                                       FStar_Syntax_Syntax.sigmeta
+                                                         =
+                                                         FStar_Syntax_Syntax.default_sigmeta;
+                                                       FStar_Syntax_Syntax.sigattrs
+                                                         = attrs
+                                                     }  in
+                                                   (let uu____8961 =
+                                                      FStar_TypeChecker_Env.debug
+                                                        env
+                                                        (FStar_Options.Other
+                                                           "LogTypes")
                                                        in
-                                                    FStar_Util.print1
-                                                      "Implementation of a projector %s\n"
-                                                      uu____8948
-                                                  else ());
-                                                 if no_decl
-                                                 then [impl]
-                                                 else [decl; impl])))))
+                                                    if uu____8961
+                                                    then
+                                                      let uu____8965 =
+                                                        FStar_Syntax_Print.sigelt_to_string
+                                                          impl
+                                                         in
+                                                      FStar_Util.print1
+                                                        "Implementation of a projector %s\n"
+                                                        uu____8965
+                                                    else ());
+                                                   if no_decl
+                                                   then [impl]
+                                                   else [decl; impl])))))
+                             in
+                          FStar_All.pipe_right uu____8457 FStar_List.flatten
                            in
-                        FStar_All.pipe_right uu____8445 FStar_List.flatten
-                         in
-                      FStar_List.append discriminator_ses projectors_ses
+                        FStar_List.append discriminator_ses projectors_ses
   
 let (mk_data_operations :
   FStar_Syntax_Syntax.qualifier Prims.list ->
@@ -3635,52 +3656,52 @@ let (mk_data_operations :
         fun se  ->
           match se.FStar_Syntax_Syntax.sigel with
           | FStar_Syntax_Syntax.Sig_datacon
-              (constr_lid,uvs,t,typ_lid,n_typars,uu____9002) when
-              let uu____9009 =
+              (constr_lid,uvs,t,typ_lid,n_typars,uu____9019) when
+              let uu____9026 =
                 FStar_Ident.lid_equals constr_lid
                   FStar_Parser_Const.lexcons_lid
                  in
-              Prims.op_Negation uu____9009 ->
-              let uu____9011 = FStar_Syntax_Subst.univ_var_opening uvs  in
-              (match uu____9011 with
+              Prims.op_Negation uu____9026 ->
+              let uu____9028 = FStar_Syntax_Subst.univ_var_opening uvs  in
+              (match uu____9028 with
                | (univ_opening,uvs1) ->
                    let t1 = FStar_Syntax_Subst.subst univ_opening t  in
-                   let uu____9033 = FStar_Syntax_Util.arrow_formals t1  in
-                   (match uu____9033 with
-                    | (formals,uu____9051) ->
-                        let uu____9072 =
+                   let uu____9050 = FStar_Syntax_Util.arrow_formals t1  in
+                   (match uu____9050 with
+                    | (formals,uu____9068) ->
+                        let uu____9089 =
                           let tps_opt =
                             FStar_Util.find_map tcs
                               (fun se1  ->
-                                 let uu____9107 =
-                                   let uu____9109 =
-                                     let uu____9110 =
+                                 let uu____9124 =
+                                   let uu____9126 =
+                                     let uu____9127 =
                                        FStar_Syntax_Util.lid_of_sigelt se1
                                         in
-                                     FStar_Util.must uu____9110  in
-                                   FStar_Ident.lid_equals typ_lid uu____9109
+                                     FStar_Util.must uu____9127  in
+                                   FStar_Ident.lid_equals typ_lid uu____9126
                                     in
-                                 if uu____9107
+                                 if uu____9124
                                  then
                                    match se1.FStar_Syntax_Syntax.sigel with
                                    | FStar_Syntax_Syntax.Sig_inductive_typ
-                                       (uu____9132,uvs',tps,typ0,uu____9136,constrs)
+                                       (uu____9149,uvs',tps,typ0,uu____9153,constrs)
                                        ->
                                        FStar_Pervasives_Native.Some
                                          (tps, typ0,
                                            ((FStar_List.length constrs) >
                                               Prims.int_one))
-                                   | uu____9156 -> failwith "Impossible"
+                                   | uu____9173 -> failwith "Impossible"
                                  else FStar_Pervasives_Native.None)
                              in
                           match tps_opt with
                           | FStar_Pervasives_Native.Some x -> x
                           | FStar_Pervasives_Native.None  ->
-                              let uu____9205 =
+                              let uu____9222 =
                                 FStar_Ident.lid_equals typ_lid
                                   FStar_Parser_Const.exn_lid
                                  in
-                              if uu____9205
+                              if uu____9222
                               then ([], FStar_Syntax_Util.ktype0, true)
                               else
                                 FStar_Errors.raise_error
@@ -3688,7 +3709,7 @@ let (mk_data_operations :
                                     "Unexpected data constructor")
                                   se.FStar_Syntax_Syntax.sigrng
                            in
-                        (match uu____9072 with
+                        (match uu____9089 with
                          | (inductive_tps,typ0,should_refine) ->
                              let inductive_tps1 =
                                FStar_Syntax_Subst.subst_binders univ_opening
@@ -3696,41 +3717,41 @@ let (mk_data_operations :
                                 in
                              let typ01 =
                                FStar_Syntax_Subst.subst univ_opening typ0  in
-                             let uu____9243 =
+                             let uu____9260 =
                                FStar_Syntax_Util.arrow_formals typ01  in
-                             (match uu____9243 with
-                              | (indices,uu____9261) ->
+                             (match uu____9260 with
+                              | (indices,uu____9278) ->
                                   let refine_domain =
-                                    let uu____9284 =
+                                    let uu____9301 =
                                       FStar_All.pipe_right
                                         se.FStar_Syntax_Syntax.sigquals
                                         (FStar_Util.for_some
-                                           (fun uu___7_9291  ->
-                                              match uu___7_9291 with
+                                           (fun uu___7_9308  ->
+                                              match uu___7_9308 with
                                               | FStar_Syntax_Syntax.RecordConstructor
-                                                  uu____9293 -> true
-                                              | uu____9303 -> false))
+                                                  uu____9310 -> true
+                                              | uu____9320 -> false))
                                        in
-                                    if uu____9284
+                                    if uu____9301
                                     then false
                                     else should_refine  in
                                   let fv_qual =
-                                    let filter_records uu___8_9318 =
-                                      match uu___8_9318 with
+                                    let filter_records uu___8_9335 =
+                                      match uu___8_9335 with
                                       | FStar_Syntax_Syntax.RecordConstructor
-                                          (uu____9321,fns) ->
+                                          (uu____9338,fns) ->
                                           FStar_Pervasives_Native.Some
                                             (FStar_Syntax_Syntax.Record_ctor
                                                (constr_lid, fns))
-                                      | uu____9333 ->
+                                      | uu____9350 ->
                                           FStar_Pervasives_Native.None
                                        in
-                                    let uu____9334 =
+                                    let uu____9351 =
                                       FStar_Util.find_map
                                         se.FStar_Syntax_Syntax.sigquals
                                         filter_records
                                        in
-                                    match uu____9334 with
+                                    match uu____9351 with
                                     | FStar_Pervasives_Native.None  ->
                                         FStar_Syntax_Syntax.Data_ctor
                                     | FStar_Pervasives_Native.Some q -> q  in
@@ -3747,35 +3768,40 @@ let (mk_data_operations :
                                       iquals
                                     else iquals  in
                                   let fields =
-                                    let uu____9347 =
+                                    let uu____9364 =
                                       FStar_Util.first_N n_typars formals  in
-                                    match uu____9347 with
+                                    match uu____9364 with
                                     | (imp_tps,fields) ->
                                         let rename =
                                           FStar_List.map2
-                                            (fun uu____9430  ->
-                                               fun uu____9431  ->
-                                                 match (uu____9430,
-                                                         uu____9431)
+                                            (fun uu____9447  ->
+                                               fun uu____9448  ->
+                                                 match (uu____9447,
+                                                         uu____9448)
                                                  with
-                                                 | ((x,uu____9457),(x',uu____9459))
+                                                 | ((x,uu____9474),(x',uu____9476))
                                                      ->
-                                                     let uu____9480 =
-                                                       let uu____9487 =
+                                                     let uu____9497 =
+                                                       let uu____9504 =
                                                          FStar_Syntax_Syntax.bv_to_name
                                                            x'
                                                           in
-                                                       (x, uu____9487)  in
+                                                       (x, uu____9504)  in
                                                      FStar_Syntax_Syntax.NT
-                                                       uu____9480) imp_tps
+                                                       uu____9497) imp_tps
                                             inductive_tps1
                                            in
                                         FStar_Syntax_Subst.subst_binders
                                           rename fields
                                      in
+                                  let erasable1 =
+                                    FStar_Syntax_Util.has_attribute
+                                      se.FStar_Syntax_Syntax.sigattrs
+                                      FStar_Parser_Const.erasable_attr
+                                     in
                                   mk_discriminator_and_indexed_projectors
                                     iquals1 fv_qual refine_domain env typ_lid
                                     constr_lid uvs1 inductive_tps1 indices
-                                    fields))))
-          | uu____9492 -> []
+                                    fields erasable1))))
+          | uu____9511 -> []
   

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -79,7 +79,9 @@ let (instantiate_both :
       FStar_TypeChecker_Env.dsenv = (uu___8_5.FStar_TypeChecker_Env.dsenv);
       FStar_TypeChecker_Env.nbe = (uu___8_5.FStar_TypeChecker_Env.nbe);
       FStar_TypeChecker_Env.strict_args_tab =
-        (uu___8_5.FStar_TypeChecker_Env.strict_args_tab)
+        (uu___8_5.FStar_TypeChecker_Env.strict_args_tab);
+      FStar_TypeChecker_Env.erasable_types_tab =
+        (uu___8_5.FStar_TypeChecker_Env.erasable_types_tab)
     }
   
 let (no_inst : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
@@ -166,7 +168,9 @@ let (no_inst : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
       FStar_TypeChecker_Env.dsenv = (uu___11_13.FStar_TypeChecker_Env.dsenv);
       FStar_TypeChecker_Env.nbe = (uu___11_13.FStar_TypeChecker_Env.nbe);
       FStar_TypeChecker_Env.strict_args_tab =
-        (uu___11_13.FStar_TypeChecker_Env.strict_args_tab)
+        (uu___11_13.FStar_TypeChecker_Env.strict_args_tab);
+      FStar_TypeChecker_Env.erasable_types_tab =
+        (uu___11_13.FStar_TypeChecker_Env.erasable_types_tab)
     }
   
 let (mk_lex_list :
@@ -1013,7 +1017,9 @@ let (guard_letrecs :
                 FStar_TypeChecker_Env.nbe =
                   (uu___359_2276.FStar_TypeChecker_Env.nbe);
                 FStar_TypeChecker_Env.strict_args_tab =
-                  (uu___359_2276.FStar_TypeChecker_Env.strict_args_tab)
+                  (uu___359_2276.FStar_TypeChecker_Env.strict_args_tab);
+                FStar_TypeChecker_Env.erasable_types_tab =
+                  (uu___359_2276.FStar_TypeChecker_Env.erasable_types_tab)
               }  in
             let precedes =
               FStar_TypeChecker_Util.fvar_const env1
@@ -1213,148 +1219,150 @@ let rec (tc_term :
   =
   fun env  ->
     fun e  ->
-      (let uu____3515 = FStar_TypeChecker_Env.debug env FStar_Options.Medium
+      (let uu____3521 = FStar_TypeChecker_Env.debug env FStar_Options.Medium
           in
-       if uu____3515
+       if uu____3521
        then
-         let uu____3518 =
-           let uu____3520 = FStar_TypeChecker_Env.get_range env  in
-           FStar_All.pipe_left FStar_Range.string_of_range uu____3520  in
-         let uu____3522 = FStar_Syntax_Print.term_to_string e  in
          let uu____3524 =
-           let uu____3526 = FStar_Syntax_Subst.compress e  in
-           FStar_Syntax_Print.tag_of_term uu____3526  in
-         FStar_Util.print3 "(%s) Starting tc_term of %s (%s) {\n" uu____3518
-           uu____3522 uu____3524
+           let uu____3526 = FStar_TypeChecker_Env.get_range env  in
+           FStar_All.pipe_left FStar_Range.string_of_range uu____3526  in
+         let uu____3528 = FStar_Syntax_Print.term_to_string e  in
+         let uu____3530 =
+           let uu____3532 = FStar_Syntax_Subst.compress e  in
+           FStar_Syntax_Print.tag_of_term uu____3532  in
+         FStar_Util.print3 "(%s) Starting tc_term of %s (%s) {\n" uu____3524
+           uu____3528 uu____3530
        else ());
-      (let uu____3530 =
+      (let uu____3536 =
          FStar_Util.record_time
-           (fun uu____3549  ->
+           (fun uu____3555  ->
               tc_maybe_toplevel_term
-                (let uu___445_3552 = env  in
+                (let uu___445_3558 = env  in
                  {
                    FStar_TypeChecker_Env.solver =
-                     (uu___445_3552.FStar_TypeChecker_Env.solver);
+                     (uu___445_3558.FStar_TypeChecker_Env.solver);
                    FStar_TypeChecker_Env.range =
-                     (uu___445_3552.FStar_TypeChecker_Env.range);
+                     (uu___445_3558.FStar_TypeChecker_Env.range);
                    FStar_TypeChecker_Env.curmodule =
-                     (uu___445_3552.FStar_TypeChecker_Env.curmodule);
+                     (uu___445_3558.FStar_TypeChecker_Env.curmodule);
                    FStar_TypeChecker_Env.gamma =
-                     (uu___445_3552.FStar_TypeChecker_Env.gamma);
+                     (uu___445_3558.FStar_TypeChecker_Env.gamma);
                    FStar_TypeChecker_Env.gamma_sig =
-                     (uu___445_3552.FStar_TypeChecker_Env.gamma_sig);
+                     (uu___445_3558.FStar_TypeChecker_Env.gamma_sig);
                    FStar_TypeChecker_Env.gamma_cache =
-                     (uu___445_3552.FStar_TypeChecker_Env.gamma_cache);
+                     (uu___445_3558.FStar_TypeChecker_Env.gamma_cache);
                    FStar_TypeChecker_Env.modules =
-                     (uu___445_3552.FStar_TypeChecker_Env.modules);
+                     (uu___445_3558.FStar_TypeChecker_Env.modules);
                    FStar_TypeChecker_Env.expected_typ =
-                     (uu___445_3552.FStar_TypeChecker_Env.expected_typ);
+                     (uu___445_3558.FStar_TypeChecker_Env.expected_typ);
                    FStar_TypeChecker_Env.sigtab =
-                     (uu___445_3552.FStar_TypeChecker_Env.sigtab);
+                     (uu___445_3558.FStar_TypeChecker_Env.sigtab);
                    FStar_TypeChecker_Env.attrtab =
-                     (uu___445_3552.FStar_TypeChecker_Env.attrtab);
+                     (uu___445_3558.FStar_TypeChecker_Env.attrtab);
                    FStar_TypeChecker_Env.is_pattern =
-                     (uu___445_3552.FStar_TypeChecker_Env.is_pattern);
+                     (uu___445_3558.FStar_TypeChecker_Env.is_pattern);
                    FStar_TypeChecker_Env.instantiate_imp =
-                     (uu___445_3552.FStar_TypeChecker_Env.instantiate_imp);
+                     (uu___445_3558.FStar_TypeChecker_Env.instantiate_imp);
                    FStar_TypeChecker_Env.effects =
-                     (uu___445_3552.FStar_TypeChecker_Env.effects);
+                     (uu___445_3558.FStar_TypeChecker_Env.effects);
                    FStar_TypeChecker_Env.generalize =
-                     (uu___445_3552.FStar_TypeChecker_Env.generalize);
+                     (uu___445_3558.FStar_TypeChecker_Env.generalize);
                    FStar_TypeChecker_Env.letrecs =
-                     (uu___445_3552.FStar_TypeChecker_Env.letrecs);
+                     (uu___445_3558.FStar_TypeChecker_Env.letrecs);
                    FStar_TypeChecker_Env.top_level = false;
                    FStar_TypeChecker_Env.check_uvars =
-                     (uu___445_3552.FStar_TypeChecker_Env.check_uvars);
+                     (uu___445_3558.FStar_TypeChecker_Env.check_uvars);
                    FStar_TypeChecker_Env.use_eq =
-                     (uu___445_3552.FStar_TypeChecker_Env.use_eq);
+                     (uu___445_3558.FStar_TypeChecker_Env.use_eq);
                    FStar_TypeChecker_Env.is_iface =
-                     (uu___445_3552.FStar_TypeChecker_Env.is_iface);
+                     (uu___445_3558.FStar_TypeChecker_Env.is_iface);
                    FStar_TypeChecker_Env.admit =
-                     (uu___445_3552.FStar_TypeChecker_Env.admit);
+                     (uu___445_3558.FStar_TypeChecker_Env.admit);
                    FStar_TypeChecker_Env.lax =
-                     (uu___445_3552.FStar_TypeChecker_Env.lax);
+                     (uu___445_3558.FStar_TypeChecker_Env.lax);
                    FStar_TypeChecker_Env.lax_universes =
-                     (uu___445_3552.FStar_TypeChecker_Env.lax_universes);
+                     (uu___445_3558.FStar_TypeChecker_Env.lax_universes);
                    FStar_TypeChecker_Env.phase1 =
-                     (uu___445_3552.FStar_TypeChecker_Env.phase1);
+                     (uu___445_3558.FStar_TypeChecker_Env.phase1);
                    FStar_TypeChecker_Env.failhard =
-                     (uu___445_3552.FStar_TypeChecker_Env.failhard);
+                     (uu___445_3558.FStar_TypeChecker_Env.failhard);
                    FStar_TypeChecker_Env.nosynth =
-                     (uu___445_3552.FStar_TypeChecker_Env.nosynth);
+                     (uu___445_3558.FStar_TypeChecker_Env.nosynth);
                    FStar_TypeChecker_Env.uvar_subtyping =
-                     (uu___445_3552.FStar_TypeChecker_Env.uvar_subtyping);
+                     (uu___445_3558.FStar_TypeChecker_Env.uvar_subtyping);
                    FStar_TypeChecker_Env.tc_term =
-                     (uu___445_3552.FStar_TypeChecker_Env.tc_term);
+                     (uu___445_3558.FStar_TypeChecker_Env.tc_term);
                    FStar_TypeChecker_Env.type_of =
-                     (uu___445_3552.FStar_TypeChecker_Env.type_of);
+                     (uu___445_3558.FStar_TypeChecker_Env.type_of);
                    FStar_TypeChecker_Env.universe_of =
-                     (uu___445_3552.FStar_TypeChecker_Env.universe_of);
+                     (uu___445_3558.FStar_TypeChecker_Env.universe_of);
                    FStar_TypeChecker_Env.check_type_of =
-                     (uu___445_3552.FStar_TypeChecker_Env.check_type_of);
+                     (uu___445_3558.FStar_TypeChecker_Env.check_type_of);
                    FStar_TypeChecker_Env.use_bv_sorts =
-                     (uu___445_3552.FStar_TypeChecker_Env.use_bv_sorts);
+                     (uu___445_3558.FStar_TypeChecker_Env.use_bv_sorts);
                    FStar_TypeChecker_Env.qtbl_name_and_index =
-                     (uu___445_3552.FStar_TypeChecker_Env.qtbl_name_and_index);
+                     (uu___445_3558.FStar_TypeChecker_Env.qtbl_name_and_index);
                    FStar_TypeChecker_Env.normalized_eff_names =
-                     (uu___445_3552.FStar_TypeChecker_Env.normalized_eff_names);
+                     (uu___445_3558.FStar_TypeChecker_Env.normalized_eff_names);
                    FStar_TypeChecker_Env.fv_delta_depths =
-                     (uu___445_3552.FStar_TypeChecker_Env.fv_delta_depths);
+                     (uu___445_3558.FStar_TypeChecker_Env.fv_delta_depths);
                    FStar_TypeChecker_Env.proof_ns =
-                     (uu___445_3552.FStar_TypeChecker_Env.proof_ns);
+                     (uu___445_3558.FStar_TypeChecker_Env.proof_ns);
                    FStar_TypeChecker_Env.synth_hook =
-                     (uu___445_3552.FStar_TypeChecker_Env.synth_hook);
+                     (uu___445_3558.FStar_TypeChecker_Env.synth_hook);
                    FStar_TypeChecker_Env.splice =
-                     (uu___445_3552.FStar_TypeChecker_Env.splice);
+                     (uu___445_3558.FStar_TypeChecker_Env.splice);
                    FStar_TypeChecker_Env.postprocess =
-                     (uu___445_3552.FStar_TypeChecker_Env.postprocess);
+                     (uu___445_3558.FStar_TypeChecker_Env.postprocess);
                    FStar_TypeChecker_Env.is_native_tactic =
-                     (uu___445_3552.FStar_TypeChecker_Env.is_native_tactic);
+                     (uu___445_3558.FStar_TypeChecker_Env.is_native_tactic);
                    FStar_TypeChecker_Env.identifier_info =
-                     (uu___445_3552.FStar_TypeChecker_Env.identifier_info);
+                     (uu___445_3558.FStar_TypeChecker_Env.identifier_info);
                    FStar_TypeChecker_Env.tc_hooks =
-                     (uu___445_3552.FStar_TypeChecker_Env.tc_hooks);
+                     (uu___445_3558.FStar_TypeChecker_Env.tc_hooks);
                    FStar_TypeChecker_Env.dsenv =
-                     (uu___445_3552.FStar_TypeChecker_Env.dsenv);
+                     (uu___445_3558.FStar_TypeChecker_Env.dsenv);
                    FStar_TypeChecker_Env.nbe =
-                     (uu___445_3552.FStar_TypeChecker_Env.nbe);
+                     (uu___445_3558.FStar_TypeChecker_Env.nbe);
                    FStar_TypeChecker_Env.strict_args_tab =
-                     (uu___445_3552.FStar_TypeChecker_Env.strict_args_tab)
+                     (uu___445_3558.FStar_TypeChecker_Env.strict_args_tab);
+                   FStar_TypeChecker_Env.erasable_types_tab =
+                     (uu___445_3558.FStar_TypeChecker_Env.erasable_types_tab)
                  }) e)
           in
-       match uu____3530 with
+       match uu____3536 with
        | (r,ms) ->
-           ((let uu____3577 =
+           ((let uu____3583 =
                FStar_TypeChecker_Env.debug env FStar_Options.Medium  in
-             if uu____3577
+             if uu____3583
              then
-               ((let uu____3581 =
-                   let uu____3583 = FStar_TypeChecker_Env.get_range env  in
-                   FStar_All.pipe_left FStar_Range.string_of_range uu____3583
+               ((let uu____3587 =
+                   let uu____3589 = FStar_TypeChecker_Env.get_range env  in
+                   FStar_All.pipe_left FStar_Range.string_of_range uu____3589
                     in
-                 let uu____3585 = FStar_Syntax_Print.term_to_string e  in
-                 let uu____3587 =
-                   let uu____3589 = FStar_Syntax_Subst.compress e  in
-                   FStar_Syntax_Print.tag_of_term uu____3589  in
-                 let uu____3590 = FStar_Util.string_of_int ms  in
+                 let uu____3591 = FStar_Syntax_Print.term_to_string e  in
+                 let uu____3593 =
+                   let uu____3595 = FStar_Syntax_Subst.compress e  in
+                   FStar_Syntax_Print.tag_of_term uu____3595  in
+                 let uu____3596 = FStar_Util.string_of_int ms  in
                  FStar_Util.print4 "(%s) } tc_term of %s (%s) took %sms\n"
-                   uu____3581 uu____3585 uu____3587 uu____3590);
-                (let uu____3593 = r  in
-                 match uu____3593 with
-                 | (e1,uu____3601,uu____3602) ->
-                     let uu____3603 =
-                       let uu____3605 = FStar_TypeChecker_Env.get_range env
+                   uu____3587 uu____3591 uu____3593 uu____3596);
+                (let uu____3599 = r  in
+                 match uu____3599 with
+                 | (e1,uu____3607,uu____3608) ->
+                     let uu____3609 =
+                       let uu____3611 = FStar_TypeChecker_Env.get_range env
                           in
                        FStar_All.pipe_left FStar_Range.string_of_range
-                         uu____3605
+                         uu____3611
                         in
-                     let uu____3607 = FStar_Syntax_Print.term_to_string e1
+                     let uu____3613 = FStar_Syntax_Print.term_to_string e1
                         in
-                     let uu____3609 =
-                       let uu____3611 = FStar_Syntax_Subst.compress e1  in
-                       FStar_Syntax_Print.tag_of_term uu____3611  in
-                     FStar_Util.print3 "(%s) Result is: %s (%s)\n" uu____3603
-                       uu____3607 uu____3609))
+                     let uu____3615 =
+                       let uu____3617 = FStar_Syntax_Subst.compress e1  in
+                       FStar_Syntax_Print.tag_of_term uu____3617  in
+                     FStar_Util.print3 "(%s) Result is: %s (%s)\n" uu____3609
+                       uu____3613 uu____3615))
              else ());
             r))
 
@@ -1372,50 +1380,50 @@ and (tc_maybe_toplevel_term :
         else FStar_TypeChecker_Env.set_range env e.FStar_Syntax_Syntax.pos
          in
       let top = FStar_Syntax_Subst.compress e  in
-      (let uu____3629 = FStar_TypeChecker_Env.debug env1 FStar_Options.Medium
+      (let uu____3635 = FStar_TypeChecker_Env.debug env1 FStar_Options.Medium
           in
-       if uu____3629
+       if uu____3635
        then
-         let uu____3632 =
-           let uu____3634 = FStar_TypeChecker_Env.get_range env1  in
-           FStar_All.pipe_left FStar_Range.string_of_range uu____3634  in
-         let uu____3636 = FStar_Syntax_Print.tag_of_term top  in
-         let uu____3638 = FStar_Syntax_Print.term_to_string top  in
-         FStar_Util.print3 "Typechecking %s (%s): %s\n" uu____3632 uu____3636
-           uu____3638
+         let uu____3638 =
+           let uu____3640 = FStar_TypeChecker_Env.get_range env1  in
+           FStar_All.pipe_left FStar_Range.string_of_range uu____3640  in
+         let uu____3642 = FStar_Syntax_Print.tag_of_term top  in
+         let uu____3644 = FStar_Syntax_Print.term_to_string top  in
+         FStar_Util.print3 "Typechecking %s (%s): %s\n" uu____3638 uu____3642
+           uu____3644
        else ());
       (match top.FStar_Syntax_Syntax.n with
-       | FStar_Syntax_Syntax.Tm_delayed uu____3649 -> failwith "Impossible"
-       | FStar_Syntax_Syntax.Tm_uinst uu____3679 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_uvar uu____3686 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_bvar uu____3699 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_name uu____3700 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_fvar uu____3701 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_constant uu____3702 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_abs uu____3703 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_arrow uu____3722 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_refine uu____3737 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_type uu____3744 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_delayed uu____3655 -> failwith "Impossible"
+       | FStar_Syntax_Syntax.Tm_uinst uu____3685 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_uvar uu____3692 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_bvar uu____3705 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_name uu____3706 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_fvar uu____3707 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_constant uu____3708 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_abs uu____3709 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_arrow uu____3728 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_refine uu____3743 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_type uu____3750 -> tc_value env1 e
        | FStar_Syntax_Syntax.Tm_unknown  -> tc_value env1 e
        | FStar_Syntax_Syntax.Tm_quoted (qt,qi) ->
-           let projl uu___2_3760 =
-             match uu___2_3760 with
+           let projl uu___2_3766 =
+             match uu___2_3766 with
              | FStar_Util.Inl x -> x
-             | FStar_Util.Inr uu____3766 -> failwith "projl fail"  in
+             | FStar_Util.Inr uu____3772 -> failwith "projl fail"  in
            let non_trivial_antiquotes qi1 =
              let is_name1 t =
-               let uu____3782 =
-                 let uu____3783 = FStar_Syntax_Subst.compress t  in
-                 uu____3783.FStar_Syntax_Syntax.n  in
-               match uu____3782 with
-               | FStar_Syntax_Syntax.Tm_name uu____3787 -> true
-               | uu____3789 -> false  in
+               let uu____3788 =
+                 let uu____3789 = FStar_Syntax_Subst.compress t  in
+                 uu____3789.FStar_Syntax_Syntax.n  in
+               match uu____3788 with
+               | FStar_Syntax_Syntax.Tm_name uu____3793 -> true
+               | uu____3795 -> false  in
              FStar_Util.for_some
-               (fun uu____3799  ->
-                  match uu____3799 with
-                  | (uu____3805,t) ->
-                      let uu____3807 = is_name1 t  in
-                      Prims.op_Negation uu____3807)
+               (fun uu____3805  ->
+                  match uu____3805 with
+                  | (uu____3811,t) ->
+                      let uu____3813 = is_name1 t  in
+                      Prims.op_Negation uu____3813)
                qi1.FStar_Syntax_Syntax.antiquotes
               in
            (match qi.FStar_Syntax_Syntax.qkind with
@@ -1424,7 +1432,7 @@ and (tc_maybe_toplevel_term :
                 let e0 = e  in
                 let newbvs =
                   FStar_List.map
-                    (fun uu____3826  ->
+                    (fun uu____3832  ->
                        FStar_Syntax_Syntax.new_bv
                          FStar_Pervasives_Native.None
                          FStar_Syntax_Syntax.t_term)
@@ -1434,8 +1442,8 @@ and (tc_maybe_toplevel_term :
                   FStar_List.zip qi.FStar_Syntax_Syntax.antiquotes newbvs  in
                 let lbs =
                   FStar_List.map
-                    (fun uu____3869  ->
-                       match uu____3869 with
+                    (fun uu____3875  ->
+                       match uu____3875 with
                        | ((bv,t),bv') ->
                            FStar_Syntax_Util.close_univs_and_mk_letbinding
                              FStar_Pervasives_Native.None
@@ -1445,20 +1453,20 @@ and (tc_maybe_toplevel_term :
                              t.FStar_Syntax_Syntax.pos) z
                    in
                 let qi1 =
-                  let uu___518_3898 = qi  in
-                  let uu____3899 =
+                  let uu___518_3904 = qi  in
+                  let uu____3905 =
                     FStar_List.map
-                      (fun uu____3927  ->
-                         match uu____3927 with
-                         | ((bv,uu____3943),bv') ->
-                             let uu____3955 =
+                      (fun uu____3933  ->
+                         match uu____3933 with
+                         | ((bv,uu____3949),bv') ->
+                             let uu____3961 =
                                FStar_Syntax_Syntax.bv_to_name bv'  in
-                             (bv, uu____3955)) z
+                             (bv, uu____3961)) z
                      in
                   {
                     FStar_Syntax_Syntax.qkind =
-                      (uu___518_3898.FStar_Syntax_Syntax.qkind);
-                    FStar_Syntax_Syntax.antiquotes = uu____3899
+                      (uu___518_3904.FStar_Syntax_Syntax.qkind);
+                    FStar_Syntax_Syntax.antiquotes = uu____3905
                   }  in
                 let nq =
                   FStar_Syntax_Syntax.mk
@@ -1469,23 +1477,23 @@ and (tc_maybe_toplevel_term :
                   FStar_List.fold_left
                     (fun t  ->
                        fun lb  ->
-                         let uu____3967 =
-                           let uu____3974 =
-                             let uu____3975 =
-                               let uu____3989 =
-                                 let uu____3992 =
-                                   let uu____3993 =
-                                     let uu____4000 =
+                         let uu____3973 =
+                           let uu____3980 =
+                             let uu____3981 =
+                               let uu____3995 =
+                                 let uu____3998 =
+                                   let uu____3999 =
+                                     let uu____4006 =
                                        projl lb.FStar_Syntax_Syntax.lbname
                                         in
-                                     FStar_Syntax_Syntax.mk_binder uu____4000
+                                     FStar_Syntax_Syntax.mk_binder uu____4006
                                       in
-                                   [uu____3993]  in
-                                 FStar_Syntax_Subst.close uu____3992 t  in
-                               ((false, [lb]), uu____3989)  in
-                             FStar_Syntax_Syntax.Tm_let uu____3975  in
-                           FStar_Syntax_Syntax.mk uu____3974  in
-                         uu____3967 FStar_Pervasives_Native.None
+                                   [uu____3999]  in
+                                 FStar_Syntax_Subst.close uu____3998 t  in
+                               ((false, [lb]), uu____3995)  in
+                             FStar_Syntax_Syntax.Tm_let uu____3981  in
+                           FStar_Syntax_Syntax.mk uu____3980  in
+                         uu____3973 FStar_Pervasives_Native.None
                            top.FStar_Syntax_Syntax.pos) nq lbs
                    in
                 tc_maybe_toplevel_term env1 e1
@@ -1495,28 +1503,28 @@ and (tc_maybe_toplevel_term :
                   FStar_TypeChecker_Env.set_expected_typ env1
                     FStar_Syntax_Syntax.t_term
                    in
-                let uu____4036 =
+                let uu____4042 =
                   FStar_List.fold_right
-                    (fun uu____4072  ->
-                       fun uu____4073  ->
-                         match (uu____4072, uu____4073) with
+                    (fun uu____4078  ->
+                       fun uu____4079  ->
+                         match (uu____4078, uu____4079) with
                          | ((bv,tm),(aqs_rev,guard)) ->
-                             let uu____4142 = tc_term env_tm tm  in
-                             (match uu____4142 with
-                              | (tm1,uu____4160,g) ->
-                                  let uu____4162 =
+                             let uu____4148 = tc_term env_tm tm  in
+                             (match uu____4148 with
+                              | (tm1,uu____4166,g) ->
+                                  let uu____4168 =
                                     FStar_TypeChecker_Env.conj_guard g guard
                                      in
-                                  (((bv, tm1) :: aqs_rev), uu____4162))) aqs
+                                  (((bv, tm1) :: aqs_rev), uu____4168))) aqs
                     ([], FStar_TypeChecker_Env.trivial_guard)
                    in
-                (match uu____4036 with
+                (match uu____4042 with
                  | (aqs_rev,guard) ->
                      let qi1 =
-                       let uu___546_4204 = qi  in
+                       let uu___546_4210 = qi  in
                        {
                          FStar_Syntax_Syntax.qkind =
-                           (uu___546_4204.FStar_Syntax_Syntax.qkind);
+                           (uu___546_4210.FStar_Syntax_Syntax.qkind);
                          FStar_Syntax_Syntax.antiquotes =
                            (FStar_List.rev aqs_rev)
                        }  in
@@ -1544,120 +1552,122 @@ and (tc_maybe_toplevel_term :
                         FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION]
                     }
                    in
-                let uu____4223 =
+                let uu____4229 =
                   FStar_TypeChecker_Env.clear_expected_typ env1  in
-                (match uu____4223 with
-                 | (env',uu____4237) ->
-                     let uu____4242 =
+                (match uu____4229 with
+                 | (env',uu____4243) ->
+                     let uu____4248 =
                        tc_term
-                         (let uu___555_4251 = env'  in
+                         (let uu___555_4257 = env'  in
                           {
                             FStar_TypeChecker_Env.solver =
-                              (uu___555_4251.FStar_TypeChecker_Env.solver);
+                              (uu___555_4257.FStar_TypeChecker_Env.solver);
                             FStar_TypeChecker_Env.range =
-                              (uu___555_4251.FStar_TypeChecker_Env.range);
+                              (uu___555_4257.FStar_TypeChecker_Env.range);
                             FStar_TypeChecker_Env.curmodule =
-                              (uu___555_4251.FStar_TypeChecker_Env.curmodule);
+                              (uu___555_4257.FStar_TypeChecker_Env.curmodule);
                             FStar_TypeChecker_Env.gamma =
-                              (uu___555_4251.FStar_TypeChecker_Env.gamma);
+                              (uu___555_4257.FStar_TypeChecker_Env.gamma);
                             FStar_TypeChecker_Env.gamma_sig =
-                              (uu___555_4251.FStar_TypeChecker_Env.gamma_sig);
+                              (uu___555_4257.FStar_TypeChecker_Env.gamma_sig);
                             FStar_TypeChecker_Env.gamma_cache =
-                              (uu___555_4251.FStar_TypeChecker_Env.gamma_cache);
+                              (uu___555_4257.FStar_TypeChecker_Env.gamma_cache);
                             FStar_TypeChecker_Env.modules =
-                              (uu___555_4251.FStar_TypeChecker_Env.modules);
+                              (uu___555_4257.FStar_TypeChecker_Env.modules);
                             FStar_TypeChecker_Env.expected_typ =
-                              (uu___555_4251.FStar_TypeChecker_Env.expected_typ);
+                              (uu___555_4257.FStar_TypeChecker_Env.expected_typ);
                             FStar_TypeChecker_Env.sigtab =
-                              (uu___555_4251.FStar_TypeChecker_Env.sigtab);
+                              (uu___555_4257.FStar_TypeChecker_Env.sigtab);
                             FStar_TypeChecker_Env.attrtab =
-                              (uu___555_4251.FStar_TypeChecker_Env.attrtab);
+                              (uu___555_4257.FStar_TypeChecker_Env.attrtab);
                             FStar_TypeChecker_Env.is_pattern =
-                              (uu___555_4251.FStar_TypeChecker_Env.is_pattern);
+                              (uu___555_4257.FStar_TypeChecker_Env.is_pattern);
                             FStar_TypeChecker_Env.instantiate_imp =
-                              (uu___555_4251.FStar_TypeChecker_Env.instantiate_imp);
+                              (uu___555_4257.FStar_TypeChecker_Env.instantiate_imp);
                             FStar_TypeChecker_Env.effects =
-                              (uu___555_4251.FStar_TypeChecker_Env.effects);
+                              (uu___555_4257.FStar_TypeChecker_Env.effects);
                             FStar_TypeChecker_Env.generalize =
-                              (uu___555_4251.FStar_TypeChecker_Env.generalize);
+                              (uu___555_4257.FStar_TypeChecker_Env.generalize);
                             FStar_TypeChecker_Env.letrecs =
-                              (uu___555_4251.FStar_TypeChecker_Env.letrecs);
+                              (uu___555_4257.FStar_TypeChecker_Env.letrecs);
                             FStar_TypeChecker_Env.top_level =
-                              (uu___555_4251.FStar_TypeChecker_Env.top_level);
+                              (uu___555_4257.FStar_TypeChecker_Env.top_level);
                             FStar_TypeChecker_Env.check_uvars =
-                              (uu___555_4251.FStar_TypeChecker_Env.check_uvars);
+                              (uu___555_4257.FStar_TypeChecker_Env.check_uvars);
                             FStar_TypeChecker_Env.use_eq =
-                              (uu___555_4251.FStar_TypeChecker_Env.use_eq);
+                              (uu___555_4257.FStar_TypeChecker_Env.use_eq);
                             FStar_TypeChecker_Env.is_iface =
-                              (uu___555_4251.FStar_TypeChecker_Env.is_iface);
+                              (uu___555_4257.FStar_TypeChecker_Env.is_iface);
                             FStar_TypeChecker_Env.admit =
-                              (uu___555_4251.FStar_TypeChecker_Env.admit);
+                              (uu___555_4257.FStar_TypeChecker_Env.admit);
                             FStar_TypeChecker_Env.lax = true;
                             FStar_TypeChecker_Env.lax_universes =
-                              (uu___555_4251.FStar_TypeChecker_Env.lax_universes);
+                              (uu___555_4257.FStar_TypeChecker_Env.lax_universes);
                             FStar_TypeChecker_Env.phase1 =
-                              (uu___555_4251.FStar_TypeChecker_Env.phase1);
+                              (uu___555_4257.FStar_TypeChecker_Env.phase1);
                             FStar_TypeChecker_Env.failhard =
-                              (uu___555_4251.FStar_TypeChecker_Env.failhard);
+                              (uu___555_4257.FStar_TypeChecker_Env.failhard);
                             FStar_TypeChecker_Env.nosynth =
-                              (uu___555_4251.FStar_TypeChecker_Env.nosynth);
+                              (uu___555_4257.FStar_TypeChecker_Env.nosynth);
                             FStar_TypeChecker_Env.uvar_subtyping =
-                              (uu___555_4251.FStar_TypeChecker_Env.uvar_subtyping);
+                              (uu___555_4257.FStar_TypeChecker_Env.uvar_subtyping);
                             FStar_TypeChecker_Env.tc_term =
-                              (uu___555_4251.FStar_TypeChecker_Env.tc_term);
+                              (uu___555_4257.FStar_TypeChecker_Env.tc_term);
                             FStar_TypeChecker_Env.type_of =
-                              (uu___555_4251.FStar_TypeChecker_Env.type_of);
+                              (uu___555_4257.FStar_TypeChecker_Env.type_of);
                             FStar_TypeChecker_Env.universe_of =
-                              (uu___555_4251.FStar_TypeChecker_Env.universe_of);
+                              (uu___555_4257.FStar_TypeChecker_Env.universe_of);
                             FStar_TypeChecker_Env.check_type_of =
-                              (uu___555_4251.FStar_TypeChecker_Env.check_type_of);
+                              (uu___555_4257.FStar_TypeChecker_Env.check_type_of);
                             FStar_TypeChecker_Env.use_bv_sorts =
-                              (uu___555_4251.FStar_TypeChecker_Env.use_bv_sorts);
+                              (uu___555_4257.FStar_TypeChecker_Env.use_bv_sorts);
                             FStar_TypeChecker_Env.qtbl_name_and_index =
-                              (uu___555_4251.FStar_TypeChecker_Env.qtbl_name_and_index);
+                              (uu___555_4257.FStar_TypeChecker_Env.qtbl_name_and_index);
                             FStar_TypeChecker_Env.normalized_eff_names =
-                              (uu___555_4251.FStar_TypeChecker_Env.normalized_eff_names);
+                              (uu___555_4257.FStar_TypeChecker_Env.normalized_eff_names);
                             FStar_TypeChecker_Env.fv_delta_depths =
-                              (uu___555_4251.FStar_TypeChecker_Env.fv_delta_depths);
+                              (uu___555_4257.FStar_TypeChecker_Env.fv_delta_depths);
                             FStar_TypeChecker_Env.proof_ns =
-                              (uu___555_4251.FStar_TypeChecker_Env.proof_ns);
+                              (uu___555_4257.FStar_TypeChecker_Env.proof_ns);
                             FStar_TypeChecker_Env.synth_hook =
-                              (uu___555_4251.FStar_TypeChecker_Env.synth_hook);
+                              (uu___555_4257.FStar_TypeChecker_Env.synth_hook);
                             FStar_TypeChecker_Env.splice =
-                              (uu___555_4251.FStar_TypeChecker_Env.splice);
+                              (uu___555_4257.FStar_TypeChecker_Env.splice);
                             FStar_TypeChecker_Env.postprocess =
-                              (uu___555_4251.FStar_TypeChecker_Env.postprocess);
+                              (uu___555_4257.FStar_TypeChecker_Env.postprocess);
                             FStar_TypeChecker_Env.is_native_tactic =
-                              (uu___555_4251.FStar_TypeChecker_Env.is_native_tactic);
+                              (uu___555_4257.FStar_TypeChecker_Env.is_native_tactic);
                             FStar_TypeChecker_Env.identifier_info =
-                              (uu___555_4251.FStar_TypeChecker_Env.identifier_info);
+                              (uu___555_4257.FStar_TypeChecker_Env.identifier_info);
                             FStar_TypeChecker_Env.tc_hooks =
-                              (uu___555_4251.FStar_TypeChecker_Env.tc_hooks);
+                              (uu___555_4257.FStar_TypeChecker_Env.tc_hooks);
                             FStar_TypeChecker_Env.dsenv =
-                              (uu___555_4251.FStar_TypeChecker_Env.dsenv);
+                              (uu___555_4257.FStar_TypeChecker_Env.dsenv);
                             FStar_TypeChecker_Env.nbe =
-                              (uu___555_4251.FStar_TypeChecker_Env.nbe);
+                              (uu___555_4257.FStar_TypeChecker_Env.nbe);
                             FStar_TypeChecker_Env.strict_args_tab =
-                              (uu___555_4251.FStar_TypeChecker_Env.strict_args_tab)
+                              (uu___555_4257.FStar_TypeChecker_Env.strict_args_tab);
+                            FStar_TypeChecker_Env.erasable_types_tab =
+                              (uu___555_4257.FStar_TypeChecker_Env.erasable_types_tab)
                           }) qt
                         in
-                     (match uu____4242 with
-                      | (qt1,uu____4260,uu____4261) ->
+                     (match uu____4248 with
+                      | (qt1,uu____4266,uu____4267) ->
                           let t =
                             FStar_Syntax_Syntax.mk
                               (FStar_Syntax_Syntax.Tm_quoted (qt1, qi))
                               FStar_Pervasives_Native.None
                               top.FStar_Syntax_Syntax.pos
                              in
-                          let uu____4267 =
-                            let uu____4274 =
-                              let uu____4279 =
+                          let uu____4273 =
+                            let uu____4280 =
+                              let uu____4285 =
                                 FStar_Syntax_Util.lcomp_of_comp c  in
-                              FStar_Util.Inr uu____4279  in
-                            value_check_expected_typ env1 top uu____4274
+                              FStar_Util.Inr uu____4285  in
+                            value_check_expected_typ env1 top uu____4280
                               FStar_TypeChecker_Env.trivial_guard
                              in
-                          (match uu____4267 with
+                          (match uu____4273 with
                            | (t1,lc,g) ->
                                let t2 =
                                  FStar_Syntax_Syntax.mk
@@ -1672,14 +1682,14 @@ and (tc_maybe_toplevel_term :
                                   in
                                (t2, lc, g)))))
        | FStar_Syntax_Syntax.Tm_lazy
-           { FStar_Syntax_Syntax.blob = uu____4296;
+           { FStar_Syntax_Syntax.blob = uu____4302;
              FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
-               uu____4297;
-             FStar_Syntax_Syntax.ltyp = uu____4298;
-             FStar_Syntax_Syntax.rng = uu____4299;_}
+               uu____4303;
+             FStar_Syntax_Syntax.ltyp = uu____4304;
+             FStar_Syntax_Syntax.rng = uu____4305;_}
            ->
-           let uu____4310 = FStar_Syntax_Util.unlazy top  in
-           tc_term env1 uu____4310
+           let uu____4316 = FStar_Syntax_Util.unlazy top  in
+           tc_term env1 uu____4316
        | FStar_Syntax_Syntax.Tm_lazy i ->
            value_check_expected_typ env1 top
              (FStar_Util.Inl (i.FStar_Syntax_Syntax.ltyp))
@@ -1688,22 +1698,22 @@ and (tc_maybe_toplevel_term :
            (e1,FStar_Syntax_Syntax.Meta_desugared
             (FStar_Syntax_Syntax.Meta_smt_pat ))
            ->
-           let uu____4317 = tc_tot_or_gtot_term env1 e1  in
-           (match uu____4317 with
+           let uu____4323 = tc_tot_or_gtot_term env1 e1  in
+           (match uu____4323 with
             | (e2,c,g) ->
                 let g1 =
-                  let uu___585_4334 = g  in
+                  let uu___585_4340 = g  in
                   {
                     FStar_TypeChecker_Env.guard_f =
                       FStar_TypeChecker_Common.Trivial;
                     FStar_TypeChecker_Env.deferred =
-                      (uu___585_4334.FStar_TypeChecker_Env.deferred);
+                      (uu___585_4340.FStar_TypeChecker_Env.deferred);
                     FStar_TypeChecker_Env.univ_ineqs =
-                      (uu___585_4334.FStar_TypeChecker_Env.univ_ineqs);
+                      (uu___585_4340.FStar_TypeChecker_Env.univ_ineqs);
                     FStar_TypeChecker_Env.implicits =
-                      (uu___585_4334.FStar_TypeChecker_Env.implicits)
+                      (uu___585_4340.FStar_TypeChecker_Env.implicits)
                   }  in
-                let uu____4335 =
+                let uu____4341 =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_meta
                        (e2,
@@ -1711,35 +1721,35 @@ and (tc_maybe_toplevel_term :
                             FStar_Syntax_Syntax.Meta_smt_pat)))
                     FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos
                    in
-                (uu____4335, c, g1))
+                (uu____4341, c, g1))
        | FStar_Syntax_Syntax.Tm_meta
            (e1,FStar_Syntax_Syntax.Meta_pattern (names1,pats)) ->
-           let uu____4377 = FStar_Syntax_Util.type_u ()  in
-           (match uu____4377 with
+           let uu____4383 = FStar_Syntax_Util.type_u ()  in
+           (match uu____4383 with
             | (t,u) ->
-                let uu____4390 = tc_check_tot_or_gtot_term env1 e1 t  in
-                (match uu____4390 with
+                let uu____4396 = tc_check_tot_or_gtot_term env1 e1 t  in
+                (match uu____4396 with
                  | (e2,c,g) ->
-                     let uu____4406 =
-                       let uu____4423 =
+                     let uu____4412 =
+                       let uu____4429 =
                          FStar_TypeChecker_Env.clear_expected_typ env1  in
-                       match uu____4423 with
-                       | (env2,uu____4447) -> tc_smt_pats env2 pats  in
-                     (match uu____4406 with
+                       match uu____4429 with
+                       | (env2,uu____4453) -> tc_smt_pats env2 pats  in
+                     (match uu____4412 with
                       | (pats1,g') ->
                           let g'1 =
-                            let uu___608_4485 = g'  in
+                            let uu___608_4491 = g'  in
                             {
                               FStar_TypeChecker_Env.guard_f =
                                 FStar_TypeChecker_Common.Trivial;
                               FStar_TypeChecker_Env.deferred =
-                                (uu___608_4485.FStar_TypeChecker_Env.deferred);
+                                (uu___608_4491.FStar_TypeChecker_Env.deferred);
                               FStar_TypeChecker_Env.univ_ineqs =
-                                (uu___608_4485.FStar_TypeChecker_Env.univ_ineqs);
+                                (uu___608_4491.FStar_TypeChecker_Env.univ_ineqs);
                               FStar_TypeChecker_Env.implicits =
-                                (uu___608_4485.FStar_TypeChecker_Env.implicits)
+                                (uu___608_4491.FStar_TypeChecker_Env.implicits)
                             }  in
-                          let uu____4486 =
+                          let uu____4492 =
                             FStar_Syntax_Syntax.mk
                               (FStar_Syntax_Syntax.Tm_meta
                                  (e2,
@@ -1748,36 +1758,36 @@ and (tc_maybe_toplevel_term :
                               FStar_Pervasives_Native.None
                               top.FStar_Syntax_Syntax.pos
                              in
-                          let uu____4505 =
+                          let uu____4511 =
                             FStar_TypeChecker_Env.conj_guard g g'1  in
-                          (uu____4486, c, uu____4505))))
+                          (uu____4492, c, uu____4511))))
        | FStar_Syntax_Syntax.Tm_meta
            (e1,FStar_Syntax_Syntax.Meta_desugared
             (FStar_Syntax_Syntax.Sequence ))
            ->
-           let uu____4511 =
-             let uu____4512 = FStar_Syntax_Subst.compress e1  in
-             uu____4512.FStar_Syntax_Syntax.n  in
-           (match uu____4511 with
+           let uu____4517 =
+             let uu____4518 = FStar_Syntax_Subst.compress e1  in
+             uu____4518.FStar_Syntax_Syntax.n  in
+           (match uu____4517 with
             | FStar_Syntax_Syntax.Tm_let
-                ((uu____4521,{ FStar_Syntax_Syntax.lbname = x;
-                               FStar_Syntax_Syntax.lbunivs = uu____4523;
-                               FStar_Syntax_Syntax.lbtyp = uu____4524;
-                               FStar_Syntax_Syntax.lbeff = uu____4525;
+                ((uu____4527,{ FStar_Syntax_Syntax.lbname = x;
+                               FStar_Syntax_Syntax.lbunivs = uu____4529;
+                               FStar_Syntax_Syntax.lbtyp = uu____4530;
+                               FStar_Syntax_Syntax.lbeff = uu____4531;
                                FStar_Syntax_Syntax.lbdef = e11;
-                               FStar_Syntax_Syntax.lbattrs = uu____4527;
-                               FStar_Syntax_Syntax.lbpos = uu____4528;_}::[]),e2)
+                               FStar_Syntax_Syntax.lbattrs = uu____4533;
+                               FStar_Syntax_Syntax.lbpos = uu____4534;_}::[]),e2)
                 ->
-                let uu____4559 =
-                  let uu____4566 =
+                let uu____4565 =
+                  let uu____4572 =
                     FStar_TypeChecker_Env.set_expected_typ env1
                       FStar_Syntax_Syntax.t_unit
                      in
-                  tc_term uu____4566 e11  in
-                (match uu____4559 with
+                  tc_term uu____4572 e11  in
+                (match uu____4565 with
                  | (e12,c1,g1) ->
-                     let uu____4576 = tc_term env1 e2  in
-                     (match uu____4576 with
+                     let uu____4582 = tc_term env1 e2  in
+                     (match uu____4582 with
                       | (e21,c2,g2) ->
                           let c =
                             FStar_TypeChecker_Util.maybe_return_e2_and_bind
@@ -1798,20 +1808,20 @@ and (tc_maybe_toplevel_term :
                               c2.FStar_Syntax_Syntax.res_typ
                              in
                           let attrs =
-                            let uu____4600 =
+                            let uu____4606 =
                               FStar_TypeChecker_Util.is_pure_or_ghost_effect
                                 env1 c1.FStar_Syntax_Syntax.eff_name
                                in
-                            if uu____4600
+                            if uu____4606
                             then [FStar_Syntax_Util.inline_let_attr]
                             else []  in
                           let e3 =
-                            let uu____4610 =
-                              let uu____4617 =
-                                let uu____4618 =
-                                  let uu____4632 =
-                                    let uu____4640 =
-                                      let uu____4643 =
+                            let uu____4616 =
+                              let uu____4623 =
+                                let uu____4624 =
+                                  let uu____4638 =
+                                    let uu____4646 =
+                                      let uu____4649 =
                                         FStar_Syntax_Syntax.mk_lb
                                           (x, [],
                                             (c1.FStar_Syntax_Syntax.eff_name),
@@ -1819,12 +1829,12 @@ and (tc_maybe_toplevel_term :
                                             attrs,
                                             (e13.FStar_Syntax_Syntax.pos))
                                          in
-                                      [uu____4643]  in
-                                    (false, uu____4640)  in
-                                  (uu____4632, e22)  in
-                                FStar_Syntax_Syntax.Tm_let uu____4618  in
-                              FStar_Syntax_Syntax.mk uu____4617  in
-                            uu____4610 FStar_Pervasives_Native.None
+                                      [uu____4649]  in
+                                    (false, uu____4646)  in
+                                  (uu____4638, e22)  in
+                                FStar_Syntax_Syntax.Tm_let uu____4624  in
+                              FStar_Syntax_Syntax.mk uu____4623  in
+                            uu____4616 FStar_Pervasives_Native.None
                               e1.FStar_Syntax_Syntax.pos
                              in
                           let e4 =
@@ -1841,12 +1851,12 @@ and (tc_maybe_toplevel_term :
                               FStar_Pervasives_Native.None
                               top.FStar_Syntax_Syntax.pos
                              in
-                          let uu____4667 =
+                          let uu____4673 =
                             FStar_TypeChecker_Env.conj_guard g1 g2  in
-                          (e5, c, uu____4667)))
-            | uu____4668 ->
-                let uu____4669 = tc_term env1 e1  in
-                (match uu____4669 with
+                          (e5, c, uu____4673)))
+            | uu____4674 ->
+                let uu____4675 = tc_term env1 e1  in
+                (match uu____4675 with
                  | (e2,c,g) ->
                      let e3 =
                        FStar_Syntax_Syntax.mk
@@ -1859,14 +1869,14 @@ and (tc_maybe_toplevel_term :
                         in
                      (e3, c, g)))
        | FStar_Syntax_Syntax.Tm_meta
-           (e1,FStar_Syntax_Syntax.Meta_monadic uu____4691) ->
+           (e1,FStar_Syntax_Syntax.Meta_monadic uu____4697) ->
            tc_term env1 e1
        | FStar_Syntax_Syntax.Tm_meta
-           (e1,FStar_Syntax_Syntax.Meta_monadic_lift uu____4703) ->
+           (e1,FStar_Syntax_Syntax.Meta_monadic_lift uu____4709) ->
            tc_term env1 e1
        | FStar_Syntax_Syntax.Tm_meta (e1,m) ->
-           let uu____4722 = tc_term env1 e1  in
-           (match uu____4722 with
+           let uu____4728 = tc_term env1 e1  in
+           (match uu____4728 with
             | (e2,c,g) ->
                 let e3 =
                   FStar_Syntax_Syntax.mk
@@ -1875,35 +1885,35 @@ and (tc_maybe_toplevel_term :
                    in
                 (e3, c, g))
        | FStar_Syntax_Syntax.Tm_ascribed
-           (e1,(FStar_Util.Inr expected_c,topt),uu____4746) ->
-           let uu____4793 = FStar_TypeChecker_Env.clear_expected_typ env1  in
-           (match uu____4793 with
-            | (env0,uu____4807) ->
-                let uu____4812 = tc_comp env0 expected_c  in
-                (match uu____4812 with
-                 | (expected_c1,uu____4826,g) ->
-                     let uu____4828 =
-                       let uu____4835 =
+           (e1,(FStar_Util.Inr expected_c,topt),uu____4752) ->
+           let uu____4799 = FStar_TypeChecker_Env.clear_expected_typ env1  in
+           (match uu____4799 with
+            | (env0,uu____4813) ->
+                let uu____4818 = tc_comp env0 expected_c  in
+                (match uu____4818 with
+                 | (expected_c1,uu____4832,g) ->
+                     let uu____4834 =
+                       let uu____4841 =
                          FStar_All.pipe_right
                            (FStar_Syntax_Util.comp_result expected_c1)
                            (FStar_TypeChecker_Env.set_expected_typ env0)
                           in
-                       tc_term uu____4835 e1  in
-                     (match uu____4828 with
+                       tc_term uu____4841 e1  in
+                     (match uu____4834 with
                       | (e2,c',g') ->
-                          let uu____4845 =
-                            let uu____4852 =
-                              let uu____4857 =
+                          let uu____4851 =
+                            let uu____4858 =
+                              let uu____4863 =
                                 FStar_Syntax_Syntax.lcomp_comp c'  in
-                              (e2, uu____4857)  in
+                              (e2, uu____4863)  in
                             check_expected_effect env0
                               (FStar_Pervasives_Native.Some expected_c1)
-                              uu____4852
+                              uu____4858
                              in
-                          (match uu____4845 with
+                          (match uu____4851 with
                            | (e3,expected_c2,g'') ->
-                               let uu____4867 = tc_tactic_opt env0 topt  in
-                               (match uu____4867 with
+                               let uu____4873 = tc_tactic_opt env0 topt  in
+                               (match uu____4873 with
                                 | (topt1,gtac) ->
                                     let e4 =
                                       FStar_Syntax_Syntax.mk
@@ -1922,64 +1932,64 @@ and (tc_maybe_toplevel_term :
                                         expected_c2
                                        in
                                     let f =
-                                      let uu____4927 =
+                                      let uu____4933 =
                                         FStar_TypeChecker_Env.conj_guard g'
                                           g''
                                          in
                                       FStar_TypeChecker_Env.conj_guard g
-                                        uu____4927
+                                        uu____4933
                                        in
-                                    let uu____4928 =
+                                    let uu____4934 =
                                       comp_check_expected_typ env1 e4 lc  in
-                                    (match uu____4928 with
+                                    (match uu____4934 with
                                      | (e5,c,f2) ->
                                          let final_guard =
-                                           let uu____4945 =
+                                           let uu____4951 =
                                              FStar_TypeChecker_Env.conj_guard
                                                f f2
                                               in
                                            wrap_guard_with_tactic_opt topt1
-                                             uu____4945
+                                             uu____4951
                                             in
-                                         let uu____4946 =
+                                         let uu____4952 =
                                            FStar_TypeChecker_Env.conj_guard
                                              final_guard gtac
                                             in
-                                         (e5, c, uu____4946)))))))
+                                         (e5, c, uu____4952)))))))
        | FStar_Syntax_Syntax.Tm_ascribed
-           (e1,(FStar_Util.Inl t,topt),uu____4950) ->
-           let uu____4997 = FStar_Syntax_Util.type_u ()  in
-           (match uu____4997 with
+           (e1,(FStar_Util.Inl t,topt),uu____4956) ->
+           let uu____5003 = FStar_Syntax_Util.type_u ()  in
+           (match uu____5003 with
             | (k,u) ->
-                let uu____5010 = tc_check_tot_or_gtot_term env1 t k  in
-                (match uu____5010 with
-                 | (t1,uu____5024,f) ->
-                     let uu____5026 = tc_tactic_opt env1 topt  in
-                     (match uu____5026 with
+                let uu____5016 = tc_check_tot_or_gtot_term env1 t k  in
+                (match uu____5016 with
+                 | (t1,uu____5030,f) ->
+                     let uu____5032 = tc_tactic_opt env1 topt  in
+                     (match uu____5032 with
                       | (topt1,gtac) ->
-                          let uu____5045 =
-                            let uu____5052 =
+                          let uu____5051 =
+                            let uu____5058 =
                               FStar_TypeChecker_Env.set_expected_typ env1 t1
                                in
-                            tc_term uu____5052 e1  in
-                          (match uu____5045 with
+                            tc_term uu____5058 e1  in
+                          (match uu____5051 with
                            | (e2,c,g) ->
-                               let uu____5062 =
-                                 let uu____5067 =
+                               let uu____5068 =
+                                 let uu____5073 =
                                    FStar_TypeChecker_Env.set_range env1
                                      t1.FStar_Syntax_Syntax.pos
                                     in
                                  FStar_TypeChecker_Util.strengthen_precondition
                                    (FStar_Pervasives_Native.Some
-                                      (fun uu____5073  ->
+                                      (fun uu____5079  ->
                                          FStar_Util.return_all
                                            FStar_TypeChecker_Err.ill_kinded_type))
-                                   uu____5067 e2 c f
+                                   uu____5073 e2 c f
                                   in
-                               (match uu____5062 with
+                               (match uu____5068 with
                                 | (c1,f1) ->
-                                    let uu____5083 =
-                                      let uu____5090 =
+                                    let uu____5089 =
+                                      let uu____5096 =
                                         FStar_Syntax_Syntax.mk
                                           (FStar_Syntax_Syntax.Tm_ascribed
                                              (e2,
@@ -1989,48 +1999,48 @@ and (tc_maybe_toplevel_term :
                                           FStar_Pervasives_Native.None
                                           top.FStar_Syntax_Syntax.pos
                                          in
-                                      comp_check_expected_typ env1 uu____5090
+                                      comp_check_expected_typ env1 uu____5096
                                         c1
                                        in
-                                    (match uu____5083 with
+                                    (match uu____5089 with
                                      | (e3,c2,f2) ->
                                          let final_guard =
-                                           let uu____5137 =
+                                           let uu____5143 =
                                              FStar_TypeChecker_Env.conj_guard
                                                g f2
                                               in
                                            FStar_TypeChecker_Env.conj_guard
-                                             f1 uu____5137
+                                             f1 uu____5143
                                             in
                                          let final_guard1 =
                                            wrap_guard_with_tactic_opt topt1
                                              final_guard
                                             in
-                                         let uu____5139 =
+                                         let uu____5145 =
                                            FStar_TypeChecker_Env.conj_guard
                                              final_guard1 gtac
                                             in
-                                         (e3, c2, uu____5139)))))))
+                                         (e3, c2, uu____5145)))))))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_range_of );
-              FStar_Syntax_Syntax.pos = uu____5140;
-              FStar_Syntax_Syntax.vars = uu____5141;_},a::hd1::rest)
+              FStar_Syntax_Syntax.pos = uu____5146;
+              FStar_Syntax_Syntax.vars = uu____5147;_},a::hd1::rest)
            ->
            let rest1 = hd1 :: rest  in
-           let uu____5220 = FStar_Syntax_Util.head_and_args top  in
-           (match uu____5220 with
-            | (unary_op1,uu____5244) ->
+           let uu____5226 = FStar_Syntax_Util.head_and_args top  in
+           (match uu____5226 with
+            | (unary_op1,uu____5250) ->
                 let head1 =
-                  let uu____5272 =
+                  let uu____5278 =
                     FStar_Range.union_ranges
                       unary_op1.FStar_Syntax_Syntax.pos
                       (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos
                      in
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (unary_op1, [a]))
-                    FStar_Pervasives_Native.None uu____5272
+                    FStar_Pervasives_Native.None uu____5278
                    in
                 let t =
                   FStar_Syntax_Syntax.mk
@@ -2042,22 +2052,22 @@ and (tc_maybe_toplevel_term :
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_reify );
-              FStar_Syntax_Syntax.pos = uu____5320;
-              FStar_Syntax_Syntax.vars = uu____5321;_},a::hd1::rest)
+              FStar_Syntax_Syntax.pos = uu____5326;
+              FStar_Syntax_Syntax.vars = uu____5327;_},a::hd1::rest)
            ->
            let rest1 = hd1 :: rest  in
-           let uu____5400 = FStar_Syntax_Util.head_and_args top  in
-           (match uu____5400 with
-            | (unary_op1,uu____5424) ->
+           let uu____5406 = FStar_Syntax_Util.head_and_args top  in
+           (match uu____5406 with
+            | (unary_op1,uu____5430) ->
                 let head1 =
-                  let uu____5452 =
+                  let uu____5458 =
                     FStar_Range.union_ranges
                       unary_op1.FStar_Syntax_Syntax.pos
                       (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos
                      in
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (unary_op1, [a]))
-                    FStar_Pervasives_Native.None uu____5452
+                    FStar_Pervasives_Native.None uu____5458
                    in
                 let t =
                   FStar_Syntax_Syntax.mk
@@ -2068,23 +2078,23 @@ and (tc_maybe_toplevel_term :
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_reflect uu____5500);
-              FStar_Syntax_Syntax.pos = uu____5501;
-              FStar_Syntax_Syntax.vars = uu____5502;_},a::hd1::rest)
+                (FStar_Const.Const_reflect uu____5506);
+              FStar_Syntax_Syntax.pos = uu____5507;
+              FStar_Syntax_Syntax.vars = uu____5508;_},a::hd1::rest)
            ->
            let rest1 = hd1 :: rest  in
-           let uu____5581 = FStar_Syntax_Util.head_and_args top  in
-           (match uu____5581 with
-            | (unary_op1,uu____5605) ->
+           let uu____5587 = FStar_Syntax_Util.head_and_args top  in
+           (match uu____5587 with
+            | (unary_op1,uu____5611) ->
                 let head1 =
-                  let uu____5633 =
+                  let uu____5639 =
                     FStar_Range.union_ranges
                       unary_op1.FStar_Syntax_Syntax.pos
                       (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos
                      in
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (unary_op1, [a]))
-                    FStar_Pervasives_Native.None uu____5633
+                    FStar_Pervasives_Native.None uu____5639
                    in
                 let t =
                   FStar_Syntax_Syntax.mk
@@ -2096,22 +2106,22 @@ and (tc_maybe_toplevel_term :
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_set_range_of );
-              FStar_Syntax_Syntax.pos = uu____5681;
-              FStar_Syntax_Syntax.vars = uu____5682;_},a1::a2::hd1::rest)
+              FStar_Syntax_Syntax.pos = uu____5687;
+              FStar_Syntax_Syntax.vars = uu____5688;_},a1::a2::hd1::rest)
            ->
            let rest1 = hd1 :: rest  in
-           let uu____5778 = FStar_Syntax_Util.head_and_args top  in
-           (match uu____5778 with
-            | (unary_op1,uu____5802) ->
+           let uu____5784 = FStar_Syntax_Util.head_and_args top  in
+           (match uu____5784 with
+            | (unary_op1,uu____5808) ->
                 let head1 =
-                  let uu____5830 =
+                  let uu____5836 =
                     FStar_Range.union_ranges
                       unary_op1.FStar_Syntax_Syntax.pos
                       (FStar_Pervasives_Native.fst a1).FStar_Syntax_Syntax.pos
                      in
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (unary_op1, [a1; a2]))
-                    FStar_Pervasives_Native.None uu____5830
+                    FStar_Pervasives_Native.None uu____5836
                    in
                 let t =
                   FStar_Syntax_Syntax.mk
@@ -2123,111 +2133,111 @@ and (tc_maybe_toplevel_term :
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_range_of );
-              FStar_Syntax_Syntax.pos = uu____5886;
-              FStar_Syntax_Syntax.vars = uu____5887;_},(e1,FStar_Pervasives_Native.None
+              FStar_Syntax_Syntax.pos = uu____5892;
+              FStar_Syntax_Syntax.vars = uu____5893;_},(e1,FStar_Pervasives_Native.None
                                                         )::[])
            ->
-           let uu____5925 =
-             let uu____5932 =
-               let uu____5933 = FStar_TypeChecker_Env.clear_expected_typ env1
+           let uu____5931 =
+             let uu____5938 =
+               let uu____5939 = FStar_TypeChecker_Env.clear_expected_typ env1
                   in
-               FStar_All.pipe_left FStar_Pervasives_Native.fst uu____5933  in
-             tc_term uu____5932 e1  in
-           (match uu____5925 with
+               FStar_All.pipe_left FStar_Pervasives_Native.fst uu____5939  in
+             tc_term uu____5938 e1  in
+           (match uu____5931 with
             | (e2,c,g) ->
-                let uu____5957 = FStar_Syntax_Util.head_and_args top  in
-                (match uu____5957 with
-                 | (head1,uu____5981) ->
-                     let uu____6006 =
+                let uu____5963 = FStar_Syntax_Util.head_and_args top  in
+                (match uu____5963 with
+                 | (head1,uu____5987) ->
+                     let uu____6012 =
                        FStar_Syntax_Syntax.mk
                          (FStar_Syntax_Syntax.Tm_app
                             (head1, [(e2, FStar_Pervasives_Native.None)]))
                          FStar_Pervasives_Native.None
                          top.FStar_Syntax_Syntax.pos
                         in
-                     let uu____6039 =
-                       let uu____6040 =
-                         let uu____6041 =
+                     let uu____6045 =
+                       let uu____6046 =
+                         let uu____6047 =
                            FStar_Syntax_Syntax.tabbrev
                              FStar_Parser_Const.range_lid
                             in
-                         FStar_Syntax_Syntax.mk_Total uu____6041  in
+                         FStar_Syntax_Syntax.mk_Total uu____6047  in
                        FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp
-                         uu____6040
+                         uu____6046
                         in
-                     (uu____6006, uu____6039, g)))
+                     (uu____6012, uu____6045, g)))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_set_range_of );
-              FStar_Syntax_Syntax.pos = uu____6042;
-              FStar_Syntax_Syntax.vars = uu____6043;_},(t,FStar_Pervasives_Native.None
+              FStar_Syntax_Syntax.pos = uu____6048;
+              FStar_Syntax_Syntax.vars = uu____6049;_},(t,FStar_Pervasives_Native.None
                                                         )::(r,FStar_Pervasives_Native.None
                                                             )::[])
            ->
-           let uu____6096 = FStar_Syntax_Util.head_and_args top  in
-           (match uu____6096 with
-            | (head1,uu____6120) ->
+           let uu____6102 = FStar_Syntax_Util.head_and_args top  in
+           (match uu____6102 with
+            | (head1,uu____6126) ->
                 let env' =
-                  let uu____6146 =
+                  let uu____6152 =
                     FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.range_lid
                      in
-                  FStar_TypeChecker_Env.set_expected_typ env1 uu____6146  in
-                let uu____6147 = tc_term env' r  in
-                (match uu____6147 with
-                 | (er,uu____6161,gr) ->
-                     let uu____6163 = tc_term env1 t  in
-                     (match uu____6163 with
+                  FStar_TypeChecker_Env.set_expected_typ env1 uu____6152  in
+                let uu____6153 = tc_term env' r  in
+                (match uu____6153 with
+                 | (er,uu____6167,gr) ->
+                     let uu____6169 = tc_term env1 t  in
+                     (match uu____6169 with
                       | (t1,tt,gt1) ->
                           let g = FStar_TypeChecker_Env.conj_guard gr gt1  in
-                          let uu____6180 =
-                            let uu____6181 =
-                              let uu____6186 =
-                                let uu____6187 =
+                          let uu____6186 =
+                            let uu____6187 =
+                              let uu____6192 =
+                                let uu____6193 =
                                   FStar_Syntax_Syntax.as_arg t1  in
-                                let uu____6196 =
-                                  let uu____6207 =
+                                let uu____6202 =
+                                  let uu____6213 =
                                     FStar_Syntax_Syntax.as_arg r  in
-                                  [uu____6207]  in
-                                uu____6187 :: uu____6196  in
-                              FStar_Syntax_Syntax.mk_Tm_app head1 uu____6186
+                                  [uu____6213]  in
+                                uu____6193 :: uu____6202  in
+                              FStar_Syntax_Syntax.mk_Tm_app head1 uu____6192
                                in
-                            uu____6181 FStar_Pervasives_Native.None
+                            uu____6187 FStar_Pervasives_Native.None
                               top.FStar_Syntax_Syntax.pos
                              in
-                          (uu____6180, tt, g))))
+                          (uu____6186, tt, g))))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_range_of );
-              FStar_Syntax_Syntax.pos = uu____6240;
-              FStar_Syntax_Syntax.vars = uu____6241;_},uu____6242)
+              FStar_Syntax_Syntax.pos = uu____6246;
+              FStar_Syntax_Syntax.vars = uu____6247;_},uu____6248)
            ->
-           let uu____6267 =
-             let uu____6273 =
-               let uu____6275 = FStar_Syntax_Print.term_to_string top  in
-               FStar_Util.format1 "Ill-applied constant %s" uu____6275  in
-             (FStar_Errors.Fatal_IllAppliedConstant, uu____6273)  in
-           FStar_Errors.raise_error uu____6267 e.FStar_Syntax_Syntax.pos
+           let uu____6273 =
+             let uu____6279 =
+               let uu____6281 = FStar_Syntax_Print.term_to_string top  in
+               FStar_Util.format1 "Ill-applied constant %s" uu____6281  in
+             (FStar_Errors.Fatal_IllAppliedConstant, uu____6279)  in
+           FStar_Errors.raise_error uu____6273 e.FStar_Syntax_Syntax.pos
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_set_range_of );
-              FStar_Syntax_Syntax.pos = uu____6285;
-              FStar_Syntax_Syntax.vars = uu____6286;_},uu____6287)
+              FStar_Syntax_Syntax.pos = uu____6291;
+              FStar_Syntax_Syntax.vars = uu____6292;_},uu____6293)
            ->
-           let uu____6312 =
-             let uu____6318 =
-               let uu____6320 = FStar_Syntax_Print.term_to_string top  in
-               FStar_Util.format1 "Ill-applied constant %s" uu____6320  in
-             (FStar_Errors.Fatal_IllAppliedConstant, uu____6318)  in
-           FStar_Errors.raise_error uu____6312 e.FStar_Syntax_Syntax.pos
+           let uu____6318 =
+             let uu____6324 =
+               let uu____6326 = FStar_Syntax_Print.term_to_string top  in
+               FStar_Util.format1 "Ill-applied constant %s" uu____6326  in
+             (FStar_Errors.Fatal_IllAppliedConstant, uu____6324)  in
+           FStar_Errors.raise_error uu____6318 e.FStar_Syntax_Syntax.pos
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_reify );
-              FStar_Syntax_Syntax.pos = uu____6330;
-              FStar_Syntax_Syntax.vars = uu____6331;_},(e1,aqual)::[])
+              FStar_Syntax_Syntax.pos = uu____6336;
+              FStar_Syntax_Syntax.vars = uu____6337;_},(e1,aqual)::[])
            ->
            (if FStar_Option.isSome aqual
             then
@@ -2235,51 +2245,51 @@ and (tc_maybe_toplevel_term :
                 (FStar_Errors.Warning_IrrelevantQualifierOnArgumentToReify,
                   "Qualifier on argument to reify is irrelevant and will be ignored")
             else ();
-            (let uu____6378 = FStar_TypeChecker_Env.clear_expected_typ env1
+            (let uu____6384 = FStar_TypeChecker_Env.clear_expected_typ env1
                 in
-             match uu____6378 with
-             | (env0,uu____6392) ->
-                 let uu____6397 = tc_term env0 e1  in
-                 (match uu____6397 with
+             match uu____6384 with
+             | (env0,uu____6398) ->
+                 let uu____6403 = tc_term env0 e1  in
+                 (match uu____6403 with
                   | (e2,c,g) ->
-                      let uu____6413 = FStar_Syntax_Util.head_and_args top
+                      let uu____6419 = FStar_Syntax_Util.head_and_args top
                          in
-                      (match uu____6413 with
-                       | (reify_op,uu____6437) ->
+                      (match uu____6419 with
+                       | (reify_op,uu____6443) ->
                            let u_c =
                              env1.FStar_TypeChecker_Env.universe_of env1
                                c.FStar_Syntax_Syntax.res_typ
                               in
                            let ef =
-                             let uu____6464 =
+                             let uu____6470 =
                                FStar_Syntax_Syntax.lcomp_comp c  in
-                             FStar_Syntax_Util.comp_effect_name uu____6464
+                             FStar_Syntax_Util.comp_effect_name uu____6470
                               in
-                           ((let uu____6468 =
-                               let uu____6470 =
+                           ((let uu____6474 =
+                               let uu____6476 =
                                  FStar_TypeChecker_Env.is_user_reifiable_effect
                                    env1 ef
                                   in
-                               Prims.op_Negation uu____6470  in
-                             if uu____6468
+                               Prims.op_Negation uu____6476  in
+                             if uu____6474
                              then
-                               let uu____6473 =
-                                 let uu____6479 =
+                               let uu____6479 =
+                                 let uu____6485 =
                                    FStar_Util.format1
                                      "Effect %s cannot be reified"
                                      ef.FStar_Ident.str
                                     in
                                  (FStar_Errors.Fatal_EffectCannotBeReified,
-                                   uu____6479)
+                                   uu____6485)
                                   in
-                               FStar_Errors.raise_error uu____6473
+                               FStar_Errors.raise_error uu____6479
                                  e2.FStar_Syntax_Syntax.pos
                              else ());
                             (let repr =
-                               let uu____6486 =
+                               let uu____6492 =
                                  FStar_Syntax_Syntax.lcomp_comp c  in
                                FStar_TypeChecker_Env.reify_comp env1
-                                 uu____6486 u_c
+                                 uu____6492 u_c
                                 in
                              let e3 =
                                FStar_Syntax_Syntax.mk
@@ -2289,15 +2299,15 @@ and (tc_maybe_toplevel_term :
                                  top.FStar_Syntax_Syntax.pos
                                 in
                              let c1 =
-                               let uu____6523 =
+                               let uu____6529 =
                                  FStar_TypeChecker_Env.is_total_effect env1
                                    ef
                                   in
-                               if uu____6523
+                               if uu____6529
                                then
-                                 let uu____6526 =
+                                 let uu____6532 =
                                    FStar_Syntax_Syntax.mk_Total repr  in
-                                 FStar_All.pipe_right uu____6526
+                                 FStar_All.pipe_right uu____6532
                                    FStar_Syntax_Util.lcomp_of_comp
                                else
                                  (let ct =
@@ -2309,24 +2319,24 @@ and (tc_maybe_toplevel_term :
                                       FStar_Syntax_Syntax.effect_args = [];
                                       FStar_Syntax_Syntax.flags = []
                                     }  in
-                                  let uu____6538 =
+                                  let uu____6544 =
                                     FStar_Syntax_Syntax.mk_Comp ct  in
-                                  FStar_All.pipe_right uu____6538
+                                  FStar_All.pipe_right uu____6544
                                     FStar_Syntax_Util.lcomp_of_comp)
                                 in
-                             let uu____6539 =
+                             let uu____6545 =
                                comp_check_expected_typ env1 e3 c1  in
-                             match uu____6539 with
+                             match uu____6545 with
                              | (e4,c2,g') ->
-                                 let uu____6555 =
+                                 let uu____6561 =
                                    FStar_TypeChecker_Env.conj_guard g g'  in
-                                 (e4, c2, uu____6555)))))))
+                                 (e4, c2, uu____6561)))))))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_reflect l);
-              FStar_Syntax_Syntax.pos = uu____6557;
-              FStar_Syntax_Syntax.vars = uu____6558;_},(e1,aqual)::[])
+              FStar_Syntax_Syntax.pos = uu____6563;
+              FStar_Syntax_Syntax.vars = uu____6564;_},(e1,aqual)::[])
            ->
            (if FStar_Option.isSome aqual
             then
@@ -2334,100 +2344,100 @@ and (tc_maybe_toplevel_term :
                 (FStar_Errors.Warning_IrrelevantQualifierOnArgumentToReflect,
                   "Qualifier on argument to reflect is irrelevant and will be ignored")
             else ();
-            (let uu____6606 =
-               let uu____6608 =
+            (let uu____6612 =
+               let uu____6614 =
                  FStar_TypeChecker_Env.is_user_reifiable_effect env1 l  in
-               Prims.op_Negation uu____6608  in
-             if uu____6606
+               Prims.op_Negation uu____6614  in
+             if uu____6612
              then
-               let uu____6611 =
-                 let uu____6617 =
+               let uu____6617 =
+                 let uu____6623 =
                    FStar_Util.format1 "Effect %s cannot be reified"
                      l.FStar_Ident.str
                     in
-                 (FStar_Errors.Fatal_EffectCannotBeReified, uu____6617)  in
-               FStar_Errors.raise_error uu____6611 e1.FStar_Syntax_Syntax.pos
+                 (FStar_Errors.Fatal_EffectCannotBeReified, uu____6623)  in
+               FStar_Errors.raise_error uu____6617 e1.FStar_Syntax_Syntax.pos
              else ());
-            (let uu____6623 = FStar_Syntax_Util.head_and_args top  in
-             match uu____6623 with
-             | (reflect_op,uu____6647) ->
-                 let uu____6672 =
+            (let uu____6629 = FStar_Syntax_Util.head_and_args top  in
+             match uu____6629 with
+             | (reflect_op,uu____6653) ->
+                 let uu____6678 =
                    FStar_TypeChecker_Env.effect_decl_opt env1 l  in
-                 (match uu____6672 with
+                 (match uu____6678 with
                   | FStar_Pervasives_Native.None  ->
                       failwith
                         "internal error: user reifiable effect has no decl?"
                   | FStar_Pervasives_Native.Some (ed,qualifiers) ->
-                      let uu____6712 =
+                      let uu____6718 =
                         FStar_TypeChecker_Env.clear_expected_typ env1  in
-                      (match uu____6712 with
+                      (match uu____6718 with
                        | (env_no_ex,topt) ->
-                           let uu____6731 =
+                           let uu____6737 =
                              let u = FStar_TypeChecker_Env.new_u_univ ()  in
                              let repr =
                                FStar_TypeChecker_Env.inst_effect_fun_with 
                                  [u] env1 ed ed.FStar_Syntax_Syntax.repr
                                 in
                              let t =
-                               let uu____6747 =
-                                 let uu____6754 =
-                                   let uu____6755 =
-                                     let uu____6772 =
-                                       let uu____6783 =
+                               let uu____6753 =
+                                 let uu____6760 =
+                                   let uu____6761 =
+                                     let uu____6778 =
+                                       let uu____6789 =
                                          FStar_Syntax_Syntax.as_arg
                                            FStar_Syntax_Syntax.tun
                                           in
-                                       let uu____6792 =
-                                         let uu____6803 =
+                                       let uu____6798 =
+                                         let uu____6809 =
                                            FStar_Syntax_Syntax.as_arg
                                              FStar_Syntax_Syntax.tun
                                             in
-                                         [uu____6803]  in
-                                       uu____6783 :: uu____6792  in
-                                     (repr, uu____6772)  in
-                                   FStar_Syntax_Syntax.Tm_app uu____6755  in
-                                 FStar_Syntax_Syntax.mk uu____6754  in
-                               uu____6747 FStar_Pervasives_Native.None
+                                         [uu____6809]  in
+                                       uu____6789 :: uu____6798  in
+                                     (repr, uu____6778)  in
+                                   FStar_Syntax_Syntax.Tm_app uu____6761  in
+                                 FStar_Syntax_Syntax.mk uu____6760  in
+                               uu____6753 FStar_Pervasives_Native.None
                                  top.FStar_Syntax_Syntax.pos
                                 in
-                             let uu____6848 =
-                               let uu____6855 =
-                                 let uu____6856 =
+                             let uu____6854 =
+                               let uu____6861 =
+                                 let uu____6862 =
                                    FStar_TypeChecker_Env.clear_expected_typ
                                      env1
                                     in
-                                 FStar_All.pipe_right uu____6856
+                                 FStar_All.pipe_right uu____6862
                                    FStar_Pervasives_Native.fst
                                   in
-                               tc_tot_or_gtot_term uu____6855 t  in
-                             match uu____6848 with
-                             | (t1,uu____6882,g) ->
-                                 let uu____6884 =
-                                   let uu____6885 =
+                               tc_tot_or_gtot_term uu____6861 t  in
+                             match uu____6854 with
+                             | (t1,uu____6888,g) ->
+                                 let uu____6890 =
+                                   let uu____6891 =
                                      FStar_Syntax_Subst.compress t1  in
-                                   uu____6885.FStar_Syntax_Syntax.n  in
-                                 (match uu____6884 with
+                                   uu____6891.FStar_Syntax_Syntax.n  in
+                                 (match uu____6890 with
                                   | FStar_Syntax_Syntax.Tm_app
-                                      (uu____6898,(res,uu____6900)::(wp,uu____6902)::[])
+                                      (uu____6904,(res,uu____6906)::(wp,uu____6908)::[])
                                       -> (t1, res, wp, g)
-                                  | uu____6959 -> failwith "Impossible")
+                                  | uu____6965 -> failwith "Impossible")
                               in
-                           (match uu____6731 with
+                           (match uu____6737 with
                             | (expected_repr_typ,res_typ,wp,g0) ->
-                                let uu____6985 =
-                                  let uu____6992 =
+                                let uu____6991 =
+                                  let uu____6998 =
                                     tc_tot_or_gtot_term env_no_ex e1  in
-                                  match uu____6992 with
+                                  match uu____6998 with
                                   | (e2,c,g) ->
-                                      ((let uu____7009 =
-                                          let uu____7011 =
+                                      ((let uu____7015 =
+                                          let uu____7017 =
                                             FStar_Syntax_Util.is_total_lcomp
                                               c
                                              in
                                           FStar_All.pipe_left
-                                            Prims.op_Negation uu____7011
+                                            Prims.op_Negation uu____7017
                                            in
-                                        if uu____7009
+                                        if uu____7015
                                         then
                                           FStar_TypeChecker_Err.add_errors
                                             env1
@@ -2435,84 +2445,84 @@ and (tc_maybe_toplevel_term :
                                                "Expected Tot, got a GTot computation",
                                                (e2.FStar_Syntax_Syntax.pos))]
                                         else ());
-                                       (let uu____7034 =
+                                       (let uu____7040 =
                                           FStar_TypeChecker_Rel.try_teq true
                                             env_no_ex
                                             c.FStar_Syntax_Syntax.res_typ
                                             expected_repr_typ
                                            in
-                                        match uu____7034 with
+                                        match uu____7040 with
                                         | FStar_Pervasives_Native.None  ->
-                                            ((let uu____7045 =
-                                                let uu____7055 =
-                                                  let uu____7063 =
-                                                    let uu____7065 =
+                                            ((let uu____7051 =
+                                                let uu____7061 =
+                                                  let uu____7069 =
+                                                    let uu____7071 =
                                                       FStar_Syntax_Print.tscheme_to_string
                                                         ed.FStar_Syntax_Syntax.repr
                                                        in
-                                                    let uu____7067 =
+                                                    let uu____7073 =
                                                       FStar_Syntax_Print.term_to_string
                                                         c.FStar_Syntax_Syntax.res_typ
                                                        in
                                                     FStar_Util.format2
                                                       "Expected an instance of %s; got %s"
-                                                      uu____7065 uu____7067
+                                                      uu____7071 uu____7073
                                                      in
                                                   (FStar_Errors.Error_UnexpectedInstance,
-                                                    uu____7063,
+                                                    uu____7069,
                                                     (e2.FStar_Syntax_Syntax.pos))
                                                    in
-                                                [uu____7055]  in
+                                                [uu____7061]  in
                                               FStar_TypeChecker_Err.add_errors
-                                                env1 uu____7045);
-                                             (let uu____7085 =
+                                                env1 uu____7051);
+                                             (let uu____7091 =
                                                 FStar_TypeChecker_Env.conj_guard
                                                   g g0
                                                  in
-                                              (e2, uu____7085)))
+                                              (e2, uu____7091)))
                                         | FStar_Pervasives_Native.Some g' ->
-                                            let uu____7089 =
-                                              let uu____7090 =
+                                            let uu____7095 =
+                                              let uu____7096 =
                                                 FStar_TypeChecker_Env.conj_guard
                                                   g g0
                                                  in
                                               FStar_TypeChecker_Env.conj_guard
-                                                g' uu____7090
+                                                g' uu____7096
                                                in
-                                            (e2, uu____7089)))
+                                            (e2, uu____7095)))
                                    in
-                                (match uu____6985 with
+                                (match uu____6991 with
                                  | (e2,g) ->
                                      let c =
-                                       let uu____7106 =
-                                         let uu____7107 =
-                                           let uu____7108 =
-                                             let uu____7109 =
+                                       let uu____7112 =
+                                         let uu____7113 =
+                                           let uu____7114 =
+                                             let uu____7115 =
                                                env1.FStar_TypeChecker_Env.universe_of
                                                  env1 res_typ
                                                 in
-                                             [uu____7109]  in
-                                           let uu____7110 =
-                                             let uu____7121 =
+                                             [uu____7115]  in
+                                           let uu____7116 =
+                                             let uu____7127 =
                                                FStar_Syntax_Syntax.as_arg wp
                                                 in
-                                             [uu____7121]  in
+                                             [uu____7127]  in
                                            {
                                              FStar_Syntax_Syntax.comp_univs =
-                                               uu____7108;
+                                               uu____7114;
                                              FStar_Syntax_Syntax.effect_name
                                                =
                                                (ed.FStar_Syntax_Syntax.mname);
                                              FStar_Syntax_Syntax.result_typ =
                                                res_typ;
                                              FStar_Syntax_Syntax.effect_args
-                                               = uu____7110;
+                                               = uu____7116;
                                              FStar_Syntax_Syntax.flags = []
                                            }  in
                                          FStar_Syntax_Syntax.mk_Comp
-                                           uu____7107
+                                           uu____7113
                                           in
-                                       FStar_All.pipe_right uu____7106
+                                       FStar_All.pipe_right uu____7112
                                          FStar_Syntax_Util.lcomp_of_comp
                                         in
                                      let e3 =
@@ -2522,9 +2532,9 @@ and (tc_maybe_toplevel_term :
                                          FStar_Pervasives_Native.None
                                          top.FStar_Syntax_Syntax.pos
                                         in
-                                     let uu____7181 =
+                                     let uu____7187 =
                                        comp_check_expected_typ env1 e3 c  in
-                                     (match uu____7181 with
+                                     (match uu____7187 with
                                       | (e4,c1,g') ->
                                           let e5 =
                                             FStar_Syntax_Syntax.mk
@@ -2536,37 +2546,37 @@ and (tc_maybe_toplevel_term :
                                               FStar_Pervasives_Native.None
                                               e4.FStar_Syntax_Syntax.pos
                                              in
-                                          let uu____7204 =
+                                          let uu____7210 =
                                             FStar_TypeChecker_Env.conj_guard
                                               g' g
                                              in
-                                          (e5, c1, uu____7204))))))))
+                                          (e5, c1, uu____7210))))))))
        | FStar_Syntax_Syntax.Tm_app
            (head1,(tau,FStar_Pervasives_Native.None )::[]) when
            (FStar_Syntax_Util.is_synth_by_tactic head1) &&
              (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
            ->
-           let uu____7243 = FStar_Syntax_Util.head_and_args top  in
-           (match uu____7243 with
+           let uu____7249 = FStar_Syntax_Util.head_and_args top  in
+           (match uu____7249 with
             | (head2,args) ->
                 tc_synth head2 env1 args top.FStar_Syntax_Syntax.pos)
        | FStar_Syntax_Syntax.Tm_app
-           (head1,(uu____7293,FStar_Pervasives_Native.Some
-                   (FStar_Syntax_Syntax.Implicit uu____7294))::(tau,FStar_Pervasives_Native.None
+           (head1,(uu____7299,FStar_Pervasives_Native.Some
+                   (FStar_Syntax_Syntax.Implicit uu____7300))::(tau,FStar_Pervasives_Native.None
                                                                 )::[])
            when
            (FStar_Syntax_Util.is_synth_by_tactic head1) &&
              (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
            ->
-           let uu____7347 = FStar_Syntax_Util.head_and_args top  in
-           (match uu____7347 with
+           let uu____7353 = FStar_Syntax_Util.head_and_args top  in
+           (match uu____7353 with
             | (head2,args) ->
                 tc_synth head2 env1 args top.FStar_Syntax_Syntax.pos)
        | FStar_Syntax_Syntax.Tm_app (head1,args) when
            (FStar_Syntax_Util.is_synth_by_tactic head1) &&
              (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
            ->
-           let uu____7422 =
+           let uu____7428 =
              match args with
              | (tau,FStar_Pervasives_Native.None )::rest ->
                  ([(tau, FStar_Pervasives_Native.None)], rest)
@@ -2576,13 +2586,13 @@ and (tc_maybe_toplevel_term :
                      (FStar_Pervasives_Native.Some
                         (FStar_Syntax_Syntax.Implicit b)));
                   (tau, FStar_Pervasives_Native.None)], rest)
-             | uu____7632 ->
+             | uu____7638 ->
                  FStar_Errors.raise_error
                    (FStar_Errors.Fatal_SynthByTacticError,
                      "synth_by_tactic: bad application")
                    top.FStar_Syntax_Syntax.pos
               in
-           (match uu____7422 with
+           (match uu____7428 with
             | (args1,args2) ->
                 let t1 = FStar_Syntax_Util.mk_app head1 args1  in
                 let t2 = FStar_Syntax_Util.mk_app t1 args2  in
@@ -2590,95 +2600,95 @@ and (tc_maybe_toplevel_term :
        | FStar_Syntax_Syntax.Tm_app (head1,args) ->
            let env0 = env1  in
            let env2 =
-             let uu____7751 =
-               let uu____7752 = FStar_TypeChecker_Env.clear_expected_typ env1
+             let uu____7757 =
+               let uu____7758 = FStar_TypeChecker_Env.clear_expected_typ env1
                   in
-               FStar_All.pipe_right uu____7752 FStar_Pervasives_Native.fst
+               FStar_All.pipe_right uu____7758 FStar_Pervasives_Native.fst
                 in
-             FStar_All.pipe_right uu____7751 instantiate_both  in
-           ((let uu____7768 =
+             FStar_All.pipe_right uu____7757 instantiate_both  in
+           ((let uu____7774 =
                FStar_TypeChecker_Env.debug env2 FStar_Options.High  in
-             if uu____7768
+             if uu____7774
              then
-               let uu____7771 =
+               let uu____7777 =
                  FStar_Range.string_of_range top.FStar_Syntax_Syntax.pos  in
-               let uu____7773 = FStar_Syntax_Print.term_to_string top  in
-               let uu____7775 =
-                 let uu____7777 = FStar_TypeChecker_Env.expected_typ env0  in
-                 FStar_All.pipe_right uu____7777
-                   (fun uu___3_7784  ->
-                      match uu___3_7784 with
+               let uu____7779 = FStar_Syntax_Print.term_to_string top  in
+               let uu____7781 =
+                 let uu____7783 = FStar_TypeChecker_Env.expected_typ env0  in
+                 FStar_All.pipe_right uu____7783
+                   (fun uu___3_7790  ->
+                      match uu___3_7790 with
                       | FStar_Pervasives_Native.None  -> "none"
                       | FStar_Pervasives_Native.Some t ->
                           FStar_Syntax_Print.term_to_string t)
                   in
                FStar_Util.print3
-                 "(%s) Checking app %s, expected type is %s\n" uu____7771
-                 uu____7773 uu____7775
+                 "(%s) Checking app %s, expected type is %s\n" uu____7777
+                 uu____7779 uu____7781
              else ());
-            (let uu____7793 = tc_term (no_inst env2) head1  in
-             match uu____7793 with
+            (let uu____7799 = tc_term (no_inst env2) head1  in
+             match uu____7799 with
              | (head2,chead,g_head) ->
                  let chead1 = FStar_Syntax_Syntax.lcomp_comp chead  in
-                 let uu____7810 =
-                   let uu____7817 =
+                 let uu____7816 =
+                   let uu____7823 =
                      ((Prims.op_Negation env2.FStar_TypeChecker_Env.lax) &&
-                        (let uu____7820 = FStar_Options.lax ()  in
-                         Prims.op_Negation uu____7820))
+                        (let uu____7826 = FStar_Options.lax ()  in
+                         Prims.op_Negation uu____7826))
                        && (FStar_TypeChecker_Util.short_circuit_head head2)
                       in
-                   if uu____7817
+                   if uu____7823
                    then
-                     let uu____7829 =
-                       let uu____7836 =
+                     let uu____7835 =
+                       let uu____7842 =
                          FStar_TypeChecker_Env.expected_typ env0  in
                        check_short_circuit_args env2 head2 chead1 g_head args
-                         uu____7836
+                         uu____7842
                         in
-                     match uu____7829 with | (e1,c,g) -> (e1, c, g)
+                     match uu____7835 with | (e1,c,g) -> (e1, c, g)
                    else
-                     (let uu____7850 =
+                     (let uu____7856 =
                         FStar_TypeChecker_Env.expected_typ env0  in
                       check_application_args env2 head2 chead1 g_head args
-                        uu____7850)
+                        uu____7856)
                     in
-                 (match uu____7810 with
+                 (match uu____7816 with
                   | (e1,c,g) ->
-                      let uu____7862 =
-                        let uu____7869 =
+                      let uu____7868 =
+                        let uu____7875 =
                           FStar_Syntax_Util.is_tot_or_gtot_lcomp c  in
-                        if uu____7869
+                        if uu____7875
                         then
-                          let uu____7878 =
+                          let uu____7884 =
                             FStar_TypeChecker_Util.maybe_instantiate env0 e1
                               c.FStar_Syntax_Syntax.res_typ
                              in
-                          match uu____7878 with
+                          match uu____7884 with
                           | (e2,res_typ,implicits) ->
-                              let uu____7894 =
+                              let uu____7900 =
                                 FStar_Syntax_Util.set_result_typ_lc c res_typ
                                  in
-                              (e2, uu____7894, implicits)
+                              (e2, uu____7900, implicits)
                         else (e1, c, FStar_TypeChecker_Env.trivial_guard)  in
-                      (match uu____7862 with
+                      (match uu____7868 with
                        | (e2,c1,implicits) ->
-                           ((let uu____7907 =
+                           ((let uu____7913 =
                                FStar_TypeChecker_Env.debug env2
                                  FStar_Options.Extreme
                                 in
-                             if uu____7907
+                             if uu____7913
                              then
-                               let uu____7910 =
+                               let uu____7916 =
                                  FStar_TypeChecker_Rel.print_pending_implicits
                                    g
                                   in
                                FStar_Util.print1
                                  "Introduced {%s} implicits in application\n"
-                                 uu____7910
+                                 uu____7916
                              else ());
-                            (let uu____7915 =
+                            (let uu____7921 =
                                comp_check_expected_typ env0 e2 c1  in
-                             match uu____7915 with
+                             match uu____7921 with
                              | (e3,c2,g') ->
                                  let gres =
                                    FStar_TypeChecker_Env.conj_guard g g'  in
@@ -2686,68 +2696,68 @@ and (tc_maybe_toplevel_term :
                                    FStar_TypeChecker_Env.conj_guard gres
                                      implicits
                                     in
-                                 ((let uu____7934 =
+                                 ((let uu____7940 =
                                      FStar_TypeChecker_Env.debug env2
                                        FStar_Options.Extreme
                                       in
-                                   if uu____7934
+                                   if uu____7940
                                    then
-                                     let uu____7937 =
+                                     let uu____7943 =
                                        FStar_Syntax_Print.term_to_string e3
                                         in
-                                     let uu____7939 =
+                                     let uu____7945 =
                                        FStar_TypeChecker_Rel.guard_to_string
                                          env2 gres1
                                         in
                                      FStar_Util.print2
                                        "Guard from application node %s is %s\n"
-                                       uu____7937 uu____7939
+                                       uu____7943 uu____7945
                                    else ());
                                   (e3, c2, gres1))))))))
        | FStar_Syntax_Syntax.Tm_match (e1,eqns) ->
-           let uu____7982 = FStar_TypeChecker_Env.clear_expected_typ env1  in
-           (match uu____7982 with
+           let uu____7988 = FStar_TypeChecker_Env.clear_expected_typ env1  in
+           (match uu____7988 with
             | (env11,topt) ->
                 let env12 = instantiate_both env11  in
-                let uu____8002 = tc_term env12 e1  in
-                (match uu____8002 with
+                let uu____8008 = tc_term env12 e1  in
+                (match uu____8008 with
                  | (e11,c1,g1) ->
-                     let uu____8018 =
+                     let uu____8024 =
                        match topt with
                        | FStar_Pervasives_Native.Some t -> (env1, t, g1)
                        | FStar_Pervasives_Native.None  ->
-                           let uu____8032 = FStar_Syntax_Util.type_u ()  in
-                           (match uu____8032 with
-                            | (k,uu____8044) ->
-                                let uu____8045 =
+                           let uu____8038 = FStar_Syntax_Util.type_u ()  in
+                           (match uu____8038 with
+                            | (k,uu____8050) ->
+                                let uu____8051 =
                                   FStar_TypeChecker_Util.new_implicit_var
                                     "match result" e.FStar_Syntax_Syntax.pos
                                     env1 k
                                    in
-                                (match uu____8045 with
-                                 | (res_t,uu____8066,g) ->
-                                     let uu____8080 =
+                                (match uu____8051 with
+                                 | (res_t,uu____8072,g) ->
+                                     let uu____8086 =
                                        FStar_TypeChecker_Env.set_expected_typ
                                          env1 res_t
                                         in
-                                     let uu____8081 =
+                                     let uu____8087 =
                                        FStar_TypeChecker_Env.conj_guard g1 g
                                         in
-                                     (uu____8080, res_t, uu____8081)))
+                                     (uu____8086, res_t, uu____8087)))
                         in
-                     (match uu____8018 with
+                     (match uu____8024 with
                       | (env_branches,res_t,g11) ->
-                          ((let uu____8092 =
+                          ((let uu____8098 =
                               FStar_TypeChecker_Env.debug env1
                                 FStar_Options.Extreme
                                in
-                            if uu____8092
+                            if uu____8098
                             then
-                              let uu____8095 =
+                              let uu____8101 =
                                 FStar_Syntax_Print.term_to_string res_t  in
                               FStar_Util.print1
                                 "Tm_match: expected type of branches is %s\n"
-                                uu____8095
+                                uu____8101
                             else ());
                            (let guard_x =
                               FStar_Syntax_Syntax.new_bv
@@ -2759,32 +2769,35 @@ and (tc_maybe_toplevel_term :
                               FStar_All.pipe_right eqns
                                 (FStar_List.map (tc_eqn guard_x env_branches))
                                in
-                            let uu____8222 =
-                              let uu____8227 =
+                            let uu____8237 =
+                              let uu____8245 =
                                 FStar_List.fold_right
-                                  (fun uu____8309  ->
-                                     fun uu____8310  ->
-                                       match (uu____8309, uu____8310) with
-                                       | ((branch1,f,eff_label,cflags,c,g),
-                                          (caccum,gaccum)) ->
-                                           let uu____8555 =
+                                  (fun uu____8338  ->
+                                     fun uu____8339  ->
+                                       match (uu____8338, uu____8339) with
+                                       | ((branch1,f,eff_label,cflags,c,g,erasable_branch),
+                                          (caccum,gaccum,erasable1)) ->
+                                           let uu____8611 =
                                              FStar_TypeChecker_Env.conj_guard
                                                g gaccum
                                               in
                                            (((f, eff_label, cflags, c) ::
-                                             caccum), uu____8555)) t_eqns
-                                  ([], FStar_TypeChecker_Env.trivial_guard)
+                                             caccum), uu____8611,
+                                             (erasable1 || erasable_branch)))
+                                  t_eqns
+                                  ([], FStar_TypeChecker_Env.trivial_guard,
+                                    false)
                                  in
-                              match uu____8227 with
-                              | (cases,g) ->
-                                  let uu____8660 =
+                              match uu____8245 with
+                              | (cases,g,erasable1) ->
+                                  let uu____8725 =
                                     FStar_TypeChecker_Util.bind_cases env1
                                       res_t cases
                                      in
-                                  (uu____8660, g)
+                                  (uu____8725, g, erasable1)
                                in
-                            match uu____8222 with
-                            | (c_branches,g_branches) ->
+                            match uu____8237 with
+                            | (c_branches,g_branches,erasable1) ->
                                 let cres =
                                   FStar_TypeChecker_Util.bind
                                     e11.FStar_Syntax_Syntax.pos env1
@@ -2792,22 +2805,41 @@ and (tc_maybe_toplevel_term :
                                     ((FStar_Pervasives_Native.Some guard_x),
                                       c_branches)
                                    in
+                                let cres1 =
+                                  if erasable1
+                                  then
+                                    let e2 = FStar_Syntax_Util.exp_true_bool
+                                       in
+                                    let c =
+                                      FStar_Syntax_Syntax.mk_GTotal'
+                                        FStar_Syntax_Util.t_bool
+                                        (FStar_Pervasives_Native.Some
+                                           FStar_Syntax_Syntax.U_zero)
+                                       in
+                                    let uu____8745 =
+                                      FStar_Syntax_Util.lcomp_of_comp c  in
+                                    FStar_TypeChecker_Util.bind
+                                      e2.FStar_Syntax_Syntax.pos env1
+                                      (FStar_Pervasives_Native.Some e2)
+                                      uu____8745
+                                      (FStar_Pervasives_Native.None, cres)
+                                  else cres  in
                                 let e2 =
                                   let mk_match scrutinee =
                                     let branches =
                                       FStar_All.pipe_right t_eqns
                                         (FStar_List.map
-                                           (fun uu____8802  ->
-                                              match uu____8802 with
-                                              | ((pat,wopt,br),uu____8847,eff_label,uu____8849,uu____8850,uu____8851)
+                                           (fun uu____8887  ->
+                                              match uu____8887 with
+                                              | ((pat,wopt,br),uu____8935,eff_label,uu____8937,uu____8938,uu____8939,uu____8940)
                                                   ->
-                                                  let uu____8888 =
+                                                  let uu____8979 =
                                                     FStar_TypeChecker_Util.maybe_lift
                                                       env1 br eff_label
-                                                      cres.FStar_Syntax_Syntax.eff_name
+                                                      cres1.FStar_Syntax_Syntax.eff_name
                                                       res_t
                                                      in
-                                                  (pat, wopt, uu____8888)))
+                                                  (pat, wopt, uu____8979)))
                                        in
                                     let e2 =
                                       FStar_Syntax_Syntax.mk
@@ -2819,35 +2851,35 @@ and (tc_maybe_toplevel_term :
                                     let e3 =
                                       FStar_TypeChecker_Util.maybe_monadic
                                         env1 e2
-                                        cres.FStar_Syntax_Syntax.eff_name
-                                        cres.FStar_Syntax_Syntax.res_typ
+                                        cres1.FStar_Syntax_Syntax.eff_name
+                                        cres1.FStar_Syntax_Syntax.res_typ
                                        in
                                     FStar_Syntax_Syntax.mk
                                       (FStar_Syntax_Syntax.Tm_ascribed
                                          (e3,
                                            ((FStar_Util.Inl
-                                               (cres.FStar_Syntax_Syntax.res_typ)),
+                                               (cres1.FStar_Syntax_Syntax.res_typ)),
                                              FStar_Pervasives_Native.None),
                                            (FStar_Pervasives_Native.Some
-                                              (cres.FStar_Syntax_Syntax.eff_name))))
+                                              (cres1.FStar_Syntax_Syntax.eff_name))))
                                       FStar_Pervasives_Native.None
                                       e3.FStar_Syntax_Syntax.pos
                                      in
-                                  let uu____8955 =
+                                  let uu____9046 =
                                     FStar_TypeChecker_Util.is_pure_or_ghost_effect
                                       env1 c1.FStar_Syntax_Syntax.eff_name
                                      in
-                                  if uu____8955
+                                  if uu____9046
                                   then mk_match e11
                                   else
                                     (let e_match =
-                                       let uu____8963 =
+                                       let uu____9054 =
                                          FStar_Syntax_Syntax.bv_to_name
                                            guard_x
                                           in
-                                       mk_match uu____8963  in
+                                       mk_match uu____9054  in
                                      let lb =
-                                       let uu____8967 =
+                                       let uu____9058 =
                                          FStar_TypeChecker_Env.norm_eff_name
                                            env1
                                            c1.FStar_Syntax_Syntax.eff_name
@@ -2855,82 +2887,83 @@ and (tc_maybe_toplevel_term :
                                        FStar_Syntax_Util.mk_letbinding
                                          (FStar_Util.Inl guard_x) []
                                          c1.FStar_Syntax_Syntax.res_typ
-                                         uu____8967 e11 []
+                                         uu____9058 e11 []
                                          e11.FStar_Syntax_Syntax.pos
                                         in
                                      let e2 =
-                                       let uu____8973 =
-                                         let uu____8980 =
-                                           let uu____8981 =
-                                             let uu____8995 =
-                                               let uu____8998 =
-                                                 let uu____8999 =
+                                       let uu____9064 =
+                                         let uu____9071 =
+                                           let uu____9072 =
+                                             let uu____9086 =
+                                               let uu____9089 =
+                                                 let uu____9090 =
                                                    FStar_Syntax_Syntax.mk_binder
                                                      guard_x
                                                     in
-                                                 [uu____8999]  in
+                                                 [uu____9090]  in
                                                FStar_Syntax_Subst.close
-                                                 uu____8998 e_match
+                                                 uu____9089 e_match
                                                 in
-                                             ((false, [lb]), uu____8995)  in
+                                             ((false, [lb]), uu____9086)  in
                                            FStar_Syntax_Syntax.Tm_let
-                                             uu____8981
+                                             uu____9072
                                             in
-                                         FStar_Syntax_Syntax.mk uu____8980
+                                         FStar_Syntax_Syntax.mk uu____9071
                                           in
-                                       uu____8973
+                                       uu____9064
                                          FStar_Pervasives_Native.None
                                          top.FStar_Syntax_Syntax.pos
                                         in
                                      FStar_TypeChecker_Util.maybe_monadic
                                        env1 e2
-                                       cres.FStar_Syntax_Syntax.eff_name
-                                       cres.FStar_Syntax_Syntax.res_typ)
+                                       cres1.FStar_Syntax_Syntax.eff_name
+                                       cres1.FStar_Syntax_Syntax.res_typ)
                                    in
-                                ((let uu____9032 =
+                                ((let uu____9123 =
                                     FStar_TypeChecker_Env.debug env1
                                       FStar_Options.Extreme
                                      in
-                                  if uu____9032
+                                  if uu____9123
                                   then
-                                    let uu____9035 =
+                                    let uu____9126 =
                                       FStar_Range.string_of_range
                                         top.FStar_Syntax_Syntax.pos
                                        in
-                                    let uu____9037 =
-                                      FStar_Syntax_Print.lcomp_to_string cres
+                                    let uu____9128 =
+                                      FStar_Syntax_Print.lcomp_to_string
+                                        cres1
                                        in
                                     FStar_Util.print2 "(%s) comp type = %s\n"
-                                      uu____9035 uu____9037
+                                      uu____9126 uu____9128
                                   else ());
-                                 (let uu____9042 =
+                                 (let uu____9133 =
                                     FStar_TypeChecker_Env.conj_guard g11
                                       g_branches
                                      in
-                                  (e2, cres, uu____9042))))))))
+                                  (e2, cres1, uu____9133))))))))
        | FStar_Syntax_Syntax.Tm_let
            ((false
-             ,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____9043;
-                FStar_Syntax_Syntax.lbunivs = uu____9044;
-                FStar_Syntax_Syntax.lbtyp = uu____9045;
-                FStar_Syntax_Syntax.lbeff = uu____9046;
-                FStar_Syntax_Syntax.lbdef = uu____9047;
-                FStar_Syntax_Syntax.lbattrs = uu____9048;
-                FStar_Syntax_Syntax.lbpos = uu____9049;_}::[]),uu____9050)
+             ,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____9134;
+                FStar_Syntax_Syntax.lbunivs = uu____9135;
+                FStar_Syntax_Syntax.lbtyp = uu____9136;
+                FStar_Syntax_Syntax.lbeff = uu____9137;
+                FStar_Syntax_Syntax.lbdef = uu____9138;
+                FStar_Syntax_Syntax.lbattrs = uu____9139;
+                FStar_Syntax_Syntax.lbpos = uu____9140;_}::[]),uu____9141)
            -> check_top_level_let env1 top
-       | FStar_Syntax_Syntax.Tm_let ((false ,uu____9076),uu____9077) ->
+       | FStar_Syntax_Syntax.Tm_let ((false ,uu____9167),uu____9168) ->
            check_inner_let env1 top
        | FStar_Syntax_Syntax.Tm_let
            ((true
-             ,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____9095;
-                FStar_Syntax_Syntax.lbunivs = uu____9096;
-                FStar_Syntax_Syntax.lbtyp = uu____9097;
-                FStar_Syntax_Syntax.lbeff = uu____9098;
-                FStar_Syntax_Syntax.lbdef = uu____9099;
-                FStar_Syntax_Syntax.lbattrs = uu____9100;
-                FStar_Syntax_Syntax.lbpos = uu____9101;_}::uu____9102),uu____9103)
+             ,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____9186;
+                FStar_Syntax_Syntax.lbunivs = uu____9187;
+                FStar_Syntax_Syntax.lbtyp = uu____9188;
+                FStar_Syntax_Syntax.lbeff = uu____9189;
+                FStar_Syntax_Syntax.lbdef = uu____9190;
+                FStar_Syntax_Syntax.lbattrs = uu____9191;
+                FStar_Syntax_Syntax.lbpos = uu____9192;_}::uu____9193),uu____9194)
            -> check_top_level_let_rec env1 top
-       | FStar_Syntax_Syntax.Tm_let ((true ,uu____9131),uu____9132) ->
+       | FStar_Syntax_Syntax.Tm_let ((true ,uu____9222),uu____9223) ->
            check_inner_let_rec env1 top)
 
 and (tc_synth :
@@ -2947,83 +2980,83 @@ and (tc_synth :
     fun env  ->
       fun args  ->
         fun rng  ->
-          let uu____9166 =
+          let uu____9257 =
             match args with
             | (tau,FStar_Pervasives_Native.None )::[] ->
                 (tau, FStar_Pervasives_Native.None)
             | (a,FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit
-               uu____9205))::(tau,FStar_Pervasives_Native.None )::[] ->
+               uu____9296))::(tau,FStar_Pervasives_Native.None )::[] ->
                 (tau, (FStar_Pervasives_Native.Some a))
-            | uu____9246 ->
+            | uu____9337 ->
                 FStar_Errors.raise_error
                   (FStar_Errors.Fatal_SynthByTacticError,
                     "synth_by_tactic: bad application") rng
              in
-          match uu____9166 with
+          match uu____9257 with
           | (tau,atyp) ->
               let typ =
                 match atyp with
                 | FStar_Pervasives_Native.Some t -> t
                 | FStar_Pervasives_Native.None  ->
-                    let uu____9279 = FStar_TypeChecker_Env.expected_typ env
+                    let uu____9370 = FStar_TypeChecker_Env.expected_typ env
                        in
-                    (match uu____9279 with
+                    (match uu____9370 with
                      | FStar_Pervasives_Native.Some t -> t
                      | FStar_Pervasives_Native.None  ->
-                         let uu____9283 = FStar_TypeChecker_Env.get_range env
+                         let uu____9374 = FStar_TypeChecker_Env.get_range env
                             in
                          FStar_Errors.raise_error
                            (FStar_Errors.Fatal_SynthByTacticError,
                              "synth_by_tactic: need a type annotation when no expected type is present")
-                           uu____9283)
+                           uu____9374)
                  in
-              let uu____9286 =
-                let uu____9293 =
-                  let uu____9294 =
-                    let uu____9295 = FStar_Syntax_Util.type_u ()  in
+              let uu____9377 =
+                let uu____9384 =
+                  let uu____9385 =
+                    let uu____9386 = FStar_Syntax_Util.type_u ()  in
                     FStar_All.pipe_left FStar_Pervasives_Native.fst
-                      uu____9295
+                      uu____9386
                      in
-                  FStar_TypeChecker_Env.set_expected_typ env uu____9294  in
-                tc_term uu____9293 typ  in
-              (match uu____9286 with
-               | (typ1,uu____9311,g1) ->
+                  FStar_TypeChecker_Env.set_expected_typ env uu____9385  in
+                tc_term uu____9384 typ  in
+              (match uu____9377 with
+               | (typ1,uu____9402,g1) ->
                    (FStar_TypeChecker_Rel.force_trivial_guard env g1;
-                    (let uu____9314 = tc_tactic env tau  in
-                     match uu____9314 with
-                     | (tau1,uu____9328,g2) ->
+                    (let uu____9405 = tc_tactic env tau  in
+                     match uu____9405 with
+                     | (tau1,uu____9419,g2) ->
                          (FStar_TypeChecker_Rel.force_trivial_guard env g2;
                           (let t =
                              env.FStar_TypeChecker_Env.synth_hook env typ1
-                               (let uu___1206_9333 = tau1  in
+                               (let uu___1215_9424 = tau1  in
                                 {
                                   FStar_Syntax_Syntax.n =
-                                    (uu___1206_9333.FStar_Syntax_Syntax.n);
+                                    (uu___1215_9424.FStar_Syntax_Syntax.n);
                                   FStar_Syntax_Syntax.pos = rng;
                                   FStar_Syntax_Syntax.vars =
-                                    (uu___1206_9333.FStar_Syntax_Syntax.vars)
+                                    (uu___1215_9424.FStar_Syntax_Syntax.vars)
                                 })
                               in
-                           (let uu____9335 =
+                           (let uu____9426 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env)
                                 (FStar_Options.Other "Tac")
                                in
-                            if uu____9335
+                            if uu____9426
                             then
-                              let uu____9340 =
+                              let uu____9431 =
                                 FStar_Syntax_Print.term_to_string t  in
-                              FStar_Util.print1 "Got %s\n" uu____9340
+                              FStar_Util.print1 "Got %s\n" uu____9431
                             else ());
                            FStar_TypeChecker_Util.check_uvars
                              tau1.FStar_Syntax_Syntax.pos t;
-                           (let uu____9346 =
-                              let uu____9347 =
+                           (let uu____9437 =
+                              let uu____9438 =
                                 FStar_Syntax_Syntax.mk_Total typ1  in
                               FStar_All.pipe_left
-                                FStar_Syntax_Util.lcomp_of_comp uu____9347
+                                FStar_Syntax_Util.lcomp_of_comp uu____9438
                                in
-                            (t, uu____9346,
+                            (t, uu____9437,
                               FStar_TypeChecker_Env.trivial_guard)))))))
 
 and (tc_tactic :
@@ -3035,95 +3068,97 @@ and (tc_tactic :
   fun env  ->
     fun tau  ->
       let env1 =
-        let uu___1214_9351 = env  in
+        let uu___1223_9442 = env  in
         {
           FStar_TypeChecker_Env.solver =
-            (uu___1214_9351.FStar_TypeChecker_Env.solver);
+            (uu___1223_9442.FStar_TypeChecker_Env.solver);
           FStar_TypeChecker_Env.range =
-            (uu___1214_9351.FStar_TypeChecker_Env.range);
+            (uu___1223_9442.FStar_TypeChecker_Env.range);
           FStar_TypeChecker_Env.curmodule =
-            (uu___1214_9351.FStar_TypeChecker_Env.curmodule);
+            (uu___1223_9442.FStar_TypeChecker_Env.curmodule);
           FStar_TypeChecker_Env.gamma =
-            (uu___1214_9351.FStar_TypeChecker_Env.gamma);
+            (uu___1223_9442.FStar_TypeChecker_Env.gamma);
           FStar_TypeChecker_Env.gamma_sig =
-            (uu___1214_9351.FStar_TypeChecker_Env.gamma_sig);
+            (uu___1223_9442.FStar_TypeChecker_Env.gamma_sig);
           FStar_TypeChecker_Env.gamma_cache =
-            (uu___1214_9351.FStar_TypeChecker_Env.gamma_cache);
+            (uu___1223_9442.FStar_TypeChecker_Env.gamma_cache);
           FStar_TypeChecker_Env.modules =
-            (uu___1214_9351.FStar_TypeChecker_Env.modules);
+            (uu___1223_9442.FStar_TypeChecker_Env.modules);
           FStar_TypeChecker_Env.expected_typ =
-            (uu___1214_9351.FStar_TypeChecker_Env.expected_typ);
+            (uu___1223_9442.FStar_TypeChecker_Env.expected_typ);
           FStar_TypeChecker_Env.sigtab =
-            (uu___1214_9351.FStar_TypeChecker_Env.sigtab);
+            (uu___1223_9442.FStar_TypeChecker_Env.sigtab);
           FStar_TypeChecker_Env.attrtab =
-            (uu___1214_9351.FStar_TypeChecker_Env.attrtab);
+            (uu___1223_9442.FStar_TypeChecker_Env.attrtab);
           FStar_TypeChecker_Env.is_pattern =
-            (uu___1214_9351.FStar_TypeChecker_Env.is_pattern);
+            (uu___1223_9442.FStar_TypeChecker_Env.is_pattern);
           FStar_TypeChecker_Env.instantiate_imp =
-            (uu___1214_9351.FStar_TypeChecker_Env.instantiate_imp);
+            (uu___1223_9442.FStar_TypeChecker_Env.instantiate_imp);
           FStar_TypeChecker_Env.effects =
-            (uu___1214_9351.FStar_TypeChecker_Env.effects);
+            (uu___1223_9442.FStar_TypeChecker_Env.effects);
           FStar_TypeChecker_Env.generalize =
-            (uu___1214_9351.FStar_TypeChecker_Env.generalize);
+            (uu___1223_9442.FStar_TypeChecker_Env.generalize);
           FStar_TypeChecker_Env.letrecs =
-            (uu___1214_9351.FStar_TypeChecker_Env.letrecs);
+            (uu___1223_9442.FStar_TypeChecker_Env.letrecs);
           FStar_TypeChecker_Env.top_level =
-            (uu___1214_9351.FStar_TypeChecker_Env.top_level);
+            (uu___1223_9442.FStar_TypeChecker_Env.top_level);
           FStar_TypeChecker_Env.check_uvars =
-            (uu___1214_9351.FStar_TypeChecker_Env.check_uvars);
+            (uu___1223_9442.FStar_TypeChecker_Env.check_uvars);
           FStar_TypeChecker_Env.use_eq =
-            (uu___1214_9351.FStar_TypeChecker_Env.use_eq);
+            (uu___1223_9442.FStar_TypeChecker_Env.use_eq);
           FStar_TypeChecker_Env.is_iface =
-            (uu___1214_9351.FStar_TypeChecker_Env.is_iface);
+            (uu___1223_9442.FStar_TypeChecker_Env.is_iface);
           FStar_TypeChecker_Env.admit =
-            (uu___1214_9351.FStar_TypeChecker_Env.admit);
+            (uu___1223_9442.FStar_TypeChecker_Env.admit);
           FStar_TypeChecker_Env.lax =
-            (uu___1214_9351.FStar_TypeChecker_Env.lax);
+            (uu___1223_9442.FStar_TypeChecker_Env.lax);
           FStar_TypeChecker_Env.lax_universes =
-            (uu___1214_9351.FStar_TypeChecker_Env.lax_universes);
+            (uu___1223_9442.FStar_TypeChecker_Env.lax_universes);
           FStar_TypeChecker_Env.phase1 =
-            (uu___1214_9351.FStar_TypeChecker_Env.phase1);
+            (uu___1223_9442.FStar_TypeChecker_Env.phase1);
           FStar_TypeChecker_Env.failhard = true;
           FStar_TypeChecker_Env.nosynth =
-            (uu___1214_9351.FStar_TypeChecker_Env.nosynth);
+            (uu___1223_9442.FStar_TypeChecker_Env.nosynth);
           FStar_TypeChecker_Env.uvar_subtyping =
-            (uu___1214_9351.FStar_TypeChecker_Env.uvar_subtyping);
+            (uu___1223_9442.FStar_TypeChecker_Env.uvar_subtyping);
           FStar_TypeChecker_Env.tc_term =
-            (uu___1214_9351.FStar_TypeChecker_Env.tc_term);
+            (uu___1223_9442.FStar_TypeChecker_Env.tc_term);
           FStar_TypeChecker_Env.type_of =
-            (uu___1214_9351.FStar_TypeChecker_Env.type_of);
+            (uu___1223_9442.FStar_TypeChecker_Env.type_of);
           FStar_TypeChecker_Env.universe_of =
-            (uu___1214_9351.FStar_TypeChecker_Env.universe_of);
+            (uu___1223_9442.FStar_TypeChecker_Env.universe_of);
           FStar_TypeChecker_Env.check_type_of =
-            (uu___1214_9351.FStar_TypeChecker_Env.check_type_of);
+            (uu___1223_9442.FStar_TypeChecker_Env.check_type_of);
           FStar_TypeChecker_Env.use_bv_sorts =
-            (uu___1214_9351.FStar_TypeChecker_Env.use_bv_sorts);
+            (uu___1223_9442.FStar_TypeChecker_Env.use_bv_sorts);
           FStar_TypeChecker_Env.qtbl_name_and_index =
-            (uu___1214_9351.FStar_TypeChecker_Env.qtbl_name_and_index);
+            (uu___1223_9442.FStar_TypeChecker_Env.qtbl_name_and_index);
           FStar_TypeChecker_Env.normalized_eff_names =
-            (uu___1214_9351.FStar_TypeChecker_Env.normalized_eff_names);
+            (uu___1223_9442.FStar_TypeChecker_Env.normalized_eff_names);
           FStar_TypeChecker_Env.fv_delta_depths =
-            (uu___1214_9351.FStar_TypeChecker_Env.fv_delta_depths);
+            (uu___1223_9442.FStar_TypeChecker_Env.fv_delta_depths);
           FStar_TypeChecker_Env.proof_ns =
-            (uu___1214_9351.FStar_TypeChecker_Env.proof_ns);
+            (uu___1223_9442.FStar_TypeChecker_Env.proof_ns);
           FStar_TypeChecker_Env.synth_hook =
-            (uu___1214_9351.FStar_TypeChecker_Env.synth_hook);
+            (uu___1223_9442.FStar_TypeChecker_Env.synth_hook);
           FStar_TypeChecker_Env.splice =
-            (uu___1214_9351.FStar_TypeChecker_Env.splice);
+            (uu___1223_9442.FStar_TypeChecker_Env.splice);
           FStar_TypeChecker_Env.postprocess =
-            (uu___1214_9351.FStar_TypeChecker_Env.postprocess);
+            (uu___1223_9442.FStar_TypeChecker_Env.postprocess);
           FStar_TypeChecker_Env.is_native_tactic =
-            (uu___1214_9351.FStar_TypeChecker_Env.is_native_tactic);
+            (uu___1223_9442.FStar_TypeChecker_Env.is_native_tactic);
           FStar_TypeChecker_Env.identifier_info =
-            (uu___1214_9351.FStar_TypeChecker_Env.identifier_info);
+            (uu___1223_9442.FStar_TypeChecker_Env.identifier_info);
           FStar_TypeChecker_Env.tc_hooks =
-            (uu___1214_9351.FStar_TypeChecker_Env.tc_hooks);
+            (uu___1223_9442.FStar_TypeChecker_Env.tc_hooks);
           FStar_TypeChecker_Env.dsenv =
-            (uu___1214_9351.FStar_TypeChecker_Env.dsenv);
+            (uu___1223_9442.FStar_TypeChecker_Env.dsenv);
           FStar_TypeChecker_Env.nbe =
-            (uu___1214_9351.FStar_TypeChecker_Env.nbe);
+            (uu___1223_9442.FStar_TypeChecker_Env.nbe);
           FStar_TypeChecker_Env.strict_args_tab =
-            (uu___1214_9351.FStar_TypeChecker_Env.strict_args_tab)
+            (uu___1223_9442.FStar_TypeChecker_Env.strict_args_tab);
+          FStar_TypeChecker_Env.erasable_types_tab =
+            (uu___1223_9442.FStar_TypeChecker_Env.erasable_types_tab)
         }  in
       tc_check_tot_or_gtot_term env1 tau FStar_Syntax_Syntax.t_tactic_unit
 
@@ -3140,9 +3175,9 @@ and (tc_tactic_opt :
       | FStar_Pervasives_Native.None  ->
           (FStar_Pervasives_Native.None, FStar_TypeChecker_Env.trivial_guard)
       | FStar_Pervasives_Native.Some tactic ->
-          let uu____9374 = tc_tactic env tactic  in
-          (match uu____9374 with
-           | (tactic1,uu____9388,g) ->
+          let uu____9465 = tc_tactic env tactic  in
+          (match uu____9465 with
+           | (tactic1,uu____9479,g) ->
                ((FStar_Pervasives_Native.Some tactic1), g))
 
 and (tc_value :
@@ -3154,47 +3189,47 @@ and (tc_value :
   fun env  ->
     fun e  ->
       let check_instantiated_fvar env1 v1 dc e1 t0 =
-        let uu____9440 = FStar_TypeChecker_Util.maybe_instantiate env1 e1 t0
+        let uu____9531 = FStar_TypeChecker_Util.maybe_instantiate env1 e1 t0
            in
-        match uu____9440 with
+        match uu____9531 with
         | (e2,t,implicits) ->
             let tc =
-              let uu____9461 = FStar_TypeChecker_Env.should_verify env1  in
-              if uu____9461
+              let uu____9552 = FStar_TypeChecker_Env.should_verify env1  in
+              if uu____9552
               then FStar_Util.Inl t
               else
-                (let uu____9470 =
-                   let uu____9471 = FStar_Syntax_Syntax.mk_Total t  in
+                (let uu____9561 =
+                   let uu____9562 = FStar_Syntax_Syntax.mk_Total t  in
                    FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp
-                     uu____9471
+                     uu____9562
                     in
-                 FStar_Util.Inr uu____9470)
+                 FStar_Util.Inr uu____9561)
                in
-            let is_data_ctor uu___4_9480 =
-              match uu___4_9480 with
+            let is_data_ctor uu___4_9571 =
+              match uu___4_9571 with
               | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Data_ctor )
                   -> true
               | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Record_ctor
-                  uu____9485) -> true
-              | uu____9493 -> false  in
-            let uu____9497 =
+                  uu____9576) -> true
+              | uu____9584 -> false  in
+            let uu____9588 =
               (is_data_ctor dc) &&
-                (let uu____9500 =
+                (let uu____9591 =
                    FStar_TypeChecker_Env.is_datacon env1
                      v1.FStar_Syntax_Syntax.v
                     in
-                 Prims.op_Negation uu____9500)
+                 Prims.op_Negation uu____9591)
                in
-            if uu____9497
+            if uu____9588
             then
-              let uu____9509 =
-                let uu____9515 =
+              let uu____9600 =
+                let uu____9606 =
                   FStar_Util.format1 "Expected a data constructor; got %s"
                     (v1.FStar_Syntax_Syntax.v).FStar_Ident.str
                    in
-                (FStar_Errors.Fatal_MissingDataConstructor, uu____9515)  in
-              let uu____9519 = FStar_TypeChecker_Env.get_range env1  in
-              FStar_Errors.raise_error uu____9509 uu____9519
+                (FStar_Errors.Fatal_MissingDataConstructor, uu____9606)  in
+              let uu____9610 = FStar_TypeChecker_Env.get_range env1  in
+              FStar_Errors.raise_error uu____9600 uu____9610
             else value_check_expected_typ env1 e2 tc implicits
          in
       let env1 =
@@ -3202,143 +3237,143 @@ and (tc_value :
       let top = FStar_Syntax_Subst.compress e  in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_bvar x ->
-          let uu____9537 =
-            let uu____9539 = FStar_Syntax_Print.term_to_string top  in
+          let uu____9628 =
+            let uu____9630 = FStar_Syntax_Print.term_to_string top  in
             FStar_Util.format1
               "Impossible: Violation of locally nameless convention: %s"
-              uu____9539
+              uu____9630
              in
-          failwith uu____9537
+          failwith uu____9628
       | FStar_Syntax_Syntax.Tm_uvar (u,s) ->
-          let uu____9566 =
-            let uu____9571 =
+          let uu____9657 =
+            let uu____9662 =
               FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ
                in
-            FStar_Util.Inl uu____9571  in
-          value_check_expected_typ env1 e uu____9566
+            FStar_Util.Inl uu____9662  in
+          value_check_expected_typ env1 e uu____9657
             FStar_TypeChecker_Env.trivial_guard
       | FStar_Syntax_Syntax.Tm_unknown  ->
           let r = FStar_TypeChecker_Env.get_range env1  in
-          let uu____9573 =
-            let uu____9586 = FStar_TypeChecker_Env.expected_typ env1  in
-            match uu____9586 with
+          let uu____9664 =
+            let uu____9677 = FStar_TypeChecker_Env.expected_typ env1  in
+            match uu____9677 with
             | FStar_Pervasives_Native.None  ->
-                let uu____9601 = FStar_Syntax_Util.type_u ()  in
-                (match uu____9601 with
+                let uu____9692 = FStar_Syntax_Util.type_u ()  in
+                (match uu____9692 with
                  | (k,u) ->
                      FStar_TypeChecker_Util.new_implicit_var
                        "type of user-provided implicit term" r env1 k)
             | FStar_Pervasives_Native.Some t ->
                 (t, [], FStar_TypeChecker_Env.trivial_guard)
              in
-          (match uu____9573 with
-           | (t,uu____9639,g0) ->
-               let uu____9653 =
+          (match uu____9664 with
+           | (t,uu____9730,g0) ->
+               let uu____9744 =
                  FStar_TypeChecker_Util.new_implicit_var
                    "user-provided implicit term" r env1 t
                   in
-               (match uu____9653 with
-                | (e1,uu____9674,g1) ->
-                    let uu____9688 =
-                      let uu____9689 = FStar_Syntax_Syntax.mk_Total t  in
-                      FStar_All.pipe_right uu____9689
+               (match uu____9744 with
+                | (e1,uu____9765,g1) ->
+                    let uu____9779 =
+                      let uu____9780 = FStar_Syntax_Syntax.mk_Total t  in
+                      FStar_All.pipe_right uu____9780
                         FStar_Syntax_Util.lcomp_of_comp
                        in
-                    let uu____9690 = FStar_TypeChecker_Env.conj_guard g0 g1
+                    let uu____9781 = FStar_TypeChecker_Env.conj_guard g0 g1
                        in
-                    (e1, uu____9688, uu____9690)))
+                    (e1, uu____9779, uu____9781)))
       | FStar_Syntax_Syntax.Tm_name x ->
-          let uu____9692 =
+          let uu____9783 =
             if env1.FStar_TypeChecker_Env.use_bv_sorts
             then
-              let uu____9702 = FStar_Syntax_Syntax.range_of_bv x  in
-              ((x.FStar_Syntax_Syntax.sort), uu____9702)
+              let uu____9793 = FStar_Syntax_Syntax.range_of_bv x  in
+              ((x.FStar_Syntax_Syntax.sort), uu____9793)
             else FStar_TypeChecker_Env.lookup_bv env1 x  in
-          (match uu____9692 with
+          (match uu____9783 with
            | (t,rng) ->
                let x1 =
                  FStar_Syntax_Syntax.set_range_of_bv
-                   (let uu___1279_9716 = x  in
+                   (let uu___1288_9807 = x  in
                     {
                       FStar_Syntax_Syntax.ppname =
-                        (uu___1279_9716.FStar_Syntax_Syntax.ppname);
+                        (uu___1288_9807.FStar_Syntax_Syntax.ppname);
                       FStar_Syntax_Syntax.index =
-                        (uu___1279_9716.FStar_Syntax_Syntax.index);
+                        (uu___1288_9807.FStar_Syntax_Syntax.index);
                       FStar_Syntax_Syntax.sort = t
                     }) rng
                   in
                (FStar_TypeChecker_Env.insert_bv_info env1 x1 t;
                 (let e1 = FStar_Syntax_Syntax.bv_to_name x1  in
-                 let uu____9719 =
+                 let uu____9810 =
                    FStar_TypeChecker_Util.maybe_instantiate env1 e1 t  in
-                 match uu____9719 with
+                 match uu____9810 with
                  | (e2,t1,implicits) ->
                      let tc =
-                       let uu____9740 =
+                       let uu____9831 =
                          FStar_TypeChecker_Env.should_verify env1  in
-                       if uu____9740
+                       if uu____9831
                        then FStar_Util.Inl t1
                        else
-                         (let uu____9749 =
-                            let uu____9750 = FStar_Syntax_Syntax.mk_Total t1
+                         (let uu____9840 =
+                            let uu____9841 = FStar_Syntax_Syntax.mk_Total t1
                                in
                             FStar_All.pipe_left
-                              FStar_Syntax_Util.lcomp_of_comp uu____9750
+                              FStar_Syntax_Util.lcomp_of_comp uu____9841
                              in
-                          FStar_Util.Inr uu____9749)
+                          FStar_Util.Inr uu____9840)
                         in
                      value_check_expected_typ env1 e2 tc implicits)))
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____9752;
-             FStar_Syntax_Syntax.vars = uu____9753;_},uu____9754)
+             FStar_Syntax_Syntax.pos = uu____9843;
+             FStar_Syntax_Syntax.vars = uu____9844;_},uu____9845)
           when
           (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.synth_lid) &&
             (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
           ->
-          let uu____9759 = FStar_TypeChecker_Env.get_range env1  in
+          let uu____9850 = FStar_TypeChecker_Env.get_range env1  in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_BadlyInstantiatedSynthByTactic,
-              "Badly instantiated synth_by_tactic") uu____9759
+              "Badly instantiated synth_by_tactic") uu____9850
       | FStar_Syntax_Syntax.Tm_fvar fv when
           (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.synth_lid) &&
             (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
           ->
-          let uu____9769 = FStar_TypeChecker_Env.get_range env1  in
+          let uu____9860 = FStar_TypeChecker_Env.get_range env1  in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_BadlyInstantiatedSynthByTactic,
-              "Badly instantiated synth_by_tactic") uu____9769
+              "Badly instantiated synth_by_tactic") uu____9860
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____9779;
-             FStar_Syntax_Syntax.vars = uu____9780;_},us)
+             FStar_Syntax_Syntax.pos = uu____9870;
+             FStar_Syntax_Syntax.vars = uu____9871;_},us)
           ->
           let us1 = FStar_List.map (tc_universe env1) us  in
-          let uu____9789 =
+          let uu____9880 =
             FStar_TypeChecker_Env.lookup_lid env1
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          (match uu____9789 with
+          (match uu____9880 with
            | ((us',t),range) ->
                (if (FStar_List.length us1) <> (FStar_List.length us')
                 then
-                  (let uu____9813 =
-                     let uu____9819 =
-                       let uu____9821 = FStar_Syntax_Print.fv_to_string fv
+                  (let uu____9904 =
+                     let uu____9910 =
+                       let uu____9912 = FStar_Syntax_Print.fv_to_string fv
                           in
-                       let uu____9823 =
+                       let uu____9914 =
                          FStar_Util.string_of_int (FStar_List.length us1)  in
-                       let uu____9825 =
+                       let uu____9916 =
                          FStar_Util.string_of_int (FStar_List.length us')  in
                        FStar_Util.format3
                          "Unexpected number of universe instantiations for \"%s\" (%s vs %s)"
-                         uu____9821 uu____9823 uu____9825
+                         uu____9912 uu____9914 uu____9916
                         in
                      (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                       uu____9819)
+                       uu____9910)
                       in
-                   let uu____9829 = FStar_TypeChecker_Env.get_range env1  in
-                   FStar_Errors.raise_error uu____9813 uu____9829)
+                   let uu____9920 = FStar_TypeChecker_Env.get_range env1  in
+                   FStar_Errors.raise_error uu____9904 uu____9920)
                 else
                   FStar_List.iter2
                     (fun u'  ->
@@ -3346,56 +3381,56 @@ and (tc_value :
                          match u' with
                          | FStar_Syntax_Syntax.U_unif u'' ->
                              FStar_Syntax_Unionfind.univ_change u'' u
-                         | uu____9846 -> failwith "Impossible") us' us1;
+                         | uu____9937 -> failwith "Impossible") us' us1;
                 (let fv' = FStar_Syntax_Syntax.set_range_of_fv fv range  in
                  FStar_TypeChecker_Env.insert_fv_info env1 fv' t;
                  (let e1 =
-                    let uu____9851 =
+                    let uu____9942 =
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_fvar fv')
                         FStar_Pervasives_Native.None
                         e.FStar_Syntax_Syntax.pos
                        in
-                    FStar_Syntax_Syntax.mk_Tm_uinst uu____9851 us1  in
+                    FStar_Syntax_Syntax.mk_Tm_uinst uu____9942 us1  in
                   check_instantiated_fvar env1
                     fv'.FStar_Syntax_Syntax.fv_name
                     fv'.FStar_Syntax_Syntax.fv_qual e1 t))))
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____9853 =
+          let uu____9944 =
             FStar_TypeChecker_Env.lookup_lid env1
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          (match uu____9853 with
+          (match uu____9944 with
            | ((us,t),range) ->
-               ((let uu____9876 =
+               ((let uu____9967 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                      (FStar_Options.Other "Range")
                     in
-                 if uu____9876
+                 if uu____9967
                  then
-                   let uu____9881 =
-                     let uu____9883 = FStar_Syntax_Syntax.lid_of_fv fv  in
-                     FStar_Syntax_Print.lid_to_string uu____9883  in
-                   let uu____9884 =
+                   let uu____9972 =
+                     let uu____9974 = FStar_Syntax_Syntax.lid_of_fv fv  in
+                     FStar_Syntax_Print.lid_to_string uu____9974  in
+                   let uu____9975 =
                      FStar_Range.string_of_range e.FStar_Syntax_Syntax.pos
                       in
-                   let uu____9886 = FStar_Range.string_of_range range  in
-                   let uu____9888 = FStar_Range.string_of_use_range range  in
-                   let uu____9890 = FStar_Syntax_Print.term_to_string t  in
+                   let uu____9977 = FStar_Range.string_of_range range  in
+                   let uu____9979 = FStar_Range.string_of_use_range range  in
+                   let uu____9981 = FStar_Syntax_Print.term_to_string t  in
                    FStar_Util.print5
                      "Lookup up fvar %s at location %s (lid range = defined at %s, used at %s); got universes type %s"
-                     uu____9881 uu____9884 uu____9886 uu____9888 uu____9890
+                     uu____9972 uu____9975 uu____9977 uu____9979 uu____9981
                  else ());
                 (let fv' = FStar_Syntax_Syntax.set_range_of_fv fv range  in
                  FStar_TypeChecker_Env.insert_fv_info env1 fv' t;
                  (let e1 =
-                    let uu____9898 =
+                    let uu____9989 =
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_fvar fv')
                         FStar_Pervasives_Native.None
                         e.FStar_Syntax_Syntax.pos
                        in
-                    FStar_Syntax_Syntax.mk_Tm_uinst uu____9898 us  in
+                    FStar_Syntax_Syntax.mk_Tm_uinst uu____9989 us  in
                   check_instantiated_fvar env1
                     fv'.FStar_Syntax_Syntax.fv_name
                     fv'.FStar_Syntax_Syntax.fv_qual e1 t))))
@@ -3408,30 +3443,30 @@ and (tc_value :
           value_check_expected_typ env1 e1 (FStar_Util.Inl t)
             FStar_TypeChecker_Env.trivial_guard
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____9926 = FStar_Syntax_Subst.open_comp bs c  in
-          (match uu____9926 with
+          let uu____10017 = FStar_Syntax_Subst.open_comp bs c  in
+          (match uu____10017 with
            | (bs1,c1) ->
                let env0 = env1  in
-               let uu____9940 = FStar_TypeChecker_Env.clear_expected_typ env1
-                  in
-               (match uu____9940 with
-                | (env2,uu____9954) ->
-                    let uu____9959 = tc_binders env2 bs1  in
-                    (match uu____9959 with
+               let uu____10031 =
+                 FStar_TypeChecker_Env.clear_expected_typ env1  in
+               (match uu____10031 with
+                | (env2,uu____10045) ->
+                    let uu____10050 = tc_binders env2 bs1  in
+                    (match uu____10050 with
                      | (bs2,env3,g,us) ->
-                         let uu____9978 = tc_comp env3 c1  in
-                         (match uu____9978 with
+                         let uu____10069 = tc_comp env3 c1  in
+                         (match uu____10069 with
                           | (c2,uc,f) ->
                               let e1 =
-                                let uu___1359_9997 =
+                                let uu___1368_10088 =
                                   FStar_Syntax_Util.arrow bs2 c2  in
                                 {
                                   FStar_Syntax_Syntax.n =
-                                    (uu___1359_9997.FStar_Syntax_Syntax.n);
+                                    (uu___1368_10088.FStar_Syntax_Syntax.n);
                                   FStar_Syntax_Syntax.pos =
                                     (top.FStar_Syntax_Syntax.pos);
                                   FStar_Syntax_Syntax.vars =
-                                    (uu___1359_9997.FStar_Syntax_Syntax.vars)
+                                    (uu___1368_10088.FStar_Syntax_Syntax.vars)
                                 }  in
                               (check_smt_pat env3 e1 bs2 c2;
                                (let u = FStar_Syntax_Syntax.U_max (uc :: us)
@@ -3443,12 +3478,12 @@ and (tc_value :
                                     top.FStar_Syntax_Syntax.pos
                                    in
                                 let g1 =
-                                  let uu____10008 =
+                                  let uu____10099 =
                                     FStar_TypeChecker_Env.close_guard_univs
                                       us bs2 f
                                      in
                                   FStar_TypeChecker_Env.conj_guard g
-                                    uu____10008
+                                    uu____10099
                                    in
                                 let g2 =
                                   FStar_TypeChecker_Util.close_guard_implicits
@@ -3470,64 +3505,64 @@ and (tc_value :
           value_check_expected_typ env1 e1 (FStar_Util.Inl t)
             FStar_TypeChecker_Env.trivial_guard
       | FStar_Syntax_Syntax.Tm_refine (x,phi) ->
-          let uu____10024 =
-            let uu____10029 =
-              let uu____10030 = FStar_Syntax_Syntax.mk_binder x  in
-              [uu____10030]  in
-            FStar_Syntax_Subst.open_term uu____10029 phi  in
-          (match uu____10024 with
+          let uu____10115 =
+            let uu____10120 =
+              let uu____10121 = FStar_Syntax_Syntax.mk_binder x  in
+              [uu____10121]  in
+            FStar_Syntax_Subst.open_term uu____10120 phi  in
+          (match uu____10115 with
            | (x1,phi1) ->
                let env0 = env1  in
-               let uu____10058 =
+               let uu____10149 =
                  FStar_TypeChecker_Env.clear_expected_typ env1  in
-               (match uu____10058 with
-                | (env2,uu____10072) ->
-                    let uu____10077 =
-                      let uu____10092 = FStar_List.hd x1  in
-                      tc_binder env2 uu____10092  in
-                    (match uu____10077 with
+               (match uu____10149 with
+                | (env2,uu____10163) ->
+                    let uu____10168 =
+                      let uu____10183 = FStar_List.hd x1  in
+                      tc_binder env2 uu____10183  in
+                    (match uu____10168 with
                      | (x2,env3,f1,u) ->
-                         ((let uu____10128 =
+                         ((let uu____10219 =
                              FStar_TypeChecker_Env.debug env3
                                FStar_Options.High
                               in
-                           if uu____10128
+                           if uu____10219
                            then
-                             let uu____10131 =
+                             let uu____10222 =
                                FStar_Range.string_of_range
                                  top.FStar_Syntax_Syntax.pos
                                 in
-                             let uu____10133 =
+                             let uu____10224 =
                                FStar_Syntax_Print.term_to_string phi1  in
-                             let uu____10135 =
+                             let uu____10226 =
                                FStar_Syntax_Print.bv_to_string
                                  (FStar_Pervasives_Native.fst x2)
                                 in
                              FStar_Util.print3
                                "(%s) Checking refinement formula %s; binder is %s\n"
-                               uu____10131 uu____10133 uu____10135
+                               uu____10222 uu____10224 uu____10226
                            else ());
-                          (let uu____10142 = FStar_Syntax_Util.type_u ()  in
-                           match uu____10142 with
-                           | (t_phi,uu____10154) ->
-                               let uu____10155 =
+                          (let uu____10233 = FStar_Syntax_Util.type_u ()  in
+                           match uu____10233 with
+                           | (t_phi,uu____10245) ->
+                               let uu____10246 =
                                  tc_check_tot_or_gtot_term env3 phi1 t_phi
                                   in
-                               (match uu____10155 with
-                                | (phi2,uu____10169,f2) ->
+                               (match uu____10246 with
+                                | (phi2,uu____10260,f2) ->
                                     let e1 =
-                                      let uu___1397_10174 =
+                                      let uu___1406_10265 =
                                         FStar_Syntax_Util.refine
                                           (FStar_Pervasives_Native.fst x2)
                                           phi2
                                          in
                                       {
                                         FStar_Syntax_Syntax.n =
-                                          (uu___1397_10174.FStar_Syntax_Syntax.n);
+                                          (uu___1406_10265.FStar_Syntax_Syntax.n);
                                         FStar_Syntax_Syntax.pos =
                                           (top.FStar_Syntax_Syntax.pos);
                                         FStar_Syntax_Syntax.vars =
-                                          (uu___1397_10174.FStar_Syntax_Syntax.vars)
+                                          (uu___1406_10265.FStar_Syntax_Syntax.vars)
                                       }  in
                                     let t =
                                       FStar_Syntax_Syntax.mk
@@ -3536,12 +3571,12 @@ and (tc_value :
                                         top.FStar_Syntax_Syntax.pos
                                        in
                                     let g =
-                                      let uu____10183 =
+                                      let uu____10274 =
                                         FStar_TypeChecker_Env.close_guard_univs
                                           [u] [x2] f2
                                          in
                                       FStar_TypeChecker_Env.conj_guard f1
-                                        uu____10183
+                                        uu____10274
                                        in
                                     let g1 =
                                       FStar_TypeChecker_Util.close_guard_implicits
@@ -3549,38 +3584,38 @@ and (tc_value :
                                        in
                                     value_check_expected_typ env0 e1
                                       (FStar_Util.Inl t) g1))))))
-      | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____10211) ->
+      | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____10302) ->
           let bs1 = FStar_TypeChecker_Util.maybe_add_implicit_binders env1 bs
              in
-          ((let uu____10238 =
+          ((let uu____10329 =
               FStar_TypeChecker_Env.debug env1 FStar_Options.Medium  in
-            if uu____10238
+            if uu____10329
             then
-              let uu____10241 =
+              let uu____10332 =
                 FStar_Syntax_Print.term_to_string
-                  (let uu___1410_10245 = top  in
+                  (let uu___1419_10336 = top  in
                    {
                      FStar_Syntax_Syntax.n =
                        (FStar_Syntax_Syntax.Tm_abs
                           (bs1, body, FStar_Pervasives_Native.None));
                      FStar_Syntax_Syntax.pos =
-                       (uu___1410_10245.FStar_Syntax_Syntax.pos);
+                       (uu___1419_10336.FStar_Syntax_Syntax.pos);
                      FStar_Syntax_Syntax.vars =
-                       (uu___1410_10245.FStar_Syntax_Syntax.vars)
+                       (uu___1419_10336.FStar_Syntax_Syntax.vars)
                    })
                  in
-              FStar_Util.print1 "Abstraction is: %s\n" uu____10241
+              FStar_Util.print1 "Abstraction is: %s\n" uu____10332
             else ());
-           (let uu____10261 = FStar_Syntax_Subst.open_term bs1 body  in
-            match uu____10261 with | (bs2,body1) -> tc_abs env1 top bs2 body1))
-      | uu____10274 ->
-          let uu____10275 =
-            let uu____10277 = FStar_Syntax_Print.term_to_string top  in
-            let uu____10279 = FStar_Syntax_Print.tag_of_term top  in
-            FStar_Util.format2 "Unexpected value: %s (%s)" uu____10277
-              uu____10279
+           (let uu____10352 = FStar_Syntax_Subst.open_term bs1 body  in
+            match uu____10352 with | (bs2,body1) -> tc_abs env1 top bs2 body1))
+      | uu____10365 ->
+          let uu____10366 =
+            let uu____10368 = FStar_Syntax_Print.term_to_string top  in
+            let uu____10370 = FStar_Syntax_Print.tag_of_term top  in
+            FStar_Util.format2 "Unexpected value: %s (%s)" uu____10368
+              uu____10370
              in
-          failwith uu____10275
+          failwith uu____10366
 
 and (tc_constant :
   FStar_TypeChecker_Env.env ->
@@ -3591,11 +3626,11 @@ and (tc_constant :
       fun c  ->
         match c with
         | FStar_Const.Const_unit  -> FStar_Syntax_Syntax.t_unit
-        | FStar_Const.Const_bool uu____10291 -> FStar_Syntax_Util.t_bool
-        | FStar_Const.Const_int (uu____10293,FStar_Pervasives_Native.None )
+        | FStar_Const.Const_bool uu____10382 -> FStar_Syntax_Util.t_bool
+        | FStar_Const.Const_int (uu____10384,FStar_Pervasives_Native.None )
             -> FStar_Syntax_Syntax.t_int
         | FStar_Const.Const_int
-            (uu____10306,FStar_Pervasives_Native.Some msize) ->
+            (uu____10397,FStar_Pervasives_Native.Some msize) ->
             FStar_Syntax_Syntax.tconst
               (match msize with
                | (FStar_Const.Signed ,FStar_Const.Int8 ) ->
@@ -3614,59 +3649,59 @@ and (tc_constant :
                    FStar_Parser_Const.uint32_lid
                | (FStar_Const.Unsigned ,FStar_Const.Int64 ) ->
                    FStar_Parser_Const.uint64_lid)
-        | FStar_Const.Const_string uu____10324 ->
+        | FStar_Const.Const_string uu____10415 ->
             FStar_Syntax_Syntax.t_string
-        | FStar_Const.Const_real uu____10330 -> FStar_Syntax_Syntax.t_real
-        | FStar_Const.Const_float uu____10332 -> FStar_Syntax_Syntax.t_float
-        | FStar_Const.Const_char uu____10333 ->
-            let uu____10335 =
+        | FStar_Const.Const_real uu____10421 -> FStar_Syntax_Syntax.t_real
+        | FStar_Const.Const_float uu____10423 -> FStar_Syntax_Syntax.t_float
+        | FStar_Const.Const_char uu____10424 ->
+            let uu____10426 =
               FStar_Syntax_DsEnv.try_lookup_lid
                 env.FStar_TypeChecker_Env.dsenv FStar_Parser_Const.char_lid
                in
-            FStar_All.pipe_right uu____10335 FStar_Util.must
+            FStar_All.pipe_right uu____10426 FStar_Util.must
         | FStar_Const.Const_effect  -> FStar_Syntax_Util.ktype0
-        | FStar_Const.Const_range uu____10340 -> FStar_Syntax_Syntax.t_range
+        | FStar_Const.Const_range uu____10431 -> FStar_Syntax_Syntax.t_range
         | FStar_Const.Const_range_of  ->
-            let uu____10341 =
-              let uu____10347 =
-                let uu____10349 = FStar_Parser_Const.const_to_string c  in
+            let uu____10432 =
+              let uu____10438 =
+                let uu____10440 = FStar_Parser_Const.const_to_string c  in
                 FStar_Util.format1
                   "Ill-typed %s: this constant must be fully applied"
-                  uu____10349
+                  uu____10440
                  in
-              (FStar_Errors.Fatal_IllTyped, uu____10347)  in
-            FStar_Errors.raise_error uu____10341 r
+              (FStar_Errors.Fatal_IllTyped, uu____10438)  in
+            FStar_Errors.raise_error uu____10432 r
         | FStar_Const.Const_set_range_of  ->
-            let uu____10353 =
-              let uu____10359 =
-                let uu____10361 = FStar_Parser_Const.const_to_string c  in
+            let uu____10444 =
+              let uu____10450 =
+                let uu____10452 = FStar_Parser_Const.const_to_string c  in
                 FStar_Util.format1
                   "Ill-typed %s: this constant must be fully applied"
-                  uu____10361
+                  uu____10452
                  in
-              (FStar_Errors.Fatal_IllTyped, uu____10359)  in
-            FStar_Errors.raise_error uu____10353 r
+              (FStar_Errors.Fatal_IllTyped, uu____10450)  in
+            FStar_Errors.raise_error uu____10444 r
         | FStar_Const.Const_reify  ->
-            let uu____10365 =
-              let uu____10371 =
-                let uu____10373 = FStar_Parser_Const.const_to_string c  in
+            let uu____10456 =
+              let uu____10462 =
+                let uu____10464 = FStar_Parser_Const.const_to_string c  in
                 FStar_Util.format1
                   "Ill-typed %s: this constant must be fully applied"
-                  uu____10373
+                  uu____10464
                  in
-              (FStar_Errors.Fatal_IllTyped, uu____10371)  in
-            FStar_Errors.raise_error uu____10365 r
-        | FStar_Const.Const_reflect uu____10377 ->
-            let uu____10378 =
-              let uu____10384 =
-                let uu____10386 = FStar_Parser_Const.const_to_string c  in
+              (FStar_Errors.Fatal_IllTyped, uu____10462)  in
+            FStar_Errors.raise_error uu____10456 r
+        | FStar_Const.Const_reflect uu____10468 ->
+            let uu____10469 =
+              let uu____10475 =
+                let uu____10477 = FStar_Parser_Const.const_to_string c  in
                 FStar_Util.format1
                   "Ill-typed %s: this constant must be fully applied"
-                  uu____10386
+                  uu____10477
                  in
-              (FStar_Errors.Fatal_IllTyped, uu____10384)  in
-            FStar_Errors.raise_error uu____10378 r
-        | uu____10390 ->
+              (FStar_Errors.Fatal_IllTyped, uu____10475)  in
+            FStar_Errors.raise_error uu____10469 r
+        | uu____10481 ->
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_UnsupportedConstant,
                 "Unsupported constant") r
@@ -3681,30 +3716,30 @@ and (tc_comp :
     fun c  ->
       let c0 = c  in
       match c.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Total (t,uu____10409) ->
-          let uu____10418 = FStar_Syntax_Util.type_u ()  in
-          (match uu____10418 with
+      | FStar_Syntax_Syntax.Total (t,uu____10500) ->
+          let uu____10509 = FStar_Syntax_Util.type_u ()  in
+          (match uu____10509 with
            | (k,u) ->
-               let uu____10431 = tc_check_tot_or_gtot_term env t k  in
-               (match uu____10431 with
-                | (t1,uu____10445,g) ->
-                    let uu____10447 =
+               let uu____10522 = tc_check_tot_or_gtot_term env t k  in
+               (match uu____10522 with
+                | (t1,uu____10536,g) ->
+                    let uu____10538 =
                       FStar_Syntax_Syntax.mk_Total' t1
                         (FStar_Pervasives_Native.Some u)
                        in
-                    (uu____10447, u, g)))
-      | FStar_Syntax_Syntax.GTotal (t,uu____10449) ->
-          let uu____10458 = FStar_Syntax_Util.type_u ()  in
-          (match uu____10458 with
+                    (uu____10538, u, g)))
+      | FStar_Syntax_Syntax.GTotal (t,uu____10540) ->
+          let uu____10549 = FStar_Syntax_Util.type_u ()  in
+          (match uu____10549 with
            | (k,u) ->
-               let uu____10471 = tc_check_tot_or_gtot_term env t k  in
-               (match uu____10471 with
-                | (t1,uu____10485,g) ->
-                    let uu____10487 =
+               let uu____10562 = tc_check_tot_or_gtot_term env t k  in
+               (match uu____10562 with
+                | (t1,uu____10576,g) ->
+                    let uu____10578 =
                       FStar_Syntax_Syntax.mk_GTotal' t1
                         (FStar_Pervasives_Native.Some u)
                        in
-                    (uu____10487, u, g)))
+                    (uu____10578, u, g)))
       | FStar_Syntax_Syntax.Comp c1 ->
           let head1 =
             FStar_Syntax_Syntax.fvar c1.FStar_Syntax_Syntax.effect_name
@@ -3719,72 +3754,72 @@ and (tc_comp :
                   FStar_Pervasives_Native.None c0.FStar_Syntax_Syntax.pos
              in
           let tc =
-            let uu____10497 =
-              let uu____10502 =
-                let uu____10503 =
+            let uu____10588 =
+              let uu____10593 =
+                let uu____10594 =
                   FStar_Syntax_Syntax.as_arg
                     c1.FStar_Syntax_Syntax.result_typ
                    in
-                uu____10503 :: (c1.FStar_Syntax_Syntax.effect_args)  in
-              FStar_Syntax_Syntax.mk_Tm_app head2 uu____10502  in
-            uu____10497 FStar_Pervasives_Native.None
+                uu____10594 :: (c1.FStar_Syntax_Syntax.effect_args)  in
+              FStar_Syntax_Syntax.mk_Tm_app head2 uu____10593  in
+            uu____10588 FStar_Pervasives_Native.None
               (c1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos
              in
-          let uu____10520 =
+          let uu____10611 =
             tc_check_tot_or_gtot_term env tc FStar_Syntax_Syntax.teff  in
-          (match uu____10520 with
-           | (tc1,uu____10534,f) ->
-               let uu____10536 = FStar_Syntax_Util.head_and_args tc1  in
-               (match uu____10536 with
+          (match uu____10611 with
+           | (tc1,uu____10625,f) ->
+               let uu____10627 = FStar_Syntax_Util.head_and_args tc1  in
+               (match uu____10627 with
                 | (head3,args) ->
                     let comp_univs =
-                      let uu____10586 =
-                        let uu____10587 = FStar_Syntax_Subst.compress head3
+                      let uu____10677 =
+                        let uu____10678 = FStar_Syntax_Subst.compress head3
                            in
-                        uu____10587.FStar_Syntax_Syntax.n  in
-                      match uu____10586 with
-                      | FStar_Syntax_Syntax.Tm_uinst (uu____10590,us) -> us
-                      | uu____10596 -> []  in
-                    let uu____10597 = FStar_Syntax_Util.head_and_args tc1  in
-                    (match uu____10597 with
-                     | (uu____10620,args1) ->
-                         let uu____10646 =
-                           let uu____10669 = FStar_List.hd args1  in
-                           let uu____10686 = FStar_List.tl args1  in
-                           (uu____10669, uu____10686)  in
-                         (match uu____10646 with
+                        uu____10678.FStar_Syntax_Syntax.n  in
+                      match uu____10677 with
+                      | FStar_Syntax_Syntax.Tm_uinst (uu____10681,us) -> us
+                      | uu____10687 -> []  in
+                    let uu____10688 = FStar_Syntax_Util.head_and_args tc1  in
+                    (match uu____10688 with
+                     | (uu____10711,args1) ->
+                         let uu____10737 =
+                           let uu____10760 = FStar_List.hd args1  in
+                           let uu____10777 = FStar_List.tl args1  in
+                           (uu____10760, uu____10777)  in
+                         (match uu____10737 with
                           | (res,args2) ->
-                              let uu____10767 =
-                                let uu____10776 =
+                              let uu____10858 =
+                                let uu____10867 =
                                   FStar_All.pipe_right
                                     c1.FStar_Syntax_Syntax.flags
                                     (FStar_List.map
-                                       (fun uu___5_10804  ->
-                                          match uu___5_10804 with
+                                       (fun uu___5_10895  ->
+                                          match uu___5_10895 with
                                           | FStar_Syntax_Syntax.DECREASES e
                                               ->
-                                              let uu____10812 =
+                                              let uu____10903 =
                                                 FStar_TypeChecker_Env.clear_expected_typ
                                                   env
                                                  in
-                                              (match uu____10812 with
-                                               | (env1,uu____10824) ->
-                                                   let uu____10829 =
+                                              (match uu____10903 with
+                                               | (env1,uu____10915) ->
+                                                   let uu____10920 =
                                                      tc_tot_or_gtot_term env1
                                                        e
                                                       in
-                                                   (match uu____10829 with
-                                                    | (e1,uu____10841,g) ->
+                                                   (match uu____10920 with
+                                                    | (e1,uu____10932,g) ->
                                                         ((FStar_Syntax_Syntax.DECREASES
                                                             e1), g)))
                                           | f1 ->
                                               (f1,
                                                 FStar_TypeChecker_Env.trivial_guard)))
                                    in
-                                FStar_All.pipe_right uu____10776
+                                FStar_All.pipe_right uu____10867
                                   FStar_List.unzip
                                  in
-                              (match uu____10767 with
+                              (match uu____10858 with
                                | (flags,guards) ->
                                    let u =
                                      env.FStar_TypeChecker_Env.universe_of
@@ -3792,18 +3827,18 @@ and (tc_comp :
                                       in
                                    let c2 =
                                      FStar_Syntax_Syntax.mk_Comp
-                                       (let uu___1539_10882 = c1  in
+                                       (let uu___1548_10973 = c1  in
                                         {
                                           FStar_Syntax_Syntax.comp_univs =
                                             comp_univs;
                                           FStar_Syntax_Syntax.effect_name =
-                                            (uu___1539_10882.FStar_Syntax_Syntax.effect_name);
+                                            (uu___1548_10973.FStar_Syntax_Syntax.effect_name);
                                           FStar_Syntax_Syntax.result_typ =
                                             (FStar_Pervasives_Native.fst res);
                                           FStar_Syntax_Syntax.effect_args =
                                             args2;
                                           FStar_Syntax_Syntax.flags =
-                                            (uu___1539_10882.FStar_Syntax_Syntax.flags)
+                                            (uu___1548_10973.FStar_Syntax_Syntax.flags)
                                         })
                                       in
                                    let u_c =
@@ -3811,12 +3846,12 @@ and (tc_comp :
                                        (FStar_TypeChecker_Util.universe_of_comp
                                           env u)
                                       in
-                                   let uu____10888 =
+                                   let uu____10979 =
                                      FStar_List.fold_left
                                        FStar_TypeChecker_Env.conj_guard f
                                        guards
                                       in
-                                   (c2, u_c, uu____10888))))))
+                                   (c2, u_c, uu____10979))))))
 
 and (tc_universe :
   FStar_TypeChecker_Env.env ->
@@ -3827,40 +3862,40 @@ and (tc_universe :
       let rec aux u1 =
         let u2 = FStar_Syntax_Subst.compress_univ u1  in
         match u2 with
-        | FStar_Syntax_Syntax.U_bvar uu____10898 ->
+        | FStar_Syntax_Syntax.U_bvar uu____10989 ->
             failwith "Impossible: locally nameless"
         | FStar_Syntax_Syntax.U_unknown  -> failwith "Unknown universe"
-        | FStar_Syntax_Syntax.U_unif uu____10902 -> u2
+        | FStar_Syntax_Syntax.U_unif uu____10993 -> u2
         | FStar_Syntax_Syntax.U_zero  -> u2
         | FStar_Syntax_Syntax.U_succ u3 ->
-            let uu____10912 = aux u3  in
-            FStar_Syntax_Syntax.U_succ uu____10912
+            let uu____11003 = aux u3  in
+            FStar_Syntax_Syntax.U_succ uu____11003
         | FStar_Syntax_Syntax.U_max us ->
-            let uu____10916 = FStar_List.map aux us  in
-            FStar_Syntax_Syntax.U_max uu____10916
+            let uu____11007 = FStar_List.map aux us  in
+            FStar_Syntax_Syntax.U_max uu____11007
         | FStar_Syntax_Syntax.U_name x ->
-            let uu____10920 =
+            let uu____11011 =
               env.FStar_TypeChecker_Env.use_bv_sorts ||
                 (FStar_TypeChecker_Env.lookup_univ env x)
                in
-            if uu____10920
+            if uu____11011
             then u2
             else
-              (let uu____10925 =
-                 let uu____10927 =
-                   let uu____10929 = FStar_Syntax_Print.univ_to_string u2  in
-                   Prims.op_Hat uu____10929 " not found"  in
-                 Prims.op_Hat "Universe variable " uu____10927  in
-               failwith uu____10925)
+              (let uu____11016 =
+                 let uu____11018 =
+                   let uu____11020 = FStar_Syntax_Print.univ_to_string u2  in
+                   Prims.op_Hat uu____11020 " not found"  in
+                 Prims.op_Hat "Universe variable " uu____11018  in
+               failwith uu____11016)
          in
       if env.FStar_TypeChecker_Env.lax_universes
       then FStar_Syntax_Syntax.U_zero
       else
         (match u with
          | FStar_Syntax_Syntax.U_unknown  ->
-             let uu____10936 = FStar_Syntax_Util.type_u ()  in
-             FStar_All.pipe_right uu____10936 FStar_Pervasives_Native.snd
-         | uu____10945 -> aux u)
+             let uu____11027 = FStar_Syntax_Util.type_u ()  in
+             FStar_All.pipe_right uu____11027 FStar_Pervasives_Native.snd
+         | uu____11036 -> aux u)
 
 and (tc_abs :
   FStar_TypeChecker_Env.env ->
@@ -3875,15 +3910,15 @@ and (tc_abs :
       fun bs  ->
         fun body  ->
           let fail1 msg t =
-            let uu____10976 =
+            let uu____11067 =
               FStar_TypeChecker_Err.expected_a_term_of_type_t_got_a_function
                 env msg t top
                in
-            FStar_Errors.raise_error uu____10976 top.FStar_Syntax_Syntax.pos
+            FStar_Errors.raise_error uu____11067 top.FStar_Syntax_Syntax.pos
              in
           let check_binders env1 bs1 bs_expected =
-            let rec aux uu____11065 bs2 bs_expected1 =
-              match uu____11065 with
+            let rec aux uu____11156 bs2 bs_expected1 =
+              match uu____11156 with
               | (env2,subst1) ->
                   (match (bs2, bs_expected1) with
                    | ([],[]) ->
@@ -3894,99 +3929,99 @@ and (tc_abs :
                            match (q1, q2) with
                            | (FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Meta
-                              uu____11256),FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Syntax.Meta uu____11257)) -> true
+                              uu____11347),FStar_Pervasives_Native.Some
+                              (FStar_Syntax_Syntax.Meta uu____11348)) -> true
                            | (FStar_Pervasives_Native.None
                               ,FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Equality )) -> true
                            | (FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Implicit
-                              uu____11272),FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Syntax.Meta uu____11273)) -> true
-                           | uu____11282 -> false  in
-                         let uu____11292 =
+                              uu____11363),FStar_Pervasives_Native.Some
+                              (FStar_Syntax_Syntax.Meta uu____11364)) -> true
+                           | uu____11373 -> false  in
+                         let uu____11383 =
                            (Prims.op_Negation (special imp imp')) &&
-                             (let uu____11295 =
+                             (let uu____11386 =
                                 FStar_Syntax_Util.eq_aqual imp imp'  in
-                              uu____11295 <> FStar_Syntax_Util.Equal)
+                              uu____11386 <> FStar_Syntax_Util.Equal)
                             in
-                         if uu____11292
+                         if uu____11383
                          then
-                           let uu____11297 =
-                             let uu____11303 =
-                               let uu____11305 =
+                           let uu____11388 =
+                             let uu____11394 =
+                               let uu____11396 =
                                  FStar_Syntax_Print.bv_to_string hd1  in
                                FStar_Util.format1
                                  "Inconsistent implicit argument annotation on argument %s"
-                                 uu____11305
+                                 uu____11396
                                 in
                              (FStar_Errors.Fatal_InconsistentImplicitArgumentAnnotation,
-                               uu____11303)
+                               uu____11394)
                               in
-                           let uu____11309 =
+                           let uu____11400 =
                              FStar_Syntax_Syntax.range_of_bv hd1  in
-                           FStar_Errors.raise_error uu____11297 uu____11309
+                           FStar_Errors.raise_error uu____11388 uu____11400
                          else ());
                         (let expected_t =
                            FStar_Syntax_Subst.subst subst1
                              hd_expected.FStar_Syntax_Syntax.sort
                             in
-                         let uu____11313 =
-                           let uu____11320 =
-                             let uu____11321 =
+                         let uu____11404 =
+                           let uu____11411 =
+                             let uu____11412 =
                                FStar_Syntax_Util.unmeta
                                  hd1.FStar_Syntax_Syntax.sort
                                 in
-                             uu____11321.FStar_Syntax_Syntax.n  in
-                           match uu____11320 with
+                             uu____11412.FStar_Syntax_Syntax.n  in
+                           match uu____11411 with
                            | FStar_Syntax_Syntax.Tm_unknown  ->
                                (expected_t,
                                  FStar_TypeChecker_Env.trivial_guard)
-                           | uu____11332 ->
-                               ((let uu____11334 =
+                           | uu____11423 ->
+                               ((let uu____11425 =
                                    FStar_TypeChecker_Env.debug env2
                                      FStar_Options.High
                                     in
-                                 if uu____11334
+                                 if uu____11425
                                  then
-                                   let uu____11337 =
+                                   let uu____11428 =
                                      FStar_Syntax_Print.bv_to_string hd1  in
                                    FStar_Util.print1 "Checking binder %s\n"
-                                     uu____11337
+                                     uu____11428
                                  else ());
-                                (let uu____11342 =
+                                (let uu____11433 =
                                    tc_tot_or_gtot_term env2
                                      hd1.FStar_Syntax_Syntax.sort
                                     in
-                                 match uu____11342 with
-                                 | (t,uu____11356,g1_env) ->
+                                 match uu____11433 with
+                                 | (t,uu____11447,g1_env) ->
                                      let g2_env =
-                                       let uu____11359 =
+                                       let uu____11450 =
                                          FStar_TypeChecker_Rel.teq_nosmt_force
                                            env2 t expected_t
                                           in
-                                       if uu____11359
+                                       if uu____11450
                                        then
                                          FStar_TypeChecker_Env.trivial_guard
                                        else
-                                         (let uu____11364 =
+                                         (let uu____11455 =
                                             FStar_TypeChecker_Rel.get_subtyping_prop
                                               env2 expected_t t
                                              in
-                                          match uu____11364 with
+                                          match uu____11455 with
                                           | FStar_Pervasives_Native.None  ->
-                                              let uu____11367 =
+                                              let uu____11458 =
                                                 FStar_TypeChecker_Err.basic_type_error
                                                   env2
                                                   FStar_Pervasives_Native.None
                                                   expected_t t
                                                  in
-                                              let uu____11373 =
+                                              let uu____11464 =
                                                 FStar_TypeChecker_Env.get_range
                                                   env2
                                                  in
                                               FStar_Errors.raise_error
-                                                uu____11367 uu____11373
+                                                uu____11458 uu____11464
                                           | FStar_Pervasives_Native.Some
                                               g_env ->
                                               FStar_TypeChecker_Util.label_guard
@@ -3994,45 +4029,45 @@ and (tc_abs :
                                                 "Type annotation on parameter incompatible with the expected type"
                                                 g_env)
                                         in
-                                     let uu____11376 =
+                                     let uu____11467 =
                                        FStar_TypeChecker_Env.conj_guard
                                          g1_env g2_env
                                         in
-                                     (t, uu____11376)))
+                                     (t, uu____11467)))
                             in
-                         match uu____11313 with
+                         match uu____11404 with
                          | (t,g_env) ->
                              let hd2 =
-                               let uu___1637_11402 = hd1  in
+                               let uu___1646_11493 = hd1  in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___1637_11402.FStar_Syntax_Syntax.ppname);
+                                   (uu___1646_11493.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___1637_11402.FStar_Syntax_Syntax.index);
+                                   (uu___1646_11493.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = t
                                }  in
                              let b = (hd2, imp)  in
                              let b_expected = (hd_expected, imp')  in
                              let env_b = push_binding env2 b  in
                              let subst2 =
-                               let uu____11425 =
+                               let uu____11516 =
                                  FStar_Syntax_Syntax.bv_to_name hd2  in
                                maybe_extend_subst subst1 b_expected
-                                 uu____11425
+                                 uu____11516
                                 in
-                             let uu____11428 =
+                             let uu____11519 =
                                aux (env_b, subst2) bs3 bs_expected2  in
-                             (match uu____11428 with
+                             (match uu____11519 with
                               | (env_bs,bs4,rest,g'_env_b,subst3) ->
                                   let g'_env =
                                     FStar_TypeChecker_Env.close_guard env_bs
                                       [b] g'_env_b
                                      in
-                                  let uu____11493 =
+                                  let uu____11584 =
                                     FStar_TypeChecker_Env.conj_guard g_env
                                       g'_env
                                      in
-                                  (env_bs, (b :: bs4), rest, uu____11493,
+                                  (env_bs, (b :: bs4), rest, uu____11584,
                                     subst3))))
                    | (rest,[]) ->
                        (env2, [],
@@ -4049,101 +4084,101 @@ and (tc_abs :
             | FStar_Pervasives_Native.None  ->
                 ((match env1.FStar_TypeChecker_Env.letrecs with
                   | [] -> ()
-                  | uu____11665 ->
+                  | uu____11756 ->
                       failwith
                         "Impossible: Can't have a let rec annotation but no expected type");
-                 (let uu____11675 = tc_binders env1 bs  in
-                  match uu____11675 with
-                  | (bs1,envbody,g_env,uu____11705) ->
+                 (let uu____11766 = tc_binders env1 bs  in
+                  match uu____11766 with
+                  | (bs1,envbody,g_env,uu____11796) ->
                       (FStar_Pervasives_Native.None, bs1, [],
                         FStar_Pervasives_Native.None, envbody, body1, g_env)))
             | FStar_Pervasives_Native.Some t ->
                 let t1 = FStar_Syntax_Subst.compress t  in
                 let rec as_function_typ norm1 t2 =
-                  let uu____11761 =
-                    let uu____11762 = FStar_Syntax_Subst.compress t2  in
-                    uu____11762.FStar_Syntax_Syntax.n  in
-                  match uu____11761 with
-                  | FStar_Syntax_Syntax.Tm_uvar uu____11795 ->
+                  let uu____11852 =
+                    let uu____11853 = FStar_Syntax_Subst.compress t2  in
+                    uu____11853.FStar_Syntax_Syntax.n  in
+                  match uu____11852 with
+                  | FStar_Syntax_Syntax.Tm_uvar uu____11886 ->
                       ((match env1.FStar_TypeChecker_Env.letrecs with
                         | [] -> ()
-                        | uu____11815 -> failwith "Impossible");
-                       (let uu____11825 = tc_binders env1 bs  in
-                        match uu____11825 with
-                        | (bs1,envbody,g_env,uu____11867) ->
-                            let uu____11868 =
+                        | uu____11906 -> failwith "Impossible");
+                       (let uu____11916 = tc_binders env1 bs  in
+                        match uu____11916 with
+                        | (bs1,envbody,g_env,uu____11958) ->
+                            let uu____11959 =
                               FStar_TypeChecker_Env.clear_expected_typ
                                 envbody
                                in
-                            (match uu____11868 with
-                             | (envbody1,uu____11906) ->
+                            (match uu____11959 with
+                             | (envbody1,uu____11997) ->
                                  ((FStar_Pervasives_Native.Some t2), bs1, [],
                                    FStar_Pervasives_Native.None, envbody1,
                                    body1, g_env))))
                   | FStar_Syntax_Syntax.Tm_app
                       ({
                          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                           uu____11927;
-                         FStar_Syntax_Syntax.pos = uu____11928;
-                         FStar_Syntax_Syntax.vars = uu____11929;_},uu____11930)
+                           uu____12018;
+                         FStar_Syntax_Syntax.pos = uu____12019;
+                         FStar_Syntax_Syntax.vars = uu____12020;_},uu____12021)
                       ->
                       ((match env1.FStar_TypeChecker_Env.letrecs with
                         | [] -> ()
-                        | uu____11974 -> failwith "Impossible");
-                       (let uu____11984 = tc_binders env1 bs  in
-                        match uu____11984 with
-                        | (bs1,envbody,g_env,uu____12026) ->
-                            let uu____12027 =
+                        | uu____12065 -> failwith "Impossible");
+                       (let uu____12075 = tc_binders env1 bs  in
+                        match uu____12075 with
+                        | (bs1,envbody,g_env,uu____12117) ->
+                            let uu____12118 =
                               FStar_TypeChecker_Env.clear_expected_typ
                                 envbody
                                in
-                            (match uu____12027 with
-                             | (envbody1,uu____12065) ->
+                            (match uu____12118 with
+                             | (envbody1,uu____12156) ->
                                  ((FStar_Pervasives_Native.Some t2), bs1, [],
                                    FStar_Pervasives_Native.None, envbody1,
                                    body1, g_env))))
-                  | FStar_Syntax_Syntax.Tm_refine (b,uu____12087) ->
-                      let uu____12092 =
+                  | FStar_Syntax_Syntax.Tm_refine (b,uu____12178) ->
+                      let uu____12183 =
                         as_function_typ norm1 b.FStar_Syntax_Syntax.sort  in
-                      (match uu____12092 with
-                       | (uu____12153,bs1,bs',copt,env_body,body2,g_env) ->
+                      (match uu____12183 with
+                       | (uu____12244,bs1,bs',copt,env_body,body2,g_env) ->
                            ((FStar_Pervasives_Native.Some t2), bs1, bs',
                              copt, env_body, body2, g_env))
                   | FStar_Syntax_Syntax.Tm_arrow (bs_expected,c_expected) ->
-                      let uu____12230 =
+                      let uu____12321 =
                         FStar_Syntax_Subst.open_comp bs_expected c_expected
                          in
-                      (match uu____12230 with
+                      (match uu____12321 with
                        | (bs_expected1,c_expected1) ->
                            let check_actuals_against_formals env2 bs1
                              bs_expected2 body2 =
-                             let rec handle_more uu____12375 c_expected2
+                             let rec handle_more uu____12466 c_expected2
                                body3 =
-                               match uu____12375 with
+                               match uu____12466 with
                                | (env_bs,bs2,more,guard_env,subst1) ->
                                    (match more with
                                     | FStar_Pervasives_Native.None  ->
-                                        let uu____12489 =
+                                        let uu____12580 =
                                           FStar_Syntax_Subst.subst_comp
                                             subst1 c_expected2
                                            in
-                                        (env_bs, bs2, guard_env, uu____12489,
+                                        (env_bs, bs2, guard_env, uu____12580,
                                           body3)
                                     | FStar_Pervasives_Native.Some
                                         (FStar_Util.Inr more_bs_expected) ->
                                         let c =
-                                          let uu____12506 =
+                                          let uu____12597 =
                                             FStar_Syntax_Util.arrow
                                               more_bs_expected c_expected2
                                              in
                                           FStar_Syntax_Syntax.mk_Total
-                                            uu____12506
+                                            uu____12597
                                            in
-                                        let uu____12507 =
+                                        let uu____12598 =
                                           FStar_Syntax_Subst.subst_comp
                                             subst1 c
                                            in
-                                        (env_bs, bs2, guard_env, uu____12507,
+                                        (env_bs, bs2, guard_env, uu____12598,
                                           body3)
                                     | FStar_Pervasives_Native.Some
                                         (FStar_Util.Inl more_bs) ->
@@ -4151,11 +4186,11 @@ and (tc_abs :
                                           FStar_Syntax_Subst.subst_comp
                                             subst1 c_expected2
                                            in
-                                        let uu____12524 =
+                                        let uu____12615 =
                                           (FStar_Options.ml_ish ()) ||
                                             (FStar_Syntax_Util.is_named_tot c)
                                            in
-                                        if uu____12524
+                                        if uu____12615
                                         then
                                           let t3 =
                                             FStar_TypeChecker_Normalize.unfold_whnf
@@ -4167,18 +4202,18 @@ and (tc_abs :
                                            with
                                            | FStar_Syntax_Syntax.Tm_arrow
                                                (bs_expected3,c_expected3) ->
-                                               let uu____12590 =
+                                               let uu____12681 =
                                                  FStar_Syntax_Subst.open_comp
                                                    bs_expected3 c_expected3
                                                   in
-                                               (match uu____12590 with
+                                               (match uu____12681 with
                                                 | (bs_expected4,c_expected4)
                                                     ->
-                                                    let uu____12617 =
+                                                    let uu____12708 =
                                                       check_binders env_bs
                                                         more_bs bs_expected4
                                                        in
-                                                    (match uu____12617 with
+                                                    (match uu____12708 with
                                                      | (env_bs_bs',bs',more1,guard'_env_bs,subst2)
                                                          ->
                                                          let guard'_env =
@@ -4186,8 +4221,8 @@ and (tc_abs :
                                                              env_bs bs2
                                                              guard'_env_bs
                                                             in
-                                                         let uu____12672 =
-                                                           let uu____12699 =
+                                                         let uu____12763 =
+                                                           let uu____12790 =
                                                              FStar_TypeChecker_Env.conj_guard
                                                                guard_env
                                                                guard'_env
@@ -4196,13 +4231,13 @@ and (tc_abs :
                                                              (FStar_List.append
                                                                 bs2 bs'),
                                                              more1,
-                                                             uu____12699,
+                                                             uu____12790,
                                                              subst2)
                                                             in
                                                          handle_more
-                                                           uu____12672
+                                                           uu____12763
                                                            c_expected4 body3))
-                                           | uu____12722 ->
+                                           | uu____12813 ->
                                                let body4 =
                                                  FStar_Syntax_Util.abs
                                                    more_bs body3
@@ -4218,124 +4253,126 @@ and (tc_abs :
                                               in
                                            (env_bs, bs2, guard_env, c, body4)))
                                 in
-                             let uu____12751 =
+                             let uu____12842 =
                                check_binders env2 bs1 bs_expected2  in
-                             handle_more uu____12751 c_expected1 body2  in
+                             handle_more uu____12842 c_expected1 body2  in
                            let mk_letrec_env envbody bs1 c =
                              let letrecs = guard_letrecs envbody bs1 c  in
                              let envbody1 =
-                               let uu___1763_12816 = envbody  in
+                               let uu___1772_12907 = envbody  in
                                {
                                  FStar_TypeChecker_Env.solver =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.solver);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.solver);
                                  FStar_TypeChecker_Env.range =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.range);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.range);
                                  FStar_TypeChecker_Env.curmodule =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.curmodule);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.curmodule);
                                  FStar_TypeChecker_Env.gamma =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.gamma);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.gamma);
                                  FStar_TypeChecker_Env.gamma_sig =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.gamma_sig);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.gamma_sig);
                                  FStar_TypeChecker_Env.gamma_cache =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.gamma_cache);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.gamma_cache);
                                  FStar_TypeChecker_Env.modules =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.modules);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.modules);
                                  FStar_TypeChecker_Env.expected_typ =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.expected_typ);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.expected_typ);
                                  FStar_TypeChecker_Env.sigtab =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.sigtab);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.sigtab);
                                  FStar_TypeChecker_Env.attrtab =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.attrtab);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.attrtab);
                                  FStar_TypeChecker_Env.is_pattern =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.is_pattern);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.is_pattern);
                                  FStar_TypeChecker_Env.instantiate_imp =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.instantiate_imp);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.instantiate_imp);
                                  FStar_TypeChecker_Env.effects =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.effects);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.effects);
                                  FStar_TypeChecker_Env.generalize =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.generalize);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.generalize);
                                  FStar_TypeChecker_Env.letrecs = [];
                                  FStar_TypeChecker_Env.top_level =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.top_level);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.top_level);
                                  FStar_TypeChecker_Env.check_uvars =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.check_uvars);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.check_uvars);
                                  FStar_TypeChecker_Env.use_eq =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.use_eq);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.use_eq);
                                  FStar_TypeChecker_Env.is_iface =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.is_iface);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.is_iface);
                                  FStar_TypeChecker_Env.admit =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.admit);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.admit);
                                  FStar_TypeChecker_Env.lax =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.lax);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.lax);
                                  FStar_TypeChecker_Env.lax_universes =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.lax_universes);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.lax_universes);
                                  FStar_TypeChecker_Env.phase1 =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.phase1);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.phase1);
                                  FStar_TypeChecker_Env.failhard =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.failhard);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.failhard);
                                  FStar_TypeChecker_Env.nosynth =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.nosynth);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.nosynth);
                                  FStar_TypeChecker_Env.uvar_subtyping =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.uvar_subtyping);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.uvar_subtyping);
                                  FStar_TypeChecker_Env.tc_term =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.tc_term);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.tc_term);
                                  FStar_TypeChecker_Env.type_of =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.type_of);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.type_of);
                                  FStar_TypeChecker_Env.universe_of =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.universe_of);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.universe_of);
                                  FStar_TypeChecker_Env.check_type_of =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.check_type_of);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.check_type_of);
                                  FStar_TypeChecker_Env.use_bv_sorts =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.use_bv_sorts);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.use_bv_sorts);
                                  FStar_TypeChecker_Env.qtbl_name_and_index =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.qtbl_name_and_index);
                                  FStar_TypeChecker_Env.normalized_eff_names =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.normalized_eff_names);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.normalized_eff_names);
                                  FStar_TypeChecker_Env.fv_delta_depths =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.fv_delta_depths);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.fv_delta_depths);
                                  FStar_TypeChecker_Env.proof_ns =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.proof_ns);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.proof_ns);
                                  FStar_TypeChecker_Env.synth_hook =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.synth_hook);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.synth_hook);
                                  FStar_TypeChecker_Env.splice =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.splice);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.splice);
                                  FStar_TypeChecker_Env.postprocess =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.postprocess);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.postprocess);
                                  FStar_TypeChecker_Env.is_native_tactic =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.is_native_tactic);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.is_native_tactic);
                                  FStar_TypeChecker_Env.identifier_info =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.identifier_info);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.identifier_info);
                                  FStar_TypeChecker_Env.tc_hooks =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.tc_hooks);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.tc_hooks);
                                  FStar_TypeChecker_Env.dsenv =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.dsenv);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.dsenv);
                                  FStar_TypeChecker_Env.nbe =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.nbe);
+                                   (uu___1772_12907.FStar_TypeChecker_Env.nbe);
                                  FStar_TypeChecker_Env.strict_args_tab =
-                                   (uu___1763_12816.FStar_TypeChecker_Env.strict_args_tab)
+                                   (uu___1772_12907.FStar_TypeChecker_Env.strict_args_tab);
+                                 FStar_TypeChecker_Env.erasable_types_tab =
+                                   (uu___1772_12907.FStar_TypeChecker_Env.erasable_types_tab)
                                }  in
-                             let uu____12823 =
+                             let uu____12914 =
                                FStar_All.pipe_right letrecs
                                  (FStar_List.fold_left
-                                    (fun uu____12889  ->
-                                       fun uu____12890  ->
-                                         match (uu____12889, uu____12890)
+                                    (fun uu____12980  ->
+                                       fun uu____12981  ->
+                                         match (uu____12980, uu____12981)
                                          with
                                          | ((env2,letrec_binders,g),(l,t3,u_names))
                                              ->
-                                             let uu____12981 =
-                                               let uu____12988 =
-                                                 let uu____12989 =
+                                             let uu____13072 =
+                                               let uu____13079 =
+                                                 let uu____13080 =
                                                    FStar_TypeChecker_Env.clear_expected_typ
                                                      env2
                                                     in
                                                  FStar_All.pipe_right
-                                                   uu____12989
+                                                   uu____13080
                                                    FStar_Pervasives_Native.fst
                                                   in
-                                               tc_term uu____12988 t3  in
-                                             (match uu____12981 with
-                                              | (t4,uu____13013,g') ->
+                                               tc_term uu____13079 t3  in
+                                             (match uu____13072 with
+                                              | (t4,uu____13104,g') ->
                                                   let env3 =
                                                     FStar_TypeChecker_Env.push_let_binding
                                                       env2 l (u_names, t4)
@@ -4343,84 +4380,84 @@ and (tc_abs :
                                                   let lb =
                                                     match l with
                                                     | FStar_Util.Inl x ->
-                                                        let uu____13026 =
+                                                        let uu____13117 =
                                                           FStar_Syntax_Syntax.mk_binder
-                                                            (let uu___1781_13029
+                                                            (let uu___1790_13120
                                                                = x  in
                                                              {
                                                                FStar_Syntax_Syntax.ppname
                                                                  =
-                                                                 (uu___1781_13029.FStar_Syntax_Syntax.ppname);
+                                                                 (uu___1790_13120.FStar_Syntax_Syntax.ppname);
                                                                FStar_Syntax_Syntax.index
                                                                  =
-                                                                 (uu___1781_13029.FStar_Syntax_Syntax.index);
+                                                                 (uu___1790_13120.FStar_Syntax_Syntax.index);
                                                                FStar_Syntax_Syntax.sort
                                                                  = t4
                                                              })
                                                            in
-                                                        uu____13026 ::
+                                                        uu____13117 ::
                                                           letrec_binders
-                                                    | uu____13030 ->
+                                                    | uu____13121 ->
                                                         letrec_binders
                                                      in
-                                                  let uu____13035 =
+                                                  let uu____13126 =
                                                     FStar_TypeChecker_Env.conj_guard
                                                       g g'
                                                      in
-                                                  (env3, lb, uu____13035)))
+                                                  (env3, lb, uu____13126)))
                                     (envbody1, [],
                                       FStar_TypeChecker_Env.trivial_guard))
                                 in
-                             match uu____12823 with
+                             match uu____12914 with
                              | (envbody2,letrec_binders,g) ->
-                                 let uu____13055 =
+                                 let uu____13146 =
                                    FStar_TypeChecker_Env.close_guard envbody2
                                      bs1 g
                                     in
-                                 (envbody2, letrec_binders, uu____13055)
+                                 (envbody2, letrec_binders, uu____13146)
                               in
-                           let uu____13058 =
+                           let uu____13149 =
                              check_actuals_against_formals env1 bs
                                bs_expected1 body1
                               in
-                           (match uu____13058 with
+                           (match uu____13149 with
                             | (envbody,bs1,g_env,c,body2) ->
-                                let uu____13134 = mk_letrec_env envbody bs1 c
+                                let uu____13225 = mk_letrec_env envbody bs1 c
                                    in
-                                (match uu____13134 with
+                                (match uu____13225 with
                                  | (envbody1,letrecs,g_annots) ->
                                      let envbody2 =
                                        FStar_TypeChecker_Env.set_expected_typ
                                          envbody1
                                          (FStar_Syntax_Util.comp_result c)
                                         in
-                                     let uu____13181 =
+                                     let uu____13272 =
                                        FStar_TypeChecker_Env.conj_guard g_env
                                          g_annots
                                         in
                                      ((FStar_Pervasives_Native.Some t2), bs1,
                                        letrecs,
                                        (FStar_Pervasives_Native.Some c),
-                                       envbody2, body2, uu____13181))))
-                  | uu____13198 ->
+                                       envbody2, body2, uu____13272))))
+                  | uu____13289 ->
                       if Prims.op_Negation norm1
                       then
-                        let uu____13230 =
-                          let uu____13231 =
+                        let uu____13321 =
+                          let uu____13322 =
                             FStar_All.pipe_right t2
                               (FStar_TypeChecker_Normalize.unfold_whnf env1)
                              in
-                          FStar_All.pipe_right uu____13231
+                          FStar_All.pipe_right uu____13322
                             FStar_Syntax_Util.unascribe
                            in
-                        as_function_typ true uu____13230
+                        as_function_typ true uu____13321
                       else
-                        (let uu____13235 =
+                        (let uu____13326 =
                            expected_function_typ1 env1
                              FStar_Pervasives_Native.None body1
                             in
-                         match uu____13235 with
-                         | (uu____13284,bs1,uu____13286,c_opt,envbody,body2,g_env)
+                         match uu____13326 with
+                         | (uu____13375,bs1,uu____13377,c_opt,envbody,body2,g_env)
                              ->
                              ((FStar_Pervasives_Native.Some t2), bs1, [],
                                c_opt, envbody, body2, g_env))
@@ -4428,14 +4465,14 @@ and (tc_abs :
                 as_function_typ false t1
              in
           let use_eq = env.FStar_TypeChecker_Env.use_eq  in
-          let uu____13318 = FStar_TypeChecker_Env.clear_expected_typ env  in
-          match uu____13318 with
+          let uu____13409 = FStar_TypeChecker_Env.clear_expected_typ env  in
+          match uu____13409 with
           | (env1,topt) ->
-              ((let uu____13338 =
+              ((let uu____13429 =
                   FStar_TypeChecker_Env.debug env1 FStar_Options.High  in
-                if uu____13338
+                if uu____13429
                 then
-                  let uu____13341 =
+                  let uu____13432 =
                     match topt with
                     | FStar_Pervasives_Native.None  -> "None"
                     | FStar_Pervasives_Native.Some t ->
@@ -4443,172 +4480,174 @@ and (tc_abs :
                      in
                   FStar_Util.print2
                     "!!!!!!!!!!!!!!!Expected type is %s, top_level=%s\n"
-                    uu____13341
+                    uu____13432
                     (if env1.FStar_TypeChecker_Env.top_level
                      then "true"
                      else "false")
                 else ());
-               (let uu____13355 = expected_function_typ1 env1 topt body  in
-                match uu____13355 with
+               (let uu____13446 = expected_function_typ1 env1 topt body  in
+                match uu____13446 with
                 | (tfun_opt,bs1,letrec_binders,c_opt,envbody,body1,g_env) ->
-                    ((let uu____13396 =
+                    ((let uu____13487 =
                         FStar_TypeChecker_Env.debug env1
                           FStar_Options.Extreme
                          in
-                      if uu____13396
+                      if uu____13487
                       then
-                        let uu____13399 =
+                        let uu____13490 =
                           match tfun_opt with
                           | FStar_Pervasives_Native.None  -> "None"
                           | FStar_Pervasives_Native.Some t ->
                               FStar_Syntax_Print.term_to_string t
                            in
-                        let uu____13404 =
+                        let uu____13495 =
                           match c_opt with
                           | FStar_Pervasives_Native.None  -> "None"
                           | FStar_Pervasives_Native.Some t ->
                               FStar_Syntax_Print.comp_to_string t
                            in
-                        let uu____13409 =
-                          let uu____13411 =
+                        let uu____13500 =
+                          let uu____13502 =
                             FStar_TypeChecker_Env.expected_typ envbody  in
-                          match uu____13411 with
+                          match uu____13502 with
                           | FStar_Pervasives_Native.None  -> "None"
                           | FStar_Pervasives_Native.Some t ->
                               FStar_Syntax_Print.term_to_string t
                            in
                         FStar_Util.print3
                           "After expected_function_typ, tfun_opt: %s, c_opt: %s, and expected type in envbody: %s\n"
-                          uu____13399 uu____13404 uu____13409
+                          uu____13490 uu____13495 uu____13500
                       else ());
-                     (let uu____13421 =
+                     (let uu____13512 =
                         FStar_All.pipe_left
                           (FStar_TypeChecker_Env.debug env1)
                           (FStar_Options.Other "NYC")
                          in
-                      if uu____13421
+                      if uu____13512
                       then
-                        let uu____13426 =
+                        let uu____13517 =
                           FStar_Syntax_Print.binders_to_string ", " bs1  in
-                        let uu____13429 =
+                        let uu____13520 =
                           FStar_TypeChecker_Rel.guard_to_string env1 g_env
                            in
                         FStar_Util.print2
                           "!!!!!!!!!!!!!!!Guard for function with binders %s is %s\n"
-                          uu____13426 uu____13429
+                          uu____13517 uu____13520
                       else ());
                      (let envbody1 =
                         FStar_TypeChecker_Env.set_range envbody
                           body1.FStar_Syntax_Syntax.pos
                          in
-                      let uu____13435 =
+                      let uu____13526 =
                         let should_check_expected_effect =
-                          let uu____13448 =
-                            let uu____13455 =
-                              let uu____13456 =
+                          let uu____13539 =
+                            let uu____13546 =
+                              let uu____13547 =
                                 FStar_Syntax_Subst.compress body1  in
-                              uu____13456.FStar_Syntax_Syntax.n  in
-                            (c_opt, uu____13455)  in
-                          match uu____13448 with
+                              uu____13547.FStar_Syntax_Syntax.n  in
+                            (c_opt, uu____13546)  in
+                          match uu____13539 with
                           | (FStar_Pervasives_Native.None
                              ,FStar_Syntax_Syntax.Tm_ascribed
-                             (uu____13462,(FStar_Util.Inr
-                                           expected_c,uu____13464),uu____13465))
+                             (uu____13553,(FStar_Util.Inr
+                                           expected_c,uu____13555),uu____13556))
                               -> false
-                          | uu____13515 -> true  in
-                        let uu____13523 =
+                          | uu____13606 -> true  in
+                        let uu____13614 =
                           tc_term
-                            (let uu___1854_13532 = envbody1  in
+                            (let uu___1863_13623 = envbody1  in
                              {
                                FStar_TypeChecker_Env.solver =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.solver);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.solver);
                                FStar_TypeChecker_Env.range =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.range);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.range);
                                FStar_TypeChecker_Env.curmodule =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.curmodule);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.curmodule);
                                FStar_TypeChecker_Env.gamma =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.gamma);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.gamma);
                                FStar_TypeChecker_Env.gamma_sig =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.gamma_sig);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.gamma_sig);
                                FStar_TypeChecker_Env.gamma_cache =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.gamma_cache);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.gamma_cache);
                                FStar_TypeChecker_Env.modules =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.modules);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.modules);
                                FStar_TypeChecker_Env.expected_typ =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.expected_typ);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.expected_typ);
                                FStar_TypeChecker_Env.sigtab =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.sigtab);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.sigtab);
                                FStar_TypeChecker_Env.attrtab =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.attrtab);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.attrtab);
                                FStar_TypeChecker_Env.is_pattern =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.is_pattern);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.is_pattern);
                                FStar_TypeChecker_Env.instantiate_imp =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.instantiate_imp);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.instantiate_imp);
                                FStar_TypeChecker_Env.effects =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.effects);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.effects);
                                FStar_TypeChecker_Env.generalize =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.generalize);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.generalize);
                                FStar_TypeChecker_Env.letrecs =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.letrecs);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.letrecs);
                                FStar_TypeChecker_Env.top_level = false;
                                FStar_TypeChecker_Env.check_uvars =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.check_uvars);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.check_uvars);
                                FStar_TypeChecker_Env.use_eq = use_eq;
                                FStar_TypeChecker_Env.is_iface =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.is_iface);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.is_iface);
                                FStar_TypeChecker_Env.admit =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.admit);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.admit);
                                FStar_TypeChecker_Env.lax =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.lax);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.lax);
                                FStar_TypeChecker_Env.lax_universes =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.lax_universes);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.lax_universes);
                                FStar_TypeChecker_Env.phase1 =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.phase1);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.phase1);
                                FStar_TypeChecker_Env.failhard =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.failhard);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.failhard);
                                FStar_TypeChecker_Env.nosynth =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.nosynth);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.nosynth);
                                FStar_TypeChecker_Env.uvar_subtyping =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.uvar_subtyping);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.uvar_subtyping);
                                FStar_TypeChecker_Env.tc_term =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.tc_term);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.tc_term);
                                FStar_TypeChecker_Env.type_of =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.type_of);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.type_of);
                                FStar_TypeChecker_Env.universe_of =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.universe_of);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.universe_of);
                                FStar_TypeChecker_Env.check_type_of =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.check_type_of);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.check_type_of);
                                FStar_TypeChecker_Env.use_bv_sorts =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.use_bv_sorts);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.use_bv_sorts);
                                FStar_TypeChecker_Env.qtbl_name_and_index =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.qtbl_name_and_index);
                                FStar_TypeChecker_Env.normalized_eff_names =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.normalized_eff_names);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.normalized_eff_names);
                                FStar_TypeChecker_Env.fv_delta_depths =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.fv_delta_depths);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.fv_delta_depths);
                                FStar_TypeChecker_Env.proof_ns =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.proof_ns);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.proof_ns);
                                FStar_TypeChecker_Env.synth_hook =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.synth_hook);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.synth_hook);
                                FStar_TypeChecker_Env.splice =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.splice);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.splice);
                                FStar_TypeChecker_Env.postprocess =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.postprocess);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.postprocess);
                                FStar_TypeChecker_Env.is_native_tactic =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.is_native_tactic);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.is_native_tactic);
                                FStar_TypeChecker_Env.identifier_info =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.identifier_info);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.identifier_info);
                                FStar_TypeChecker_Env.tc_hooks =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.tc_hooks);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.tc_hooks);
                                FStar_TypeChecker_Env.dsenv =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.dsenv);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.dsenv);
                                FStar_TypeChecker_Env.nbe =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.nbe);
+                                 (uu___1863_13623.FStar_TypeChecker_Env.nbe);
                                FStar_TypeChecker_Env.strict_args_tab =
-                                 (uu___1854_13532.FStar_TypeChecker_Env.strict_args_tab)
+                                 (uu___1863_13623.FStar_TypeChecker_Env.strict_args_tab);
+                               FStar_TypeChecker_Env.erasable_types_tab =
+                                 (uu___1863_13623.FStar_TypeChecker_Env.erasable_types_tab)
                              }) body1
                            in
-                        match uu____13523 with
+                        match uu____13614 with
                         | (body2,cbody,guard_body) ->
                             let guard_body1 =
                               FStar_TypeChecker_Rel.solve_deferred_constraints
@@ -4616,148 +4655,151 @@ and (tc_abs :
                                in
                             if should_check_expected_effect
                             then
-                              let uu____13559 =
-                                let uu____13566 =
-                                  let uu____13571 =
+                              let uu____13650 =
+                                let uu____13657 =
+                                  let uu____13662 =
                                     FStar_Syntax_Syntax.lcomp_comp cbody  in
-                                  (body2, uu____13571)  in
+                                  (body2, uu____13662)  in
                                 check_expected_effect
-                                  (let uu___1862_13574 = envbody1  in
+                                  (let uu___1871_13665 = envbody1  in
                                    {
                                      FStar_TypeChecker_Env.solver =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.solver);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.solver);
                                      FStar_TypeChecker_Env.range =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.range);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.range);
                                      FStar_TypeChecker_Env.curmodule =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.curmodule);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.curmodule);
                                      FStar_TypeChecker_Env.gamma =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.gamma);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.gamma);
                                      FStar_TypeChecker_Env.gamma_sig =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.gamma_sig);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.gamma_sig);
                                      FStar_TypeChecker_Env.gamma_cache =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.gamma_cache);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.gamma_cache);
                                      FStar_TypeChecker_Env.modules =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.modules);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.modules);
                                      FStar_TypeChecker_Env.expected_typ =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.expected_typ);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.expected_typ);
                                      FStar_TypeChecker_Env.sigtab =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.sigtab);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.sigtab);
                                      FStar_TypeChecker_Env.attrtab =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.attrtab);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.attrtab);
                                      FStar_TypeChecker_Env.is_pattern =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.is_pattern);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.is_pattern);
                                      FStar_TypeChecker_Env.instantiate_imp =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.instantiate_imp);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.instantiate_imp);
                                      FStar_TypeChecker_Env.effects =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.effects);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.effects);
                                      FStar_TypeChecker_Env.generalize =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.generalize);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.generalize);
                                      FStar_TypeChecker_Env.letrecs =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.letrecs);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.letrecs);
                                      FStar_TypeChecker_Env.top_level =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.top_level);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.top_level);
                                      FStar_TypeChecker_Env.check_uvars =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.check_uvars);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.check_uvars);
                                      FStar_TypeChecker_Env.use_eq = use_eq;
                                      FStar_TypeChecker_Env.is_iface =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.is_iface);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.is_iface);
                                      FStar_TypeChecker_Env.admit =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.admit);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.admit);
                                      FStar_TypeChecker_Env.lax =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.lax);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.lax);
                                      FStar_TypeChecker_Env.lax_universes =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.lax_universes);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.lax_universes);
                                      FStar_TypeChecker_Env.phase1 =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.phase1);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.phase1);
                                      FStar_TypeChecker_Env.failhard =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.failhard);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.failhard);
                                      FStar_TypeChecker_Env.nosynth =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.nosynth);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.nosynth);
                                      FStar_TypeChecker_Env.uvar_subtyping =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.uvar_subtyping);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.uvar_subtyping);
                                      FStar_TypeChecker_Env.tc_term =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.tc_term);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.tc_term);
                                      FStar_TypeChecker_Env.type_of =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.type_of);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.type_of);
                                      FStar_TypeChecker_Env.universe_of =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.universe_of);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.universe_of);
                                      FStar_TypeChecker_Env.check_type_of =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.check_type_of);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.check_type_of);
                                      FStar_TypeChecker_Env.use_bv_sorts =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.use_bv_sorts);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.use_bv_sorts);
                                      FStar_TypeChecker_Env.qtbl_name_and_index
                                        =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.qtbl_name_and_index);
                                      FStar_TypeChecker_Env.normalized_eff_names
                                        =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.normalized_eff_names);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.normalized_eff_names);
                                      FStar_TypeChecker_Env.fv_delta_depths =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.fv_delta_depths);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.fv_delta_depths);
                                      FStar_TypeChecker_Env.proof_ns =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.proof_ns);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.proof_ns);
                                      FStar_TypeChecker_Env.synth_hook =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.synth_hook);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.synth_hook);
                                      FStar_TypeChecker_Env.splice =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.splice);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.splice);
                                      FStar_TypeChecker_Env.postprocess =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.postprocess);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.postprocess);
                                      FStar_TypeChecker_Env.is_native_tactic =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.is_native_tactic);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.is_native_tactic);
                                      FStar_TypeChecker_Env.identifier_info =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.identifier_info);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.identifier_info);
                                      FStar_TypeChecker_Env.tc_hooks =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.tc_hooks);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.tc_hooks);
                                      FStar_TypeChecker_Env.dsenv =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.dsenv);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.dsenv);
                                      FStar_TypeChecker_Env.nbe =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.nbe);
+                                       (uu___1871_13665.FStar_TypeChecker_Env.nbe);
                                      FStar_TypeChecker_Env.strict_args_tab =
-                                       (uu___1862_13574.FStar_TypeChecker_Env.strict_args_tab)
-                                   }) c_opt uu____13566
+                                       (uu___1871_13665.FStar_TypeChecker_Env.strict_args_tab);
+                                     FStar_TypeChecker_Env.erasable_types_tab
+                                       =
+                                       (uu___1871_13665.FStar_TypeChecker_Env.erasable_types_tab)
+                                   }) c_opt uu____13657
                                  in
-                              (match uu____13559 with
+                              (match uu____13650 with
                                | (body3,cbody1,guard) ->
-                                   let uu____13588 =
+                                   let uu____13679 =
                                      FStar_TypeChecker_Env.conj_guard
                                        guard_body1 guard
                                       in
-                                   (body3, cbody1, uu____13588))
+                                   (body3, cbody1, uu____13679))
                             else
-                              (let uu____13595 =
+                              (let uu____13686 =
                                  FStar_Syntax_Syntax.lcomp_comp cbody  in
-                               (body2, uu____13595, guard_body1))
+                               (body2, uu____13686, guard_body1))
                          in
-                      match uu____13435 with
+                      match uu____13526 with
                       | (body2,cbody,guard_body) ->
                           let guard =
-                            let uu____13620 =
+                            let uu____13711 =
                               env1.FStar_TypeChecker_Env.top_level ||
-                                (let uu____13623 =
+                                (let uu____13714 =
                                    FStar_TypeChecker_Env.should_verify env1
                                     in
-                                 Prims.op_Negation uu____13623)
+                                 Prims.op_Negation uu____13714)
                                in
-                            if uu____13620
+                            if uu____13711
                             then
-                              let uu____13626 =
+                              let uu____13717 =
                                 FStar_TypeChecker_Rel.discharge_guard env1
                                   g_env
                                  in
-                              let uu____13627 =
+                              let uu____13718 =
                                 FStar_TypeChecker_Rel.discharge_guard
                                   envbody1 guard_body
                                  in
-                              FStar_TypeChecker_Env.conj_guard uu____13626
-                                uu____13627
+                              FStar_TypeChecker_Env.conj_guard uu____13717
+                                uu____13718
                             else
                               (let guard =
-                                 let uu____13631 =
+                                 let uu____13722 =
                                    FStar_TypeChecker_Env.close_guard env1
                                      (FStar_List.append bs1 letrec_binders)
                                      guard_body
                                     in
                                  FStar_TypeChecker_Env.conj_guard g_env
-                                   uu____13631
+                                   uu____13722
                                   in
                                guard)
                              in
@@ -4773,7 +4815,7 @@ and (tc_abs :
                                  (FStar_Syntax_Util.residual_comp_of_comp
                                     (FStar_Util.dflt cbody c_opt)))
                              in
-                          let uu____13645 =
+                          let uu____13736 =
                             match tfun_opt with
                             | FStar_Pervasives_Native.Some t ->
                                 let t1 = FStar_Syntax_Subst.compress t  in
@@ -4785,34 +4827,34 @@ and (tc_abs :
                                         "Impossible! tc_abs: if tfun_computed is Some, expected topt to also be Some"
                                    in
                                 (match t1.FStar_Syntax_Syntax.n with
-                                 | FStar_Syntax_Syntax.Tm_arrow uu____13669
+                                 | FStar_Syntax_Syntax.Tm_arrow uu____13760
                                      -> (e, t_annot, guard1)
-                                 | uu____13684 ->
-                                     let uu____13685 =
+                                 | uu____13775 ->
+                                     let uu____13776 =
                                        FStar_TypeChecker_Util.check_and_ascribe
                                          env1 e tfun_computed t1
                                         in
-                                     (match uu____13685 with
+                                     (match uu____13776 with
                                       | (e1,guard') ->
-                                          let uu____13698 =
+                                          let uu____13789 =
                                             FStar_TypeChecker_Env.conj_guard
                                               guard1 guard'
                                              in
-                                          (e1, t_annot, uu____13698)))
+                                          (e1, t_annot, uu____13789)))
                             | FStar_Pervasives_Native.None  ->
                                 (e, tfun_computed, guard1)
                              in
-                          (match uu____13645 with
+                          (match uu____13736 with
                            | (e1,tfun,guard2) ->
                                let c = FStar_Syntax_Syntax.mk_Total tfun  in
-                               let uu____13709 =
-                                 let uu____13714 =
+                               let uu____13800 =
+                                 let uu____13805 =
                                    FStar_Syntax_Util.lcomp_of_comp c  in
                                  FStar_TypeChecker_Util.strengthen_precondition
                                    FStar_Pervasives_Native.None env1 e1
-                                   uu____13714 guard2
+                                   uu____13805 guard2
                                   in
-                               (match uu____13709 with
+                               (match uu____13800 with
                                 | (c1,g) -> (e1, c1, g)))))))
 
 and (check_application_args :
@@ -4836,98 +4878,98 @@ and (check_application_args :
               let n_args = FStar_List.length args  in
               let r = FStar_TypeChecker_Env.get_range env  in
               let thead = FStar_Syntax_Util.comp_result chead  in
-              (let uu____13765 =
+              (let uu____13856 =
                  FStar_TypeChecker_Env.debug env FStar_Options.High  in
-               if uu____13765
+               if uu____13856
                then
-                 let uu____13768 =
+                 let uu____13859 =
                    FStar_Range.string_of_range head1.FStar_Syntax_Syntax.pos
                     in
-                 let uu____13770 = FStar_Syntax_Print.term_to_string thead
+                 let uu____13861 = FStar_Syntax_Print.term_to_string thead
                     in
-                 FStar_Util.print2 "(%s) Type of head is %s\n" uu____13768
-                   uu____13770
+                 FStar_Util.print2 "(%s) Type of head is %s\n" uu____13859
+                   uu____13861
                else ());
-              (let monadic_application uu____13852 subst1 arg_comps_rev
+              (let monadic_application uu____13943 subst1 arg_comps_rev
                  arg_rets_rev guard fvs bs =
-                 match uu____13852 with
+                 match uu____13943 with
                  | (head2,chead1,ghead1,cres) ->
-                     let uu____13921 =
+                     let uu____14012 =
                        check_no_escape (FStar_Pervasives_Native.Some head2)
                          env fvs (FStar_Syntax_Util.comp_result cres)
                         in
-                     (match uu____13921 with
+                     (match uu____14012 with
                       | (rt,g0) ->
                           let cres1 =
                             FStar_Syntax_Util.set_result_typ cres rt  in
-                          let uu____13935 =
+                          let uu____14026 =
                             match bs with
                             | [] ->
                                 let g =
-                                  let uu____13951 =
+                                  let uu____14042 =
                                     FStar_TypeChecker_Env.conj_guard ghead1
                                       guard
                                      in
                                   FStar_All.pipe_left
                                     (FStar_TypeChecker_Env.conj_guard g0)
-                                    uu____13951
+                                    uu____14042
                                    in
                                 (cres1, g)
-                            | uu____13952 ->
+                            | uu____14043 ->
                                 let g =
-                                  let uu____13962 =
-                                    let uu____13963 =
+                                  let uu____14053 =
+                                    let uu____14054 =
                                       FStar_TypeChecker_Env.conj_guard ghead1
                                         guard
                                        in
-                                    FStar_All.pipe_right uu____13963
+                                    FStar_All.pipe_right uu____14054
                                       (FStar_TypeChecker_Rel.solve_deferred_constraints
                                          env)
                                      in
                                   FStar_TypeChecker_Env.conj_guard g0
-                                    uu____13962
+                                    uu____14053
                                    in
-                                let uu____13964 =
-                                  let uu____13965 =
+                                let uu____14055 =
+                                  let uu____14056 =
                                     FStar_Syntax_Util.arrow bs cres1  in
-                                  FStar_Syntax_Syntax.mk_Total uu____13965
+                                  FStar_Syntax_Syntax.mk_Total uu____14056
                                    in
-                                (uu____13964, g)
+                                (uu____14055, g)
                              in
-                          (match uu____13935 with
+                          (match uu____14026 with
                            | (cres2,guard1) ->
-                               ((let uu____13975 =
+                               ((let uu____14066 =
                                    FStar_TypeChecker_Env.debug env
                                      FStar_Options.Low
                                     in
-                                 if uu____13975
+                                 if uu____14066
                                  then
-                                   let uu____13978 =
+                                   let uu____14069 =
                                      FStar_Syntax_Print.comp_to_string cres2
                                       in
                                    FStar_Util.print1
                                      "\t Type of result cres is %s\n"
-                                     uu____13978
+                                     uu____14069
                                  else ());
-                                (let uu____13983 =
-                                   let uu____13988 =
-                                     let uu____13989 =
+                                (let uu____14074 =
+                                   let uu____14079 =
+                                     let uu____14080 =
                                        FStar_Syntax_Subst.subst_comp subst1
                                          chead1
                                         in
-                                     FStar_All.pipe_right uu____13989
+                                     FStar_All.pipe_right uu____14080
                                        FStar_Syntax_Util.lcomp_of_comp
                                       in
-                                   let uu____13990 =
-                                     let uu____13991 =
+                                   let uu____14081 =
+                                     let uu____14082 =
                                        FStar_Syntax_Subst.subst_comp subst1
                                          cres2
                                         in
-                                     FStar_All.pipe_right uu____13991
+                                     FStar_All.pipe_right uu____14082
                                        FStar_Syntax_Util.lcomp_of_comp
                                       in
-                                   (uu____13988, uu____13990)  in
-                                 match uu____13983 with
+                                   (uu____14079, uu____14081)  in
+                                 match uu____14074 with
                                  | (chead2,cres3) ->
                                      let cres4 =
                                        let head_is_pure_and_some_arg_is_effectful
@@ -4936,16 +4978,16 @@ and (check_application_args :
                                             chead2)
                                            &&
                                            (FStar_Util.for_some
-                                              (fun uu____14015  ->
-                                                 match uu____14015 with
-                                                 | (uu____14025,uu____14026,lc)
+                                              (fun uu____14106  ->
+                                                 match uu____14106 with
+                                                 | (uu____14116,uu____14117,lc)
                                                      ->
-                                                     (let uu____14034 =
+                                                     (let uu____14125 =
                                                         FStar_Syntax_Util.is_pure_or_ghost_lcomp
                                                           lc
                                                          in
                                                       Prims.op_Negation
-                                                        uu____14034)
+                                                        uu____14125)
                                                        ||
                                                        (FStar_TypeChecker_Util.should_not_inline_lc
                                                           lc)) arg_comps_rev)
@@ -4956,61 +4998,61 @@ and (check_application_args :
                                            FStar_Pervasives_Native.None
                                            head2.FStar_Syntax_Syntax.pos
                                           in
-                                       let uu____14047 =
+                                       let uu____14138 =
                                          (FStar_Syntax_Util.is_pure_or_ghost_lcomp
                                             cres3)
                                            &&
                                            head_is_pure_and_some_arg_is_effectful
                                           in
-                                       if uu____14047
+                                       if uu____14138
                                        then
-                                         ((let uu____14051 =
+                                         ((let uu____14142 =
                                              FStar_TypeChecker_Env.debug env
                                                FStar_Options.Extreme
                                               in
-                                           if uu____14051
+                                           if uu____14142
                                            then
-                                             let uu____14054 =
+                                             let uu____14145 =
                                                FStar_Syntax_Print.term_to_string
                                                  term
                                                 in
                                              FStar_Util.print1
                                                "(a) Monadic app: Return inserted in monadic application: %s\n"
-                                               uu____14054
+                                               uu____14145
                                            else ());
                                           FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
                                             env term cres3)
                                        else
-                                         ((let uu____14062 =
+                                         ((let uu____14153 =
                                              FStar_TypeChecker_Env.debug env
                                                FStar_Options.Extreme
                                               in
-                                           if uu____14062
+                                           if uu____14153
                                            then
-                                             let uu____14065 =
+                                             let uu____14156 =
                                                FStar_Syntax_Print.term_to_string
                                                  term
                                                 in
                                              FStar_Util.print1
                                                "(a) Monadic app: No return inserted in monadic application: %s\n"
-                                               uu____14065
+                                               uu____14156
                                            else ());
                                           cres3)
                                         in
                                      let comp =
                                        FStar_List.fold_left
                                          (fun out_c  ->
-                                            fun uu____14096  ->
-                                              match uu____14096 with
+                                            fun uu____14187  ->
+                                              match uu____14187 with
                                               | ((e,q),x,c) ->
-                                                  ((let uu____14138 =
+                                                  ((let uu____14229 =
                                                       FStar_TypeChecker_Env.debug
                                                         env
                                                         FStar_Options.Extreme
                                                        in
-                                                    if uu____14138
+                                                    if uu____14229
                                                     then
-                                                      let uu____14141 =
+                                                      let uu____14232 =
                                                         match x with
                                                         | FStar_Pervasives_Native.None
                                                              -> "_"
@@ -5019,25 +5061,25 @@ and (check_application_args :
                                                             FStar_Syntax_Print.bv_to_string
                                                               x1
                                                          in
-                                                      let uu____14146 =
+                                                      let uu____14237 =
                                                         FStar_Syntax_Print.term_to_string
                                                           e
                                                          in
-                                                      let uu____14148 =
+                                                      let uu____14239 =
                                                         FStar_Syntax_Print.lcomp_to_string
                                                           c
                                                          in
                                                       FStar_Util.print3
                                                         "(b) Monadic app: Binding argument %s : %s of type (%s)\n"
-                                                        uu____14141
-                                                        uu____14146
-                                                        uu____14148
+                                                        uu____14232
+                                                        uu____14237
+                                                        uu____14239
                                                     else ());
-                                                   (let uu____14153 =
+                                                   (let uu____14244 =
                                                       FStar_Syntax_Util.is_pure_or_ghost_lcomp
                                                         c
                                                        in
-                                                    if uu____14153
+                                                    if uu____14244
                                                     then
                                                       FStar_TypeChecker_Util.bind
                                                         e.FStar_Syntax_Syntax.pos
@@ -5053,25 +5095,25 @@ and (check_application_args :
                                          arg_comps_rev
                                         in
                                      let comp1 =
-                                       (let uu____14164 =
+                                       (let uu____14255 =
                                           FStar_TypeChecker_Env.debug env
                                             FStar_Options.Extreme
                                            in
-                                        if uu____14164
+                                        if uu____14255
                                         then
-                                          let uu____14167 =
+                                          let uu____14258 =
                                             FStar_Syntax_Print.term_to_string
                                               head2
                                              in
                                           FStar_Util.print1
                                             "(c) Monadic app: Binding head %s\n"
-                                            uu____14167
+                                            uu____14258
                                         else ());
-                                       (let uu____14172 =
+                                       (let uu____14263 =
                                           FStar_Syntax_Util.is_pure_or_ghost_lcomp
                                             chead2
                                            in
-                                        if uu____14172
+                                        if uu____14263
                                         then
                                           FStar_TypeChecker_Util.bind
                                             head2.FStar_Syntax_Syntax.pos env
@@ -5088,29 +5130,29 @@ and (check_application_args :
                                               comp))
                                         in
                                      let shortcuts_evaluation_order =
-                                       let uu____14183 =
-                                         let uu____14184 =
+                                       let uu____14274 =
+                                         let uu____14275 =
                                            FStar_Syntax_Subst.compress head2
                                             in
-                                         uu____14184.FStar_Syntax_Syntax.n
+                                         uu____14275.FStar_Syntax_Syntax.n
                                           in
-                                       match uu____14183 with
+                                       match uu____14274 with
                                        | FStar_Syntax_Syntax.Tm_fvar fv ->
                                            (FStar_Syntax_Syntax.fv_eq_lid fv
                                               FStar_Parser_Const.op_And)
                                              ||
                                              (FStar_Syntax_Syntax.fv_eq_lid
                                                 fv FStar_Parser_Const.op_Or)
-                                       | uu____14189 -> false  in
+                                       | uu____14280 -> false  in
                                      let app =
                                        if shortcuts_evaluation_order
                                        then
                                          let args1 =
                                            FStar_List.fold_left
                                              (fun args1  ->
-                                                fun uu____14212  ->
-                                                  match uu____14212 with
-                                                  | (arg,uu____14226,uu____14227)
+                                                fun uu____14303  ->
+                                                  match uu____14303 with
+                                                  | (arg,uu____14317,uu____14318)
                                                       -> arg :: args1) []
                                              arg_comps_rev
                                             in
@@ -5131,42 +5173,42 @@ and (check_application_args :
                                            comp1.FStar_Syntax_Syntax.eff_name
                                            comp1.FStar_Syntax_Syntax.res_typ
                                        else
-                                         (let uu____14238 =
-                                            let map_fun uu____14304 =
-                                              match uu____14304 with
-                                              | ((e,q),uu____14345,c) ->
-                                                  ((let uu____14368 =
+                                         (let uu____14329 =
+                                            let map_fun uu____14395 =
+                                              match uu____14395 with
+                                              | ((e,q),uu____14436,c) ->
+                                                  ((let uu____14459 =
                                                       FStar_TypeChecker_Env.debug
                                                         env
                                                         FStar_Options.Extreme
                                                        in
-                                                    if uu____14368
+                                                    if uu____14459
                                                     then
-                                                      let uu____14371 =
+                                                      let uu____14462 =
                                                         FStar_Syntax_Print.term_to_string
                                                           e
                                                          in
-                                                      let uu____14373 =
+                                                      let uu____14464 =
                                                         FStar_Syntax_Print.lcomp_to_string
                                                           c
                                                          in
                                                       FStar_Util.print2
                                                         "For arg e=(%s) c=(%s)... "
-                                                        uu____14371
-                                                        uu____14373
+                                                        uu____14462
+                                                        uu____14464
                                                     else ());
-                                                   (let uu____14378 =
+                                                   (let uu____14469 =
                                                       FStar_Syntax_Util.is_pure_or_ghost_lcomp
                                                         c
                                                        in
-                                                    if uu____14378
+                                                    if uu____14469
                                                     then
-                                                      ((let uu____14404 =
+                                                      ((let uu____14495 =
                                                           FStar_TypeChecker_Env.debug
                                                             env
                                                             FStar_Options.Extreme
                                                            in
-                                                        if uu____14404
+                                                        if uu____14495
                                                         then
                                                           FStar_Util.print_string
                                                             "... not lifting\n"
@@ -5180,67 +5222,67 @@ and (check_application_args :
                                                             env
                                                             chead2.FStar_Syntax_Syntax.res_typ)
                                                            &&
-                                                           (let uu____14445 =
-                                                              let uu____14447
+                                                           (let uu____14536 =
+                                                              let uu____14538
                                                                 =
-                                                                let uu____14448
+                                                                let uu____14539
                                                                   =
                                                                   FStar_Syntax_Util.un_uinst
                                                                     head2
                                                                    in
-                                                                uu____14448.FStar_Syntax_Syntax.n
+                                                                uu____14539.FStar_Syntax_Syntax.n
                                                                  in
-                                                              match uu____14447
+                                                              match uu____14538
                                                               with
                                                               | FStar_Syntax_Syntax.Tm_fvar
                                                                   fv ->
-                                                                  let uu____14453
+                                                                  let uu____14544
                                                                     =
                                                                     FStar_Parser_Const.psconst
                                                                     "ignore"
                                                                      in
                                                                   FStar_Syntax_Syntax.fv_eq_lid
                                                                     fv
-                                                                    uu____14453
-                                                              | uu____14455
+                                                                    uu____14544
+                                                              | uu____14546
                                                                   -> true
                                                                in
                                                             Prims.op_Negation
-                                                              uu____14445)
+                                                              uu____14536)
                                                           in
                                                        if warn_effectful_args
                                                        then
-                                                         (let uu____14459 =
-                                                            let uu____14465 =
-                                                              let uu____14467
+                                                         (let uu____14550 =
+                                                            let uu____14556 =
+                                                              let uu____14558
                                                                 =
                                                                 FStar_Syntax_Print.term_to_string
                                                                   e
                                                                  in
-                                                              let uu____14469
+                                                              let uu____14560
                                                                 =
                                                                 FStar_Syntax_Print.term_to_string
                                                                   head2
                                                                  in
                                                               FStar_Util.format3
                                                                 "Effectful argument %s (%s) to erased function %s, consider let binding it"
-                                                                uu____14467
+                                                                uu____14558
                                                                 (c.FStar_Syntax_Syntax.eff_name).FStar_Ident.str
-                                                                uu____14469
+                                                                uu____14560
                                                                in
                                                             (FStar_Errors.Warning_EffectfulArgumentToErasedFunction,
-                                                              uu____14465)
+                                                              uu____14556)
                                                              in
                                                           FStar_Errors.log_issue
                                                             e.FStar_Syntax_Syntax.pos
-                                                            uu____14459)
+                                                            uu____14550)
                                                        else ();
-                                                       (let uu____14476 =
+                                                       (let uu____14567 =
                                                           FStar_TypeChecker_Env.debug
                                                             env
                                                             FStar_Options.Extreme
                                                            in
-                                                        if uu____14476
+                                                        if uu____14567
                                                         then
                                                           FStar_Util.print_string
                                                             "... lifting!\n"
@@ -5257,62 +5299,62 @@ and (check_application_args :
                                                             comp1.FStar_Syntax_Syntax.eff_name
                                                             c.FStar_Syntax_Syntax.res_typ
                                                            in
-                                                        let uu____14484 =
-                                                          let uu____14493 =
+                                                        let uu____14575 =
+                                                          let uu____14584 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               x
                                                              in
-                                                          (uu____14493, q)
+                                                          (uu____14584, q)
                                                            in
                                                         ((FStar_Pervasives_Native.Some
                                                             (x,
                                                               (c.FStar_Syntax_Syntax.eff_name),
                                                               (c.FStar_Syntax_Syntax.res_typ),
                                                               e1)),
-                                                          uu____14484)))))
+                                                          uu____14575)))))
                                                in
-                                            let uu____14522 =
-                                              let uu____14553 =
-                                                let uu____14582 =
-                                                  let uu____14593 =
-                                                    let uu____14602 =
+                                            let uu____14613 =
+                                              let uu____14644 =
+                                                let uu____14673 =
+                                                  let uu____14684 =
+                                                    let uu____14693 =
                                                       FStar_Syntax_Syntax.as_arg
                                                         head2
                                                        in
-                                                    (uu____14602,
+                                                    (uu____14693,
                                                       FStar_Pervasives_Native.None,
                                                       chead2)
                                                      in
-                                                  uu____14593 ::
+                                                  uu____14684 ::
                                                     arg_comps_rev
                                                    in
                                                 FStar_List.map map_fun
-                                                  uu____14582
+                                                  uu____14673
                                                  in
                                               FStar_All.pipe_left
-                                                FStar_List.split uu____14553
+                                                FStar_List.split uu____14644
                                                in
-                                            match uu____14522 with
+                                            match uu____14613 with
                                             | (lifted_args,reverse_args) ->
-                                                let uu____14803 =
-                                                  let uu____14804 =
+                                                let uu____14894 =
+                                                  let uu____14895 =
                                                     FStar_List.hd
                                                       reverse_args
                                                      in
                                                   FStar_Pervasives_Native.fst
-                                                    uu____14804
+                                                    uu____14895
                                                    in
-                                                let uu____14825 =
-                                                  let uu____14826 =
+                                                let uu____14916 =
+                                                  let uu____14917 =
                                                     FStar_List.tl
                                                       reverse_args
                                                      in
-                                                  FStar_List.rev uu____14826
+                                                  FStar_List.rev uu____14917
                                                    in
-                                                (lifted_args, uu____14803,
-                                                  uu____14825)
+                                                (lifted_args, uu____14894,
+                                                  uu____14916)
                                              in
-                                          match uu____14238 with
+                                          match uu____14329 with
                                           | (lifted_args,head3,args1) ->
                                               let app =
                                                 FStar_Syntax_Syntax.mk_Tm_app
@@ -5334,8 +5376,8 @@ and (check_application_args :
                                                   comp1.FStar_Syntax_Syntax.res_typ
                                                  in
                                               let bind_lifted_args e
-                                                uu___6_14937 =
-                                                match uu___6_14937 with
+                                                uu___6_15028 =
+                                                match uu___6_15028 with
                                                 | FStar_Pervasives_Native.None
                                                      -> e
                                                 | FStar_Pervasives_Native.Some
@@ -5347,32 +5389,32 @@ and (check_application_args :
                                                         e1.FStar_Syntax_Syntax.pos
                                                        in
                                                     let letbinding =
-                                                      let uu____14998 =
-                                                        let uu____15005 =
-                                                          let uu____15006 =
-                                                            let uu____15020 =
-                                                              let uu____15023
+                                                      let uu____15089 =
+                                                        let uu____15096 =
+                                                          let uu____15097 =
+                                                            let uu____15111 =
+                                                              let uu____15114
                                                                 =
-                                                                let uu____15024
+                                                                let uu____15115
                                                                   =
                                                                   FStar_Syntax_Syntax.mk_binder
                                                                     x
                                                                    in
-                                                                [uu____15024]
+                                                                [uu____15115]
                                                                  in
                                                               FStar_Syntax_Subst.close
-                                                                uu____15023 e
+                                                                uu____15114 e
                                                                in
                                                             ((false, [lb]),
-                                                              uu____15020)
+                                                              uu____15111)
                                                              in
                                                           FStar_Syntax_Syntax.Tm_let
-                                                            uu____15006
+                                                            uu____15097
                                                            in
                                                         FStar_Syntax_Syntax.mk
-                                                          uu____15005
+                                                          uu____15096
                                                          in
-                                                      uu____14998
+                                                      uu____15089
                                                         FStar_Pervasives_Native.None
                                                         e.FStar_Syntax_Syntax.pos
                                                        in
@@ -5389,207 +5431,207 @@ and (check_application_args :
                                                 bind_lifted_args app2
                                                 lifted_args)
                                         in
-                                     let uu____15076 =
+                                     let uu____15167 =
                                        FStar_TypeChecker_Util.strengthen_precondition
                                          FStar_Pervasives_Native.None env app
                                          comp1 guard1
                                         in
-                                     (match uu____15076 with
+                                     (match uu____15167 with
                                       | (comp2,g) ->
-                                          ((let uu____15094 =
+                                          ((let uu____15185 =
                                               FStar_TypeChecker_Env.debug env
                                                 FStar_Options.Extreme
                                                in
-                                            if uu____15094
+                                            if uu____15185
                                             then
-                                              let uu____15097 =
+                                              let uu____15188 =
                                                 FStar_Syntax_Print.term_to_string
                                                   app
                                                  in
-                                              let uu____15099 =
+                                              let uu____15190 =
                                                 FStar_Syntax_Print.lcomp_to_string
                                                   comp2
                                                  in
                                               FStar_Util.print2
                                                 "(d) Monadic app: type of app\n\t(%s)\n\t: %s\n"
-                                                uu____15097 uu____15099
+                                                uu____15188 uu____15190
                                             else ());
                                            (app, comp2, g)))))))
                   in
-               let rec tc_args head_info uu____15180 bs args1 =
-                 match uu____15180 with
+               let rec tc_args head_info uu____15271 bs args1 =
+                 match uu____15271 with
                  | (subst1,outargs,arg_rets,g,fvs) ->
                      (match (bs, args1) with
                       | ((x,FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Implicit uu____15319))::rest,
-                         (uu____15321,FStar_Pervasives_Native.None )::uu____15322)
+                          (FStar_Syntax_Syntax.Implicit uu____15410))::rest,
+                         (uu____15412,FStar_Pervasives_Native.None )::uu____15413)
                           ->
                           let t =
                             FStar_Syntax_Subst.subst subst1
                               x.FStar_Syntax_Syntax.sort
                              in
-                          let uu____15383 =
+                          let uu____15474 =
                             check_no_escape
                               (FStar_Pervasives_Native.Some head1) env fvs t
                              in
-                          (match uu____15383 with
+                          (match uu____15474 with
                            | (t1,g_ex) ->
-                               let uu____15396 =
+                               let uu____15487 =
                                  FStar_TypeChecker_Util.new_implicit_var
                                    "Instantiating implicit argument in application"
                                    head1.FStar_Syntax_Syntax.pos env t1
                                   in
-                               (match uu____15396 with
-                                | (varg,uu____15417,implicits) ->
+                               (match uu____15487 with
+                                | (varg,uu____15508,implicits) ->
                                     let subst2 =
                                       (FStar_Syntax_Syntax.NT (x, varg)) ::
                                       subst1  in
                                     let arg =
-                                      let uu____15445 =
+                                      let uu____15536 =
                                         FStar_Syntax_Syntax.as_implicit true
                                          in
-                                      (varg, uu____15445)  in
+                                      (varg, uu____15536)  in
                                     let guard =
                                       FStar_List.fold_right
                                         FStar_TypeChecker_Env.conj_guard
                                         [g_ex; g] implicits
                                        in
-                                    let uu____15454 =
-                                      let uu____15489 =
-                                        let uu____15500 =
-                                          let uu____15509 =
-                                            let uu____15510 =
+                                    let uu____15545 =
+                                      let uu____15580 =
+                                        let uu____15591 =
+                                          let uu____15600 =
+                                            let uu____15601 =
                                               FStar_Syntax_Syntax.mk_Total t1
                                                in
-                                            FStar_All.pipe_right uu____15510
+                                            FStar_All.pipe_right uu____15601
                                               FStar_Syntax_Util.lcomp_of_comp
                                              in
                                           (arg, FStar_Pervasives_Native.None,
-                                            uu____15509)
+                                            uu____15600)
                                            in
-                                        uu____15500 :: outargs  in
-                                      (subst2, uu____15489, (arg ::
+                                        uu____15591 :: outargs  in
+                                      (subst2, uu____15580, (arg ::
                                         arg_rets), guard, fvs)
                                        in
-                                    tc_args head_info uu____15454 rest args1))
+                                    tc_args head_info uu____15545 rest args1))
                       | ((x,FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Meta tau))::rest,(uu____15556,FStar_Pervasives_Native.None
-                                                                 )::uu____15557)
+                          (FStar_Syntax_Syntax.Meta tau))::rest,(uu____15647,FStar_Pervasives_Native.None
+                                                                 )::uu____15648)
                           ->
                           let tau1 = FStar_Syntax_Subst.subst subst1 tau  in
-                          let uu____15619 = tc_tactic env tau1  in
-                          (match uu____15619 with
-                           | (tau2,uu____15633,g_tau) ->
+                          let uu____15710 = tc_tactic env tau1  in
+                          (match uu____15710 with
+                           | (tau2,uu____15724,g_tau) ->
                                let t =
                                  FStar_Syntax_Subst.subst subst1
                                    x.FStar_Syntax_Syntax.sort
                                   in
-                               let uu____15636 =
+                               let uu____15727 =
                                  check_no_escape
                                    (FStar_Pervasives_Native.Some head1) env
                                    fvs t
                                   in
-                               (match uu____15636 with
+                               (match uu____15727 with
                                 | (t1,g_ex) ->
-                                    let uu____15649 =
-                                      let uu____15662 =
-                                        let uu____15669 =
-                                          let uu____15674 =
+                                    let uu____15740 =
+                                      let uu____15753 =
+                                        let uu____15760 =
+                                          let uu____15765 =
                                             FStar_Dyn.mkdyn env  in
-                                          (uu____15674, tau2)  in
+                                          (uu____15765, tau2)  in
                                         FStar_Pervasives_Native.Some
-                                          uu____15669
+                                          uu____15760
                                          in
                                       FStar_TypeChecker_Env.new_implicit_var_aux
                                         "Instantiating meta argument in application"
                                         head1.FStar_Syntax_Syntax.pos env t1
                                         FStar_Syntax_Syntax.Strict
-                                        uu____15662
+                                        uu____15753
                                        in
-                                    (match uu____15649 with
-                                     | (varg,uu____15687,implicits) ->
+                                    (match uu____15740 with
+                                     | (varg,uu____15778,implicits) ->
                                          let subst2 =
                                            (FStar_Syntax_Syntax.NT (x, varg))
                                            :: subst1  in
                                          let arg =
-                                           let uu____15715 =
+                                           let uu____15806 =
                                              FStar_Syntax_Syntax.as_implicit
                                                true
                                               in
-                                           (varg, uu____15715)  in
+                                           (varg, uu____15806)  in
                                          let guard =
                                            FStar_List.fold_right
                                              FStar_TypeChecker_Env.conj_guard
                                              [g_ex; g; g_tau] implicits
                                             in
-                                         let uu____15724 =
-                                           let uu____15759 =
-                                             let uu____15770 =
-                                               let uu____15779 =
-                                                 let uu____15780 =
+                                         let uu____15815 =
+                                           let uu____15850 =
+                                             let uu____15861 =
+                                               let uu____15870 =
+                                                 let uu____15871 =
                                                    FStar_Syntax_Syntax.mk_Total
                                                      t1
                                                     in
                                                  FStar_All.pipe_right
-                                                   uu____15780
+                                                   uu____15871
                                                    FStar_Syntax_Util.lcomp_of_comp
                                                   in
                                                (arg,
                                                  FStar_Pervasives_Native.None,
-                                                 uu____15779)
+                                                 uu____15870)
                                                 in
-                                             uu____15770 :: outargs  in
-                                           (subst2, uu____15759, (arg ::
+                                             uu____15861 :: outargs  in
+                                           (subst2, uu____15850, (arg ::
                                              arg_rets), guard, fvs)
                                             in
-                                         tc_args head_info uu____15724 rest
+                                         tc_args head_info uu____15815 rest
                                            args1)))
                       | ((x,aqual)::rest,(e,aq)::rest') ->
                           ((match (aqual, aq) with
-                            | (uu____15896,FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Meta uu____15897)) ->
+                            | (uu____15987,FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Meta uu____15988)) ->
                                 FStar_Errors.raise_error
                                   (FStar_Errors.Fatal_InconsistentImplicitQualifier,
                                     "Inconsistent implicit qualifier; cannot apply meta arguments, just use #")
                                   e.FStar_Syntax_Syntax.pos
                             | (FStar_Pervasives_Native.Some
                                (FStar_Syntax_Syntax.Meta
-                               uu____15908),FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu____15909)) ->
+                               uu____15999),FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Implicit uu____16000)) ->
                                 ()
                             | (FStar_Pervasives_Native.Some
                                (FStar_Syntax_Syntax.Implicit
-                               uu____15917),FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu____15918)) ->
+                               uu____16008),FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Implicit uu____16009)) ->
                                 ()
                             | (FStar_Pervasives_Native.None
                                ,FStar_Pervasives_Native.None ) -> ()
                             | (FStar_Pervasives_Native.Some
                                (FStar_Syntax_Syntax.Equality
                                ),FStar_Pervasives_Native.None ) -> ()
-                            | uu____15933 ->
-                                let uu____15942 =
-                                  let uu____15948 =
-                                    let uu____15950 =
+                            | uu____16024 ->
+                                let uu____16033 =
+                                  let uu____16039 =
+                                    let uu____16041 =
                                       FStar_Syntax_Print.aqual_to_string
                                         aqual
                                        in
-                                    let uu____15952 =
+                                    let uu____16043 =
                                       FStar_Syntax_Print.aqual_to_string aq
                                        in
-                                    let uu____15954 =
+                                    let uu____16045 =
                                       FStar_Syntax_Print.bv_to_string x  in
-                                    let uu____15956 =
+                                    let uu____16047 =
                                       FStar_Syntax_Print.term_to_string e  in
                                     FStar_Util.format4
                                       "Inconsistent implicit qualifier; %s vs %s\nfor bvar %s and term %s"
-                                      uu____15950 uu____15952 uu____15954
-                                      uu____15956
+                                      uu____16041 uu____16043 uu____16045
+                                      uu____16047
                                      in
                                   (FStar_Errors.Fatal_InconsistentImplicitQualifier,
-                                    uu____15948)
+                                    uu____16039)
                                    in
-                                FStar_Errors.raise_error uu____15942
+                                FStar_Errors.raise_error uu____16033
                                   e.FStar_Syntax_Syntax.pos);
                            (let targ =
                               FStar_Syntax_Subst.subst subst1
@@ -5598,190 +5640,193 @@ and (check_application_args :
                             let aqual1 =
                               FStar_Syntax_Subst.subst_imp subst1 aqual  in
                             let x1 =
-                              let uu___2136_15963 = x  in
+                              let uu___2145_16054 = x  in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___2136_15963.FStar_Syntax_Syntax.ppname);
+                                  (uu___2145_16054.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___2136_15963.FStar_Syntax_Syntax.index);
+                                  (uu___2145_16054.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = targ
                               }  in
-                            (let uu____15965 =
+                            (let uu____16056 =
                                FStar_TypeChecker_Env.debug env
                                  FStar_Options.Extreme
                                 in
-                             if uu____15965
+                             if uu____16056
                              then
-                               let uu____15968 =
+                               let uu____16059 =
                                  FStar_Syntax_Print.bv_to_string x1  in
-                               let uu____15970 =
+                               let uu____16061 =
                                  FStar_Syntax_Print.term_to_string
                                    x1.FStar_Syntax_Syntax.sort
                                   in
-                               let uu____15972 =
+                               let uu____16063 =
                                  FStar_Syntax_Print.term_to_string e  in
-                               let uu____15974 =
+                               let uu____16065 =
                                  FStar_Syntax_Print.subst_to_string subst1
                                   in
-                               let uu____15976 =
+                               let uu____16067 =
                                  FStar_Syntax_Print.term_to_string targ  in
                                FStar_Util.print5
                                  "\tFormal is %s : %s\tType of arg %s (after subst %s) = %s\n"
-                                 uu____15968 uu____15970 uu____15972
-                                 uu____15974 uu____15976
+                                 uu____16059 uu____16061 uu____16063
+                                 uu____16065 uu____16067
                              else ());
-                            (let uu____15981 =
+                            (let uu____16072 =
                                check_no_escape
                                  (FStar_Pervasives_Native.Some head1) env fvs
                                  targ
                                 in
-                             match uu____15981 with
+                             match uu____16072 with
                              | (targ1,g_ex) ->
                                  let env1 =
                                    FStar_TypeChecker_Env.set_expected_typ env
                                      targ1
                                     in
                                  let env2 =
-                                   let uu___2145_15996 = env1  in
+                                   let uu___2154_16087 = env1  in
                                    {
                                      FStar_TypeChecker_Env.solver =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.solver);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.solver);
                                      FStar_TypeChecker_Env.range =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.range);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.range);
                                      FStar_TypeChecker_Env.curmodule =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.curmodule);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.curmodule);
                                      FStar_TypeChecker_Env.gamma =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.gamma);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.gamma);
                                      FStar_TypeChecker_Env.gamma_sig =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.gamma_sig);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.gamma_sig);
                                      FStar_TypeChecker_Env.gamma_cache =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.gamma_cache);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.gamma_cache);
                                      FStar_TypeChecker_Env.modules =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.modules);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.modules);
                                      FStar_TypeChecker_Env.expected_typ =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.expected_typ);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.expected_typ);
                                      FStar_TypeChecker_Env.sigtab =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.sigtab);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.sigtab);
                                      FStar_TypeChecker_Env.attrtab =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.attrtab);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.attrtab);
                                      FStar_TypeChecker_Env.is_pattern =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.is_pattern);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.is_pattern);
                                      FStar_TypeChecker_Env.instantiate_imp =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.instantiate_imp);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.instantiate_imp);
                                      FStar_TypeChecker_Env.effects =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.effects);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.effects);
                                      FStar_TypeChecker_Env.generalize =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.generalize);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.generalize);
                                      FStar_TypeChecker_Env.letrecs =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.letrecs);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.letrecs);
                                      FStar_TypeChecker_Env.top_level =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.top_level);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.top_level);
                                      FStar_TypeChecker_Env.check_uvars =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.check_uvars);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.check_uvars);
                                      FStar_TypeChecker_Env.use_eq =
                                        (is_eq aqual1);
                                      FStar_TypeChecker_Env.is_iface =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.is_iface);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.is_iface);
                                      FStar_TypeChecker_Env.admit =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.admit);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.admit);
                                      FStar_TypeChecker_Env.lax =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.lax);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.lax);
                                      FStar_TypeChecker_Env.lax_universes =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.lax_universes);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.lax_universes);
                                      FStar_TypeChecker_Env.phase1 =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.phase1);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.phase1);
                                      FStar_TypeChecker_Env.failhard =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.failhard);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.failhard);
                                      FStar_TypeChecker_Env.nosynth =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.nosynth);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.nosynth);
                                      FStar_TypeChecker_Env.uvar_subtyping =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.uvar_subtyping);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.uvar_subtyping);
                                      FStar_TypeChecker_Env.tc_term =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.tc_term);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.tc_term);
                                      FStar_TypeChecker_Env.type_of =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.type_of);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.type_of);
                                      FStar_TypeChecker_Env.universe_of =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.universe_of);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.universe_of);
                                      FStar_TypeChecker_Env.check_type_of =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.check_type_of);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.check_type_of);
                                      FStar_TypeChecker_Env.use_bv_sorts =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.use_bv_sorts);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.use_bv_sorts);
                                      FStar_TypeChecker_Env.qtbl_name_and_index
                                        =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.qtbl_name_and_index);
                                      FStar_TypeChecker_Env.normalized_eff_names
                                        =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.normalized_eff_names);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.normalized_eff_names);
                                      FStar_TypeChecker_Env.fv_delta_depths =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.fv_delta_depths);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.fv_delta_depths);
                                      FStar_TypeChecker_Env.proof_ns =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.proof_ns);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.proof_ns);
                                      FStar_TypeChecker_Env.synth_hook =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.synth_hook);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.synth_hook);
                                      FStar_TypeChecker_Env.splice =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.splice);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.splice);
                                      FStar_TypeChecker_Env.postprocess =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.postprocess);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.postprocess);
                                      FStar_TypeChecker_Env.is_native_tactic =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.is_native_tactic);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.is_native_tactic);
                                      FStar_TypeChecker_Env.identifier_info =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.identifier_info);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.identifier_info);
                                      FStar_TypeChecker_Env.tc_hooks =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.tc_hooks);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.tc_hooks);
                                      FStar_TypeChecker_Env.dsenv =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.dsenv);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.dsenv);
                                      FStar_TypeChecker_Env.nbe =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.nbe);
+                                       (uu___2154_16087.FStar_TypeChecker_Env.nbe);
                                      FStar_TypeChecker_Env.strict_args_tab =
-                                       (uu___2145_15996.FStar_TypeChecker_Env.strict_args_tab)
+                                       (uu___2154_16087.FStar_TypeChecker_Env.strict_args_tab);
+                                     FStar_TypeChecker_Env.erasable_types_tab
+                                       =
+                                       (uu___2154_16087.FStar_TypeChecker_Env.erasable_types_tab)
                                    }  in
-                                 ((let uu____15998 =
+                                 ((let uu____16089 =
                                      FStar_TypeChecker_Env.debug env2
                                        FStar_Options.High
                                       in
-                                   if uu____15998
+                                   if uu____16089
                                    then
-                                     let uu____16001 =
+                                     let uu____16092 =
                                        FStar_Syntax_Print.tag_of_term e  in
-                                     let uu____16003 =
+                                     let uu____16094 =
                                        FStar_Syntax_Print.term_to_string e
                                         in
-                                     let uu____16005 =
+                                     let uu____16096 =
                                        FStar_Syntax_Print.term_to_string
                                          targ1
                                         in
                                      FStar_Util.print3
                                        "Checking arg (%s) %s at type %s\n"
-                                       uu____16001 uu____16003 uu____16005
+                                       uu____16092 uu____16094 uu____16096
                                    else ());
-                                  (let uu____16010 = tc_term env2 e  in
-                                   match uu____16010 with
+                                  (let uu____16101 = tc_term env2 e  in
+                                   match uu____16101 with
                                    | (e1,c,g_e) ->
                                        let g1 =
-                                         let uu____16027 =
+                                         let uu____16118 =
                                            FStar_TypeChecker_Env.conj_guard g
                                              g_e
                                             in
                                          FStar_All.pipe_left
                                            (FStar_TypeChecker_Env.conj_guard
-                                              g_ex) uu____16027
+                                              g_ex) uu____16118
                                           in
                                        let arg = (e1, aq)  in
                                        let xterm =
-                                         let uu____16050 =
-                                           let uu____16053 =
-                                             let uu____16062 =
+                                         let uu____16141 =
+                                           let uu____16144 =
+                                             let uu____16153 =
                                                FStar_Syntax_Syntax.bv_to_name
                                                  x1
                                                 in
                                              FStar_Syntax_Syntax.as_arg
-                                               uu____16062
+                                               uu____16153
                                               in
                                            FStar_Pervasives_Native.fst
-                                             uu____16053
+                                             uu____16144
                                             in
-                                         (uu____16050, aq)  in
-                                       let uu____16071 =
+                                         (uu____16141, aq)  in
+                                       let uu____16162 =
                                          (FStar_Syntax_Util.is_tot_or_gtot_lcomp
                                             c)
                                            ||
@@ -5789,13 +5834,13 @@ and (check_application_args :
                                               env2
                                               c.FStar_Syntax_Syntax.eff_name)
                                           in
-                                       if uu____16071
+                                       if uu____16162
                                        then
                                          let subst2 =
-                                           let uu____16081 = FStar_List.hd bs
+                                           let uu____16172 = FStar_List.hd bs
                                               in
                                            maybe_extend_subst subst1
-                                             uu____16081 e1
+                                             uu____16172 e1
                                             in
                                          tc_args head_info
                                            (subst2,
@@ -5812,41 +5857,41 @@ and (check_application_args :
                                                    x1), c) :: outargs),
                                              (xterm :: arg_rets), g1, (x1 ::
                                              fvs)) rest rest')))))
-                      | (uu____16180,[]) ->
+                      | (uu____16271,[]) ->
                           monadic_application head_info subst1 outargs
                             arg_rets g fvs bs
-                      | ([],arg::uu____16216) ->
-                          let uu____16267 =
+                      | ([],arg::uu____16307) ->
+                          let uu____16358 =
                             monadic_application head_info subst1 outargs
                               arg_rets g fvs []
                              in
-                          (match uu____16267 with
+                          (match uu____16358 with
                            | (head2,chead1,ghead1) ->
                                let chead2 =
                                  FStar_Syntax_Syntax.lcomp_comp chead1  in
                                let rec aux norm1 solve ghead2 tres =
                                  let tres1 =
-                                   let uu____16324 =
+                                   let uu____16415 =
                                      FStar_Syntax_Subst.compress tres  in
-                                   FStar_All.pipe_right uu____16324
+                                   FStar_All.pipe_right uu____16415
                                      FStar_Syntax_Util.unrefine
                                     in
                                  match tres1.FStar_Syntax_Syntax.n with
                                  | FStar_Syntax_Syntax.Tm_arrow (bs1,cres')
                                      ->
-                                     let uu____16355 =
+                                     let uu____16446 =
                                        FStar_Syntax_Subst.open_comp bs1 cres'
                                         in
-                                     (match uu____16355 with
+                                     (match uu____16446 with
                                       | (bs2,cres'1) ->
                                           let head_info1 =
                                             (head2, chead2, ghead2, cres'1)
                                              in
-                                          ((let uu____16378 =
+                                          ((let uu____16469 =
                                               FStar_TypeChecker_Env.debug env
                                                 FStar_Options.Low
                                                in
-                                            if uu____16378
+                                            if uu____16469
                                             then
                                               FStar_Errors.log_issue
                                                 tres1.FStar_Syntax_Syntax.pos
@@ -5857,325 +5902,325 @@ and (check_application_args :
                                              ([], [], [],
                                                FStar_TypeChecker_Env.trivial_guard,
                                                []) bs2 args1))
-                                 | uu____16425 when Prims.op_Negation norm1
+                                 | uu____16516 when Prims.op_Negation norm1
                                      ->
                                      let rec norm_tres tres2 =
                                        let tres3 =
-                                         let uu____16433 =
+                                         let uu____16524 =
                                            FStar_All.pipe_right tres2
                                              (FStar_TypeChecker_Normalize.unfold_whnf
                                                 env)
                                             in
-                                         FStar_All.pipe_right uu____16433
+                                         FStar_All.pipe_right uu____16524
                                            FStar_Syntax_Util.unascribe
                                           in
-                                       let uu____16434 =
-                                         let uu____16435 =
+                                       let uu____16525 =
+                                         let uu____16526 =
                                            FStar_Syntax_Subst.compress tres3
                                             in
-                                         uu____16435.FStar_Syntax_Syntax.n
+                                         uu____16526.FStar_Syntax_Syntax.n
                                           in
-                                       match uu____16434 with
+                                       match uu____16525 with
                                        | FStar_Syntax_Syntax.Tm_refine
                                            ({
                                               FStar_Syntax_Syntax.ppname =
-                                                uu____16438;
+                                                uu____16529;
                                               FStar_Syntax_Syntax.index =
-                                                uu____16439;
+                                                uu____16530;
                                               FStar_Syntax_Syntax.sort =
-                                                tres4;_},uu____16441)
+                                                tres4;_},uu____16532)
                                            -> norm_tres tres4
-                                       | uu____16449 -> tres3  in
-                                     let uu____16450 = norm_tres tres1  in
-                                     aux true solve ghead2 uu____16450
-                                 | uu____16452 when Prims.op_Negation solve
+                                       | uu____16540 -> tres3  in
+                                     let uu____16541 = norm_tres tres1  in
+                                     aux true solve ghead2 uu____16541
+                                 | uu____16543 when Prims.op_Negation solve
                                      ->
                                      let ghead3 =
                                        FStar_TypeChecker_Rel.solve_deferred_constraints
                                          env ghead2
                                         in
                                      aux norm1 true ghead3 tres1
-                                 | uu____16455 ->
-                                     let uu____16456 =
-                                       let uu____16462 =
-                                         let uu____16464 =
+                                 | uu____16546 ->
+                                     let uu____16547 =
+                                       let uu____16553 =
+                                         let uu____16555 =
                                            FStar_TypeChecker_Normalize.term_to_string
                                              env thead
                                             in
-                                         let uu____16466 =
+                                         let uu____16557 =
                                            FStar_Util.string_of_int n_args
                                             in
-                                         let uu____16468 =
+                                         let uu____16559 =
                                            FStar_Syntax_Print.term_to_string
                                              tres1
                                             in
                                          FStar_Util.format3
                                            "Too many arguments to function of type %s; got %s arguments, remaining type is %s"
-                                           uu____16464 uu____16466
-                                           uu____16468
+                                           uu____16555 uu____16557
+                                           uu____16559
                                           in
                                        (FStar_Errors.Fatal_ToManyArgumentToFunction,
-                                         uu____16462)
+                                         uu____16553)
                                         in
-                                     let uu____16472 =
+                                     let uu____16563 =
                                        FStar_Syntax_Syntax.argpos arg  in
-                                     FStar_Errors.raise_error uu____16456
-                                       uu____16472
+                                     FStar_Errors.raise_error uu____16547
+                                       uu____16563
                                   in
                                aux false false ghead1
                                  (FStar_Syntax_Util.comp_result chead2)))
                   in
                let rec check_function_app tf guard =
-                 let uu____16502 =
-                   let uu____16503 =
+                 let uu____16593 =
+                   let uu____16594 =
                      FStar_TypeChecker_Normalize.unfold_whnf env tf  in
-                   uu____16503.FStar_Syntax_Syntax.n  in
-                 match uu____16502 with
-                 | FStar_Syntax_Syntax.Tm_uvar uu____16512 ->
-                     let uu____16525 =
+                   uu____16594.FStar_Syntax_Syntax.n  in
+                 match uu____16593 with
+                 | FStar_Syntax_Syntax.Tm_uvar uu____16603 ->
+                     let uu____16616 =
                        FStar_List.fold_right
-                         (fun uu____16556  ->
-                            fun uu____16557  ->
-                              match uu____16557 with
+                         (fun uu____16647  ->
+                            fun uu____16648  ->
+                              match uu____16648 with
                               | (bs,guard1) ->
-                                  let uu____16584 =
-                                    let uu____16597 =
-                                      let uu____16598 =
+                                  let uu____16675 =
+                                    let uu____16688 =
+                                      let uu____16689 =
                                         FStar_Syntax_Util.type_u ()  in
-                                      FStar_All.pipe_right uu____16598
+                                      FStar_All.pipe_right uu____16689
                                         FStar_Pervasives_Native.fst
                                        in
                                     FStar_TypeChecker_Util.new_implicit_var
                                       "formal parameter"
                                       tf.FStar_Syntax_Syntax.pos env
-                                      uu____16597
+                                      uu____16688
                                      in
-                                  (match uu____16584 with
-                                   | (t,uu____16615,g) ->
-                                       let uu____16629 =
-                                         let uu____16632 =
+                                  (match uu____16675 with
+                                   | (t,uu____16706,g) ->
+                                       let uu____16720 =
+                                         let uu____16723 =
                                            FStar_Syntax_Syntax.null_binder t
                                             in
-                                         uu____16632 :: bs  in
-                                       let uu____16633 =
+                                         uu____16723 :: bs  in
+                                       let uu____16724 =
                                          FStar_TypeChecker_Env.conj_guard g
                                            guard1
                                           in
-                                       (uu____16629, uu____16633))) args
+                                       (uu____16720, uu____16724))) args
                          ([], guard)
                         in
-                     (match uu____16525 with
+                     (match uu____16616 with
                       | (bs,guard1) ->
-                          let uu____16650 =
-                            let uu____16657 =
-                              let uu____16670 =
-                                let uu____16671 = FStar_Syntax_Util.type_u ()
+                          let uu____16741 =
+                            let uu____16748 =
+                              let uu____16761 =
+                                let uu____16762 = FStar_Syntax_Util.type_u ()
                                    in
-                                FStar_All.pipe_right uu____16671
+                                FStar_All.pipe_right uu____16762
                                   FStar_Pervasives_Native.fst
                                  in
                               FStar_TypeChecker_Util.new_implicit_var
                                 "result type" tf.FStar_Syntax_Syntax.pos env
-                                uu____16670
+                                uu____16761
                                in
-                            match uu____16657 with
-                            | (t,uu____16688,g) ->
-                                let uu____16702 = FStar_Options.ml_ish ()  in
-                                if uu____16702
+                            match uu____16748 with
+                            | (t,uu____16779,g) ->
+                                let uu____16793 = FStar_Options.ml_ish ()  in
+                                if uu____16793
                                 then
-                                  let uu____16711 =
+                                  let uu____16802 =
                                     FStar_Syntax_Util.ml_comp t r  in
-                                  let uu____16714 =
+                                  let uu____16805 =
                                     FStar_TypeChecker_Env.conj_guard guard1 g
                                      in
-                                  (uu____16711, uu____16714)
+                                  (uu____16802, uu____16805)
                                 else
-                                  (let uu____16719 =
+                                  (let uu____16810 =
                                      FStar_Syntax_Syntax.mk_Total t  in
-                                   let uu____16722 =
+                                   let uu____16813 =
                                      FStar_TypeChecker_Env.conj_guard guard1
                                        g
                                       in
-                                   (uu____16719, uu____16722))
+                                   (uu____16810, uu____16813))
                              in
-                          (match uu____16650 with
+                          (match uu____16741 with
                            | (cres,guard2) ->
                                let bs_cres = FStar_Syntax_Util.arrow bs cres
                                   in
-                               ((let uu____16741 =
+                               ((let uu____16832 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env)
                                      FStar_Options.Extreme
                                     in
-                                 if uu____16741
+                                 if uu____16832
                                  then
-                                   let uu____16745 =
+                                   let uu____16836 =
                                      FStar_Syntax_Print.term_to_string head1
                                       in
-                                   let uu____16747 =
+                                   let uu____16838 =
                                      FStar_Syntax_Print.term_to_string tf  in
-                                   let uu____16749 =
+                                   let uu____16840 =
                                      FStar_Syntax_Print.term_to_string
                                        bs_cres
                                       in
                                    FStar_Util.print3
                                      "Forcing the type of %s from %s to %s\n"
-                                     uu____16745 uu____16747 uu____16749
+                                     uu____16836 uu____16838 uu____16840
                                  else ());
                                 (let g =
-                                   let uu____16755 =
+                                   let uu____16846 =
                                      FStar_TypeChecker_Rel.teq env tf bs_cres
                                       in
                                    FStar_TypeChecker_Rel.solve_deferred_constraints
-                                     env uu____16755
+                                     env uu____16846
                                     in
-                                 let uu____16756 =
+                                 let uu____16847 =
                                    FStar_TypeChecker_Env.conj_guard g guard2
                                     in
-                                 check_function_app bs_cres uu____16756))))
+                                 check_function_app bs_cres uu____16847))))
                  | FStar_Syntax_Syntax.Tm_app
                      ({
                         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                          uu____16757;
-                        FStar_Syntax_Syntax.pos = uu____16758;
-                        FStar_Syntax_Syntax.vars = uu____16759;_},uu____16760)
+                          uu____16848;
+                        FStar_Syntax_Syntax.pos = uu____16849;
+                        FStar_Syntax_Syntax.vars = uu____16850;_},uu____16851)
                      ->
-                     let uu____16797 =
+                     let uu____16888 =
                        FStar_List.fold_right
-                         (fun uu____16828  ->
-                            fun uu____16829  ->
-                              match uu____16829 with
+                         (fun uu____16919  ->
+                            fun uu____16920  ->
+                              match uu____16920 with
                               | (bs,guard1) ->
-                                  let uu____16856 =
-                                    let uu____16869 =
-                                      let uu____16870 =
+                                  let uu____16947 =
+                                    let uu____16960 =
+                                      let uu____16961 =
                                         FStar_Syntax_Util.type_u ()  in
-                                      FStar_All.pipe_right uu____16870
+                                      FStar_All.pipe_right uu____16961
                                         FStar_Pervasives_Native.fst
                                        in
                                     FStar_TypeChecker_Util.new_implicit_var
                                       "formal parameter"
                                       tf.FStar_Syntax_Syntax.pos env
-                                      uu____16869
+                                      uu____16960
                                      in
-                                  (match uu____16856 with
-                                   | (t,uu____16887,g) ->
-                                       let uu____16901 =
-                                         let uu____16904 =
+                                  (match uu____16947 with
+                                   | (t,uu____16978,g) ->
+                                       let uu____16992 =
+                                         let uu____16995 =
                                            FStar_Syntax_Syntax.null_binder t
                                             in
-                                         uu____16904 :: bs  in
-                                       let uu____16905 =
+                                         uu____16995 :: bs  in
+                                       let uu____16996 =
                                          FStar_TypeChecker_Env.conj_guard g
                                            guard1
                                           in
-                                       (uu____16901, uu____16905))) args
+                                       (uu____16992, uu____16996))) args
                          ([], guard)
                         in
-                     (match uu____16797 with
+                     (match uu____16888 with
                       | (bs,guard1) ->
-                          let uu____16922 =
-                            let uu____16929 =
-                              let uu____16942 =
-                                let uu____16943 = FStar_Syntax_Util.type_u ()
+                          let uu____17013 =
+                            let uu____17020 =
+                              let uu____17033 =
+                                let uu____17034 = FStar_Syntax_Util.type_u ()
                                    in
-                                FStar_All.pipe_right uu____16943
+                                FStar_All.pipe_right uu____17034
                                   FStar_Pervasives_Native.fst
                                  in
                               FStar_TypeChecker_Util.new_implicit_var
                                 "result type" tf.FStar_Syntax_Syntax.pos env
-                                uu____16942
+                                uu____17033
                                in
-                            match uu____16929 with
-                            | (t,uu____16960,g) ->
-                                let uu____16974 = FStar_Options.ml_ish ()  in
-                                if uu____16974
+                            match uu____17020 with
+                            | (t,uu____17051,g) ->
+                                let uu____17065 = FStar_Options.ml_ish ()  in
+                                if uu____17065
                                 then
-                                  let uu____16983 =
+                                  let uu____17074 =
                                     FStar_Syntax_Util.ml_comp t r  in
-                                  let uu____16986 =
+                                  let uu____17077 =
                                     FStar_TypeChecker_Env.conj_guard guard1 g
                                      in
-                                  (uu____16983, uu____16986)
+                                  (uu____17074, uu____17077)
                                 else
-                                  (let uu____16991 =
+                                  (let uu____17082 =
                                      FStar_Syntax_Syntax.mk_Total t  in
-                                   let uu____16994 =
+                                   let uu____17085 =
                                      FStar_TypeChecker_Env.conj_guard guard1
                                        g
                                       in
-                                   (uu____16991, uu____16994))
+                                   (uu____17082, uu____17085))
                              in
-                          (match uu____16922 with
+                          (match uu____17013 with
                            | (cres,guard2) ->
                                let bs_cres = FStar_Syntax_Util.arrow bs cres
                                   in
-                               ((let uu____17013 =
+                               ((let uu____17104 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env)
                                      FStar_Options.Extreme
                                     in
-                                 if uu____17013
+                                 if uu____17104
                                  then
-                                   let uu____17017 =
+                                   let uu____17108 =
                                      FStar_Syntax_Print.term_to_string head1
                                       in
-                                   let uu____17019 =
+                                   let uu____17110 =
                                      FStar_Syntax_Print.term_to_string tf  in
-                                   let uu____17021 =
+                                   let uu____17112 =
                                      FStar_Syntax_Print.term_to_string
                                        bs_cres
                                       in
                                    FStar_Util.print3
                                      "Forcing the type of %s from %s to %s\n"
-                                     uu____17017 uu____17019 uu____17021
+                                     uu____17108 uu____17110 uu____17112
                                  else ());
                                 (let g =
-                                   let uu____17027 =
+                                   let uu____17118 =
                                      FStar_TypeChecker_Rel.teq env tf bs_cres
                                       in
                                    FStar_TypeChecker_Rel.solve_deferred_constraints
-                                     env uu____17027
+                                     env uu____17118
                                     in
-                                 let uu____17028 =
+                                 let uu____17119 =
                                    FStar_TypeChecker_Env.conj_guard g guard2
                                     in
-                                 check_function_app bs_cres uu____17028))))
+                                 check_function_app bs_cres uu____17119))))
                  | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-                     let uu____17051 = FStar_Syntax_Subst.open_comp bs c  in
-                     (match uu____17051 with
+                     let uu____17142 = FStar_Syntax_Subst.open_comp bs c  in
+                     (match uu____17142 with
                       | (bs1,c1) ->
                           let head_info = (head1, chead, ghead, c1)  in
-                          ((let uu____17074 =
+                          ((let uu____17165 =
                               FStar_TypeChecker_Env.debug env
                                 FStar_Options.Extreme
                                in
-                            if uu____17074
+                            if uu____17165
                             then
-                              let uu____17077 =
+                              let uu____17168 =
                                 FStar_Syntax_Print.term_to_string head1  in
-                              let uu____17079 =
+                              let uu____17170 =
                                 FStar_Syntax_Print.term_to_string tf  in
-                              let uu____17081 =
+                              let uu____17172 =
                                 FStar_Syntax_Print.binders_to_string ", " bs1
                                  in
-                              let uu____17084 =
+                              let uu____17175 =
                                 FStar_Syntax_Print.comp_to_string c1  in
                               FStar_Util.print4
                                 "######tc_args of head %s @ %s with formals=%s and result type=%s\n"
-                                uu____17077 uu____17079 uu____17081
-                                uu____17084
+                                uu____17168 uu____17170 uu____17172
+                                uu____17175
                             else ());
                            tc_args head_info ([], [], [], guard, []) bs1 args))
-                 | FStar_Syntax_Syntax.Tm_refine (bv,uu____17130) ->
+                 | FStar_Syntax_Syntax.Tm_refine (bv,uu____17221) ->
                      check_function_app bv.FStar_Syntax_Syntax.sort guard
                  | FStar_Syntax_Syntax.Tm_ascribed
-                     (t,uu____17136,uu____17137) ->
+                     (t,uu____17227,uu____17228) ->
                      check_function_app t guard
-                 | uu____17178 ->
-                     let uu____17179 =
+                 | uu____17269 ->
+                     let uu____17270 =
                        FStar_TypeChecker_Err.expected_function_typ env tf  in
-                     FStar_Errors.raise_error uu____17179
+                     FStar_Errors.raise_error uu____17270
                        head1.FStar_Syntax_Syntax.pos
                   in
                check_function_app thead FStar_TypeChecker_Env.trivial_guard)
@@ -6209,75 +6254,75 @@ and (check_short_circuit_args :
                     ((FStar_List.length bs) = (FStar_List.length args))
                   ->
                   let res_t = FStar_Syntax_Util.comp_result c  in
-                  let uu____17262 =
+                  let uu____17353 =
                     FStar_List.fold_left2
-                      (fun uu____17331  ->
-                         fun uu____17332  ->
-                           fun uu____17333  ->
-                             match (uu____17331, uu____17332, uu____17333)
+                      (fun uu____17422  ->
+                         fun uu____17423  ->
+                           fun uu____17424  ->
+                             match (uu____17422, uu____17423, uu____17424)
                              with
                              | ((seen,guard,ghost),(e,aq),(b,aq')) ->
-                                 ((let uu____17486 =
-                                     let uu____17488 =
+                                 ((let uu____17577 =
+                                     let uu____17579 =
                                        FStar_Syntax_Util.eq_aqual aq aq'  in
-                                     uu____17488 <> FStar_Syntax_Util.Equal
+                                     uu____17579 <> FStar_Syntax_Util.Equal
                                       in
-                                   if uu____17486
+                                   if uu____17577
                                    then
                                      FStar_Errors.raise_error
                                        (FStar_Errors.Fatal_InconsistentImplicitQualifier,
                                          "Inconsistent implicit qualifiers")
                                        e.FStar_Syntax_Syntax.pos
                                    else ());
-                                  (let uu____17494 =
+                                  (let uu____17585 =
                                      tc_check_tot_or_gtot_term env e
                                        b.FStar_Syntax_Syntax.sort
                                       in
-                                   match uu____17494 with
+                                   match uu____17585 with
                                    | (e1,c1,g) ->
                                        let short =
                                          FStar_TypeChecker_Util.short_circuit
                                            head1 seen
                                           in
                                        let g1 =
-                                         let uu____17523 =
+                                         let uu____17614 =
                                            FStar_TypeChecker_Env.guard_of_guard_formula
                                              short
                                             in
                                          FStar_TypeChecker_Env.imp_guard
-                                           uu____17523 g
+                                           uu____17614 g
                                           in
                                        let ghost1 =
                                          ghost ||
-                                           ((let uu____17528 =
+                                           ((let uu____17619 =
                                                FStar_Syntax_Util.is_total_lcomp
                                                  c1
                                                 in
-                                             Prims.op_Negation uu____17528)
+                                             Prims.op_Negation uu____17619)
                                               &&
-                                              (let uu____17531 =
+                                              (let uu____17622 =
                                                  FStar_TypeChecker_Util.is_pure_effect
                                                    env
                                                    c1.FStar_Syntax_Syntax.eff_name
                                                   in
-                                               Prims.op_Negation uu____17531))
+                                               Prims.op_Negation uu____17622))
                                           in
-                                       let uu____17533 =
-                                         let uu____17544 =
-                                           let uu____17555 =
+                                       let uu____17624 =
+                                         let uu____17635 =
+                                           let uu____17646 =
                                              FStar_Syntax_Syntax.as_arg e1
                                               in
-                                           [uu____17555]  in
-                                         FStar_List.append seen uu____17544
+                                           [uu____17646]  in
+                                         FStar_List.append seen uu____17635
                                           in
-                                       let uu____17588 =
+                                       let uu____17679 =
                                          FStar_TypeChecker_Env.conj_guard
                                            guard g1
                                           in
-                                       (uu____17533, uu____17588, ghost1))))
+                                       (uu____17624, uu____17679, ghost1))))
                       ([], g_head, false) args bs
                      in
-                  (match uu____17262 with
+                  (match uu____17353 with
                    | (args1,guard,ghost) ->
                        let e =
                          FStar_Syntax_Syntax.mk_Tm_app head1 args1
@@ -6286,17 +6331,17 @@ and (check_short_circuit_args :
                        let c1 =
                          if ghost
                          then
-                           let uu____17656 =
+                           let uu____17747 =
                              FStar_Syntax_Syntax.mk_GTotal res_t  in
-                           FStar_All.pipe_right uu____17656
+                           FStar_All.pipe_right uu____17747
                              FStar_Syntax_Util.lcomp_of_comp
                          else FStar_Syntax_Util.lcomp_of_comp c  in
-                       let uu____17659 =
+                       let uu____17750 =
                          FStar_TypeChecker_Util.strengthen_precondition
                            FStar_Pervasives_Native.None env e c1 guard
                           in
-                       (match uu____17659 with | (c2,g) -> (e, c2, g)))
-              | uu____17676 ->
+                       (match uu____17750 with | (c2,g) -> (e, c2, g)))
+              | uu____17767 ->
                   check_application_args env head1 chead g_head args
                     expected_topt
 
@@ -6306,7 +6351,8 @@ and (tc_pat :
       FStar_Syntax_Syntax.pat ->
         (FStar_Syntax_Syntax.pat * FStar_Syntax_Syntax.bv Prims.list *
           FStar_TypeChecker_Env.env * FStar_Syntax_Syntax.term *
-          FStar_Syntax_Syntax.term * FStar_TypeChecker_Env.guard_t))
+          FStar_Syntax_Syntax.term * FStar_TypeChecker_Env.guard_t *
+          Prims.bool))
   =
   fun env  ->
     fun pat_t  ->
@@ -6319,25 +6365,25 @@ and (tc_pat :
         let expected_pat_typ env1 pos scrutinee_t =
           let rec aux norm1 t =
             let t1 = FStar_Syntax_Util.unrefine t  in
-            let uu____17767 = FStar_Syntax_Util.head_and_args t1  in
-            match uu____17767 with
+            let uu____17861 = FStar_Syntax_Util.head_and_args t1  in
+            match uu____17861 with
             | (head1,args) ->
-                let uu____17810 =
-                  let uu____17811 = FStar_Syntax_Subst.compress head1  in
-                  uu____17811.FStar_Syntax_Syntax.n  in
-                (match uu____17810 with
+                let uu____17904 =
+                  let uu____17905 = FStar_Syntax_Subst.compress head1  in
+                  uu____17905.FStar_Syntax_Syntax.n  in
+                (match uu____17904 with
                  | FStar_Syntax_Syntax.Tm_uinst
                      ({
                         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar f;
-                        FStar_Syntax_Syntax.pos = uu____17815;
-                        FStar_Syntax_Syntax.vars = uu____17816;_},us)
+                        FStar_Syntax_Syntax.pos = uu____17909;
+                        FStar_Syntax_Syntax.vars = uu____17910;_},us)
                      -> unfold_once t1 f us args
                  | FStar_Syntax_Syntax.Tm_fvar f -> unfold_once t1 f [] args
-                 | uu____17823 ->
+                 | uu____17917 ->
                      if norm1
                      then t1
                      else
-                       (let uu____17827 =
+                       (let uu____17921 =
                           FStar_TypeChecker_Normalize.normalize
                             [FStar_TypeChecker_Env.HNF;
                             FStar_TypeChecker_Env.Unmeta;
@@ -6345,30 +6391,30 @@ and (tc_pat :
                             FStar_TypeChecker_Env.UnfoldUntil
                               FStar_Syntax_Syntax.delta_constant] env1 t1
                            in
-                        aux true uu____17827))
+                        aux true uu____17921))
           
           and unfold_once t f us args =
-            let uu____17845 =
+            let uu____17939 =
               FStar_TypeChecker_Env.is_type_constructor env1
                 (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                in
-            if uu____17845
+            if uu____17939
             then t
             else
-              (let uu____17850 =
+              (let uu____17944 =
                  FStar_TypeChecker_Env.lookup_definition
                    [FStar_TypeChecker_Env.Unfold
                       FStar_Syntax_Syntax.delta_constant] env1
                    (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                   in
-               match uu____17850 with
+               match uu____17944 with
                | FStar_Pervasives_Native.None  -> t
                | FStar_Pervasives_Native.Some head_def_ts ->
-                   let uu____17870 =
+                   let uu____17964 =
                      FStar_TypeChecker_Env.inst_tscheme_with head_def_ts us
                       in
-                   (match uu____17870 with
-                    | (uu____17875,head_def) ->
+                   (match uu____17964 with
+                    | (uu____17969,head_def) ->
                         let t' =
                           FStar_Syntax_Syntax.mk_Tm_app head_def args
                             FStar_Pervasives_Native.None
@@ -6381,79 +6427,79 @@ and (tc_pat :
                            in
                         aux false t'1))
            in
-          let uu____17882 =
+          let uu____17976 =
             FStar_TypeChecker_Normalize.normalize
               [FStar_TypeChecker_Env.Beta; FStar_TypeChecker_Env.Iota] env1
               scrutinee_t
              in
-          aux false uu____17882  in
+          aux false uu____17976  in
         let pat_typ_ok env1 pat_t1 scrutinee_t =
-          (let uu____17901 =
+          (let uu____17995 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                (FStar_Options.Other "Patterns")
               in
-           if uu____17901
+           if uu____17995
            then
-             let uu____17906 = FStar_Syntax_Print.term_to_string pat_t1  in
-             let uu____17908 = FStar_Syntax_Print.term_to_string scrutinee_t
+             let uu____18000 = FStar_Syntax_Print.term_to_string pat_t1  in
+             let uu____18002 = FStar_Syntax_Print.term_to_string scrutinee_t
                 in
              FStar_Util.print2 "$$$$$$$$$$$$pat_typ_ok? %s vs. %s\n"
-               uu____17906 uu____17908
+               uu____18000 uu____18002
            else ());
           (let fail2 msg =
              let msg1 =
-               let uu____17928 = FStar_Syntax_Print.term_to_string pat_t1  in
-               let uu____17930 =
+               let uu____18022 = FStar_Syntax_Print.term_to_string pat_t1  in
+               let uu____18024 =
                  FStar_Syntax_Print.term_to_string scrutinee_t  in
                FStar_Util.format3
                  "Type of pattern (%s) does not match type of scrutinee (%s)%s"
-                 uu____17928 uu____17930 msg
+                 uu____18022 uu____18024 msg
                 in
              FStar_Errors.raise_error
                (FStar_Errors.Fatal_MismatchedPatternType, msg1)
                p0.FStar_Syntax_Syntax.p
               in
-           let uu____17934 = FStar_Syntax_Util.head_and_args scrutinee_t  in
-           match uu____17934 with
+           let uu____18028 = FStar_Syntax_Util.head_and_args scrutinee_t  in
+           match uu____18028 with
            | (head_s,args_s) ->
                let pat_t2 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.Beta] env1 pat_t1
                   in
-               let uu____17978 = FStar_Syntax_Util.un_uinst head_s  in
-               (match uu____17978 with
+               let uu____18072 = FStar_Syntax_Util.un_uinst head_s  in
+               (match uu____18072 with
                 | {
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
-                      uu____17979;
-                    FStar_Syntax_Syntax.pos = uu____17980;
-                    FStar_Syntax_Syntax.vars = uu____17981;_} ->
-                    let uu____17984 = FStar_Syntax_Util.head_and_args pat_t2
+                      uu____18073;
+                    FStar_Syntax_Syntax.pos = uu____18074;
+                    FStar_Syntax_Syntax.vars = uu____18075;_} ->
+                    let uu____18078 = FStar_Syntax_Util.head_and_args pat_t2
                        in
-                    (match uu____17984 with
+                    (match uu____18078 with
                      | (head_p,args_p) ->
-                         let uu____18027 =
+                         let uu____18121 =
                            FStar_TypeChecker_Rel.teq_nosmt_force env1 head_p
                              head_s
                             in
-                         if uu____18027
+                         if uu____18121
                          then
-                           let uu____18030 =
-                             let uu____18031 =
+                           let uu____18124 =
+                             let uu____18125 =
                                FStar_Syntax_Util.un_uinst head_p  in
-                             uu____18031.FStar_Syntax_Syntax.n  in
-                           (match uu____18030 with
+                             uu____18125.FStar_Syntax_Syntax.n  in
+                           (match uu____18124 with
                             | FStar_Syntax_Syntax.Tm_fvar f ->
-                                ((let uu____18036 =
-                                    let uu____18038 =
-                                      let uu____18040 =
+                                ((let uu____18130 =
+                                    let uu____18132 =
+                                      let uu____18134 =
                                         FStar_Syntax_Syntax.lid_of_fv f  in
                                       FStar_TypeChecker_Env.is_type_constructor
-                                        env1 uu____18040
+                                        env1 uu____18134
                                        in
                                     FStar_All.pipe_left Prims.op_Negation
-                                      uu____18038
+                                      uu____18132
                                      in
-                                  if uu____18036
+                                  if uu____18130
                                   then
                                     fail2
                                       "Pattern matching a non-inductive type"
@@ -6463,61 +6509,61 @@ and (tc_pat :
                                      (FStar_List.length args_s)
                                  then fail2 ""
                                  else ();
-                                 (let uu____18068 =
-                                    let uu____18093 =
-                                      let uu____18097 =
+                                 (let uu____18162 =
+                                    let uu____18187 =
+                                      let uu____18191 =
                                         FStar_Syntax_Syntax.lid_of_fv f  in
                                       FStar_TypeChecker_Env.num_inductive_ty_params
-                                        env1 uu____18097
+                                        env1 uu____18191
                                        in
-                                    match uu____18093 with
+                                    match uu____18187 with
                                     | FStar_Pervasives_Native.None  ->
                                         (args_p, args_s)
                                     | FStar_Pervasives_Native.Some n1 ->
-                                        let uu____18146 =
+                                        let uu____18240 =
                                           FStar_Util.first_N n1 args_p  in
-                                        (match uu____18146 with
-                                         | (params_p,uu____18204) ->
-                                             let uu____18245 =
+                                        (match uu____18240 with
+                                         | (params_p,uu____18298) ->
+                                             let uu____18339 =
                                                FStar_Util.first_N n1 args_s
                                                 in
-                                             (match uu____18245 with
-                                              | (params_s,uu____18303) ->
+                                             (match uu____18339 with
+                                              | (params_s,uu____18397) ->
                                                   (params_p, params_s)))
                                      in
-                                  match uu____18068 with
+                                  match uu____18162 with
                                   | (params_p,params_s) ->
                                       FStar_List.fold_left2
                                         (fun out  ->
-                                           fun uu____18432  ->
-                                             fun uu____18433  ->
-                                               match (uu____18432,
-                                                       uu____18433)
+                                           fun uu____18526  ->
+                                             fun uu____18527  ->
+                                               match (uu____18526,
+                                                       uu____18527)
                                                with
-                                               | ((p,uu____18467),(s,uu____18469))
+                                               | ((p,uu____18561),(s,uu____18563))
                                                    ->
-                                                   let uu____18502 =
+                                                   let uu____18596 =
                                                      FStar_TypeChecker_Rel.teq_nosmt
                                                        env1 p s
                                                       in
-                                                   (match uu____18502 with
+                                                   (match uu____18596 with
                                                     | FStar_Pervasives_Native.None
                                                          ->
-                                                        let uu____18505 =
-                                                          let uu____18507 =
+                                                        let uu____18599 =
+                                                          let uu____18601 =
                                                             FStar_Syntax_Print.term_to_string
                                                               p
                                                              in
-                                                          let uu____18509 =
+                                                          let uu____18603 =
                                                             FStar_Syntax_Print.term_to_string
                                                               s
                                                              in
                                                           FStar_Util.format2
                                                             "; parameter %s <> parameter %s"
-                                                            uu____18507
-                                                            uu____18509
+                                                            uu____18601
+                                                            uu____18603
                                                            in
-                                                        fail2 uu____18505
+                                                        fail2 uu____18599
                                                     | FStar_Pervasives_Native.Some
                                                         g ->
                                                         let g1 =
@@ -6528,23 +6574,23 @@ and (tc_pat :
                                                           g1 out))
                                         FStar_TypeChecker_Env.trivial_guard
                                         params_p params_s))
-                            | uu____18514 ->
+                            | uu____18608 ->
                                 fail2 "Pattern matching a non-inductive type")
                          else
-                           (let uu____18518 =
-                              let uu____18520 =
+                           (let uu____18612 =
+                              let uu____18614 =
                                 FStar_Syntax_Print.term_to_string head_p  in
-                              let uu____18522 =
+                              let uu____18616 =
                                 FStar_Syntax_Print.term_to_string head_s  in
                               FStar_Util.format2 "; head mismatch %s vs %s"
-                                uu____18520 uu____18522
+                                uu____18614 uu____18616
                                in
-                            fail2 uu____18518))
-                | uu____18525 ->
-                    let uu____18526 =
+                            fail2 uu____18612))
+                | uu____18619 ->
+                    let uu____18620 =
                       FStar_TypeChecker_Rel.teq_nosmt env1 pat_t2 scrutinee_t
                        in
-                    (match uu____18526 with
+                    (match uu____18620 with
                      | FStar_Pervasives_Native.None  -> fail2 ""
                      | FStar_Pervasives_Native.Some g ->
                          let g1 =
@@ -6554,21 +6600,24 @@ and (tc_pat :
                          g1)))
            in
         let type_of_simple_pat env1 e =
-          let uu____18563 = FStar_Syntax_Util.head_and_args e  in
-          match uu____18563 with
+          let uu____18663 = FStar_Syntax_Util.head_and_args e  in
+          match uu____18663 with
           | (head1,args) ->
               (match head1.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_fvar f ->
-                   let uu____18627 =
+                   let uu____18733 =
                      FStar_TypeChecker_Env.lookup_datacon env1
                        (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                       in
-                   (match uu____18627 with
+                   (match uu____18733 with
                     | (us,t_f) ->
-                        let uu____18644 = FStar_Syntax_Util.arrow_formals t_f
+                        let uu____18753 = FStar_Syntax_Util.arrow_formals t_f
                            in
-                        (match uu____18644 with
+                        (match uu____18753 with
                          | (formals,t) ->
+                             let erasable1 =
+                               FStar_TypeChecker_Env.non_informative env1 t
+                                in
                              (if
                                 (FStar_List.length formals) <>
                                   (FStar_List.length args)
@@ -6576,8 +6625,8 @@ and (tc_pat :
                                 fail1
                                   "Pattern is not a fully-applied data constructor"
                               else ();
-                              (let rec aux uu____18773 formals1 args1 =
-                                 match uu____18773 with
+                              (let rec aux uu____18890 formals1 args1 =
+                                 match uu____18890 with
                                  | (subst1,args_out,bvs,guard) ->
                                      (match (formals1, args1) with
                                       | ([],[]) ->
@@ -6591,35 +6640,36 @@ and (tc_pat :
                                               FStar_Pervasives_Native.None
                                               e.FStar_Syntax_Syntax.pos
                                              in
-                                          let uu____18918 =
+                                          let uu____19041 =
                                             FStar_Syntax_Subst.subst subst1 t
                                              in
-                                          (pat_e, uu____18918, bvs, guard)
-                                      | ((f1,uu____18924)::formals2,(a,imp_a)::args2)
+                                          (pat_e, uu____19041, bvs, guard,
+                                            erasable1)
+                                      | ((f1,uu____19048)::formals2,(a,imp_a)::args2)
                                           ->
                                           let t_f1 =
                                             FStar_Syntax_Subst.subst subst1
                                               f1.FStar_Syntax_Syntax.sort
                                              in
-                                          let uu____18982 =
-                                            let uu____19003 =
-                                              let uu____19004 =
+                                          let uu____19106 =
+                                            let uu____19127 =
+                                              let uu____19128 =
                                                 FStar_Syntax_Subst.compress a
                                                  in
-                                              uu____19004.FStar_Syntax_Syntax.n
+                                              uu____19128.FStar_Syntax_Syntax.n
                                                in
-                                            match uu____19003 with
+                                            match uu____19127 with
                                             | FStar_Syntax_Syntax.Tm_name x
                                                 ->
                                                 let x1 =
-                                                  let uu___2446_19029 = x  in
+                                                  let uu___2456_19153 = x  in
                                                   {
                                                     FStar_Syntax_Syntax.ppname
                                                       =
-                                                      (uu___2446_19029.FStar_Syntax_Syntax.ppname);
+                                                      (uu___2456_19153.FStar_Syntax_Syntax.ppname);
                                                     FStar_Syntax_Syntax.index
                                                       =
-                                                      (uu___2446_19029.FStar_Syntax_Syntax.index);
+                                                      (uu___2456_19153.FStar_Syntax_Syntax.index);
                                                     FStar_Syntax_Syntax.sort
                                                       = t_f1
                                                   }  in
@@ -6635,16 +6685,16 @@ and (tc_pat :
                                                   (FStar_List.append bvs [x1]),
                                                   FStar_TypeChecker_Env.trivial_guard)
                                             | FStar_Syntax_Syntax.Tm_uvar
-                                                uu____19052 ->
+                                                uu____19176 ->
                                                 let env2 =
                                                   FStar_TypeChecker_Env.set_expected_typ
                                                     env1 t_f1
                                                    in
-                                                let uu____19066 =
+                                                let uu____19190 =
                                                   tc_tot_or_gtot_term env2 a
                                                    in
-                                                (match uu____19066 with
-                                                 | (a1,uu____19094,g) ->
+                                                (match uu____19190 with
+                                                 | (a1,uu____19218,g) ->
                                                      let g1 =
                                                        FStar_TypeChecker_Rel.discharge_guard_no_smt
                                                          env2 g
@@ -6655,289 +6705,292 @@ and (tc_pat :
                                                        :: subst1  in
                                                      ((a1, imp_a), subst2,
                                                        bvs, g1))
-                                            | uu____19118 ->
+                                            | uu____19242 ->
                                                 fail1 "Not a simple pattern"
                                              in
-                                          (match uu____18982 with
+                                          (match uu____19106 with
                                            | (a1,subst2,bvs1,g) ->
-                                               let uu____19180 =
-                                                 let uu____19203 =
+                                               let uu____19307 =
+                                                 let uu____19330 =
                                                    FStar_TypeChecker_Env.conj_guard
                                                      g guard
                                                     in
                                                  (subst2,
                                                    (FStar_List.append
                                                       args_out [a1]), bvs1,
-                                                   uu____19203)
+                                                   uu____19330)
                                                   in
-                                               aux uu____19180 formals2 args2)
-                                      | uu____19242 ->
+                                               aux uu____19307 formals2 args2)
+                                      | uu____19369 ->
                                           fail1 "Not a fully applued pattern")
                                   in
                                aux
                                  ([], [], [],
                                    FStar_TypeChecker_Env.trivial_guard)
                                  formals args))))
-               | uu____19298 -> fail1 "Not a simple pattern")
+               | uu____19428 -> fail1 "Not a simple pattern")
            in
         let rec check_nested_pattern env1 p t =
-          (let uu____19347 =
+          (let uu____19486 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                (FStar_Options.Other "Patterns")
               in
-           if uu____19347
+           if uu____19486
            then
-             let uu____19352 = FStar_Syntax_Print.pat_to_string p  in
-             let uu____19354 = FStar_Syntax_Print.term_to_string t  in
-             FStar_Util.print2 "Checking pattern %s at type %s\n" uu____19352
-               uu____19354
+             let uu____19491 = FStar_Syntax_Print.pat_to_string p  in
+             let uu____19493 = FStar_Syntax_Print.term_to_string t  in
+             FStar_Util.print2 "Checking pattern %s at type %s\n" uu____19491
+               uu____19493
            else ());
           (match p.FStar_Syntax_Syntax.v with
-           | FStar_Syntax_Syntax.Pat_dot_term uu____19369 ->
-               let uu____19376 =
-                 let uu____19378 = FStar_Syntax_Print.pat_to_string p  in
+           | FStar_Syntax_Syntax.Pat_dot_term uu____19511 ->
+               let uu____19518 =
+                 let uu____19520 = FStar_Syntax_Print.pat_to_string p  in
                  FStar_Util.format1
                    "Impossible: Expected an undecorated pattern, got %s"
-                   uu____19378
+                   uu____19520
                   in
-               failwith uu____19376
+               failwith uu____19518
            | FStar_Syntax_Syntax.Pat_wild x ->
                let x1 =
-                 let uu___2478_19393 = x  in
+                 let uu___2488_19538 = x  in
                  {
                    FStar_Syntax_Syntax.ppname =
-                     (uu___2478_19393.FStar_Syntax_Syntax.ppname);
+                     (uu___2488_19538.FStar_Syntax_Syntax.ppname);
                    FStar_Syntax_Syntax.index =
-                     (uu___2478_19393.FStar_Syntax_Syntax.index);
+                     (uu___2488_19538.FStar_Syntax_Syntax.index);
                    FStar_Syntax_Syntax.sort = t
                  }  in
-               let uu____19394 = FStar_Syntax_Syntax.bv_to_name x1  in
-               ([x1], uu____19394,
-                 (let uu___2481_19398 = p  in
+               let uu____19539 = FStar_Syntax_Syntax.bv_to_name x1  in
+               ([x1], uu____19539,
+                 (let uu___2491_19544 = p  in
                   {
                     FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x1);
                     FStar_Syntax_Syntax.p =
-                      (uu___2481_19398.FStar_Syntax_Syntax.p)
-                  }), FStar_TypeChecker_Env.trivial_guard)
+                      (uu___2491_19544.FStar_Syntax_Syntax.p)
+                  }), FStar_TypeChecker_Env.trivial_guard, false)
            | FStar_Syntax_Syntax.Pat_var x ->
                let x1 =
-                 let uu___2485_19401 = x  in
+                 let uu___2495_19548 = x  in
                  {
                    FStar_Syntax_Syntax.ppname =
-                     (uu___2485_19401.FStar_Syntax_Syntax.ppname);
+                     (uu___2495_19548.FStar_Syntax_Syntax.ppname);
                    FStar_Syntax_Syntax.index =
-                     (uu___2485_19401.FStar_Syntax_Syntax.index);
+                     (uu___2495_19548.FStar_Syntax_Syntax.index);
                    FStar_Syntax_Syntax.sort = t
                  }  in
-               let uu____19402 = FStar_Syntax_Syntax.bv_to_name x1  in
-               ([x1], uu____19402,
-                 (let uu___2488_19406 = p  in
+               let uu____19549 = FStar_Syntax_Syntax.bv_to_name x1  in
+               ([x1], uu____19549,
+                 (let uu___2498_19554 = p  in
                   {
                     FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x1);
                     FStar_Syntax_Syntax.p =
-                      (uu___2488_19406.FStar_Syntax_Syntax.p)
-                  }), FStar_TypeChecker_Env.trivial_guard)
-           | FStar_Syntax_Syntax.Pat_constant uu____19407 ->
-               let uu____19408 =
+                      (uu___2498_19554.FStar_Syntax_Syntax.p)
+                  }), FStar_TypeChecker_Env.trivial_guard, false)
+           | FStar_Syntax_Syntax.Pat_constant uu____19556 ->
+               let uu____19557 =
                  FStar_TypeChecker_PatternUtils.pat_as_exp false env1 p  in
-               (match uu____19408 with
-                | (uu____19430,e_c,uu____19432,uu____19433) ->
-                    let uu____19438 = tc_tot_or_gtot_term env1 e_c  in
-                    (match uu____19438 with
+               (match uu____19557 with
+                | (uu____19582,e_c,uu____19584,uu____19585) ->
+                    let uu____19590 = tc_tot_or_gtot_term env1 e_c  in
+                    (match uu____19590 with
                      | (e_c1,lc,g) ->
                          (FStar_TypeChecker_Rel.force_trivial_guard env1 g;
                           (let expected_t =
                              expected_pat_typ env1 p0.FStar_Syntax_Syntax.p t
                               in
-                           (let uu____19461 =
-                              let uu____19463 =
+                           (let uu____19616 =
+                              let uu____19618 =
                                 FStar_TypeChecker_Rel.teq_nosmt_force env1
                                   lc.FStar_Syntax_Syntax.res_typ expected_t
                                  in
-                              Prims.op_Negation uu____19463  in
-                            if uu____19461
+                              Prims.op_Negation uu____19618  in
+                            if uu____19616
                             then
-                              let uu____19466 =
-                                let uu____19468 =
+                              let uu____19621 =
+                                let uu____19623 =
                                   FStar_Syntax_Print.term_to_string
                                     lc.FStar_Syntax_Syntax.res_typ
                                    in
-                                let uu____19470 =
+                                let uu____19625 =
                                   FStar_Syntax_Print.term_to_string
                                     expected_t
                                    in
                                 FStar_Util.format2
                                   "Type of pattern (%s) does not match type of scrutinee (%s)"
-                                  uu____19468 uu____19470
+                                  uu____19623 uu____19625
                                  in
-                              fail1 uu____19466
+                              fail1 uu____19621
                             else ());
-                           ([], e_c1, p, FStar_TypeChecker_Env.trivial_guard)))))
+                           ([], e_c1, p, FStar_TypeChecker_Env.trivial_guard,
+                             false)))))
            | FStar_Syntax_Syntax.Pat_cons (fv,sub_pats) ->
                let simple_pat =
                  let simple_sub_pats =
                    FStar_List.map
-                     (fun uu____19528  ->
-                        match uu____19528 with
+                     (fun uu____19685  ->
+                        match uu____19685 with
                         | (p1,b) ->
                             (match p1.FStar_Syntax_Syntax.v with
-                             | FStar_Syntax_Syntax.Pat_dot_term uu____19558
+                             | FStar_Syntax_Syntax.Pat_dot_term uu____19715
                                  -> (p1, b)
-                             | uu____19568 ->
-                                 let uu____19569 =
-                                   let uu____19572 =
-                                     let uu____19573 =
+                             | uu____19725 ->
+                                 let uu____19726 =
+                                   let uu____19729 =
+                                     let uu____19730 =
                                        FStar_Syntax_Syntax.new_bv
                                          (FStar_Pervasives_Native.Some
                                             (p1.FStar_Syntax_Syntax.p))
                                          FStar_Syntax_Syntax.tun
                                         in
-                                     FStar_Syntax_Syntax.Pat_var uu____19573
+                                     FStar_Syntax_Syntax.Pat_var uu____19730
                                       in
-                                   FStar_Syntax_Syntax.withinfo uu____19572
+                                   FStar_Syntax_Syntax.withinfo uu____19729
                                      p1.FStar_Syntax_Syntax.p
                                     in
-                                 (uu____19569, b))) sub_pats
+                                 (uu____19726, b))) sub_pats
                     in
-                 let uu___2516_19577 = p  in
+                 let uu___2526_19734 = p  in
                  {
                    FStar_Syntax_Syntax.v =
                      (FStar_Syntax_Syntax.Pat_cons (fv, simple_sub_pats));
                    FStar_Syntax_Syntax.p =
-                     (uu___2516_19577.FStar_Syntax_Syntax.p)
+                     (uu___2526_19734.FStar_Syntax_Syntax.p)
                  }  in
                let sub_pats1 =
                  FStar_All.pipe_right sub_pats
                    (FStar_List.filter
-                      (fun uu____19622  ->
-                         match uu____19622 with
-                         | (x,uu____19632) ->
+                      (fun uu____19779  ->
+                         match uu____19779 with
+                         | (x,uu____19789) ->
                              (match x.FStar_Syntax_Syntax.v with
-                              | FStar_Syntax_Syntax.Pat_dot_term uu____19640
+                              | FStar_Syntax_Syntax.Pat_dot_term uu____19797
                                   -> false
-                              | uu____19648 -> true)))
+                              | uu____19805 -> true)))
                   in
-               let uu____19650 =
+               let uu____19807 =
                  FStar_TypeChecker_PatternUtils.pat_as_exp false env1
                    simple_pat
                   in
-               (match uu____19650 with
+               (match uu____19807 with
                 | (simple_bvs,simple_pat_e,g0,simple_pat_elab) ->
                     (if
                        (FStar_List.length simple_bvs) <>
                          (FStar_List.length sub_pats1)
                      then
-                       (let uu____19687 =
-                          let uu____19689 =
+                       (let uu____19847 =
+                          let uu____19849 =
                             FStar_Range.string_of_range
                               p.FStar_Syntax_Syntax.p
                              in
-                          let uu____19691 =
+                          let uu____19851 =
                             FStar_Syntax_Print.pat_to_string simple_pat  in
-                          let uu____19693 =
+                          let uu____19853 =
                             FStar_Util.string_of_int
                               (FStar_List.length sub_pats1)
                              in
-                          let uu____19700 =
+                          let uu____19860 =
                             FStar_Util.string_of_int
                               (FStar_List.length simple_bvs)
                              in
                           FStar_Util.format4
                             "(%s) Impossible: pattern bvar mismatch: %s; expected %s sub pats; got %s"
-                            uu____19689 uu____19691 uu____19693 uu____19700
+                            uu____19849 uu____19851 uu____19853 uu____19860
                            in
-                        failwith uu____19687)
+                        failwith uu____19847)
                      else ();
-                     (let uu____19705 =
-                        let uu____19714 =
+                     (let uu____19865 =
+                        let uu____19877 =
                           type_of_simple_pat env1 simple_pat_e  in
-                        match uu____19714 with
-                        | (simple_pat_e1,simple_pat_t,simple_bvs1,guard) ->
+                        match uu____19877 with
+                        | (simple_pat_e1,simple_pat_t,simple_bvs1,guard,erasable1)
+                            ->
                             let g' =
-                              let uu____19742 =
+                              let uu____19914 =
                                 expected_pat_typ env1
                                   p0.FStar_Syntax_Syntax.p t
                                  in
-                              pat_typ_ok env1 simple_pat_t uu____19742  in
+                              pat_typ_ok env1 simple_pat_t uu____19914  in
                             let guard1 =
                               FStar_TypeChecker_Env.conj_guard guard g'  in
-                            ((let uu____19745 =
+                            ((let uu____19917 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env1)
                                   (FStar_Options.Other "Patterns")
                                  in
-                              if uu____19745
+                              if uu____19917
                               then
-                                let uu____19750 =
+                                let uu____19922 =
                                   FStar_Syntax_Print.term_to_string
                                     simple_pat_e1
                                    in
-                                let uu____19752 =
+                                let uu____19924 =
                                   FStar_Syntax_Print.term_to_string
                                     simple_pat_t
                                    in
-                                let uu____19754 =
-                                  let uu____19756 =
+                                let uu____19926 =
+                                  let uu____19928 =
                                     FStar_List.map
                                       (fun x  ->
-                                         let uu____19764 =
-                                           let uu____19766 =
+                                         let uu____19936 =
+                                           let uu____19938 =
                                              FStar_Syntax_Print.bv_to_string
                                                x
                                               in
-                                           let uu____19768 =
-                                             let uu____19770 =
-                                               let uu____19772 =
+                                           let uu____19940 =
+                                             let uu____19942 =
+                                               let uu____19944 =
                                                  FStar_Syntax_Print.term_to_string
                                                    x.FStar_Syntax_Syntax.sort
                                                   in
-                                               Prims.op_Hat uu____19772 ")"
+                                               Prims.op_Hat uu____19944 ")"
                                                 in
-                                             Prims.op_Hat " : " uu____19770
+                                             Prims.op_Hat " : " uu____19942
                                               in
-                                           Prims.op_Hat uu____19766
-                                             uu____19768
+                                           Prims.op_Hat uu____19938
+                                             uu____19940
                                             in
-                                         Prims.op_Hat "(" uu____19764)
+                                         Prims.op_Hat "(" uu____19936)
                                       simple_bvs1
                                      in
-                                  FStar_All.pipe_right uu____19756
+                                  FStar_All.pipe_right uu____19928
                                     (FStar_String.concat " ")
                                    in
                                 FStar_Util.print3
                                   "$$$$$$$$$$$$Checked simple pattern %s at type %s with bvs=%s\n"
-                                  uu____19750 uu____19752 uu____19754
+                                  uu____19922 uu____19924 uu____19926
                               else ());
-                             (simple_pat_e1, simple_bvs1, guard1))
+                             (simple_pat_e1, simple_bvs1, guard1, erasable1))
                          in
-                      match uu____19705 with
-                      | (simple_pat_e1,simple_bvs1,g1) ->
-                          let uu____19804 =
-                            let uu____19826 =
-                              let uu____19848 =
+                      match uu____19865 with
+                      | (simple_pat_e1,simple_bvs1,g1,erasable1) ->
+                          let uu____19983 =
+                            let uu____20008 =
+                              let uu____20033 =
                                 FStar_TypeChecker_Env.conj_guard g0 g1  in
-                              (env1, [], [], [], uu____19848)  in
+                              (env1, [], [], [], uu____20033, erasable1)  in
                             FStar_List.fold_left2
-                              (fun uu____19909  ->
-                                 fun uu____19910  ->
+                              (fun uu____20100  ->
+                                 fun uu____20101  ->
                                    fun x  ->
-                                     match (uu____19909, uu____19910) with
-                                     | ((env2,bvs,pats,subst1,g),(p1,b)) ->
+                                     match (uu____20100, uu____20101) with
+                                     | ((env2,bvs,pats,subst1,g,erasable2),
+                                        (p1,b)) ->
                                          let expected_t =
                                            FStar_Syntax_Subst.subst subst1
                                              x.FStar_Syntax_Syntax.sort
                                             in
-                                         let uu____20043 =
+                                         let uu____20249 =
                                            check_nested_pattern env2 p1
                                              expected_t
                                             in
-                                         (match uu____20043 with
-                                          | (bvs_p,e_p,p2,g') ->
+                                         (match uu____20249 with
+                                          | (bvs_p,e_p,p2,g',erasable_p) ->
                                               let env3 =
                                                 FStar_TypeChecker_Env.push_bvs
                                                   env2 bvs_p
                                                  in
-                                              let uu____20084 =
+                                              let uu____20299 =
                                                 FStar_TypeChecker_Env.conj_guard
                                                   g g'
                                                  in
@@ -6947,11 +7000,13 @@ and (tc_pat :
                                                    [(p2, b)]),
                                                 ((FStar_Syntax_Syntax.NT
                                                     (x, e_p)) :: subst1),
-                                                uu____20084))) uu____19826
-                              sub_pats1 simple_bvs1
+                                                uu____20299,
+                                                (erasable2 || erasable_p))))
+                              uu____20008 sub_pats1 simple_bvs1
                              in
-                          (match uu____19804 with
-                           | (_env,bvs,checked_sub_pats,subst1,g) ->
+                          (match uu____19983 with
+                           | (_env,bvs,checked_sub_pats,subst1,g,erasable2)
+                               ->
                                let pat_e =
                                  FStar_Syntax_Subst.subst subst1
                                    simple_pat_e1
@@ -6969,34 +7024,34 @@ and (tc_pat :
                                                 e
                                                in
                                             let hd2 =
-                                              let uu___2588_20296 = hd1  in
+                                              let uu___2603_20518 = hd1  in
                                               {
                                                 FStar_Syntax_Syntax.v =
                                                   (FStar_Syntax_Syntax.Pat_dot_term
                                                      (x, e1));
                                                 FStar_Syntax_Syntax.p =
-                                                  (uu___2588_20296.FStar_Syntax_Syntax.p)
+                                                  (uu___2603_20518.FStar_Syntax_Syntax.p)
                                               }  in
-                                            let uu____20301 =
+                                            let uu____20523 =
                                               aux simple_pats1 bvs1 sub_pats2
                                                in
-                                            (hd2, b) :: uu____20301
+                                            (hd2, b) :: uu____20523
                                         | FStar_Syntax_Syntax.Pat_var x ->
                                             (match (bvs1, sub_pats2) with
-                                             | (x'::bvs2,(hd2,uu____20345)::sub_pats3)
+                                             | (x'::bvs2,(hd2,uu____20567)::sub_pats3)
                                                  when
                                                  FStar_Syntax_Syntax.bv_eq x
                                                    x'
                                                  ->
-                                                 let uu____20382 =
+                                                 let uu____20604 =
                                                    aux simple_pats1 bvs2
                                                      sub_pats3
                                                     in
-                                                 (hd2, b) :: uu____20382
-                                             | uu____20402 ->
+                                                 (hd2, b) :: uu____20604
+                                             | uu____20624 ->
                                                  failwith
                                                    "Impossible: simple pat variable mismatch")
-                                        | uu____20428 ->
+                                        | uu____20650 ->
                                             failwith
                                               "Impossible: expected a simple pattern")
                                     in
@@ -7007,148 +7062,150 @@ and (tc_pat :
                                        aux simple_pats simple_bvs1
                                          checked_sub_pats
                                         in
-                                     let uu___2609_20471 = pat  in
+                                     let uu___2624_20693 = pat  in
                                      {
                                        FStar_Syntax_Syntax.v =
                                          (FStar_Syntax_Syntax.Pat_cons
                                             (fv1, nested_pats));
                                        FStar_Syntax_Syntax.p =
-                                         (uu___2609_20471.FStar_Syntax_Syntax.p)
+                                         (uu___2624_20693.FStar_Syntax_Syntax.p)
                                      }
-                                 | uu____20483 -> failwith "Impossible"  in
-                               let uu____20487 =
+                                 | uu____20705 -> failwith "Impossible"  in
+                               let uu____20709 =
                                  reconstruct_nested_pat simple_pat_elab  in
-                               (bvs, pat_e, uu____20487, g))))))
+                               (bvs, pat_e, uu____20709, g, erasable2))))))
            in
-        (let uu____20491 =
+        (let uu____20714 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Patterns")
             in
-         if uu____20491
+         if uu____20714
          then
-           let uu____20496 = FStar_Syntax_Print.pat_to_string p0  in
-           FStar_Util.print1 "Checking pattern: %s\n" uu____20496
+           let uu____20719 = FStar_Syntax_Print.pat_to_string p0  in
+           FStar_Util.print1 "Checking pattern: %s\n" uu____20719
          else ());
-        (let uu____20501 =
-           let uu____20512 =
-             let uu___2614_20513 =
-               let uu____20514 = FStar_TypeChecker_Env.clear_expected_typ env
+        (let uu____20724 =
+           let uu____20738 =
+             let uu___2629_20739 =
+               let uu____20740 = FStar_TypeChecker_Env.clear_expected_typ env
                   in
-               FStar_All.pipe_right uu____20514 FStar_Pervasives_Native.fst
+               FStar_All.pipe_right uu____20740 FStar_Pervasives_Native.fst
                 in
              {
                FStar_TypeChecker_Env.solver =
-                 (uu___2614_20513.FStar_TypeChecker_Env.solver);
+                 (uu___2629_20739.FStar_TypeChecker_Env.solver);
                FStar_TypeChecker_Env.range =
-                 (uu___2614_20513.FStar_TypeChecker_Env.range);
+                 (uu___2629_20739.FStar_TypeChecker_Env.range);
                FStar_TypeChecker_Env.curmodule =
-                 (uu___2614_20513.FStar_TypeChecker_Env.curmodule);
+                 (uu___2629_20739.FStar_TypeChecker_Env.curmodule);
                FStar_TypeChecker_Env.gamma =
-                 (uu___2614_20513.FStar_TypeChecker_Env.gamma);
+                 (uu___2629_20739.FStar_TypeChecker_Env.gamma);
                FStar_TypeChecker_Env.gamma_sig =
-                 (uu___2614_20513.FStar_TypeChecker_Env.gamma_sig);
+                 (uu___2629_20739.FStar_TypeChecker_Env.gamma_sig);
                FStar_TypeChecker_Env.gamma_cache =
-                 (uu___2614_20513.FStar_TypeChecker_Env.gamma_cache);
+                 (uu___2629_20739.FStar_TypeChecker_Env.gamma_cache);
                FStar_TypeChecker_Env.modules =
-                 (uu___2614_20513.FStar_TypeChecker_Env.modules);
+                 (uu___2629_20739.FStar_TypeChecker_Env.modules);
                FStar_TypeChecker_Env.expected_typ =
-                 (uu___2614_20513.FStar_TypeChecker_Env.expected_typ);
+                 (uu___2629_20739.FStar_TypeChecker_Env.expected_typ);
                FStar_TypeChecker_Env.sigtab =
-                 (uu___2614_20513.FStar_TypeChecker_Env.sigtab);
+                 (uu___2629_20739.FStar_TypeChecker_Env.sigtab);
                FStar_TypeChecker_Env.attrtab =
-                 (uu___2614_20513.FStar_TypeChecker_Env.attrtab);
+                 (uu___2629_20739.FStar_TypeChecker_Env.attrtab);
                FStar_TypeChecker_Env.is_pattern =
-                 (uu___2614_20513.FStar_TypeChecker_Env.is_pattern);
+                 (uu___2629_20739.FStar_TypeChecker_Env.is_pattern);
                FStar_TypeChecker_Env.instantiate_imp =
-                 (uu___2614_20513.FStar_TypeChecker_Env.instantiate_imp);
+                 (uu___2629_20739.FStar_TypeChecker_Env.instantiate_imp);
                FStar_TypeChecker_Env.effects =
-                 (uu___2614_20513.FStar_TypeChecker_Env.effects);
+                 (uu___2629_20739.FStar_TypeChecker_Env.effects);
                FStar_TypeChecker_Env.generalize =
-                 (uu___2614_20513.FStar_TypeChecker_Env.generalize);
+                 (uu___2629_20739.FStar_TypeChecker_Env.generalize);
                FStar_TypeChecker_Env.letrecs =
-                 (uu___2614_20513.FStar_TypeChecker_Env.letrecs);
+                 (uu___2629_20739.FStar_TypeChecker_Env.letrecs);
                FStar_TypeChecker_Env.top_level =
-                 (uu___2614_20513.FStar_TypeChecker_Env.top_level);
+                 (uu___2629_20739.FStar_TypeChecker_Env.top_level);
                FStar_TypeChecker_Env.check_uvars =
-                 (uu___2614_20513.FStar_TypeChecker_Env.check_uvars);
+                 (uu___2629_20739.FStar_TypeChecker_Env.check_uvars);
                FStar_TypeChecker_Env.use_eq = true;
                FStar_TypeChecker_Env.is_iface =
-                 (uu___2614_20513.FStar_TypeChecker_Env.is_iface);
+                 (uu___2629_20739.FStar_TypeChecker_Env.is_iface);
                FStar_TypeChecker_Env.admit =
-                 (uu___2614_20513.FStar_TypeChecker_Env.admit);
+                 (uu___2629_20739.FStar_TypeChecker_Env.admit);
                FStar_TypeChecker_Env.lax =
-                 (uu___2614_20513.FStar_TypeChecker_Env.lax);
+                 (uu___2629_20739.FStar_TypeChecker_Env.lax);
                FStar_TypeChecker_Env.lax_universes =
-                 (uu___2614_20513.FStar_TypeChecker_Env.lax_universes);
+                 (uu___2629_20739.FStar_TypeChecker_Env.lax_universes);
                FStar_TypeChecker_Env.phase1 =
-                 (uu___2614_20513.FStar_TypeChecker_Env.phase1);
+                 (uu___2629_20739.FStar_TypeChecker_Env.phase1);
                FStar_TypeChecker_Env.failhard =
-                 (uu___2614_20513.FStar_TypeChecker_Env.failhard);
+                 (uu___2629_20739.FStar_TypeChecker_Env.failhard);
                FStar_TypeChecker_Env.nosynth =
-                 (uu___2614_20513.FStar_TypeChecker_Env.nosynth);
+                 (uu___2629_20739.FStar_TypeChecker_Env.nosynth);
                FStar_TypeChecker_Env.uvar_subtyping =
-                 (uu___2614_20513.FStar_TypeChecker_Env.uvar_subtyping);
+                 (uu___2629_20739.FStar_TypeChecker_Env.uvar_subtyping);
                FStar_TypeChecker_Env.tc_term =
-                 (uu___2614_20513.FStar_TypeChecker_Env.tc_term);
+                 (uu___2629_20739.FStar_TypeChecker_Env.tc_term);
                FStar_TypeChecker_Env.type_of =
-                 (uu___2614_20513.FStar_TypeChecker_Env.type_of);
+                 (uu___2629_20739.FStar_TypeChecker_Env.type_of);
                FStar_TypeChecker_Env.universe_of =
-                 (uu___2614_20513.FStar_TypeChecker_Env.universe_of);
+                 (uu___2629_20739.FStar_TypeChecker_Env.universe_of);
                FStar_TypeChecker_Env.check_type_of =
-                 (uu___2614_20513.FStar_TypeChecker_Env.check_type_of);
+                 (uu___2629_20739.FStar_TypeChecker_Env.check_type_of);
                FStar_TypeChecker_Env.use_bv_sorts =
-                 (uu___2614_20513.FStar_TypeChecker_Env.use_bv_sorts);
+                 (uu___2629_20739.FStar_TypeChecker_Env.use_bv_sorts);
                FStar_TypeChecker_Env.qtbl_name_and_index =
-                 (uu___2614_20513.FStar_TypeChecker_Env.qtbl_name_and_index);
+                 (uu___2629_20739.FStar_TypeChecker_Env.qtbl_name_and_index);
                FStar_TypeChecker_Env.normalized_eff_names =
-                 (uu___2614_20513.FStar_TypeChecker_Env.normalized_eff_names);
+                 (uu___2629_20739.FStar_TypeChecker_Env.normalized_eff_names);
                FStar_TypeChecker_Env.fv_delta_depths =
-                 (uu___2614_20513.FStar_TypeChecker_Env.fv_delta_depths);
+                 (uu___2629_20739.FStar_TypeChecker_Env.fv_delta_depths);
                FStar_TypeChecker_Env.proof_ns =
-                 (uu___2614_20513.FStar_TypeChecker_Env.proof_ns);
+                 (uu___2629_20739.FStar_TypeChecker_Env.proof_ns);
                FStar_TypeChecker_Env.synth_hook =
-                 (uu___2614_20513.FStar_TypeChecker_Env.synth_hook);
+                 (uu___2629_20739.FStar_TypeChecker_Env.synth_hook);
                FStar_TypeChecker_Env.splice =
-                 (uu___2614_20513.FStar_TypeChecker_Env.splice);
+                 (uu___2629_20739.FStar_TypeChecker_Env.splice);
                FStar_TypeChecker_Env.postprocess =
-                 (uu___2614_20513.FStar_TypeChecker_Env.postprocess);
+                 (uu___2629_20739.FStar_TypeChecker_Env.postprocess);
                FStar_TypeChecker_Env.is_native_tactic =
-                 (uu___2614_20513.FStar_TypeChecker_Env.is_native_tactic);
+                 (uu___2629_20739.FStar_TypeChecker_Env.is_native_tactic);
                FStar_TypeChecker_Env.identifier_info =
-                 (uu___2614_20513.FStar_TypeChecker_Env.identifier_info);
+                 (uu___2629_20739.FStar_TypeChecker_Env.identifier_info);
                FStar_TypeChecker_Env.tc_hooks =
-                 (uu___2614_20513.FStar_TypeChecker_Env.tc_hooks);
+                 (uu___2629_20739.FStar_TypeChecker_Env.tc_hooks);
                FStar_TypeChecker_Env.dsenv =
-                 (uu___2614_20513.FStar_TypeChecker_Env.dsenv);
+                 (uu___2629_20739.FStar_TypeChecker_Env.dsenv);
                FStar_TypeChecker_Env.nbe =
-                 (uu___2614_20513.FStar_TypeChecker_Env.nbe);
+                 (uu___2629_20739.FStar_TypeChecker_Env.nbe);
                FStar_TypeChecker_Env.strict_args_tab =
-                 (uu___2614_20513.FStar_TypeChecker_Env.strict_args_tab)
+                 (uu___2629_20739.FStar_TypeChecker_Env.strict_args_tab);
+               FStar_TypeChecker_Env.erasable_types_tab =
+                 (uu___2629_20739.FStar_TypeChecker_Env.erasable_types_tab)
              }  in
-           let uu____20530 =
+           let uu____20756 =
              FStar_TypeChecker_PatternUtils.elaborate_pat env p0  in
-           check_nested_pattern uu____20512 uu____20530 pat_t  in
-         match uu____20501 with
-         | (bvs,pat_e,pat,g) ->
-             ((let uu____20554 =
+           check_nested_pattern uu____20738 uu____20756 pat_t  in
+         match uu____20724 with
+         | (bvs,pat_e,pat,g,erasable1) ->
+             ((let uu____20786 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "Patterns")
                   in
-               if uu____20554
+               if uu____20786
                then
-                 let uu____20559 = FStar_Syntax_Print.pat_to_string pat  in
-                 let uu____20561 = FStar_Syntax_Print.term_to_string pat_e
+                 let uu____20791 = FStar_Syntax_Print.pat_to_string pat  in
+                 let uu____20793 = FStar_Syntax_Print.term_to_string pat_e
                     in
                  FStar_Util.print2
-                   "Done checking pattern %s as expression %s\n" uu____20559
-                   uu____20561
+                   "Done checking pattern %s as expression %s\n" uu____20791
+                   uu____20793
                else ());
-              (let uu____20566 = FStar_TypeChecker_Env.push_bvs env bvs  in
-               let uu____20567 =
+              (let uu____20798 = FStar_TypeChecker_Env.push_bvs env bvs  in
+               let uu____20799 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.Beta] env pat_e
                   in
-               (pat, bvs, uu____20566, pat_e, uu____20567, g))))
+               (pat, bvs, uu____20798, pat_e, uu____20799, g, erasable1))))
 
 and (tc_eqn :
   FStar_Syntax_Syntax.bv ->
@@ -7162,64 +7219,64 @@ and (tc_eqn :
           FStar_Syntax_Syntax.term * FStar_Ident.lident *
           FStar_Syntax_Syntax.cflag Prims.list *
           (Prims.bool -> FStar_Syntax_Syntax.lcomp) *
-          FStar_TypeChecker_Env.guard_t))
+          FStar_TypeChecker_Env.guard_t * Prims.bool))
   =
   fun scrutinee  ->
     fun env  ->
       fun branch1  ->
-        let uu____20613 = FStar_Syntax_Subst.open_branch branch1  in
-        match uu____20613 with
+        let uu____20849 = FStar_Syntax_Subst.open_branch branch1  in
+        match uu____20849 with
         | (pattern,when_clause,branch_exp) ->
-            let uu____20659 = branch1  in
-            (match uu____20659 with
-             | (cpat,uu____20701,cbr) ->
+            let uu____20898 = branch1  in
+            (match uu____20898 with
+             | (cpat,uu____20943,cbr) ->
                  let pat_t = scrutinee.FStar_Syntax_Syntax.sort  in
                  let scrutinee_tm = FStar_Syntax_Syntax.bv_to_name scrutinee
                     in
-                 let uu____20723 =
-                   let uu____20730 =
+                 let uu____20965 =
+                   let uu____20972 =
                      FStar_TypeChecker_Env.push_bv env scrutinee  in
-                   FStar_All.pipe_right uu____20730
+                   FStar_All.pipe_right uu____20972
                      FStar_TypeChecker_Env.clear_expected_typ
                     in
-                 (match uu____20723 with
-                  | (scrutinee_env,uu____20764) ->
-                      let uu____20769 = tc_pat env pat_t pattern  in
-                      (match uu____20769 with
-                       | (pattern1,pat_bvs1,pat_env,pat_exp,norm_pat_exp,guard_pat)
+                 (match uu____20965 with
+                  | (scrutinee_env,uu____21009) ->
+                      let uu____21014 = tc_pat env pat_t pattern  in
+                      (match uu____21014 with
+                       | (pattern1,pat_bvs1,pat_env,pat_exp,norm_pat_exp,guard_pat,erasable1)
                            ->
-                           let uu____20820 =
+                           let uu____21074 =
                              match when_clause with
                              | FStar_Pervasives_Native.None  ->
                                  (FStar_Pervasives_Native.None,
                                    FStar_TypeChecker_Env.trivial_guard)
                              | FStar_Pervasives_Native.Some e ->
-                                 let uu____20850 =
+                                 let uu____21104 =
                                    FStar_TypeChecker_Env.should_verify env
                                     in
-                                 if uu____20850
+                                 if uu____21104
                                  then
                                    FStar_Errors.raise_error
                                      (FStar_Errors.Fatal_WhenClauseNotSupported,
                                        "When clauses are not yet supported in --verify mode; they will be some day")
                                      e.FStar_Syntax_Syntax.pos
                                  else
-                                   (let uu____20873 =
-                                      let uu____20880 =
+                                   (let uu____21127 =
+                                      let uu____21134 =
                                         FStar_TypeChecker_Env.set_expected_typ
                                           pat_env FStar_Syntax_Util.t_bool
                                          in
-                                      tc_term uu____20880 e  in
-                                    match uu____20873 with
+                                      tc_term uu____21134 e  in
+                                    match uu____21127 with
                                     | (e1,c,g) ->
                                         ((FStar_Pervasives_Native.Some e1),
                                           g))
                               in
-                           (match uu____20820 with
+                           (match uu____21074 with
                             | (when_clause1,g_when) ->
-                                let uu____20934 = tc_term pat_env branch_exp
+                                let uu____21191 = tc_term pat_env branch_exp
                                    in
-                                (match uu____20934 with
+                                (match uu____21191 with
                                  | (branch_exp1,c,g_branch) ->
                                      (FStar_TypeChecker_Env.def_check_guard_wf
                                         cbr.FStar_Syntax_Syntax.pos
@@ -7229,27 +7286,27 @@ and (tc_eqn :
                                          | FStar_Pervasives_Native.None  ->
                                              FStar_Pervasives_Native.None
                                          | FStar_Pervasives_Native.Some w ->
-                                             let uu____20990 =
+                                             let uu____21250 =
                                                FStar_Syntax_Util.mk_eq2
                                                  FStar_Syntax_Syntax.U_zero
                                                  FStar_Syntax_Util.t_bool w
                                                  FStar_Syntax_Util.exp_true_bool
                                                 in
                                              FStar_All.pipe_left
-                                               (fun _21001  ->
+                                               (fun _21261  ->
                                                   FStar_Pervasives_Native.Some
-                                                    _21001) uu____20990
+                                                    _21261) uu____21250
                                           in
-                                       let uu____21002 =
+                                       let uu____21262 =
                                          let eqs =
-                                           let uu____21024 =
-                                             let uu____21026 =
+                                           let uu____21284 =
+                                             let uu____21286 =
                                                FStar_TypeChecker_Env.should_verify
                                                  env
                                                 in
-                                             Prims.op_Negation uu____21026
+                                             Prims.op_Negation uu____21286
                                               in
-                                           if uu____21024
+                                           if uu____21284
                                            then FStar_Pervasives_Native.None
                                            else
                                              (let e =
@@ -7259,44 +7316,44 @@ and (tc_eqn :
                                               match e.FStar_Syntax_Syntax.n
                                               with
                                               | FStar_Syntax_Syntax.Tm_uvar
-                                                  uu____21042 ->
+                                                  uu____21302 ->
                                                   FStar_Pervasives_Native.None
                                               | FStar_Syntax_Syntax.Tm_constant
-                                                  uu____21057 ->
+                                                  uu____21317 ->
                                                   FStar_Pervasives_Native.None
                                               | FStar_Syntax_Syntax.Tm_fvar
-                                                  uu____21060 ->
+                                                  uu____21320 ->
                                                   FStar_Pervasives_Native.None
-                                              | uu____21063 ->
-                                                  let uu____21064 =
-                                                    let uu____21067 =
+                                              | uu____21323 ->
+                                                  let uu____21324 =
+                                                    let uu____21327 =
                                                       env.FStar_TypeChecker_Env.universe_of
                                                         env pat_t
                                                        in
                                                     FStar_Syntax_Util.mk_eq2
-                                                      uu____21067 pat_t
+                                                      uu____21327 pat_t
                                                       scrutinee_tm e
                                                      in
                                                   FStar_Pervasives_Native.Some
-                                                    uu____21064)
+                                                    uu____21324)
                                             in
-                                         let uu____21070 =
+                                         let uu____21330 =
                                            FStar_TypeChecker_Util.strengthen_precondition
                                              FStar_Pervasives_Native.None env
                                              branch_exp1 c g_branch
                                             in
-                                         match uu____21070 with
+                                         match uu____21330 with
                                          | (c1,g_branch1) ->
-                                             let uu____21097 =
+                                             let uu____21357 =
                                                match (eqs, when_condition)
                                                with
-                                               | uu____21114 when
-                                                   let uu____21127 =
+                                               | uu____21374 when
+                                                   let uu____21387 =
                                                      FStar_TypeChecker_Env.should_verify
                                                        env
                                                       in
                                                    Prims.op_Negation
-                                                     uu____21127
+                                                     uu____21387
                                                    -> (c1, g_when)
                                                | (FStar_Pervasives_Native.None
                                                   ,FStar_Pervasives_Native.None
@@ -7312,15 +7369,15 @@ and (tc_eqn :
                                                      FStar_TypeChecker_Env.guard_of_guard_formula
                                                        gf
                                                       in
-                                                   let uu____21158 =
+                                                   let uu____21418 =
                                                      FStar_TypeChecker_Util.weaken_precondition
                                                        env c1 gf
                                                       in
-                                                   let uu____21159 =
+                                                   let uu____21419 =
                                                      FStar_TypeChecker_Env.imp_guard
                                                        g g_when
                                                       in
-                                                   (uu____21158, uu____21159)
+                                                   (uu____21418, uu____21419)
                                                | (FStar_Pervasives_Native.Some
                                                   f,FStar_Pervasives_Native.Some
                                                   w) ->
@@ -7329,26 +7386,26 @@ and (tc_eqn :
                                                        f
                                                       in
                                                    let g_fw =
-                                                     let uu____21180 =
+                                                     let uu____21440 =
                                                        FStar_Syntax_Util.mk_conj
                                                          f w
                                                         in
                                                      FStar_TypeChecker_Common.NonTrivial
-                                                       uu____21180
+                                                       uu____21440
                                                       in
-                                                   let uu____21181 =
+                                                   let uu____21441 =
                                                      FStar_TypeChecker_Util.weaken_precondition
                                                        env c1 g_fw
                                                       in
-                                                   let uu____21182 =
-                                                     let uu____21183 =
+                                                   let uu____21442 =
+                                                     let uu____21443 =
                                                        FStar_TypeChecker_Env.guard_of_guard_formula
                                                          g_f
                                                         in
                                                      FStar_TypeChecker_Env.imp_guard
-                                                       uu____21183 g_when
+                                                       uu____21443 g_when
                                                       in
-                                                   (uu____21181, uu____21182)
+                                                   (uu____21441, uu____21442)
                                                | (FStar_Pervasives_Native.None
                                                   ,FStar_Pervasives_Native.Some
                                                   w) ->
@@ -7360,13 +7417,13 @@ and (tc_eqn :
                                                      FStar_TypeChecker_Env.guard_of_guard_formula
                                                        g_w
                                                       in
-                                                   let uu____21201 =
+                                                   let uu____21461 =
                                                      FStar_TypeChecker_Util.weaken_precondition
                                                        env c1 g_w
                                                       in
-                                                   (uu____21201, g_when)
+                                                   (uu____21461, g_when)
                                                 in
-                                             (match uu____21097 with
+                                             (match uu____21357 with
                                               | (c_weak,g_when_weak) ->
                                                   let binders =
                                                     FStar_List.map
@@ -7376,12 +7433,12 @@ and (tc_eqn :
                                                   let maybe_return_c_weak
                                                     should_return1 =
                                                     let c_weak1 =
-                                                      let uu____21244 =
+                                                      let uu____21504 =
                                                         should_return1 &&
                                                           (FStar_Syntax_Util.is_pure_or_ghost_lcomp
                                                              c_weak)
                                                          in
-                                                      if uu____21244
+                                                      if uu____21504
                                                       then
                                                         FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
                                                           env branch_exp1
@@ -7390,31 +7447,31 @@ and (tc_eqn :
                                                     FStar_TypeChecker_Util.close_lcomp
                                                       env pat_bvs1 c_weak1
                                                      in
-                                                  let uu____21249 =
+                                                  let uu____21509 =
                                                     FStar_TypeChecker_Env.close_guard
                                                       env binders g_when_weak
                                                      in
-                                                  let uu____21250 =
+                                                  let uu____21510 =
                                                     FStar_TypeChecker_Env.conj_guard
                                                       guard_pat g_branch1
                                                      in
                                                   ((c_weak.FStar_Syntax_Syntax.eff_name),
                                                     (c_weak.FStar_Syntax_Syntax.cflags),
                                                     maybe_return_c_weak,
-                                                    uu____21249, uu____21250))
+                                                    uu____21509, uu____21510))
                                           in
-                                       match uu____21002 with
+                                       match uu____21262 with
                                        | (effect_label,cflags,maybe_return_c,g_when1,g_branch1)
                                            ->
                                            let branch_guard =
-                                             let uu____21301 =
-                                               let uu____21303 =
+                                             let uu____21564 =
+                                               let uu____21566 =
                                                  FStar_TypeChecker_Env.should_verify
                                                    env
                                                   in
-                                               Prims.op_Negation uu____21303
+                                               Prims.op_Negation uu____21566
                                                 in
-                                             if uu____21301
+                                             if uu____21564
                                              then FStar_Syntax_Util.t_true
                                              else
                                                (let rec build_branch_guard
@@ -7422,16 +7479,16 @@ and (tc_eqn :
                                                   pat_exp1 =
                                                   let discriminate
                                                     scrutinee_tm2 f =
-                                                    let uu____21357 =
-                                                      let uu____21365 =
+                                                    let uu____21620 =
+                                                      let uu____21628 =
                                                         FStar_TypeChecker_Env.typ_of_datacon
                                                           env
                                                           f.FStar_Syntax_Syntax.v
                                                          in
                                                       FStar_TypeChecker_Env.datacons_of_typ
-                                                        env uu____21365
+                                                        env uu____21628
                                                        in
-                                                    match uu____21357 with
+                                                    match uu____21620 with
                                                     | (is_induc,datacons) ->
                                                         if
                                                           (Prims.op_Negation
@@ -7446,16 +7503,16 @@ and (tc_eqn :
                                                             FStar_Syntax_Util.mk_discriminator
                                                               f.FStar_Syntax_Syntax.v
                                                              in
-                                                          let uu____21381 =
+                                                          let uu____21644 =
                                                             FStar_TypeChecker_Env.try_lookup_lid
                                                               env
                                                               discriminator
                                                              in
-                                                          (match uu____21381
+                                                          (match uu____21644
                                                            with
                                                            | FStar_Pervasives_Native.None
                                                                 -> []
-                                                           | uu____21402 ->
+                                                           | uu____21665 ->
                                                                let disc =
                                                                  FStar_Syntax_Syntax.fvar
                                                                    discriminator
@@ -7464,26 +7521,26 @@ and (tc_eqn :
                                                                    FStar_Pervasives_Native.None
                                                                   in
                                                                let disc1 =
-                                                                 let uu____21418
+                                                                 let uu____21681
                                                                    =
-                                                                   let uu____21423
+                                                                   let uu____21686
                                                                     =
-                                                                    let uu____21424
+                                                                    let uu____21687
                                                                     =
                                                                     FStar_Syntax_Syntax.as_arg
                                                                     scrutinee_tm2
                                                                      in
-                                                                    [uu____21424]
+                                                                    [uu____21687]
                                                                      in
                                                                    FStar_Syntax_Syntax.mk_Tm_app
                                                                     disc
-                                                                    uu____21423
+                                                                    uu____21686
                                                                     in
-                                                                 uu____21418
+                                                                 uu____21681
                                                                    FStar_Pervasives_Native.None
                                                                    scrutinee_tm2.FStar_Syntax_Syntax.pos
                                                                   in
-                                                               let uu____21449
+                                                               let uu____21712
                                                                  =
                                                                  FStar_Syntax_Util.mk_eq2
                                                                    FStar_Syntax_Syntax.U_zero
@@ -7491,30 +7548,30 @@ and (tc_eqn :
                                                                    disc1
                                                                    FStar_Syntax_Util.exp_true_bool
                                                                   in
-                                                               [uu____21449])
+                                                               [uu____21712])
                                                         else []
                                                      in
-                                                  let fail1 uu____21457 =
-                                                    let uu____21458 =
-                                                      let uu____21460 =
+                                                  let fail1 uu____21720 =
+                                                    let uu____21721 =
+                                                      let uu____21723 =
                                                         FStar_Range.string_of_range
                                                           pat_exp1.FStar_Syntax_Syntax.pos
                                                          in
-                                                      let uu____21462 =
+                                                      let uu____21725 =
                                                         FStar_Syntax_Print.term_to_string
                                                           pat_exp1
                                                          in
-                                                      let uu____21464 =
+                                                      let uu____21727 =
                                                         FStar_Syntax_Print.tag_of_term
                                                           pat_exp1
                                                          in
                                                       FStar_Util.format3
                                                         "tc_eqn: Impossible (%s) %s (%s)"
-                                                        uu____21460
-                                                        uu____21462
-                                                        uu____21464
+                                                        uu____21723
+                                                        uu____21725
+                                                        uu____21727
                                                        in
-                                                    failwith uu____21458  in
+                                                    failwith uu____21721  in
                                                   let rec head_constructor t
                                                     =
                                                     match t.FStar_Syntax_Syntax.n
@@ -7523,178 +7580,178 @@ and (tc_eqn :
                                                         fv ->
                                                         fv.FStar_Syntax_Syntax.fv_name
                                                     | FStar_Syntax_Syntax.Tm_uinst
-                                                        (t1,uu____21479) ->
+                                                        (t1,uu____21742) ->
                                                         head_constructor t1
-                                                    | uu____21484 -> fail1 ()
+                                                    | uu____21747 -> fail1 ()
                                                      in
                                                   let force_scrutinee
-                                                    uu____21490 =
+                                                    uu____21753 =
                                                     match scrutinee_tm1 with
                                                     | FStar_Pervasives_Native.None
                                                          ->
-                                                        let uu____21491 =
-                                                          let uu____21493 =
+                                                        let uu____21754 =
+                                                          let uu____21756 =
                                                             FStar_Range.string_of_range
                                                               pattern2.FStar_Syntax_Syntax.p
                                                              in
-                                                          let uu____21495 =
+                                                          let uu____21758 =
                                                             FStar_Syntax_Print.pat_to_string
                                                               pattern2
                                                              in
                                                           FStar_Util.format2
                                                             "Impossible (%s): scrutinee of match is not defined %s"
-                                                            uu____21493
-                                                            uu____21495
+                                                            uu____21756
+                                                            uu____21758
                                                            in
-                                                        failwith uu____21491
+                                                        failwith uu____21754
                                                     | FStar_Pervasives_Native.Some
                                                         t -> t
                                                      in
                                                   let pat_exp2 =
-                                                    let uu____21502 =
+                                                    let uu____21765 =
                                                       FStar_Syntax_Subst.compress
                                                         pat_exp1
                                                        in
                                                     FStar_All.pipe_right
-                                                      uu____21502
+                                                      uu____21765
                                                       FStar_Syntax_Util.unmeta
                                                      in
                                                   match ((pattern2.FStar_Syntax_Syntax.v),
                                                           (pat_exp2.FStar_Syntax_Syntax.n))
                                                   with
-                                                  | (uu____21507,FStar_Syntax_Syntax.Tm_name
-                                                     uu____21508) -> []
-                                                  | (uu____21509,FStar_Syntax_Syntax.Tm_constant
+                                                  | (uu____21770,FStar_Syntax_Syntax.Tm_name
+                                                     uu____21771) -> []
+                                                  | (uu____21772,FStar_Syntax_Syntax.Tm_constant
                                                      (FStar_Const.Const_unit
                                                      )) -> []
                                                   | (FStar_Syntax_Syntax.Pat_constant
                                                      _c,FStar_Syntax_Syntax.Tm_constant
                                                      c1) ->
-                                                      let uu____21512 =
-                                                        let uu____21513 =
+                                                      let uu____21775 =
+                                                        let uu____21776 =
                                                           tc_constant env
                                                             pat_exp2.FStar_Syntax_Syntax.pos
                                                             c1
                                                            in
-                                                        let uu____21514 =
+                                                        let uu____21777 =
                                                           force_scrutinee ()
                                                            in
                                                         FStar_Syntax_Util.mk_eq2
                                                           FStar_Syntax_Syntax.U_zero
-                                                          uu____21513
-                                                          uu____21514
+                                                          uu____21776
+                                                          uu____21777
                                                           pat_exp2
                                                          in
-                                                      [uu____21512]
+                                                      [uu____21775]
                                                   | (FStar_Syntax_Syntax.Pat_constant
                                                      (FStar_Const.Const_int
-                                                     (uu____21515,FStar_Pervasives_Native.Some
-                                                      uu____21516)),uu____21517)
+                                                     (uu____21778,FStar_Pervasives_Native.Some
+                                                      uu____21779)),uu____21780)
                                                       ->
-                                                      let uu____21534 =
-                                                        let uu____21541 =
+                                                      let uu____21797 =
+                                                        let uu____21804 =
                                                           FStar_TypeChecker_Env.clear_expected_typ
                                                             env
                                                            in
-                                                        match uu____21541
+                                                        match uu____21804
                                                         with
-                                                        | (env1,uu____21555)
+                                                        | (env1,uu____21818)
                                                             ->
                                                             env1.FStar_TypeChecker_Env.type_of
                                                               env1 pat_exp2
                                                          in
-                                                      (match uu____21534 with
-                                                       | (uu____21562,t,uu____21564)
+                                                      (match uu____21797 with
+                                                       | (uu____21825,t,uu____21827)
                                                            ->
-                                                           let uu____21565 =
-                                                             let uu____21566
+                                                           let uu____21828 =
+                                                             let uu____21829
                                                                =
                                                                force_scrutinee
                                                                  ()
                                                                 in
                                                              FStar_Syntax_Util.mk_eq2
                                                                FStar_Syntax_Syntax.U_zero
-                                                               t uu____21566
+                                                               t uu____21829
                                                                pat_exp2
                                                               in
-                                                           [uu____21565])
+                                                           [uu____21828])
                                                   | (FStar_Syntax_Syntax.Pat_cons
-                                                     (uu____21567,[]),FStar_Syntax_Syntax.Tm_uinst
-                                                     uu____21568) ->
+                                                     (uu____21830,[]),FStar_Syntax_Syntax.Tm_uinst
+                                                     uu____21831) ->
                                                       let f =
                                                         head_constructor
                                                           pat_exp2
                                                          in
-                                                      let uu____21592 =
-                                                        let uu____21594 =
+                                                      let uu____21855 =
+                                                        let uu____21857 =
                                                           FStar_TypeChecker_Env.is_datacon
                                                             env
                                                             f.FStar_Syntax_Syntax.v
                                                            in
                                                         Prims.op_Negation
-                                                          uu____21594
+                                                          uu____21857
                                                          in
-                                                      if uu____21592
+                                                      if uu____21855
                                                       then
                                                         failwith
                                                           "Impossible: nullary patterns must be data constructors"
                                                       else
-                                                        (let uu____21604 =
+                                                        (let uu____21867 =
                                                            force_scrutinee ()
                                                             in
-                                                         let uu____21607 =
+                                                         let uu____21870 =
                                                            head_constructor
                                                              pat_exp2
                                                             in
                                                          discriminate
-                                                           uu____21604
-                                                           uu____21607)
+                                                           uu____21867
+                                                           uu____21870)
                                                   | (FStar_Syntax_Syntax.Pat_cons
-                                                     (uu____21610,[]),FStar_Syntax_Syntax.Tm_fvar
-                                                     uu____21611) ->
+                                                     (uu____21873,[]),FStar_Syntax_Syntax.Tm_fvar
+                                                     uu____21874) ->
                                                       let f =
                                                         head_constructor
                                                           pat_exp2
                                                          in
-                                                      let uu____21629 =
-                                                        let uu____21631 =
+                                                      let uu____21892 =
+                                                        let uu____21894 =
                                                           FStar_TypeChecker_Env.is_datacon
                                                             env
                                                             f.FStar_Syntax_Syntax.v
                                                            in
                                                         Prims.op_Negation
-                                                          uu____21631
+                                                          uu____21894
                                                          in
-                                                      if uu____21629
+                                                      if uu____21892
                                                       then
                                                         failwith
                                                           "Impossible: nullary patterns must be data constructors"
                                                       else
-                                                        (let uu____21641 =
+                                                        (let uu____21904 =
                                                            force_scrutinee ()
                                                             in
-                                                         let uu____21644 =
+                                                         let uu____21907 =
                                                            head_constructor
                                                              pat_exp2
                                                             in
                                                          discriminate
-                                                           uu____21641
-                                                           uu____21644)
+                                                           uu____21904
+                                                           uu____21907)
                                                   | (FStar_Syntax_Syntax.Pat_cons
-                                                     (uu____21647,pat_args),FStar_Syntax_Syntax.Tm_app
+                                                     (uu____21910,pat_args),FStar_Syntax_Syntax.Tm_app
                                                      (head1,args)) ->
                                                       let f =
                                                         head_constructor
                                                           head1
                                                          in
-                                                      let uu____21694 =
-                                                        (let uu____21698 =
+                                                      let uu____21957 =
+                                                        (let uu____21961 =
                                                            FStar_TypeChecker_Env.is_datacon
                                                              env
                                                              f.FStar_Syntax_Syntax.v
                                                             in
                                                          Prims.op_Negation
-                                                           uu____21698)
+                                                           uu____21961)
                                                           ||
                                                           ((FStar_List.length
                                                               pat_args)
@@ -7702,32 +7759,32 @@ and (tc_eqn :
                                                              (FStar_List.length
                                                                 args))
                                                          in
-                                                      if uu____21694
+                                                      if uu____21957
                                                       then
                                                         failwith
                                                           "Impossible: application patterns must be fully-applied data constructors"
                                                       else
                                                         (let sub_term_guards
                                                            =
-                                                           let uu____21726 =
-                                                             let uu____21731
+                                                           let uu____21989 =
+                                                             let uu____21994
                                                                =
                                                                FStar_List.zip
                                                                  pat_args
                                                                  args
                                                                 in
                                                              FStar_All.pipe_right
-                                                               uu____21731
+                                                               uu____21994
                                                                (FStar_List.mapi
                                                                   (fun i  ->
                                                                     fun
-                                                                    uu____21817
+                                                                    uu____22080
                                                                      ->
-                                                                    match uu____21817
+                                                                    match uu____22080
                                                                     with
                                                                     | 
-                                                                    ((pi,uu____21839),
-                                                                    (ei,uu____21841))
+                                                                    ((pi,uu____22102),
+                                                                    (ei,uu____22104))
                                                                     ->
                                                                     let projector
                                                                     =
@@ -7737,143 +7794,143 @@ and (tc_eqn :
                                                                     i  in
                                                                     let scrutinee_tm2
                                                                     =
-                                                                    let uu____21869
+                                                                    let uu____22132
                                                                     =
                                                                     FStar_TypeChecker_Env.try_lookup_lid
                                                                     env
                                                                     projector
                                                                      in
-                                                                    match uu____21869
+                                                                    match uu____22132
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.None
                                                                      ->
                                                                     FStar_Pervasives_Native.None
                                                                     | 
-                                                                    uu____21890
+                                                                    uu____22153
                                                                     ->
                                                                     let proj
                                                                     =
-                                                                    let uu____21902
+                                                                    let uu____22165
                                                                     =
                                                                     FStar_Ident.set_lid_range
                                                                     projector
                                                                     f.FStar_Syntax_Syntax.p
                                                                      in
                                                                     FStar_Syntax_Syntax.fvar
-                                                                    uu____21902
+                                                                    uu____22165
                                                                     (FStar_Syntax_Syntax.Delta_equational_at_level
                                                                     Prims.int_one)
                                                                     FStar_Pervasives_Native.None
                                                                      in
-                                                                    let uu____21904
+                                                                    let uu____22167
                                                                     =
-                                                                    let uu____21905
+                                                                    let uu____22168
                                                                     =
-                                                                    let uu____21910
+                                                                    let uu____22173
                                                                     =
-                                                                    let uu____21911
+                                                                    let uu____22174
                                                                     =
-                                                                    let uu____21920
+                                                                    let uu____22183
                                                                     =
                                                                     force_scrutinee
                                                                     ()  in
                                                                     FStar_Syntax_Syntax.as_arg
-                                                                    uu____21920
+                                                                    uu____22183
                                                                      in
-                                                                    [uu____21911]
+                                                                    [uu____22174]
                                                                      in
                                                                     FStar_Syntax_Syntax.mk_Tm_app
                                                                     proj
-                                                                    uu____21910
+                                                                    uu____22173
                                                                      in
-                                                                    uu____21905
+                                                                    uu____22168
                                                                     FStar_Pervasives_Native.None
                                                                     f.FStar_Syntax_Syntax.p
                                                                      in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____21904
+                                                                    uu____22167
                                                                      in
                                                                     build_branch_guard
                                                                     scrutinee_tm2
                                                                     pi ei))
                                                               in
                                                            FStar_All.pipe_right
-                                                             uu____21726
+                                                             uu____21989
                                                              FStar_List.flatten
                                                             in
-                                                         let uu____21943 =
-                                                           let uu____21946 =
+                                                         let uu____22206 =
+                                                           let uu____22209 =
                                                              force_scrutinee
                                                                ()
                                                               in
                                                            discriminate
-                                                             uu____21946 f
+                                                             uu____22209 f
                                                             in
                                                          FStar_List.append
-                                                           uu____21943
+                                                           uu____22206
                                                            sub_term_guards)
                                                   | (FStar_Syntax_Syntax.Pat_dot_term
-                                                     uu____21949,uu____21950)
+                                                     uu____22212,uu____22213)
                                                       -> []
-                                                  | uu____21957 ->
-                                                      let uu____21962 =
-                                                        let uu____21964 =
+                                                  | uu____22220 ->
+                                                      let uu____22225 =
+                                                        let uu____22227 =
                                                           FStar_Syntax_Print.pat_to_string
                                                             pattern2
                                                            in
-                                                        let uu____21966 =
+                                                        let uu____22229 =
                                                           FStar_Syntax_Print.term_to_string
                                                             pat_exp2
                                                            in
                                                         FStar_Util.format2
                                                           "Internal error: unexpected elaborated pattern: %s and pattern expression %s"
-                                                          uu____21964
-                                                          uu____21966
+                                                          uu____22227
+                                                          uu____22229
                                                          in
-                                                      failwith uu____21962
+                                                      failwith uu____22225
                                                    in
                                                 let build_and_check_branch_guard
                                                   scrutinee_tm1 pattern2 pat
                                                   =
-                                                  let uu____21995 =
-                                                    let uu____21997 =
+                                                  let uu____22258 =
+                                                    let uu____22260 =
                                                       FStar_TypeChecker_Env.should_verify
                                                         env
                                                        in
                                                     Prims.op_Negation
-                                                      uu____21997
+                                                      uu____22260
                                                      in
-                                                  if uu____21995
+                                                  if uu____22258
                                                   then
                                                     FStar_TypeChecker_Util.fvar_const
                                                       env
                                                       FStar_Parser_Const.true_lid
                                                   else
                                                     (let t =
-                                                       let uu____22003 =
+                                                       let uu____22266 =
                                                          build_branch_guard
                                                            scrutinee_tm1
                                                            pattern2 pat
                                                           in
                                                        FStar_All.pipe_left
                                                          FStar_Syntax_Util.mk_conj_l
-                                                         uu____22003
+                                                         uu____22266
                                                         in
-                                                     let uu____22012 =
+                                                     let uu____22275 =
                                                        FStar_Syntax_Util.type_u
                                                          ()
                                                         in
-                                                     match uu____22012 with
-                                                     | (k,uu____22018) ->
-                                                         let uu____22019 =
+                                                     match uu____22275 with
+                                                     | (k,uu____22281) ->
+                                                         let uu____22282 =
                                                            tc_check_tot_or_gtot_term
                                                              scrutinee_env t
                                                              k
                                                             in
-                                                         (match uu____22019
+                                                         (match uu____22282
                                                           with
-                                                          | (t1,uu____22027,uu____22028)
+                                                          | (t1,uu____22290,uu____22291)
                                                               -> t1))
                                                    in
                                                 let branch_guard =
@@ -7897,38 +7954,39 @@ and (tc_eqn :
                                              FStar_TypeChecker_Env.conj_guard
                                                g_when1 g_branch1
                                               in
-                                           ((let uu____22040 =
+                                           ((let uu____22303 =
                                                FStar_TypeChecker_Env.debug
                                                  env FStar_Options.High
                                                 in
-                                             if uu____22040
+                                             if uu____22303
                                              then
-                                               let uu____22043 =
+                                               let uu____22306 =
                                                  FStar_TypeChecker_Rel.guard_to_string
                                                    env guard
                                                   in
                                                FStar_All.pipe_left
                                                  (FStar_Util.print1
                                                     "Carrying guard from match: %s\n")
-                                                 uu____22043
+                                                 uu____22306
                                              else ());
-                                            (let uu____22049 =
+                                            (let uu____22312 =
                                                FStar_Syntax_Subst.close_branch
                                                  (pattern1, when_clause1,
                                                    branch_exp1)
                                                 in
-                                             let uu____22066 =
-                                               let uu____22067 =
+                                             let uu____22329 =
+                                               let uu____22330 =
                                                  FStar_List.map
                                                    FStar_Syntax_Syntax.mk_binder
                                                    pat_bvs1
                                                   in
                                                FStar_TypeChecker_Util.close_guard_implicits
-                                                 env uu____22067 guard
+                                                 env uu____22330 guard
                                                 in
-                                             (uu____22049, branch_guard,
+                                             (uu____22312, branch_guard,
                                                effect_label, cflags,
-                                               maybe_return_c, uu____22066))))))))))
+                                               maybe_return_c, uu____22329,
+                                               erasable1))))))))))
 
 and (check_top_level_let :
   FStar_TypeChecker_Env.env ->
@@ -7941,44 +7999,44 @@ and (check_top_level_let :
       let env1 = instantiate_both env  in
       match e.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),e2) ->
-          let uu____22114 = check_let_bound_def true env1 lb  in
-          (match uu____22114 with
+          let uu____22378 = check_let_bound_def true env1 lb  in
+          (match uu____22378 with
            | (e1,univ_vars1,c1,g1,annotated) ->
-               let uu____22140 =
+               let uu____22404 =
                  if
                    annotated &&
                      (Prims.op_Negation env1.FStar_TypeChecker_Env.generalize)
                  then
-                   let uu____22162 =
+                   let uu____22426 =
                      FStar_TypeChecker_Normalize.reduce_uvar_solutions env1
                        e1
                       in
-                   (g1, uu____22162, univ_vars1, c1)
+                   (g1, uu____22426, univ_vars1, c1)
                  else
                    (let g11 =
-                      let uu____22168 =
+                      let uu____22432 =
                         FStar_TypeChecker_Rel.solve_deferred_constraints env1
                           g1
                          in
-                      FStar_All.pipe_right uu____22168
+                      FStar_All.pipe_right uu____22432
                         (FStar_TypeChecker_Rel.resolve_implicits env1)
                        in
-                    let uu____22169 =
-                      let uu____22182 =
-                        let uu____22197 =
-                          let uu____22206 =
-                            let uu____22213 =
+                    let uu____22433 =
+                      let uu____22446 =
+                        let uu____22461 =
+                          let uu____22470 =
+                            let uu____22477 =
                               FStar_Syntax_Syntax.lcomp_comp c1  in
                             ((lb.FStar_Syntax_Syntax.lbname), e1,
-                              uu____22213)
+                              uu____22477)
                              in
-                          [uu____22206]  in
+                          [uu____22470]  in
                         FStar_TypeChecker_Util.generalize env1 false
-                          uu____22197
+                          uu____22461
                          in
-                      FStar_List.hd uu____22182  in
-                    match uu____22169 with
-                    | (uu____22249,univs1,e11,c11,gvs) ->
+                      FStar_List.hd uu____22446  in
+                    match uu____22433 with
+                    | (uu____22513,univs1,e11,c11,gvs) ->
                         let g12 =
                           FStar_All.pipe_left
                             (FStar_TypeChecker_Env.map_guard g11)
@@ -7992,30 +8050,30 @@ and (check_top_level_let :
                            in
                         let g13 =
                           FStar_TypeChecker_Env.abstract_guard_n gvs g12  in
-                        let uu____22263 = FStar_Syntax_Util.lcomp_of_comp c11
+                        let uu____22527 = FStar_Syntax_Util.lcomp_of_comp c11
                            in
-                        (g13, e11, univs1, uu____22263))
+                        (g13, e11, univs1, uu____22527))
                   in
-               (match uu____22140 with
+               (match uu____22404 with
                 | (g11,e11,univ_vars2,c11) ->
-                    let uu____22280 =
-                      let uu____22289 =
+                    let uu____22544 =
+                      let uu____22553 =
                         FStar_TypeChecker_Env.should_verify env1  in
-                      if uu____22289
+                      if uu____22553
                       then
-                        let uu____22300 =
+                        let uu____22564 =
                           FStar_TypeChecker_Util.check_top_level env1 g11 c11
                            in
-                        match uu____22300 with
+                        match uu____22564 with
                         | (ok,c12) ->
                             (if ok
                              then (e2, c12)
                              else
-                               ((let uu____22334 =
+                               ((let uu____22598 =
                                    FStar_TypeChecker_Env.get_range env1  in
-                                 FStar_Errors.log_issue uu____22334
+                                 FStar_Errors.log_issue uu____22598
                                    FStar_TypeChecker_Err.top_level_effect);
-                                (let uu____22335 =
+                                (let uu____22599 =
                                    FStar_Syntax_Syntax.mk
                                      (FStar_Syntax_Syntax.Tm_meta
                                         (e2,
@@ -8024,13 +8082,13 @@ and (check_top_level_let :
                                      FStar_Pervasives_Native.None
                                      e2.FStar_Syntax_Syntax.pos
                                     in
-                                 (uu____22335, c12))))
+                                 (uu____22599, c12))))
                       else
                         (FStar_TypeChecker_Rel.force_trivial_guard env1 g11;
                          (let c =
-                            let uu____22350 =
+                            let uu____22614 =
                               FStar_Syntax_Syntax.lcomp_comp c11  in
-                            FStar_All.pipe_right uu____22350
+                            FStar_All.pipe_right uu____22614
                               (FStar_TypeChecker_Normalize.normalize_comp
                                  [FStar_TypeChecker_Env.Beta;
                                  FStar_TypeChecker_Env.NoFullNorm;
@@ -8038,14 +8096,14 @@ and (check_top_level_let :
                                  env1)
                              in
                           let e21 =
-                            let uu____22356 =
+                            let uu____22620 =
                               FStar_Syntax_Util.is_pure_comp c  in
-                            if uu____22356
+                            if uu____22620
                             then e2
                             else
-                              ((let uu____22364 =
+                              ((let uu____22628 =
                                   FStar_TypeChecker_Env.get_range env1  in
-                                FStar_Errors.log_issue uu____22364
+                                FStar_Errors.log_issue uu____22628
                                   FStar_TypeChecker_Err.top_level_effect);
                                FStar_Syntax_Syntax.mk
                                  (FStar_Syntax_Syntax.Tm_meta
@@ -8057,22 +8115,22 @@ and (check_top_level_let :
                              in
                           (e21, c)))
                        in
-                    (match uu____22280 with
+                    (match uu____22544 with
                      | (e21,c12) ->
-                         ((let uu____22388 =
+                         ((let uu____22652 =
                              FStar_TypeChecker_Env.debug env1
                                FStar_Options.Medium
                               in
-                           if uu____22388
+                           if uu____22652
                            then
-                             let uu____22391 =
+                             let uu____22655 =
                                FStar_Syntax_Print.term_to_string e11  in
                              FStar_Util.print1
-                               "Let binding BEFORE tcnorm: %s\n" uu____22391
+                               "Let binding BEFORE tcnorm: %s\n" uu____22655
                            else ());
                           (let e12 =
-                             let uu____22397 = FStar_Options.tcnorm ()  in
-                             if uu____22397
+                             let uu____22661 = FStar_Options.tcnorm ()  in
+                             if uu____22661
                              then
                                FStar_TypeChecker_Normalize.normalize
                                  [FStar_TypeChecker_Env.UnfoldAttr
@@ -8085,22 +8143,22 @@ and (check_top_level_let :
                                  FStar_TypeChecker_Env.DoNotUnfoldPureLets]
                                  env1 e11
                              else e11  in
-                           (let uu____22403 =
+                           (let uu____22667 =
                               FStar_TypeChecker_Env.debug env1
                                 FStar_Options.Medium
                                in
-                            if uu____22403
+                            if uu____22667
                             then
-                              let uu____22406 =
+                              let uu____22670 =
                                 FStar_Syntax_Print.term_to_string e12  in
                               FStar_Util.print1
-                                "Let binding AFTER tcnorm: %s\n" uu____22406
+                                "Let binding AFTER tcnorm: %s\n" uu____22670
                             else ());
                            (let cres =
-                              let uu____22412 =
+                              let uu____22676 =
                                 FStar_Syntax_Util.is_pure_or_ghost_comp c12
                                  in
-                              if uu____22412
+                              if uu____22676
                               then
                                 FStar_Syntax_Syntax.mk_Total'
                                   FStar_Syntax_Syntax.t_unit
@@ -8115,8 +8173,8 @@ and (check_top_level_let :
                                  let c1_wp =
                                    match c1_comp_typ.FStar_Syntax_Syntax.effect_args
                                    with
-                                   | (wp,uu____22420)::[] -> wp
-                                   | uu____22445 ->
+                                   | (wp,uu____22684)::[] -> wp
+                                   | uu____22709 ->
                                        failwith
                                          "Impossible! check_top_level_let: got unexpected effect args"
                                     in
@@ -8125,34 +8183,34 @@ and (check_top_level_let :
                                      c1_comp_typ.FStar_Syntax_Syntax.effect_name
                                     in
                                  let wp2 =
-                                   let uu____22461 =
-                                     let uu____22466 =
+                                   let uu____22725 =
+                                     let uu____22730 =
                                        FStar_TypeChecker_Env.inst_effect_fun_with
                                          [FStar_Syntax_Syntax.U_zero] env1
                                          c1_eff_decl
                                          c1_eff_decl.FStar_Syntax_Syntax.ret_wp
                                         in
-                                     let uu____22467 =
-                                       let uu____22468 =
+                                     let uu____22731 =
+                                       let uu____22732 =
                                          FStar_Syntax_Syntax.as_arg
                                            FStar_Syntax_Syntax.t_unit
                                           in
-                                       let uu____22477 =
-                                         let uu____22488 =
+                                       let uu____22741 =
+                                         let uu____22752 =
                                            FStar_Syntax_Syntax.as_arg
                                              FStar_Syntax_Syntax.unit_const
                                             in
-                                         [uu____22488]  in
-                                       uu____22468 :: uu____22477  in
+                                         [uu____22752]  in
+                                       uu____22732 :: uu____22741  in
                                      FStar_Syntax_Syntax.mk_Tm_app
-                                       uu____22466 uu____22467
+                                       uu____22730 uu____22731
                                       in
-                                   uu____22461 FStar_Pervasives_Native.None
+                                   uu____22725 FStar_Pervasives_Native.None
                                      e21.FStar_Syntax_Syntax.pos
                                     in
                                  let wp =
-                                   let uu____22524 =
-                                     let uu____22529 =
+                                   let uu____22788 =
+                                     let uu____22793 =
                                        FStar_TypeChecker_Env.inst_effect_fun_with
                                          (FStar_List.append
                                             c1_comp_typ.FStar_Syntax_Syntax.comp_univs
@@ -8160,9 +8218,9 @@ and (check_top_level_let :
                                          env1 c1_eff_decl
                                          c1_eff_decl.FStar_Syntax_Syntax.bind_wp
                                         in
-                                     let uu____22530 =
-                                       let uu____22531 =
-                                         let uu____22540 =
+                                     let uu____22794 =
+                                       let uu____22795 =
+                                         let uu____22804 =
                                            FStar_Syntax_Syntax.mk
                                              (FStar_Syntax_Syntax.Tm_constant
                                                 (FStar_Const.Const_range
@@ -8172,35 +8230,35 @@ and (check_top_level_let :
                                             in
                                          FStar_All.pipe_left
                                            FStar_Syntax_Syntax.as_arg
-                                           uu____22540
+                                           uu____22804
                                           in
-                                       let uu____22549 =
-                                         let uu____22560 =
+                                       let uu____22813 =
+                                         let uu____22824 =
                                            FStar_All.pipe_left
                                              FStar_Syntax_Syntax.as_arg
                                              c1_comp_typ.FStar_Syntax_Syntax.result_typ
                                             in
-                                         let uu____22577 =
-                                           let uu____22588 =
+                                         let uu____22841 =
+                                           let uu____22852 =
                                              FStar_Syntax_Syntax.as_arg
                                                FStar_Syntax_Syntax.t_unit
                                               in
-                                           let uu____22597 =
-                                             let uu____22608 =
+                                           let uu____22861 =
+                                             let uu____22872 =
                                                FStar_Syntax_Syntax.as_arg
                                                  c1_wp
                                                 in
-                                             let uu____22617 =
-                                               let uu____22628 =
-                                                 let uu____22637 =
-                                                   let uu____22638 =
-                                                     let uu____22639 =
+                                             let uu____22881 =
+                                               let uu____22892 =
+                                                 let uu____22901 =
+                                                   let uu____22902 =
+                                                     let uu____22903 =
                                                        FStar_Syntax_Syntax.null_binder
                                                          c1_comp_typ.FStar_Syntax_Syntax.result_typ
                                                         in
-                                                     [uu____22639]  in
+                                                     [uu____22903]  in
                                                    FStar_Syntax_Util.abs
-                                                     uu____22638 wp2
+                                                     uu____22902 wp2
                                                      (FStar_Pervasives_Native.Some
                                                         (FStar_Syntax_Util.mk_residual_comp
                                                            FStar_Parser_Const.effect_Tot_lid
@@ -8209,24 +8267,24 @@ and (check_top_level_let :
                                                     in
                                                  FStar_All.pipe_left
                                                    FStar_Syntax_Syntax.as_arg
-                                                   uu____22637
+                                                   uu____22901
                                                   in
-                                               [uu____22628]  in
-                                             uu____22608 :: uu____22617  in
-                                           uu____22588 :: uu____22597  in
-                                         uu____22560 :: uu____22577  in
-                                       uu____22531 :: uu____22549  in
+                                               [uu____22892]  in
+                                             uu____22872 :: uu____22881  in
+                                           uu____22852 :: uu____22861  in
+                                         uu____22824 :: uu____22841  in
+                                       uu____22795 :: uu____22813  in
                                      FStar_Syntax_Syntax.mk_Tm_app
-                                       uu____22529 uu____22530
+                                       uu____22793 uu____22794
                                       in
-                                   uu____22524 FStar_Pervasives_Native.None
+                                   uu____22788 FStar_Pervasives_Native.None
                                      lb.FStar_Syntax_Syntax.lbpos
                                     in
-                                 let uu____22716 =
-                                   let uu____22717 =
-                                     let uu____22728 =
+                                 let uu____22980 =
+                                   let uu____22981 =
+                                     let uu____22992 =
                                        FStar_Syntax_Syntax.as_arg wp  in
-                                     [uu____22728]  in
+                                     [uu____22992]  in
                                    {
                                      FStar_Syntax_Syntax.comp_univs =
                                        [FStar_Syntax_Syntax.U_zero];
@@ -8235,10 +8293,10 @@ and (check_top_level_let :
                                      FStar_Syntax_Syntax.result_typ =
                                        FStar_Syntax_Syntax.t_unit;
                                      FStar_Syntax_Syntax.effect_args =
-                                       uu____22717;
+                                       uu____22981;
                                      FStar_Syntax_Syntax.flags = []
                                    }  in
-                                 FStar_Syntax_Syntax.mk_Comp uu____22716)
+                                 FStar_Syntax_Syntax.mk_Comp uu____22980)
                                in
                             let lb1 =
                               FStar_Syntax_Util.close_univs_and_mk_letbinding
@@ -8249,18 +8307,18 @@ and (check_top_level_let :
                                 lb.FStar_Syntax_Syntax.lbattrs
                                 lb.FStar_Syntax_Syntax.lbpos
                                in
-                            let uu____22756 =
+                            let uu____23020 =
                               FStar_Syntax_Syntax.mk
                                 (FStar_Syntax_Syntax.Tm_let
                                    ((false, [lb1]), e21))
                                 FStar_Pervasives_Native.None
                                 e.FStar_Syntax_Syntax.pos
                                in
-                            let uu____22770 =
+                            let uu____23034 =
                               FStar_Syntax_Util.lcomp_of_comp cres  in
-                            (uu____22756, uu____22770,
+                            (uu____23020, uu____23034,
                               FStar_TypeChecker_Env.trivial_guard)))))))
-      | uu____22771 -> failwith "Impossible"
+      | uu____23035 -> failwith "Impossible"
 
 and (maybe_intro_smt_lemma :
   FStar_TypeChecker_Env.env ->
@@ -8270,15 +8328,15 @@ and (maybe_intro_smt_lemma :
   fun env  ->
     fun lem_typ  ->
       fun c2  ->
-        let uu____22782 = FStar_Syntax_Util.is_smt_lemma lem_typ  in
-        if uu____22782
+        let uu____23046 = FStar_Syntax_Util.is_smt_lemma lem_typ  in
+        if uu____23046
         then
           let universe_of_binders bs =
-            let uu____22809 =
+            let uu____23073 =
               FStar_List.fold_left
-                (fun uu____22834  ->
+                (fun uu____23098  ->
                    fun b  ->
-                     match uu____22834 with
+                     match uu____23098 with
                      | (env1,us) ->
                          let u =
                            env1.FStar_TypeChecker_Env.universe_of env1
@@ -8288,7 +8346,7 @@ and (maybe_intro_smt_lemma :
                            FStar_TypeChecker_Env.push_binders env1 [b]  in
                          (env2, (u :: us))) (env, []) bs
                in
-            match uu____22809 with | (uu____22882,us) -> FStar_List.rev us
+            match uu____23073 with | (uu____23146,us) -> FStar_List.rev us
              in
           let quant =
             FStar_Syntax_Util.smt_lemma_as_forall lem_typ universe_of_binders
@@ -8309,105 +8367,107 @@ and (check_inner_let :
       match e.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),e2) ->
           let env2 =
-            let uu___2937_22918 = env1  in
+            let uu___2954_23182 = env1  in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___2937_22918.FStar_TypeChecker_Env.solver);
+                (uu___2954_23182.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___2937_22918.FStar_TypeChecker_Env.range);
+                (uu___2954_23182.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___2937_22918.FStar_TypeChecker_Env.curmodule);
+                (uu___2954_23182.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___2937_22918.FStar_TypeChecker_Env.gamma);
+                (uu___2954_23182.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___2937_22918.FStar_TypeChecker_Env.gamma_sig);
+                (uu___2954_23182.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___2937_22918.FStar_TypeChecker_Env.gamma_cache);
+                (uu___2954_23182.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___2937_22918.FStar_TypeChecker_Env.modules);
+                (uu___2954_23182.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___2937_22918.FStar_TypeChecker_Env.expected_typ);
+                (uu___2954_23182.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___2937_22918.FStar_TypeChecker_Env.sigtab);
+                (uu___2954_23182.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___2937_22918.FStar_TypeChecker_Env.attrtab);
+                (uu___2954_23182.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.is_pattern =
-                (uu___2937_22918.FStar_TypeChecker_Env.is_pattern);
+                (uu___2954_23182.FStar_TypeChecker_Env.is_pattern);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___2937_22918.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___2954_23182.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___2937_22918.FStar_TypeChecker_Env.effects);
+                (uu___2954_23182.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___2937_22918.FStar_TypeChecker_Env.generalize);
+                (uu___2954_23182.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___2937_22918.FStar_TypeChecker_Env.letrecs);
+                (uu___2954_23182.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level = false;
               FStar_TypeChecker_Env.check_uvars =
-                (uu___2937_22918.FStar_TypeChecker_Env.check_uvars);
+                (uu___2954_23182.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___2937_22918.FStar_TypeChecker_Env.use_eq);
+                (uu___2954_23182.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.is_iface =
-                (uu___2937_22918.FStar_TypeChecker_Env.is_iface);
+                (uu___2954_23182.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___2937_22918.FStar_TypeChecker_Env.admit);
+                (uu___2954_23182.FStar_TypeChecker_Env.admit);
               FStar_TypeChecker_Env.lax =
-                (uu___2937_22918.FStar_TypeChecker_Env.lax);
+                (uu___2954_23182.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___2937_22918.FStar_TypeChecker_Env.lax_universes);
+                (uu___2954_23182.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___2937_22918.FStar_TypeChecker_Env.phase1);
+                (uu___2954_23182.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___2937_22918.FStar_TypeChecker_Env.failhard);
+                (uu___2954_23182.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___2937_22918.FStar_TypeChecker_Env.nosynth);
+                (uu___2954_23182.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___2937_22918.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___2954_23182.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___2937_22918.FStar_TypeChecker_Env.tc_term);
+                (uu___2954_23182.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___2937_22918.FStar_TypeChecker_Env.type_of);
+                (uu___2954_23182.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___2937_22918.FStar_TypeChecker_Env.universe_of);
+                (uu___2954_23182.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___2937_22918.FStar_TypeChecker_Env.check_type_of);
+                (uu___2954_23182.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts =
-                (uu___2937_22918.FStar_TypeChecker_Env.use_bv_sorts);
+                (uu___2954_23182.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___2937_22918.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___2954_23182.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___2937_22918.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___2954_23182.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___2937_22918.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___2954_23182.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___2937_22918.FStar_TypeChecker_Env.proof_ns);
+                (uu___2954_23182.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___2937_22918.FStar_TypeChecker_Env.synth_hook);
+                (uu___2954_23182.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___2937_22918.FStar_TypeChecker_Env.splice);
+                (uu___2954_23182.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.postprocess =
-                (uu___2937_22918.FStar_TypeChecker_Env.postprocess);
+                (uu___2954_23182.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.is_native_tactic =
-                (uu___2937_22918.FStar_TypeChecker_Env.is_native_tactic);
+                (uu___2954_23182.FStar_TypeChecker_Env.is_native_tactic);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___2937_22918.FStar_TypeChecker_Env.identifier_info);
+                (uu___2954_23182.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___2937_22918.FStar_TypeChecker_Env.tc_hooks);
+                (uu___2954_23182.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___2937_22918.FStar_TypeChecker_Env.dsenv);
+                (uu___2954_23182.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.nbe =
-                (uu___2937_22918.FStar_TypeChecker_Env.nbe);
+                (uu___2954_23182.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___2937_22918.FStar_TypeChecker_Env.strict_args_tab)
+                (uu___2954_23182.FStar_TypeChecker_Env.strict_args_tab);
+              FStar_TypeChecker_Env.erasable_types_tab =
+                (uu___2954_23182.FStar_TypeChecker_Env.erasable_types_tab)
             }  in
-          let uu____22920 =
-            let uu____22932 =
-              let uu____22933 = FStar_TypeChecker_Env.clear_expected_typ env2
+          let uu____23184 =
+            let uu____23196 =
+              let uu____23197 = FStar_TypeChecker_Env.clear_expected_typ env2
                  in
-              FStar_All.pipe_right uu____22933 FStar_Pervasives_Native.fst
+              FStar_All.pipe_right uu____23197 FStar_Pervasives_Native.fst
                in
-            check_let_bound_def false uu____22932 lb  in
-          (match uu____22920 with
-           | (e1,uu____22956,c1,g1,annotated) ->
+            check_let_bound_def false uu____23196 lb  in
+          (match uu____23184 with
+           | (e1,uu____23220,c1,g1,annotated) ->
                let pure_or_ghost =
                  FStar_Syntax_Util.is_pure_or_ghost_lcomp c1  in
                let is_inline_let =
@@ -8418,56 +8478,56 @@ and (check_inner_let :
                   in
                (if is_inline_let && (Prims.op_Negation pure_or_ghost)
                 then
-                  (let uu____22970 =
-                     let uu____22976 =
-                       let uu____22978 = FStar_Syntax_Print.term_to_string e1
+                  (let uu____23234 =
+                     let uu____23240 =
+                       let uu____23242 = FStar_Syntax_Print.term_to_string e1
                           in
-                       let uu____22980 =
+                       let uu____23244 =
                          FStar_Syntax_Print.lid_to_string
                            c1.FStar_Syntax_Syntax.eff_name
                           in
                        FStar_Util.format2
                          "Definitions marked @inline_let are expected to be pure or ghost; got an expression \"%s\" with effect \"%s\""
-                         uu____22978 uu____22980
+                         uu____23242 uu____23244
                         in
-                     (FStar_Errors.Fatal_ExpectedPureExpression, uu____22976)
+                     (FStar_Errors.Fatal_ExpectedPureExpression, uu____23240)
                       in
-                   FStar_Errors.raise_error uu____22970
+                   FStar_Errors.raise_error uu____23234
                      e1.FStar_Syntax_Syntax.pos)
                 else ();
                 (let attrs =
-                   let uu____22991 =
+                   let uu____23255 =
                      (pure_or_ghost && (Prims.op_Negation is_inline_let)) &&
                        (FStar_Syntax_Util.is_unit
                           c1.FStar_Syntax_Syntax.res_typ)
                       in
-                   if uu____22991
+                   if uu____23255
                    then FStar_Syntax_Util.inline_let_attr ::
                      (lb.FStar_Syntax_Syntax.lbattrs)
                    else lb.FStar_Syntax_Syntax.lbattrs  in
                  let x =
-                   let uu___2952_23003 =
+                   let uu___2969_23267 =
                      FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
                    {
                      FStar_Syntax_Syntax.ppname =
-                       (uu___2952_23003.FStar_Syntax_Syntax.ppname);
+                       (uu___2969_23267.FStar_Syntax_Syntax.ppname);
                      FStar_Syntax_Syntax.index =
-                       (uu___2952_23003.FStar_Syntax_Syntax.index);
+                       (uu___2969_23267.FStar_Syntax_Syntax.index);
                      FStar_Syntax_Syntax.sort =
                        (c1.FStar_Syntax_Syntax.res_typ)
                    }  in
-                 let uu____23004 =
-                   let uu____23009 =
-                     let uu____23010 = FStar_Syntax_Syntax.mk_binder x  in
-                     [uu____23010]  in
-                   FStar_Syntax_Subst.open_term uu____23009 e2  in
-                 match uu____23004 with
+                 let uu____23268 =
+                   let uu____23273 =
+                     let uu____23274 = FStar_Syntax_Syntax.mk_binder x  in
+                     [uu____23274]  in
+                   FStar_Syntax_Subst.open_term uu____23273 e2  in
+                 match uu____23268 with
                  | (xb,e21) ->
                      let xbinder = FStar_List.hd xb  in
                      let x1 = FStar_Pervasives_Native.fst xbinder  in
                      let env_x = FStar_TypeChecker_Env.push_bv env2 x1  in
-                     let uu____23054 = tc_term env_x e21  in
-                     (match uu____23054 with
+                     let uu____23318 = tc_term env_x e21  in
+                     (match uu____23318 with
                       | (e22,c2,g2) ->
                           let c21 =
                             maybe_intro_smt_lemma env_x
@@ -8499,15 +8559,15 @@ and (check_inner_let :
                               lb.FStar_Syntax_Syntax.lbpos
                              in
                           let e3 =
-                            let uu____23080 =
-                              let uu____23087 =
-                                let uu____23088 =
-                                  let uu____23102 =
+                            let uu____23344 =
+                              let uu____23351 =
+                                let uu____23352 =
+                                  let uu____23366 =
                                     FStar_Syntax_Subst.close xb e23  in
-                                  ((false, [lb1]), uu____23102)  in
-                                FStar_Syntax_Syntax.Tm_let uu____23088  in
-                              FStar_Syntax_Syntax.mk uu____23087  in
-                            uu____23080 FStar_Pervasives_Native.None
+                                  ((false, [lb1]), uu____23366)  in
+                                FStar_Syntax_Syntax.Tm_let uu____23352  in
+                              FStar_Syntax_Syntax.mk uu____23351  in
+                            uu____23344 FStar_Pervasives_Native.None
                               e.FStar_Syntax_Syntax.pos
                              in
                           let e4 =
@@ -8516,32 +8576,32 @@ and (check_inner_let :
                               cres.FStar_Syntax_Syntax.res_typ
                              in
                           let x_eq_e1 =
-                            let uu____23120 =
-                              let uu____23121 =
+                            let uu____23384 =
+                              let uu____23385 =
                                 env2.FStar_TypeChecker_Env.universe_of env2
                                   c1.FStar_Syntax_Syntax.res_typ
                                  in
-                              let uu____23122 =
+                              let uu____23386 =
                                 FStar_Syntax_Syntax.bv_to_name x1  in
-                              FStar_Syntax_Util.mk_eq2 uu____23121
-                                c1.FStar_Syntax_Syntax.res_typ uu____23122
+                              FStar_Syntax_Util.mk_eq2 uu____23385
+                                c1.FStar_Syntax_Syntax.res_typ uu____23386
                                 e11
                                in
                             FStar_All.pipe_left
-                              (fun _23123  ->
-                                 FStar_TypeChecker_Common.NonTrivial _23123)
-                              uu____23120
+                              (fun _23387  ->
+                                 FStar_TypeChecker_Common.NonTrivial _23387)
+                              uu____23384
                              in
                           let g21 =
-                            let uu____23125 =
-                              let uu____23126 =
+                            let uu____23389 =
+                              let uu____23390 =
                                 FStar_TypeChecker_Env.guard_of_guard_formula
                                   x_eq_e1
                                  in
-                              FStar_TypeChecker_Env.imp_guard uu____23126 g2
+                              FStar_TypeChecker_Env.imp_guard uu____23390 g2
                                in
                             FStar_TypeChecker_Env.close_guard env2 xb
-                              uu____23125
+                              uu____23389
                              in
                           let g22 =
                             FStar_TypeChecker_Util.close_guard_implicits env2
@@ -8549,77 +8609,77 @@ and (check_inner_let :
                              in
                           let guard = FStar_TypeChecker_Env.conj_guard g1 g22
                              in
-                          let uu____23129 =
-                            let uu____23131 =
+                          let uu____23393 =
+                            let uu____23395 =
                               FStar_TypeChecker_Env.expected_typ env2  in
-                            FStar_Option.isSome uu____23131  in
-                          if uu____23129
+                            FStar_Option.isSome uu____23395  in
+                          if uu____23393
                           then
                             let tt =
-                              let uu____23142 =
+                              let uu____23406 =
                                 FStar_TypeChecker_Env.expected_typ env2  in
-                              FStar_All.pipe_right uu____23142
+                              FStar_All.pipe_right uu____23406
                                 FStar_Option.get
                                in
-                            ((let uu____23148 =
+                            ((let uu____23412 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env2)
                                   (FStar_Options.Other "Exports")
                                  in
-                              if uu____23148
+                              if uu____23412
                               then
-                                let uu____23153 =
+                                let uu____23417 =
                                   FStar_Syntax_Print.term_to_string tt  in
-                                let uu____23155 =
+                                let uu____23419 =
                                   FStar_Syntax_Print.term_to_string
                                     cres.FStar_Syntax_Syntax.res_typ
                                    in
                                 FStar_Util.print2
                                   "Got expected type from env %s\ncres.res_typ=%s\n"
-                                  uu____23153 uu____23155
+                                  uu____23417 uu____23419
                               else ());
                              (e4, cres, guard))
                           else
-                            (let uu____23162 =
+                            (let uu____23426 =
                                check_no_escape FStar_Pervasives_Native.None
                                  env2 [x1] cres.FStar_Syntax_Syntax.res_typ
                                 in
-                             match uu____23162 with
+                             match uu____23426 with
                              | (t,g_ex) ->
-                                 ((let uu____23176 =
+                                 ((let uu____23440 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env2)
                                        (FStar_Options.Other "Exports")
                                       in
-                                   if uu____23176
+                                   if uu____23440
                                    then
-                                     let uu____23181 =
+                                     let uu____23445 =
                                        FStar_Syntax_Print.term_to_string
                                          cres.FStar_Syntax_Syntax.res_typ
                                         in
-                                     let uu____23183 =
+                                     let uu____23447 =
                                        FStar_Syntax_Print.term_to_string t
                                         in
                                      FStar_Util.print2
                                        "Checked %s has no escaping types; normalized to %s\n"
-                                       uu____23181 uu____23183
+                                       uu____23445 uu____23447
                                    else ());
-                                  (let uu____23188 =
+                                  (let uu____23452 =
                                      FStar_TypeChecker_Env.conj_guard g_ex
                                        guard
                                       in
                                    (e4,
-                                     (let uu___2985_23190 = cres  in
+                                     (let uu___3002_23454 = cres  in
                                       {
                                         FStar_Syntax_Syntax.eff_name =
-                                          (uu___2985_23190.FStar_Syntax_Syntax.eff_name);
+                                          (uu___3002_23454.FStar_Syntax_Syntax.eff_name);
                                         FStar_Syntax_Syntax.res_typ = t;
                                         FStar_Syntax_Syntax.cflags =
-                                          (uu___2985_23190.FStar_Syntax_Syntax.cflags);
+                                          (uu___3002_23454.FStar_Syntax_Syntax.cflags);
                                         FStar_Syntax_Syntax.comp_thunk =
-                                          (uu___2985_23190.FStar_Syntax_Syntax.comp_thunk)
-                                      }), uu____23188))))))))
-      | uu____23191 ->
+                                          (uu___3002_23454.FStar_Syntax_Syntax.comp_thunk)
+                                      }), uu____23452))))))))
+      | uu____23455 ->
           failwith "Impossible (inner let with more than one lb)"
 
 and (check_top_level_let_rec :
@@ -8633,44 +8693,44 @@ and (check_top_level_let_rec :
       let env1 = instantiate_both env  in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((true ,lbs),e2) ->
-          let uu____23227 = FStar_Syntax_Subst.open_let_rec lbs e2  in
-          (match uu____23227 with
+          let uu____23491 = FStar_Syntax_Subst.open_let_rec lbs e2  in
+          (match uu____23491 with
            | (lbs1,e21) ->
-               let uu____23246 =
+               let uu____23510 =
                  FStar_TypeChecker_Env.clear_expected_typ env1  in
-               (match uu____23246 with
+               (match uu____23510 with
                 | (env0,topt) ->
-                    let uu____23265 = build_let_rec_env true env0 lbs1  in
-                    (match uu____23265 with
+                    let uu____23529 = build_let_rec_env true env0 lbs1  in
+                    (match uu____23529 with
                      | (lbs2,rec_env,g_t) ->
-                         let uu____23288 = check_let_recs rec_env lbs2  in
-                         (match uu____23288 with
+                         let uu____23552 = check_let_recs rec_env lbs2  in
+                         (match uu____23552 with
                           | (lbs3,g_lbs) ->
                               let g_lbs1 =
-                                let uu____23308 =
-                                  let uu____23309 =
+                                let uu____23572 =
+                                  let uu____23573 =
                                     FStar_TypeChecker_Env.conj_guard g_t
                                       g_lbs
                                      in
-                                  FStar_All.pipe_right uu____23309
+                                  FStar_All.pipe_right uu____23573
                                     (FStar_TypeChecker_Rel.solve_deferred_constraints
                                        env1)
                                    in
-                                FStar_All.pipe_right uu____23308
+                                FStar_All.pipe_right uu____23572
                                   (FStar_TypeChecker_Rel.resolve_implicits
                                      env1)
                                  in
                               let all_lb_names =
-                                let uu____23315 =
+                                let uu____23579 =
                                   FStar_All.pipe_right lbs3
                                     (FStar_List.map
                                        (fun lb  ->
                                           FStar_Util.right
                                             lb.FStar_Syntax_Syntax.lbname))
                                    in
-                                FStar_All.pipe_right uu____23315
-                                  (fun _23332  ->
-                                     FStar_Pervasives_Native.Some _23332)
+                                FStar_All.pipe_right uu____23579
+                                  (fun _23596  ->
+                                     FStar_Pervasives_Native.Some _23596)
                                  in
                               let lbs4 =
                                 if
@@ -8701,25 +8761,25 @@ and (check_top_level_let_rec :
                                               lb.FStar_Syntax_Syntax.lbpos))
                                 else
                                   (let ecs =
-                                     let uu____23369 =
+                                     let uu____23633 =
                                        FStar_All.pipe_right lbs3
                                          (FStar_List.map
                                             (fun lb  ->
-                                               let uu____23403 =
+                                               let uu____23667 =
                                                  FStar_Syntax_Syntax.mk_Total
                                                    lb.FStar_Syntax_Syntax.lbtyp
                                                   in
                                                ((lb.FStar_Syntax_Syntax.lbname),
                                                  (lb.FStar_Syntax_Syntax.lbdef),
-                                                 uu____23403)))
+                                                 uu____23667)))
                                         in
                                      FStar_TypeChecker_Util.generalize env1
-                                       true uu____23369
+                                       true uu____23633
                                       in
                                    FStar_List.map2
-                                     (fun uu____23438  ->
+                                     (fun uu____23702  ->
                                         fun lb  ->
-                                          match uu____23438 with
+                                          match uu____23702 with
                                           | (x,uvs,e,c,gvs) ->
                                               FStar_Syntax_Util.close_univs_and_mk_letbinding
                                                 all_lb_names x uvs
@@ -8732,34 +8792,34 @@ and (check_top_level_let_rec :
                                      ecs lbs3)
                                  in
                               let cres =
-                                let uu____23486 =
+                                let uu____23750 =
                                   FStar_Syntax_Syntax.mk_Total
                                     FStar_Syntax_Syntax.t_unit
                                    in
                                 FStar_All.pipe_left
-                                  FStar_Syntax_Util.lcomp_of_comp uu____23486
+                                  FStar_Syntax_Util.lcomp_of_comp uu____23750
                                  in
-                              let uu____23487 =
+                              let uu____23751 =
                                 FStar_Syntax_Subst.close_let_rec lbs4 e21  in
-                              (match uu____23487 with
+                              (match uu____23751 with
                                | (lbs5,e22) ->
-                                   ((let uu____23507 =
+                                   ((let uu____23771 =
                                        FStar_TypeChecker_Rel.discharge_guard
                                          env1 g_lbs1
                                         in
-                                     FStar_All.pipe_right uu____23507
+                                     FStar_All.pipe_right uu____23771
                                        (FStar_TypeChecker_Rel.force_trivial_guard
                                           env1));
-                                    (let uu____23508 =
+                                    (let uu____23772 =
                                        FStar_Syntax_Syntax.mk
                                          (FStar_Syntax_Syntax.Tm_let
                                             ((true, lbs5), e22))
                                          FStar_Pervasives_Native.None
                                          top.FStar_Syntax_Syntax.pos
                                         in
-                                     (uu____23508, cres,
+                                     (uu____23772, cres,
                                        FStar_TypeChecker_Env.trivial_guard))))))))
-      | uu____23522 -> failwith "Impossible"
+      | uu____23786 -> failwith "Impossible"
 
 and (check_inner_let_rec :
   FStar_TypeChecker_Env.env ->
@@ -8772,64 +8832,64 @@ and (check_inner_let_rec :
       let env1 = instantiate_both env  in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((true ,lbs),e2) ->
-          let uu____23558 = FStar_Syntax_Subst.open_let_rec lbs e2  in
-          (match uu____23558 with
+          let uu____23822 = FStar_Syntax_Subst.open_let_rec lbs e2  in
+          (match uu____23822 with
            | (lbs1,e21) ->
-               let uu____23577 =
+               let uu____23841 =
                  FStar_TypeChecker_Env.clear_expected_typ env1  in
-               (match uu____23577 with
+               (match uu____23841 with
                 | (env0,topt) ->
-                    let uu____23596 = build_let_rec_env false env0 lbs1  in
-                    (match uu____23596 with
+                    let uu____23860 = build_let_rec_env false env0 lbs1  in
+                    (match uu____23860 with
                      | (lbs2,rec_env,g_t) ->
-                         let uu____23619 =
-                           let uu____23626 = check_let_recs rec_env lbs2  in
-                           FStar_All.pipe_right uu____23626
-                             (fun uu____23649  ->
-                                match uu____23649 with
+                         let uu____23883 =
+                           let uu____23890 = check_let_recs rec_env lbs2  in
+                           FStar_All.pipe_right uu____23890
+                             (fun uu____23913  ->
+                                match uu____23913 with
                                 | (lbs3,g) ->
-                                    let uu____23668 =
+                                    let uu____23932 =
                                       FStar_TypeChecker_Env.conj_guard g_t g
                                        in
-                                    (lbs3, uu____23668))
+                                    (lbs3, uu____23932))
                             in
-                         (match uu____23619 with
+                         (match uu____23883 with
                           | (lbs3,g_lbs) ->
-                              let uu____23683 =
+                              let uu____23947 =
                                 FStar_All.pipe_right lbs3
                                   (FStar_Util.fold_map
                                      (fun env2  ->
                                         fun lb  ->
                                           let x =
-                                            let uu___3060_23706 =
+                                            let uu___3077_23970 =
                                               FStar_Util.left
                                                 lb.FStar_Syntax_Syntax.lbname
                                                in
                                             {
                                               FStar_Syntax_Syntax.ppname =
-                                                (uu___3060_23706.FStar_Syntax_Syntax.ppname);
+                                                (uu___3077_23970.FStar_Syntax_Syntax.ppname);
                                               FStar_Syntax_Syntax.index =
-                                                (uu___3060_23706.FStar_Syntax_Syntax.index);
+                                                (uu___3077_23970.FStar_Syntax_Syntax.index);
                                               FStar_Syntax_Syntax.sort =
                                                 (lb.FStar_Syntax_Syntax.lbtyp)
                                             }  in
                                           let lb1 =
-                                            let uu___3063_23708 = lb  in
+                                            let uu___3080_23972 = lb  in
                                             {
                                               FStar_Syntax_Syntax.lbname =
                                                 (FStar_Util.Inl x);
                                               FStar_Syntax_Syntax.lbunivs =
-                                                (uu___3063_23708.FStar_Syntax_Syntax.lbunivs);
+                                                (uu___3080_23972.FStar_Syntax_Syntax.lbunivs);
                                               FStar_Syntax_Syntax.lbtyp =
-                                                (uu___3063_23708.FStar_Syntax_Syntax.lbtyp);
+                                                (uu___3080_23972.FStar_Syntax_Syntax.lbtyp);
                                               FStar_Syntax_Syntax.lbeff =
-                                                (uu___3063_23708.FStar_Syntax_Syntax.lbeff);
+                                                (uu___3080_23972.FStar_Syntax_Syntax.lbeff);
                                               FStar_Syntax_Syntax.lbdef =
-                                                (uu___3063_23708.FStar_Syntax_Syntax.lbdef);
+                                                (uu___3080_23972.FStar_Syntax_Syntax.lbdef);
                                               FStar_Syntax_Syntax.lbattrs =
-                                                (uu___3063_23708.FStar_Syntax_Syntax.lbattrs);
+                                                (uu___3080_23972.FStar_Syntax_Syntax.lbattrs);
                                               FStar_Syntax_Syntax.lbpos =
-                                                (uu___3063_23708.FStar_Syntax_Syntax.lbpos)
+                                                (uu___3080_23972.FStar_Syntax_Syntax.lbpos)
                                             }  in
                                           let env3 =
                                             FStar_TypeChecker_Env.push_let_binding
@@ -8840,7 +8900,7 @@ and (check_inner_let_rec :
                                              in
                                           (env3, lb1)) env1)
                                  in
-                              (match uu____23683 with
+                              (match uu____23947 with
                                | (env2,lbs4) ->
                                    let bvs =
                                      FStar_All.pipe_right lbs4
@@ -8849,8 +8909,8 @@ and (check_inner_let_rec :
                                              FStar_Util.left
                                                lb.FStar_Syntax_Syntax.lbname))
                                       in
-                                   let uu____23735 = tc_term env2 e21  in
-                                   (match uu____23735 with
+                                   let uu____23999 = tc_term env2 e21  in
+                                   (match uu____23999 with
                                     | (e22,cres,g2) ->
                                         let cres1 =
                                           FStar_List.fold_right
@@ -8870,17 +8930,17 @@ and (check_inner_let_rec :
                                             [FStar_Syntax_Syntax.SHOULD_NOT_INLINE]
                                            in
                                         let guard =
-                                          let uu____23759 =
-                                            let uu____23760 =
+                                          let uu____24023 =
+                                            let uu____24024 =
                                               FStar_List.map
                                                 FStar_Syntax_Syntax.mk_binder
                                                 bvs
                                                in
                                             FStar_TypeChecker_Env.close_guard
-                                              env2 uu____23760 g2
+                                              env2 uu____24024 g2
                                              in
                                           FStar_TypeChecker_Env.conj_guard
-                                            g_lbs uu____23759
+                                            g_lbs uu____24023
                                            in
                                         let cres4 =
                                           FStar_TypeChecker_Util.close_lcomp
@@ -8891,37 +8951,37 @@ and (check_inner_let_rec :
                                             cres4.FStar_Syntax_Syntax.res_typ
                                            in
                                         let cres5 =
-                                          let uu___3084_23770 = cres4  in
+                                          let uu___3101_24034 = cres4  in
                                           {
                                             FStar_Syntax_Syntax.eff_name =
-                                              (uu___3084_23770.FStar_Syntax_Syntax.eff_name);
+                                              (uu___3101_24034.FStar_Syntax_Syntax.eff_name);
                                             FStar_Syntax_Syntax.res_typ =
                                               tres;
                                             FStar_Syntax_Syntax.cflags =
-                                              (uu___3084_23770.FStar_Syntax_Syntax.cflags);
+                                              (uu___3101_24034.FStar_Syntax_Syntax.cflags);
                                             FStar_Syntax_Syntax.comp_thunk =
-                                              (uu___3084_23770.FStar_Syntax_Syntax.comp_thunk)
+                                              (uu___3101_24034.FStar_Syntax_Syntax.comp_thunk)
                                           }  in
                                         let guard1 =
                                           let bs =
                                             FStar_All.pipe_right lbs4
                                               (FStar_List.map
                                                  (fun lb  ->
-                                                    let uu____23778 =
+                                                    let uu____24042 =
                                                       FStar_Util.left
                                                         lb.FStar_Syntax_Syntax.lbname
                                                        in
                                                     FStar_Syntax_Syntax.mk_binder
-                                                      uu____23778))
+                                                      uu____24042))
                                              in
                                           FStar_TypeChecker_Util.close_guard_implicits
                                             env2 bs guard
                                            in
-                                        let uu____23779 =
+                                        let uu____24043 =
                                           FStar_Syntax_Subst.close_let_rec
                                             lbs4 e22
                                            in
-                                        (match uu____23779 with
+                                        (match uu____24043 with
                                          | (lbs5,e23) ->
                                              let e =
                                                FStar_Syntax_Syntax.mk
@@ -8932,40 +8992,40 @@ and (check_inner_let_rec :
                                                 in
                                              (match topt with
                                               | FStar_Pervasives_Native.Some
-                                                  uu____23820 ->
+                                                  uu____24084 ->
                                                   (e, cres5, guard1)
                                               | FStar_Pervasives_Native.None 
                                                   ->
-                                                  let uu____23821 =
+                                                  let uu____24085 =
                                                     check_no_escape
                                                       FStar_Pervasives_Native.None
                                                       env2 bvs tres
                                                      in
-                                                  (match uu____23821 with
+                                                  (match uu____24085 with
                                                    | (tres1,g_ex) ->
                                                        let cres6 =
-                                                         let uu___3100_23835
+                                                         let uu___3117_24099
                                                            = cres5  in
                                                          {
                                                            FStar_Syntax_Syntax.eff_name
                                                              =
-                                                             (uu___3100_23835.FStar_Syntax_Syntax.eff_name);
+                                                             (uu___3117_24099.FStar_Syntax_Syntax.eff_name);
                                                            FStar_Syntax_Syntax.res_typ
                                                              = tres1;
                                                            FStar_Syntax_Syntax.cflags
                                                              =
-                                                             (uu___3100_23835.FStar_Syntax_Syntax.cflags);
+                                                             (uu___3117_24099.FStar_Syntax_Syntax.cflags);
                                                            FStar_Syntax_Syntax.comp_thunk
                                                              =
-                                                             (uu___3100_23835.FStar_Syntax_Syntax.comp_thunk)
+                                                             (uu___3117_24099.FStar_Syntax_Syntax.comp_thunk)
                                                          }  in
-                                                       let uu____23836 =
+                                                       let uu____24100 =
                                                          FStar_TypeChecker_Env.conj_guard
                                                            g_ex guard1
                                                           in
                                                        (e, cres6,
-                                                         uu____23836))))))))))
-      | uu____23837 -> failwith "Impossible"
+                                                         uu____24100))))))))))
+      | uu____24101 -> failwith "Impossible"
 
 and (build_let_rec_env :
   Prims.bool ->
@@ -8979,43 +9039,43 @@ and (build_let_rec_env :
       fun lbs  ->
         let env0 = env  in
         let termination_check_enabled lbname lbdef lbtyp =
-          let uu____23885 = FStar_Options.ml_ish ()  in
-          if uu____23885
+          let uu____24149 = FStar_Options.ml_ish ()  in
+          if uu____24149
           then false
           else
             (let t = FStar_TypeChecker_Normalize.unfold_whnf env lbtyp  in
-             let uu____23893 = FStar_Syntax_Util.arrow_formals_comp t  in
-             match uu____23893 with
+             let uu____24157 = FStar_Syntax_Util.arrow_formals_comp t  in
+             match uu____24157 with
              | (formals,c) ->
-                 let uu____23925 = FStar_Syntax_Util.abs_formals lbdef  in
-                 (match uu____23925 with
-                  | (actuals,uu____23936,uu____23937) ->
+                 let uu____24189 = FStar_Syntax_Util.abs_formals lbdef  in
+                 (match uu____24189 with
+                  | (actuals,uu____24200,uu____24201) ->
                       if
                         ((FStar_List.length formals) < Prims.int_one) ||
                           ((FStar_List.length actuals) < Prims.int_one)
                       then
-                        let uu____23958 =
-                          let uu____23964 =
-                            let uu____23966 =
+                        let uu____24222 =
+                          let uu____24228 =
+                            let uu____24230 =
                               FStar_Syntax_Print.term_to_string lbdef  in
-                            let uu____23968 =
+                            let uu____24232 =
                               FStar_Syntax_Print.term_to_string lbtyp  in
                             FStar_Util.format2
                               "Only function literals with arrow types can be defined recursively; got %s : %s"
-                              uu____23966 uu____23968
+                              uu____24230 uu____24232
                              in
                           (FStar_Errors.Fatal_RecursiveFunctionLiteral,
-                            uu____23964)
+                            uu____24228)
                            in
-                        FStar_Errors.raise_error uu____23958
+                        FStar_Errors.raise_error uu____24222
                           lbtyp.FStar_Syntax_Syntax.pos
                       else
                         (let actuals1 =
-                           let uu____23976 =
+                           let uu____24240 =
                              FStar_TypeChecker_Env.set_expected_typ env lbtyp
                               in
                            FStar_TypeChecker_Util.maybe_add_implicit_binders
-                             uu____23976 actuals
+                             uu____24240 actuals
                             in
                          if
                            (FStar_List.length formals) <>
@@ -9026,30 +9086,30 @@ and (build_let_rec_env :
                               if n1 = Prims.int_one
                               then "1 argument was found"
                               else
-                                (let uu____24007 =
+                                (let uu____24271 =
                                    FStar_Util.string_of_int n1  in
                                  FStar_Util.format1 "%s arguments were found"
-                                   uu____24007)
+                                   uu____24271)
                                in
                             let formals_msg =
                               let n1 = FStar_List.length formals  in
                               if n1 = Prims.int_one
                               then "1 argument"
                               else
-                                (let uu____24026 =
+                                (let uu____24290 =
                                    FStar_Util.string_of_int n1  in
                                  FStar_Util.format1 "%s arguments"
-                                   uu____24026)
+                                   uu____24290)
                                in
                             let msg =
-                              let uu____24031 =
+                              let uu____24295 =
                                 FStar_Syntax_Print.term_to_string lbtyp  in
-                              let uu____24033 =
+                              let uu____24297 =
                                 FStar_Syntax_Print.lbname_to_string lbname
                                  in
                               FStar_Util.format4
                                 "From its type %s, the definition of `let rec %s` expects a function with %s, but %s"
-                                uu____24031 uu____24033 formals_msg
+                                uu____24295 uu____24297 formals_msg
                                 actuals_msg
                                in
                             FStar_Errors.raise_error
@@ -9064,17 +9124,17 @@ and (build_let_rec_env :
                             (FStar_List.contains
                                FStar_Syntax_Syntax.TotalEffect)))))
            in
-        let uu____24045 =
+        let uu____24309 =
           FStar_List.fold_left
-            (fun uu____24078  ->
+            (fun uu____24342  ->
                fun lb  ->
-                 match uu____24078 with
+                 match uu____24342 with
                  | (lbs1,env1,g_acc) ->
-                     let uu____24103 =
+                     let uu____24367 =
                        FStar_TypeChecker_Util.extract_let_rec_annotation env1
                          lb
                         in
-                     (match uu____24103 with
+                     (match uu____24367 with
                       | (univ_vars1,t,check_t) ->
                           let env2 =
                             FStar_TypeChecker_Env.push_univ_vars env1
@@ -9084,7 +9144,7 @@ and (build_let_rec_env :
                             FStar_Syntax_Util.unascribe
                               lb.FStar_Syntax_Syntax.lbdef
                              in
-                          let uu____24126 =
+                          let uu____24390 =
                             if Prims.op_Negation check_t
                             then (g_acc, t)
                             else
@@ -9092,231 +9152,237 @@ and (build_let_rec_env :
                                  FStar_TypeChecker_Env.push_univ_vars env0
                                    univ_vars1
                                   in
-                               let uu____24145 =
-                                 let uu____24152 =
-                                   let uu____24153 =
+                               let uu____24409 =
+                                 let uu____24416 =
+                                   let uu____24417 =
                                      FStar_Syntax_Util.type_u ()  in
                                    FStar_All.pipe_left
-                                     FStar_Pervasives_Native.fst uu____24153
+                                     FStar_Pervasives_Native.fst uu____24417
                                     in
                                  tc_check_tot_or_gtot_term
-                                   (let uu___3146_24164 = env01  in
+                                   (let uu___3163_24428 = env01  in
                                     {
                                       FStar_TypeChecker_Env.solver =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.solver);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.solver);
                                       FStar_TypeChecker_Env.range =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.range);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.range);
                                       FStar_TypeChecker_Env.curmodule =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.curmodule);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.curmodule);
                                       FStar_TypeChecker_Env.gamma =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.gamma);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.gamma);
                                       FStar_TypeChecker_Env.gamma_sig =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.gamma_sig);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.gamma_sig);
                                       FStar_TypeChecker_Env.gamma_cache =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.gamma_cache);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.gamma_cache);
                                       FStar_TypeChecker_Env.modules =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.modules);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.modules);
                                       FStar_TypeChecker_Env.expected_typ =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.expected_typ);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.expected_typ);
                                       FStar_TypeChecker_Env.sigtab =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.sigtab);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.sigtab);
                                       FStar_TypeChecker_Env.attrtab =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.attrtab);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.attrtab);
                                       FStar_TypeChecker_Env.is_pattern =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.is_pattern);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.is_pattern);
                                       FStar_TypeChecker_Env.instantiate_imp =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.instantiate_imp);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.instantiate_imp);
                                       FStar_TypeChecker_Env.effects =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.effects);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.effects);
                                       FStar_TypeChecker_Env.generalize =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.generalize);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.generalize);
                                       FStar_TypeChecker_Env.letrecs =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.letrecs);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.letrecs);
                                       FStar_TypeChecker_Env.top_level =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.top_level);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.top_level);
                                       FStar_TypeChecker_Env.check_uvars =
                                         true;
                                       FStar_TypeChecker_Env.use_eq =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.use_eq);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.use_eq);
                                       FStar_TypeChecker_Env.is_iface =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.is_iface);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.is_iface);
                                       FStar_TypeChecker_Env.admit =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.admit);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.admit);
                                       FStar_TypeChecker_Env.lax =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.lax);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.lax);
                                       FStar_TypeChecker_Env.lax_universes =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.lax_universes);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.lax_universes);
                                       FStar_TypeChecker_Env.phase1 =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.phase1);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.phase1);
                                       FStar_TypeChecker_Env.failhard =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.failhard);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.failhard);
                                       FStar_TypeChecker_Env.nosynth =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.nosynth);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.nosynth);
                                       FStar_TypeChecker_Env.uvar_subtyping =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.uvar_subtyping);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.uvar_subtyping);
                                       FStar_TypeChecker_Env.tc_term =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.tc_term);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.tc_term);
                                       FStar_TypeChecker_Env.type_of =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.type_of);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.type_of);
                                       FStar_TypeChecker_Env.universe_of =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.universe_of);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.universe_of);
                                       FStar_TypeChecker_Env.check_type_of =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.check_type_of);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.check_type_of);
                                       FStar_TypeChecker_Env.use_bv_sorts =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.use_bv_sorts);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.use_bv_sorts);
                                       FStar_TypeChecker_Env.qtbl_name_and_index
                                         =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.qtbl_name_and_index);
                                       FStar_TypeChecker_Env.normalized_eff_names
                                         =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.normalized_eff_names);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.normalized_eff_names);
                                       FStar_TypeChecker_Env.fv_delta_depths =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.fv_delta_depths);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.fv_delta_depths);
                                       FStar_TypeChecker_Env.proof_ns =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.proof_ns);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.proof_ns);
                                       FStar_TypeChecker_Env.synth_hook =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.synth_hook);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.synth_hook);
                                       FStar_TypeChecker_Env.splice =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.splice);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.splice);
                                       FStar_TypeChecker_Env.postprocess =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.postprocess);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.postprocess);
                                       FStar_TypeChecker_Env.is_native_tactic
                                         =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.is_native_tactic);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.is_native_tactic);
                                       FStar_TypeChecker_Env.identifier_info =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.identifier_info);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.identifier_info);
                                       FStar_TypeChecker_Env.tc_hooks =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.tc_hooks);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.tc_hooks);
                                       FStar_TypeChecker_Env.dsenv =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.dsenv);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.dsenv);
                                       FStar_TypeChecker_Env.nbe =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.nbe);
+                                        (uu___3163_24428.FStar_TypeChecker_Env.nbe);
                                       FStar_TypeChecker_Env.strict_args_tab =
-                                        (uu___3146_24164.FStar_TypeChecker_Env.strict_args_tab)
-                                    }) t uu____24152
+                                        (uu___3163_24428.FStar_TypeChecker_Env.strict_args_tab);
+                                      FStar_TypeChecker_Env.erasable_types_tab
+                                        =
+                                        (uu___3163_24428.FStar_TypeChecker_Env.erasable_types_tab)
+                                    }) t uu____24416
                                   in
-                               match uu____24145 with
-                               | (t1,uu____24173,g) ->
-                                   let uu____24175 =
-                                     let uu____24176 =
-                                       let uu____24177 =
+                               match uu____24409 with
+                               | (t1,uu____24437,g) ->
+                                   let uu____24439 =
+                                     let uu____24440 =
+                                       let uu____24441 =
                                          FStar_All.pipe_right g
                                            (FStar_TypeChecker_Rel.resolve_implicits
                                               env2)
                                           in
-                                       FStar_All.pipe_right uu____24177
+                                       FStar_All.pipe_right uu____24441
                                          (FStar_TypeChecker_Rel.discharge_guard
                                             env2)
                                         in
                                      FStar_TypeChecker_Env.conj_guard g_acc
-                                       uu____24176
+                                       uu____24440
                                       in
-                                   let uu____24178 = norm env01 t1  in
-                                   (uu____24175, uu____24178))
+                                   let uu____24442 = norm env01 t1  in
+                                   (uu____24439, uu____24442))
                              in
-                          (match uu____24126 with
+                          (match uu____24390 with
                            | (g,t1) ->
                                let env3 =
-                                 let uu____24198 =
+                                 let uu____24462 =
                                    termination_check_enabled
                                      lb.FStar_Syntax_Syntax.lbname e t1
                                     in
-                                 if uu____24198
+                                 if uu____24462
                                  then
-                                   let uu___3156_24201 = env2  in
+                                   let uu___3173_24465 = env2  in
                                    {
                                      FStar_TypeChecker_Env.solver =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.solver);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.solver);
                                      FStar_TypeChecker_Env.range =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.range);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.range);
                                      FStar_TypeChecker_Env.curmodule =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.curmodule);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.curmodule);
                                      FStar_TypeChecker_Env.gamma =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.gamma);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.gamma);
                                      FStar_TypeChecker_Env.gamma_sig =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.gamma_sig);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.gamma_sig);
                                      FStar_TypeChecker_Env.gamma_cache =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.gamma_cache);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.gamma_cache);
                                      FStar_TypeChecker_Env.modules =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.modules);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.modules);
                                      FStar_TypeChecker_Env.expected_typ =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.expected_typ);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.expected_typ);
                                      FStar_TypeChecker_Env.sigtab =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.sigtab);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.sigtab);
                                      FStar_TypeChecker_Env.attrtab =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.attrtab);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.attrtab);
                                      FStar_TypeChecker_Env.is_pattern =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.is_pattern);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.is_pattern);
                                      FStar_TypeChecker_Env.instantiate_imp =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.instantiate_imp);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.instantiate_imp);
                                      FStar_TypeChecker_Env.effects =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.effects);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.effects);
                                      FStar_TypeChecker_Env.generalize =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.generalize);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.generalize);
                                      FStar_TypeChecker_Env.letrecs =
                                        (((lb.FStar_Syntax_Syntax.lbname), t1,
                                           univ_vars1) ::
                                        (env2.FStar_TypeChecker_Env.letrecs));
                                      FStar_TypeChecker_Env.top_level =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.top_level);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.top_level);
                                      FStar_TypeChecker_Env.check_uvars =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.check_uvars);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.check_uvars);
                                      FStar_TypeChecker_Env.use_eq =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.use_eq);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.use_eq);
                                      FStar_TypeChecker_Env.is_iface =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.is_iface);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.is_iface);
                                      FStar_TypeChecker_Env.admit =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.admit);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.admit);
                                      FStar_TypeChecker_Env.lax =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.lax);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.lax);
                                      FStar_TypeChecker_Env.lax_universes =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.lax_universes);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.lax_universes);
                                      FStar_TypeChecker_Env.phase1 =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.phase1);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.phase1);
                                      FStar_TypeChecker_Env.failhard =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.failhard);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.failhard);
                                      FStar_TypeChecker_Env.nosynth =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.nosynth);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.nosynth);
                                      FStar_TypeChecker_Env.uvar_subtyping =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.uvar_subtyping);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.uvar_subtyping);
                                      FStar_TypeChecker_Env.tc_term =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.tc_term);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.tc_term);
                                      FStar_TypeChecker_Env.type_of =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.type_of);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.type_of);
                                      FStar_TypeChecker_Env.universe_of =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.universe_of);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.universe_of);
                                      FStar_TypeChecker_Env.check_type_of =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.check_type_of);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.check_type_of);
                                      FStar_TypeChecker_Env.use_bv_sorts =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.use_bv_sorts);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.use_bv_sorts);
                                      FStar_TypeChecker_Env.qtbl_name_and_index
                                        =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.qtbl_name_and_index);
                                      FStar_TypeChecker_Env.normalized_eff_names
                                        =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.normalized_eff_names);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.normalized_eff_names);
                                      FStar_TypeChecker_Env.fv_delta_depths =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.fv_delta_depths);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.fv_delta_depths);
                                      FStar_TypeChecker_Env.proof_ns =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.proof_ns);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.proof_ns);
                                      FStar_TypeChecker_Env.synth_hook =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.synth_hook);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.synth_hook);
                                      FStar_TypeChecker_Env.splice =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.splice);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.splice);
                                      FStar_TypeChecker_Env.postprocess =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.postprocess);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.postprocess);
                                      FStar_TypeChecker_Env.is_native_tactic =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.is_native_tactic);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.is_native_tactic);
                                      FStar_TypeChecker_Env.identifier_info =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.identifier_info);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.identifier_info);
                                      FStar_TypeChecker_Env.tc_hooks =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.tc_hooks);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.tc_hooks);
                                      FStar_TypeChecker_Env.dsenv =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.dsenv);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.dsenv);
                                      FStar_TypeChecker_Env.nbe =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.nbe);
+                                       (uu___3173_24465.FStar_TypeChecker_Env.nbe);
                                      FStar_TypeChecker_Env.strict_args_tab =
-                                       (uu___3156_24201.FStar_TypeChecker_Env.strict_args_tab)
+                                       (uu___3173_24465.FStar_TypeChecker_Env.strict_args_tab);
+                                     FStar_TypeChecker_Env.erasable_types_tab
+                                       =
+                                       (uu___3173_24465.FStar_TypeChecker_Env.erasable_types_tab)
                                    }
                                  else
                                    FStar_TypeChecker_Env.push_let_binding
@@ -9324,24 +9390,24 @@ and (build_let_rec_env :
                                      (univ_vars1, t1)
                                   in
                                let lb1 =
-                                 let uu___3159_24215 = lb  in
+                                 let uu___3176_24479 = lb  in
                                  {
                                    FStar_Syntax_Syntax.lbname =
-                                     (uu___3159_24215.FStar_Syntax_Syntax.lbname);
+                                     (uu___3176_24479.FStar_Syntax_Syntax.lbname);
                                    FStar_Syntax_Syntax.lbunivs = univ_vars1;
                                    FStar_Syntax_Syntax.lbtyp = t1;
                                    FStar_Syntax_Syntax.lbeff =
-                                     (uu___3159_24215.FStar_Syntax_Syntax.lbeff);
+                                     (uu___3176_24479.FStar_Syntax_Syntax.lbeff);
                                    FStar_Syntax_Syntax.lbdef = e;
                                    FStar_Syntax_Syntax.lbattrs =
-                                     (uu___3159_24215.FStar_Syntax_Syntax.lbattrs);
+                                     (uu___3176_24479.FStar_Syntax_Syntax.lbattrs);
                                    FStar_Syntax_Syntax.lbpos =
-                                     (uu___3159_24215.FStar_Syntax_Syntax.lbpos)
+                                     (uu___3176_24479.FStar_Syntax_Syntax.lbpos)
                                  }  in
                                ((lb1 :: lbs1), env3, g))))
             ([], env, FStar_TypeChecker_Env.trivial_guard) lbs
            in
-        match uu____24045 with
+        match uu____24309 with
         | (lbs1,env1,g) -> ((FStar_List.rev lbs1), env1, g)
 
 and (check_let_recs :
@@ -9352,62 +9418,62 @@ and (check_let_recs :
   =
   fun env  ->
     fun lbs  ->
-      let uu____24241 =
-        let uu____24250 =
+      let uu____24505 =
+        let uu____24514 =
           FStar_All.pipe_right lbs
             (FStar_List.map
                (fun lb  ->
-                  let uu____24276 =
+                  let uu____24540 =
                     FStar_Syntax_Util.abs_formals
                       lb.FStar_Syntax_Syntax.lbdef
                      in
-                  match uu____24276 with
+                  match uu____24540 with
                   | (bs,t,lcomp) ->
                       (match bs with
                        | [] ->
-                           let uu____24306 =
+                           let uu____24570 =
                              FStar_Syntax_Syntax.range_of_lbname
                                lb.FStar_Syntax_Syntax.lbname
                               in
                            FStar_Errors.raise_error
                              (FStar_Errors.Fatal_RecursiveFunctionLiteral,
                                "Only function literals may be defined recursively")
-                             uu____24306
-                       | uu____24313 ->
+                             uu____24570
+                       | uu____24577 ->
                            let lb1 =
-                             let uu___3176_24316 = lb  in
-                             let uu____24317 =
+                             let uu___3193_24580 = lb  in
+                             let uu____24581 =
                                FStar_Syntax_Util.abs bs t lcomp  in
                              {
                                FStar_Syntax_Syntax.lbname =
-                                 (uu___3176_24316.FStar_Syntax_Syntax.lbname);
+                                 (uu___3193_24580.FStar_Syntax_Syntax.lbname);
                                FStar_Syntax_Syntax.lbunivs =
-                                 (uu___3176_24316.FStar_Syntax_Syntax.lbunivs);
+                                 (uu___3193_24580.FStar_Syntax_Syntax.lbunivs);
                                FStar_Syntax_Syntax.lbtyp =
-                                 (uu___3176_24316.FStar_Syntax_Syntax.lbtyp);
+                                 (uu___3193_24580.FStar_Syntax_Syntax.lbtyp);
                                FStar_Syntax_Syntax.lbeff =
-                                 (uu___3176_24316.FStar_Syntax_Syntax.lbeff);
-                               FStar_Syntax_Syntax.lbdef = uu____24317;
+                                 (uu___3193_24580.FStar_Syntax_Syntax.lbeff);
+                               FStar_Syntax_Syntax.lbdef = uu____24581;
                                FStar_Syntax_Syntax.lbattrs =
-                                 (uu___3176_24316.FStar_Syntax_Syntax.lbattrs);
+                                 (uu___3193_24580.FStar_Syntax_Syntax.lbattrs);
                                FStar_Syntax_Syntax.lbpos =
-                                 (uu___3176_24316.FStar_Syntax_Syntax.lbpos)
+                                 (uu___3193_24580.FStar_Syntax_Syntax.lbpos)
                              }  in
-                           let uu____24320 =
-                             let uu____24327 =
+                           let uu____24584 =
+                             let uu____24591 =
                                FStar_TypeChecker_Env.set_expected_typ env
                                  lb1.FStar_Syntax_Syntax.lbtyp
                                 in
-                             tc_tot_or_gtot_term uu____24327
+                             tc_tot_or_gtot_term uu____24591
                                lb1.FStar_Syntax_Syntax.lbdef
                               in
-                           (match uu____24320 with
+                           (match uu____24584 with
                             | (e,c,g) ->
-                                ((let uu____24336 =
-                                    let uu____24338 =
+                                ((let uu____24600 =
+                                    let uu____24602 =
                                       FStar_Syntax_Util.is_total_lcomp c  in
-                                    Prims.op_Negation uu____24338  in
-                                  if uu____24336
+                                    Prims.op_Negation uu____24602  in
+                                  if uu____24600
                                   then
                                     FStar_Errors.raise_error
                                       (FStar_Errors.Fatal_UnexpectedGTotForLetRec,
@@ -9425,8 +9491,8 @@ and (check_let_recs :
                                      in
                                   (lb2, g)))))))
            in
-        FStar_All.pipe_right uu____24250 FStar_List.unzip  in
-      match uu____24241 with
+        FStar_All.pipe_right uu____24514 FStar_List.unzip  in
+      match uu____24505 with
       | (lbs1,gs) ->
           let g_lbs =
             FStar_List.fold_right FStar_TypeChecker_Env.conj_guard gs
@@ -9445,12 +9511,12 @@ and (check_let_bound_def :
   fun top_level  ->
     fun env  ->
       fun lb  ->
-        let uu____24394 = FStar_TypeChecker_Env.clear_expected_typ env  in
-        match uu____24394 with
-        | (env1,uu____24413) ->
+        let uu____24658 = FStar_TypeChecker_Env.clear_expected_typ env  in
+        match uu____24658 with
+        | (env1,uu____24677) ->
             let e1 = lb.FStar_Syntax_Syntax.lbdef  in
-            let uu____24421 = check_lbtyp top_level env lb  in
-            (match uu____24421 with
+            let uu____24685 = check_lbtyp top_level env lb  in
+            (match uu____24685 with
              | (topt,wf_annot,univ_vars1,univ_opening,env11) ->
                  (if (Prims.op_Negation top_level) && (univ_vars1 <> [])
                   then
@@ -9460,136 +9526,138 @@ and (check_let_bound_def :
                       e1.FStar_Syntax_Syntax.pos
                   else ();
                   (let e11 = FStar_Syntax_Subst.subst univ_opening e1  in
-                   let uu____24470 =
+                   let uu____24734 =
                      tc_maybe_toplevel_term
-                       (let uu___3207_24479 = env11  in
+                       (let uu___3224_24743 = env11  in
                         {
                           FStar_TypeChecker_Env.solver =
-                            (uu___3207_24479.FStar_TypeChecker_Env.solver);
+                            (uu___3224_24743.FStar_TypeChecker_Env.solver);
                           FStar_TypeChecker_Env.range =
-                            (uu___3207_24479.FStar_TypeChecker_Env.range);
+                            (uu___3224_24743.FStar_TypeChecker_Env.range);
                           FStar_TypeChecker_Env.curmodule =
-                            (uu___3207_24479.FStar_TypeChecker_Env.curmodule);
+                            (uu___3224_24743.FStar_TypeChecker_Env.curmodule);
                           FStar_TypeChecker_Env.gamma =
-                            (uu___3207_24479.FStar_TypeChecker_Env.gamma);
+                            (uu___3224_24743.FStar_TypeChecker_Env.gamma);
                           FStar_TypeChecker_Env.gamma_sig =
-                            (uu___3207_24479.FStar_TypeChecker_Env.gamma_sig);
+                            (uu___3224_24743.FStar_TypeChecker_Env.gamma_sig);
                           FStar_TypeChecker_Env.gamma_cache =
-                            (uu___3207_24479.FStar_TypeChecker_Env.gamma_cache);
+                            (uu___3224_24743.FStar_TypeChecker_Env.gamma_cache);
                           FStar_TypeChecker_Env.modules =
-                            (uu___3207_24479.FStar_TypeChecker_Env.modules);
+                            (uu___3224_24743.FStar_TypeChecker_Env.modules);
                           FStar_TypeChecker_Env.expected_typ =
-                            (uu___3207_24479.FStar_TypeChecker_Env.expected_typ);
+                            (uu___3224_24743.FStar_TypeChecker_Env.expected_typ);
                           FStar_TypeChecker_Env.sigtab =
-                            (uu___3207_24479.FStar_TypeChecker_Env.sigtab);
+                            (uu___3224_24743.FStar_TypeChecker_Env.sigtab);
                           FStar_TypeChecker_Env.attrtab =
-                            (uu___3207_24479.FStar_TypeChecker_Env.attrtab);
+                            (uu___3224_24743.FStar_TypeChecker_Env.attrtab);
                           FStar_TypeChecker_Env.is_pattern =
-                            (uu___3207_24479.FStar_TypeChecker_Env.is_pattern);
+                            (uu___3224_24743.FStar_TypeChecker_Env.is_pattern);
                           FStar_TypeChecker_Env.instantiate_imp =
-                            (uu___3207_24479.FStar_TypeChecker_Env.instantiate_imp);
+                            (uu___3224_24743.FStar_TypeChecker_Env.instantiate_imp);
                           FStar_TypeChecker_Env.effects =
-                            (uu___3207_24479.FStar_TypeChecker_Env.effects);
+                            (uu___3224_24743.FStar_TypeChecker_Env.effects);
                           FStar_TypeChecker_Env.generalize =
-                            (uu___3207_24479.FStar_TypeChecker_Env.generalize);
+                            (uu___3224_24743.FStar_TypeChecker_Env.generalize);
                           FStar_TypeChecker_Env.letrecs =
-                            (uu___3207_24479.FStar_TypeChecker_Env.letrecs);
+                            (uu___3224_24743.FStar_TypeChecker_Env.letrecs);
                           FStar_TypeChecker_Env.top_level = top_level;
                           FStar_TypeChecker_Env.check_uvars =
-                            (uu___3207_24479.FStar_TypeChecker_Env.check_uvars);
+                            (uu___3224_24743.FStar_TypeChecker_Env.check_uvars);
                           FStar_TypeChecker_Env.use_eq =
-                            (uu___3207_24479.FStar_TypeChecker_Env.use_eq);
+                            (uu___3224_24743.FStar_TypeChecker_Env.use_eq);
                           FStar_TypeChecker_Env.is_iface =
-                            (uu___3207_24479.FStar_TypeChecker_Env.is_iface);
+                            (uu___3224_24743.FStar_TypeChecker_Env.is_iface);
                           FStar_TypeChecker_Env.admit =
-                            (uu___3207_24479.FStar_TypeChecker_Env.admit);
+                            (uu___3224_24743.FStar_TypeChecker_Env.admit);
                           FStar_TypeChecker_Env.lax =
-                            (uu___3207_24479.FStar_TypeChecker_Env.lax);
+                            (uu___3224_24743.FStar_TypeChecker_Env.lax);
                           FStar_TypeChecker_Env.lax_universes =
-                            (uu___3207_24479.FStar_TypeChecker_Env.lax_universes);
+                            (uu___3224_24743.FStar_TypeChecker_Env.lax_universes);
                           FStar_TypeChecker_Env.phase1 =
-                            (uu___3207_24479.FStar_TypeChecker_Env.phase1);
+                            (uu___3224_24743.FStar_TypeChecker_Env.phase1);
                           FStar_TypeChecker_Env.failhard =
-                            (uu___3207_24479.FStar_TypeChecker_Env.failhard);
+                            (uu___3224_24743.FStar_TypeChecker_Env.failhard);
                           FStar_TypeChecker_Env.nosynth =
-                            (uu___3207_24479.FStar_TypeChecker_Env.nosynth);
+                            (uu___3224_24743.FStar_TypeChecker_Env.nosynth);
                           FStar_TypeChecker_Env.uvar_subtyping =
-                            (uu___3207_24479.FStar_TypeChecker_Env.uvar_subtyping);
+                            (uu___3224_24743.FStar_TypeChecker_Env.uvar_subtyping);
                           FStar_TypeChecker_Env.tc_term =
-                            (uu___3207_24479.FStar_TypeChecker_Env.tc_term);
+                            (uu___3224_24743.FStar_TypeChecker_Env.tc_term);
                           FStar_TypeChecker_Env.type_of =
-                            (uu___3207_24479.FStar_TypeChecker_Env.type_of);
+                            (uu___3224_24743.FStar_TypeChecker_Env.type_of);
                           FStar_TypeChecker_Env.universe_of =
-                            (uu___3207_24479.FStar_TypeChecker_Env.universe_of);
+                            (uu___3224_24743.FStar_TypeChecker_Env.universe_of);
                           FStar_TypeChecker_Env.check_type_of =
-                            (uu___3207_24479.FStar_TypeChecker_Env.check_type_of);
+                            (uu___3224_24743.FStar_TypeChecker_Env.check_type_of);
                           FStar_TypeChecker_Env.use_bv_sorts =
-                            (uu___3207_24479.FStar_TypeChecker_Env.use_bv_sorts);
+                            (uu___3224_24743.FStar_TypeChecker_Env.use_bv_sorts);
                           FStar_TypeChecker_Env.qtbl_name_and_index =
-                            (uu___3207_24479.FStar_TypeChecker_Env.qtbl_name_and_index);
+                            (uu___3224_24743.FStar_TypeChecker_Env.qtbl_name_and_index);
                           FStar_TypeChecker_Env.normalized_eff_names =
-                            (uu___3207_24479.FStar_TypeChecker_Env.normalized_eff_names);
+                            (uu___3224_24743.FStar_TypeChecker_Env.normalized_eff_names);
                           FStar_TypeChecker_Env.fv_delta_depths =
-                            (uu___3207_24479.FStar_TypeChecker_Env.fv_delta_depths);
+                            (uu___3224_24743.FStar_TypeChecker_Env.fv_delta_depths);
                           FStar_TypeChecker_Env.proof_ns =
-                            (uu___3207_24479.FStar_TypeChecker_Env.proof_ns);
+                            (uu___3224_24743.FStar_TypeChecker_Env.proof_ns);
                           FStar_TypeChecker_Env.synth_hook =
-                            (uu___3207_24479.FStar_TypeChecker_Env.synth_hook);
+                            (uu___3224_24743.FStar_TypeChecker_Env.synth_hook);
                           FStar_TypeChecker_Env.splice =
-                            (uu___3207_24479.FStar_TypeChecker_Env.splice);
+                            (uu___3224_24743.FStar_TypeChecker_Env.splice);
                           FStar_TypeChecker_Env.postprocess =
-                            (uu___3207_24479.FStar_TypeChecker_Env.postprocess);
+                            (uu___3224_24743.FStar_TypeChecker_Env.postprocess);
                           FStar_TypeChecker_Env.is_native_tactic =
-                            (uu___3207_24479.FStar_TypeChecker_Env.is_native_tactic);
+                            (uu___3224_24743.FStar_TypeChecker_Env.is_native_tactic);
                           FStar_TypeChecker_Env.identifier_info =
-                            (uu___3207_24479.FStar_TypeChecker_Env.identifier_info);
+                            (uu___3224_24743.FStar_TypeChecker_Env.identifier_info);
                           FStar_TypeChecker_Env.tc_hooks =
-                            (uu___3207_24479.FStar_TypeChecker_Env.tc_hooks);
+                            (uu___3224_24743.FStar_TypeChecker_Env.tc_hooks);
                           FStar_TypeChecker_Env.dsenv =
-                            (uu___3207_24479.FStar_TypeChecker_Env.dsenv);
+                            (uu___3224_24743.FStar_TypeChecker_Env.dsenv);
                           FStar_TypeChecker_Env.nbe =
-                            (uu___3207_24479.FStar_TypeChecker_Env.nbe);
+                            (uu___3224_24743.FStar_TypeChecker_Env.nbe);
                           FStar_TypeChecker_Env.strict_args_tab =
-                            (uu___3207_24479.FStar_TypeChecker_Env.strict_args_tab)
+                            (uu___3224_24743.FStar_TypeChecker_Env.strict_args_tab);
+                          FStar_TypeChecker_Env.erasable_types_tab =
+                            (uu___3224_24743.FStar_TypeChecker_Env.erasable_types_tab)
                         }) e11
                       in
-                   match uu____24470 with
+                   match uu____24734 with
                    | (e12,c1,g1) ->
-                       let uu____24494 =
-                         let uu____24499 =
+                       let uu____24758 =
+                         let uu____24763 =
                            FStar_TypeChecker_Env.set_range env11
                              e12.FStar_Syntax_Syntax.pos
                             in
                          FStar_TypeChecker_Util.strengthen_precondition
                            (FStar_Pervasives_Native.Some
-                              (fun uu____24505  ->
+                              (fun uu____24769  ->
                                  FStar_Util.return_all
                                    FStar_TypeChecker_Err.ill_kinded_type))
-                           uu____24499 e12 c1 wf_annot
+                           uu____24763 e12 c1 wf_annot
                           in
-                       (match uu____24494 with
+                       (match uu____24758 with
                         | (c11,guard_f) ->
                             let g11 =
                               FStar_TypeChecker_Env.conj_guard g1 guard_f  in
-                            ((let uu____24522 =
+                            ((let uu____24786 =
                                 FStar_TypeChecker_Env.debug env
                                   FStar_Options.Extreme
                                  in
-                              if uu____24522
+                              if uu____24786
                               then
-                                let uu____24525 =
+                                let uu____24789 =
                                   FStar_Syntax_Print.lbname_to_string
                                     lb.FStar_Syntax_Syntax.lbname
                                    in
-                                let uu____24527 =
+                                let uu____24791 =
                                   FStar_Syntax_Print.lcomp_to_string c11  in
-                                let uu____24529 =
+                                let uu____24793 =
                                   FStar_TypeChecker_Rel.guard_to_string env
                                     g11
                                    in
                                 FStar_Util.print3
                                   "checked let-bound def %s : %s guard is %s\n"
-                                  uu____24525 uu____24527 uu____24529
+                                  uu____24789 uu____24791 uu____24793
                               else ());
                              (e12, univ_vars1, c11, g11,
                                (FStar_Option.isSome topt)))))))
@@ -9609,23 +9677,23 @@ and (check_lbtyp :
         let t = FStar_Syntax_Subst.compress lb.FStar_Syntax_Syntax.lbtyp  in
         match t.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_unknown  ->
-            let uu____24568 =
+            let uu____24832 =
               FStar_Syntax_Subst.univ_var_opening
                 lb.FStar_Syntax_Syntax.lbunivs
                in
-            (match uu____24568 with
+            (match uu____24832 with
              | (univ_opening,univ_vars1) ->
-                 let uu____24601 =
+                 let uu____24865 =
                    FStar_TypeChecker_Env.push_univ_vars env univ_vars1  in
                  (FStar_Pervasives_Native.None,
                    FStar_TypeChecker_Env.trivial_guard, univ_vars1,
-                   univ_opening, uu____24601))
-        | uu____24606 ->
-            let uu____24607 =
+                   univ_opening, uu____24865))
+        | uu____24870 ->
+            let uu____24871 =
               FStar_Syntax_Subst.univ_var_opening
                 lb.FStar_Syntax_Syntax.lbunivs
                in
-            (match uu____24607 with
+            (match uu____24871 with
              | (univ_opening,univ_vars1) ->
                  let t1 = FStar_Syntax_Subst.subst univ_opening t  in
                  let env1 =
@@ -9634,45 +9702,45 @@ and (check_lbtyp :
                    top_level &&
                      (Prims.op_Negation env.FStar_TypeChecker_Env.generalize)
                  then
-                   let uu____24657 =
+                   let uu____24921 =
                      FStar_TypeChecker_Env.set_expected_typ env1 t1  in
                    ((FStar_Pervasives_Native.Some t1),
                      FStar_TypeChecker_Env.trivial_guard, univ_vars1,
-                     univ_opening, uu____24657)
+                     univ_opening, uu____24921)
                  else
-                   (let uu____24664 = FStar_Syntax_Util.type_u ()  in
-                    match uu____24664 with
-                    | (k,uu____24684) ->
-                        let uu____24685 = tc_check_tot_or_gtot_term env1 t1 k
+                   (let uu____24928 = FStar_Syntax_Util.type_u ()  in
+                    match uu____24928 with
+                    | (k,uu____24948) ->
+                        let uu____24949 = tc_check_tot_or_gtot_term env1 t1 k
                            in
-                        (match uu____24685 with
-                         | (t2,uu____24707,g) ->
-                             ((let uu____24710 =
+                        (match uu____24949 with
+                         | (t2,uu____24971,g) ->
+                             ((let uu____24974 =
                                  FStar_TypeChecker_Env.debug env
                                    FStar_Options.Medium
                                   in
-                               if uu____24710
+                               if uu____24974
                                then
-                                 let uu____24713 =
-                                   let uu____24715 =
+                                 let uu____24977 =
+                                   let uu____24979 =
                                      FStar_Syntax_Util.range_of_lbname
                                        lb.FStar_Syntax_Syntax.lbname
                                       in
-                                   FStar_Range.string_of_range uu____24715
+                                   FStar_Range.string_of_range uu____24979
                                     in
-                                 let uu____24716 =
+                                 let uu____24980 =
                                    FStar_Syntax_Print.term_to_string t2  in
                                  FStar_Util.print2
                                    "(%s) Checked type annotation %s\n"
-                                   uu____24713 uu____24716
+                                   uu____24977 uu____24980
                                else ());
                               (let t3 = norm env1 t2  in
-                               let uu____24722 =
+                               let uu____24986 =
                                  FStar_TypeChecker_Env.set_expected_typ env1
                                    t3
                                   in
                                ((FStar_Pervasives_Native.Some t3), g,
-                                 univ_vars1, univ_opening, uu____24722))))))
+                                 univ_vars1, univ_opening, uu____24986))))))
 
 and (tc_binder :
   FStar_TypeChecker_Env.env ->
@@ -9683,73 +9751,73 @@ and (tc_binder :
         FStar_TypeChecker_Env.guard_t * FStar_Syntax_Syntax.universe))
   =
   fun env  ->
-    fun uu____24728  ->
-      match uu____24728 with
+    fun uu____24992  ->
+      match uu____24992 with
       | (x,imp) ->
-          let uu____24755 = FStar_Syntax_Util.type_u ()  in
-          (match uu____24755 with
+          let uu____25019 = FStar_Syntax_Util.type_u ()  in
+          (match uu____25019 with
            | (tu,u) ->
-               ((let uu____24777 =
+               ((let uu____25041 =
                    FStar_TypeChecker_Env.debug env FStar_Options.Extreme  in
-                 if uu____24777
+                 if uu____25041
                  then
-                   let uu____24780 = FStar_Syntax_Print.bv_to_string x  in
-                   let uu____24782 =
+                   let uu____25044 = FStar_Syntax_Print.bv_to_string x  in
+                   let uu____25046 =
                      FStar_Syntax_Print.term_to_string
                        x.FStar_Syntax_Syntax.sort
                       in
-                   let uu____24784 = FStar_Syntax_Print.term_to_string tu  in
+                   let uu____25048 = FStar_Syntax_Print.term_to_string tu  in
                    FStar_Util.print3 "Checking binder %s:%s at type %s\n"
-                     uu____24780 uu____24782 uu____24784
+                     uu____25044 uu____25046 uu____25048
                  else ());
-                (let uu____24789 =
+                (let uu____25053 =
                    tc_check_tot_or_gtot_term env x.FStar_Syntax_Syntax.sort
                      tu
                     in
-                 match uu____24789 with
-                 | (t,uu____24811,g) ->
-                     let uu____24813 =
+                 match uu____25053 with
+                 | (t,uu____25075,g) ->
+                     let uu____25077 =
                        match imp with
                        | FStar_Pervasives_Native.Some
                            (FStar_Syntax_Syntax.Meta tau) ->
-                           let uu____24829 = tc_tactic env tau  in
-                           (match uu____24829 with
-                            | (tau1,uu____24843,g1) ->
+                           let uu____25093 = tc_tactic env tau  in
+                           (match uu____25093 with
+                            | (tau1,uu____25107,g1) ->
                                 ((FStar_Pervasives_Native.Some
                                     (FStar_Syntax_Syntax.Meta tau1)), g1))
-                       | uu____24847 ->
+                       | uu____25111 ->
                            (imp, FStar_TypeChecker_Env.trivial_guard)
                         in
-                     (match uu____24813 with
+                     (match uu____25077 with
                       | (imp1,g') ->
                           let x1 =
-                            ((let uu___3269_24882 = x  in
+                            ((let uu___3286_25146 = x  in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___3269_24882.FStar_Syntax_Syntax.ppname);
+                                  (uu___3286_25146.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___3269_24882.FStar_Syntax_Syntax.index);
+                                  (uu___3286_25146.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = t
                               }), imp1)
                              in
-                          ((let uu____24884 =
+                          ((let uu____25148 =
                               FStar_TypeChecker_Env.debug env
                                 FStar_Options.High
                                in
-                            if uu____24884
+                            if uu____25148
                             then
-                              let uu____24887 =
+                              let uu____25151 =
                                 FStar_Syntax_Print.bv_to_string
                                   (FStar_Pervasives_Native.fst x1)
                                  in
-                              let uu____24891 =
+                              let uu____25155 =
                                 FStar_Syntax_Print.term_to_string t  in
                               FStar_Util.print2
-                                "Pushing binder %s at type %s\n" uu____24887
-                                uu____24891
+                                "Pushing binder %s at type %s\n" uu____25151
+                                uu____25155
                             else ());
-                           (let uu____24896 = push_binding env x1  in
-                            (x1, uu____24896, g, u)))))))
+                           (let uu____25160 = push_binding env x1  in
+                            (x1, uu____25160, g, u)))))))
 
 and (tc_binders :
   FStar_TypeChecker_Env.env ->
@@ -9759,30 +9827,30 @@ and (tc_binders :
   =
   fun env  ->
     fun bs  ->
-      (let uu____24908 =
+      (let uu____25172 =
          FStar_TypeChecker_Env.debug env FStar_Options.Extreme  in
-       if uu____24908
+       if uu____25172
        then
-         let uu____24911 = FStar_Syntax_Print.binders_to_string ", " bs  in
-         FStar_Util.print1 "Checking binders %s\n" uu____24911
+         let uu____25175 = FStar_Syntax_Print.binders_to_string ", " bs  in
+         FStar_Util.print1 "Checking binders %s\n" uu____25175
        else ());
       (let rec aux env1 bs1 =
          match bs1 with
          | [] -> ([], env1, FStar_TypeChecker_Env.trivial_guard, [])
          | b::bs2 ->
-             let uu____25024 = tc_binder env1 b  in
-             (match uu____25024 with
+             let uu____25288 = tc_binder env1 b  in
+             (match uu____25288 with
               | (b1,env',g,u) ->
-                  let uu____25073 = aux env' bs2  in
-                  (match uu____25073 with
+                  let uu____25337 = aux env' bs2  in
+                  (match uu____25337 with
                    | (bs3,env'1,g',us) ->
-                       let uu____25134 =
-                         let uu____25135 =
+                       let uu____25398 =
+                         let uu____25399 =
                            FStar_TypeChecker_Env.close_guard_univs [u] 
                              [b1] g'
                             in
-                         FStar_TypeChecker_Env.conj_guard g uu____25135  in
-                       ((b1 :: bs3), env'1, uu____25134, (u :: us))))
+                         FStar_TypeChecker_Env.conj_guard g uu____25399  in
+                       ((b1 :: bs3), env'1, uu____25398, (u :: us))))
           in
        aux env bs)
 
@@ -9799,30 +9867,30 @@ and (tc_smt_pats :
     fun pats  ->
       let tc_args en1 args =
         FStar_List.fold_right
-          (fun uu____25243  ->
-             fun uu____25244  ->
-               match (uu____25243, uu____25244) with
+          (fun uu____25507  ->
+             fun uu____25508  ->
+               match (uu____25507, uu____25508) with
                | ((t,imp),(args1,g)) ->
                    (FStar_All.pipe_right t (check_no_smt_theory_symbols en1);
-                    (let uu____25336 = tc_term en1 t  in
-                     match uu____25336 with
-                     | (t1,uu____25356,g') ->
-                         let uu____25358 =
+                    (let uu____25600 = tc_term en1 t  in
+                     match uu____25600 with
+                     | (t1,uu____25620,g') ->
+                         let uu____25622 =
                            FStar_TypeChecker_Env.conj_guard g g'  in
-                         (((t1, imp) :: args1), uu____25358)))) args
+                         (((t1, imp) :: args1), uu____25622)))) args
           ([], FStar_TypeChecker_Env.trivial_guard)
          in
       FStar_List.fold_right
         (fun p  ->
-           fun uu____25412  ->
-             match uu____25412 with
+           fun uu____25676  ->
+             match uu____25676 with
              | (pats1,g) ->
-                 let uu____25439 = tc_args en p  in
-                 (match uu____25439 with
+                 let uu____25703 = tc_args en p  in
+                 (match uu____25703 with
                   | (args,g') ->
-                      let uu____25452 = FStar_TypeChecker_Env.conj_guard g g'
+                      let uu____25716 = FStar_TypeChecker_Env.conj_guard g g'
                          in
-                      ((args :: pats1), uu____25452))) pats
+                      ((args :: pats1), uu____25716))) pats
         ([], FStar_TypeChecker_Env.trivial_guard)
 
 and (tc_tot_or_gtot_term :
@@ -9833,62 +9901,62 @@ and (tc_tot_or_gtot_term :
   =
   fun env  ->
     fun e  ->
-      let uu____25465 = tc_maybe_toplevel_term env e  in
-      match uu____25465 with
+      let uu____25729 = tc_maybe_toplevel_term env e  in
+      match uu____25729 with
       | (e1,c,g) ->
-          let uu____25481 = FStar_Syntax_Util.is_tot_or_gtot_lcomp c  in
-          if uu____25481
+          let uu____25745 = FStar_Syntax_Util.is_tot_or_gtot_lcomp c  in
+          if uu____25745
           then (e1, c, g)
           else
             (let g1 = FStar_TypeChecker_Rel.solve_deferred_constraints env g
                 in
              let c1 = FStar_Syntax_Syntax.lcomp_comp c  in
              let c2 = norm_c env c1  in
-             let uu____25495 =
-               let uu____25501 =
+             let uu____25759 =
+               let uu____25765 =
                  FStar_TypeChecker_Util.is_pure_effect env
                    (FStar_Syntax_Util.comp_effect_name c2)
                   in
-               if uu____25501
+               if uu____25765
                then
-                 let uu____25509 =
+                 let uu____25773 =
                    FStar_Syntax_Syntax.mk_Total
                      (FStar_Syntax_Util.comp_result c2)
                     in
-                 (uu____25509, false)
+                 (uu____25773, false)
                else
-                 (let uu____25514 =
+                 (let uu____25778 =
                     FStar_Syntax_Syntax.mk_GTotal
                       (FStar_Syntax_Util.comp_result c2)
                      in
-                  (uu____25514, true))
+                  (uu____25778, true))
                 in
-             match uu____25495 with
+             match uu____25759 with
              | (target_comp,allow_ghost) ->
-                 let uu____25527 =
+                 let uu____25791 =
                    FStar_TypeChecker_Rel.sub_comp env c2 target_comp  in
-                 (match uu____25527 with
+                 (match uu____25791 with
                   | FStar_Pervasives_Native.Some g' ->
-                      let uu____25537 =
+                      let uu____25801 =
                         FStar_Syntax_Util.lcomp_of_comp target_comp  in
-                      let uu____25538 =
+                      let uu____25802 =
                         FStar_TypeChecker_Env.conj_guard g1 g'  in
-                      (e1, uu____25537, uu____25538)
-                  | uu____25539 ->
+                      (e1, uu____25801, uu____25802)
+                  | uu____25803 ->
                       if allow_ghost
                       then
-                        let uu____25549 =
+                        let uu____25813 =
                           FStar_TypeChecker_Err.expected_ghost_expression e1
                             c2
                            in
-                        FStar_Errors.raise_error uu____25549
+                        FStar_Errors.raise_error uu____25813
                           e1.FStar_Syntax_Syntax.pos
                       else
-                        (let uu____25563 =
+                        (let uu____25827 =
                            FStar_TypeChecker_Err.expected_pure_expression e1
                              c2
                             in
-                         FStar_Errors.raise_error uu____25563
+                         FStar_Errors.raise_error uu____25827
                            e1.FStar_Syntax_Syntax.pos)))
 
 and (tc_check_tot_or_gtot_term :
@@ -9911,8 +9979,8 @@ and (tc_trivial_guard :
   =
   fun env  ->
     fun t  ->
-      let uu____25587 = tc_tot_or_gtot_term env t  in
-      match uu____25587 with
+      let uu____25851 = tc_tot_or_gtot_term env t  in
+      match uu____25851 with
       | (t1,c,g) ->
           (FStar_TypeChecker_Rel.force_trivial_guard env g; (t1, c))
 
@@ -9924,151 +9992,153 @@ let (type_of_tot_term :
   =
   fun env  ->
     fun e  ->
-      (let uu____25620 =
+      (let uu____25884 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "RelCheck")
           in
-       if uu____25620
+       if uu____25884
        then
-         let uu____25625 = FStar_Syntax_Print.term_to_string e  in
-         FStar_Util.print1 "Checking term %s\n" uu____25625
+         let uu____25889 = FStar_Syntax_Print.term_to_string e  in
+         FStar_Util.print1 "Checking term %s\n" uu____25889
        else ());
       (let env1 =
-         let uu___3351_25631 = env  in
+         let uu___3368_25895 = env  in
          {
            FStar_TypeChecker_Env.solver =
-             (uu___3351_25631.FStar_TypeChecker_Env.solver);
+             (uu___3368_25895.FStar_TypeChecker_Env.solver);
            FStar_TypeChecker_Env.range =
-             (uu___3351_25631.FStar_TypeChecker_Env.range);
+             (uu___3368_25895.FStar_TypeChecker_Env.range);
            FStar_TypeChecker_Env.curmodule =
-             (uu___3351_25631.FStar_TypeChecker_Env.curmodule);
+             (uu___3368_25895.FStar_TypeChecker_Env.curmodule);
            FStar_TypeChecker_Env.gamma =
-             (uu___3351_25631.FStar_TypeChecker_Env.gamma);
+             (uu___3368_25895.FStar_TypeChecker_Env.gamma);
            FStar_TypeChecker_Env.gamma_sig =
-             (uu___3351_25631.FStar_TypeChecker_Env.gamma_sig);
+             (uu___3368_25895.FStar_TypeChecker_Env.gamma_sig);
            FStar_TypeChecker_Env.gamma_cache =
-             (uu___3351_25631.FStar_TypeChecker_Env.gamma_cache);
+             (uu___3368_25895.FStar_TypeChecker_Env.gamma_cache);
            FStar_TypeChecker_Env.modules =
-             (uu___3351_25631.FStar_TypeChecker_Env.modules);
+             (uu___3368_25895.FStar_TypeChecker_Env.modules);
            FStar_TypeChecker_Env.expected_typ =
-             (uu___3351_25631.FStar_TypeChecker_Env.expected_typ);
+             (uu___3368_25895.FStar_TypeChecker_Env.expected_typ);
            FStar_TypeChecker_Env.sigtab =
-             (uu___3351_25631.FStar_TypeChecker_Env.sigtab);
+             (uu___3368_25895.FStar_TypeChecker_Env.sigtab);
            FStar_TypeChecker_Env.attrtab =
-             (uu___3351_25631.FStar_TypeChecker_Env.attrtab);
+             (uu___3368_25895.FStar_TypeChecker_Env.attrtab);
            FStar_TypeChecker_Env.is_pattern =
-             (uu___3351_25631.FStar_TypeChecker_Env.is_pattern);
+             (uu___3368_25895.FStar_TypeChecker_Env.is_pattern);
            FStar_TypeChecker_Env.instantiate_imp =
-             (uu___3351_25631.FStar_TypeChecker_Env.instantiate_imp);
+             (uu___3368_25895.FStar_TypeChecker_Env.instantiate_imp);
            FStar_TypeChecker_Env.effects =
-             (uu___3351_25631.FStar_TypeChecker_Env.effects);
+             (uu___3368_25895.FStar_TypeChecker_Env.effects);
            FStar_TypeChecker_Env.generalize =
-             (uu___3351_25631.FStar_TypeChecker_Env.generalize);
+             (uu___3368_25895.FStar_TypeChecker_Env.generalize);
            FStar_TypeChecker_Env.letrecs = [];
            FStar_TypeChecker_Env.top_level = false;
            FStar_TypeChecker_Env.check_uvars =
-             (uu___3351_25631.FStar_TypeChecker_Env.check_uvars);
+             (uu___3368_25895.FStar_TypeChecker_Env.check_uvars);
            FStar_TypeChecker_Env.use_eq =
-             (uu___3351_25631.FStar_TypeChecker_Env.use_eq);
+             (uu___3368_25895.FStar_TypeChecker_Env.use_eq);
            FStar_TypeChecker_Env.is_iface =
-             (uu___3351_25631.FStar_TypeChecker_Env.is_iface);
+             (uu___3368_25895.FStar_TypeChecker_Env.is_iface);
            FStar_TypeChecker_Env.admit =
-             (uu___3351_25631.FStar_TypeChecker_Env.admit);
+             (uu___3368_25895.FStar_TypeChecker_Env.admit);
            FStar_TypeChecker_Env.lax =
-             (uu___3351_25631.FStar_TypeChecker_Env.lax);
+             (uu___3368_25895.FStar_TypeChecker_Env.lax);
            FStar_TypeChecker_Env.lax_universes =
-             (uu___3351_25631.FStar_TypeChecker_Env.lax_universes);
+             (uu___3368_25895.FStar_TypeChecker_Env.lax_universes);
            FStar_TypeChecker_Env.phase1 =
-             (uu___3351_25631.FStar_TypeChecker_Env.phase1);
+             (uu___3368_25895.FStar_TypeChecker_Env.phase1);
            FStar_TypeChecker_Env.failhard =
-             (uu___3351_25631.FStar_TypeChecker_Env.failhard);
+             (uu___3368_25895.FStar_TypeChecker_Env.failhard);
            FStar_TypeChecker_Env.nosynth =
-             (uu___3351_25631.FStar_TypeChecker_Env.nosynth);
+             (uu___3368_25895.FStar_TypeChecker_Env.nosynth);
            FStar_TypeChecker_Env.uvar_subtyping =
-             (uu___3351_25631.FStar_TypeChecker_Env.uvar_subtyping);
+             (uu___3368_25895.FStar_TypeChecker_Env.uvar_subtyping);
            FStar_TypeChecker_Env.tc_term =
-             (uu___3351_25631.FStar_TypeChecker_Env.tc_term);
+             (uu___3368_25895.FStar_TypeChecker_Env.tc_term);
            FStar_TypeChecker_Env.type_of =
-             (uu___3351_25631.FStar_TypeChecker_Env.type_of);
+             (uu___3368_25895.FStar_TypeChecker_Env.type_of);
            FStar_TypeChecker_Env.universe_of =
-             (uu___3351_25631.FStar_TypeChecker_Env.universe_of);
+             (uu___3368_25895.FStar_TypeChecker_Env.universe_of);
            FStar_TypeChecker_Env.check_type_of =
-             (uu___3351_25631.FStar_TypeChecker_Env.check_type_of);
+             (uu___3368_25895.FStar_TypeChecker_Env.check_type_of);
            FStar_TypeChecker_Env.use_bv_sorts =
-             (uu___3351_25631.FStar_TypeChecker_Env.use_bv_sorts);
+             (uu___3368_25895.FStar_TypeChecker_Env.use_bv_sorts);
            FStar_TypeChecker_Env.qtbl_name_and_index =
-             (uu___3351_25631.FStar_TypeChecker_Env.qtbl_name_and_index);
+             (uu___3368_25895.FStar_TypeChecker_Env.qtbl_name_and_index);
            FStar_TypeChecker_Env.normalized_eff_names =
-             (uu___3351_25631.FStar_TypeChecker_Env.normalized_eff_names);
+             (uu___3368_25895.FStar_TypeChecker_Env.normalized_eff_names);
            FStar_TypeChecker_Env.fv_delta_depths =
-             (uu___3351_25631.FStar_TypeChecker_Env.fv_delta_depths);
+             (uu___3368_25895.FStar_TypeChecker_Env.fv_delta_depths);
            FStar_TypeChecker_Env.proof_ns =
-             (uu___3351_25631.FStar_TypeChecker_Env.proof_ns);
+             (uu___3368_25895.FStar_TypeChecker_Env.proof_ns);
            FStar_TypeChecker_Env.synth_hook =
-             (uu___3351_25631.FStar_TypeChecker_Env.synth_hook);
+             (uu___3368_25895.FStar_TypeChecker_Env.synth_hook);
            FStar_TypeChecker_Env.splice =
-             (uu___3351_25631.FStar_TypeChecker_Env.splice);
+             (uu___3368_25895.FStar_TypeChecker_Env.splice);
            FStar_TypeChecker_Env.postprocess =
-             (uu___3351_25631.FStar_TypeChecker_Env.postprocess);
+             (uu___3368_25895.FStar_TypeChecker_Env.postprocess);
            FStar_TypeChecker_Env.is_native_tactic =
-             (uu___3351_25631.FStar_TypeChecker_Env.is_native_tactic);
+             (uu___3368_25895.FStar_TypeChecker_Env.is_native_tactic);
            FStar_TypeChecker_Env.identifier_info =
-             (uu___3351_25631.FStar_TypeChecker_Env.identifier_info);
+             (uu___3368_25895.FStar_TypeChecker_Env.identifier_info);
            FStar_TypeChecker_Env.tc_hooks =
-             (uu___3351_25631.FStar_TypeChecker_Env.tc_hooks);
+             (uu___3368_25895.FStar_TypeChecker_Env.tc_hooks);
            FStar_TypeChecker_Env.dsenv =
-             (uu___3351_25631.FStar_TypeChecker_Env.dsenv);
+             (uu___3368_25895.FStar_TypeChecker_Env.dsenv);
            FStar_TypeChecker_Env.nbe =
-             (uu___3351_25631.FStar_TypeChecker_Env.nbe);
+             (uu___3368_25895.FStar_TypeChecker_Env.nbe);
            FStar_TypeChecker_Env.strict_args_tab =
-             (uu___3351_25631.FStar_TypeChecker_Env.strict_args_tab)
+             (uu___3368_25895.FStar_TypeChecker_Env.strict_args_tab);
+           FStar_TypeChecker_Env.erasable_types_tab =
+             (uu___3368_25895.FStar_TypeChecker_Env.erasable_types_tab)
          }  in
-       let uu____25639 =
+       let uu____25903 =
          try
-           (fun uu___3355_25653  ->
+           (fun uu___3372_25917  ->
               match () with | () -> tc_tot_or_gtot_term env1 e) ()
          with
-         | FStar_Errors.Error (e1,msg,uu____25674) ->
-             let uu____25677 = FStar_TypeChecker_Env.get_range env1  in
-             FStar_Errors.raise_error (e1, msg) uu____25677
+         | FStar_Errors.Error (e1,msg,uu____25938) ->
+             let uu____25941 = FStar_TypeChecker_Env.get_range env1  in
+             FStar_Errors.raise_error (e1, msg) uu____25941
           in
-       match uu____25639 with
+       match uu____25903 with
        | (t,c,g) ->
            let c1 = FStar_TypeChecker_Normalize.ghost_to_pure_lcomp env1 c
               in
-           let uu____25695 = FStar_Syntax_Util.is_total_lcomp c1  in
-           if uu____25695
+           let uu____25959 = FStar_Syntax_Util.is_total_lcomp c1  in
+           if uu____25959
            then (t, (c1.FStar_Syntax_Syntax.res_typ), g)
            else
-             (let uu____25706 =
-                let uu____25712 =
-                  let uu____25714 = FStar_Syntax_Print.term_to_string e  in
+             (let uu____25970 =
+                let uu____25976 =
+                  let uu____25978 = FStar_Syntax_Print.term_to_string e  in
                   FStar_Util.format1
                     "Implicit argument: Expected a total term; got a ghost term: %s"
-                    uu____25714
+                    uu____25978
                    in
-                (FStar_Errors.Fatal_UnexpectedImplictArgument, uu____25712)
+                (FStar_Errors.Fatal_UnexpectedImplictArgument, uu____25976)
                  in
-              let uu____25718 = FStar_TypeChecker_Env.get_range env1  in
-              FStar_Errors.raise_error uu____25706 uu____25718))
+              let uu____25982 = FStar_TypeChecker_Env.get_range env1  in
+              FStar_Errors.raise_error uu____25970 uu____25982))
   
 let level_of_type_fail :
-  'Auu____25734 .
+  'Auu____25998 .
     FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.term -> Prims.string -> 'Auu____25734
+      FStar_Syntax_Syntax.term -> Prims.string -> 'Auu____25998
   =
   fun env  ->
     fun e  ->
       fun t  ->
-        let uu____25752 =
-          let uu____25758 =
-            let uu____25760 = FStar_Syntax_Print.term_to_string e  in
+        let uu____26016 =
+          let uu____26022 =
+            let uu____26024 = FStar_Syntax_Print.term_to_string e  in
             FStar_Util.format2 "Expected a term of type 'Type'; got %s : %s"
-              uu____25760 t
+              uu____26024 t
              in
-          (FStar_Errors.Fatal_UnexpectedTermType, uu____25758)  in
-        let uu____25764 = FStar_TypeChecker_Env.get_range env  in
-        FStar_Errors.raise_error uu____25752 uu____25764
+          (FStar_Errors.Fatal_UnexpectedTermType, uu____26022)  in
+        let uu____26028 = FStar_TypeChecker_Env.get_range env  in
+        FStar_Errors.raise_error uu____26016 uu____26028
   
 let (level_of_type :
   FStar_TypeChecker_Env.env ->
@@ -10079,12 +10149,12 @@ let (level_of_type :
     fun e  ->
       fun t  ->
         let rec aux retry t1 =
-          let uu____25798 =
-            let uu____25799 = FStar_Syntax_Util.unrefine t1  in
-            uu____25799.FStar_Syntax_Syntax.n  in
-          match uu____25798 with
+          let uu____26062 =
+            let uu____26063 = FStar_Syntax_Util.unrefine t1  in
+            uu____26063.FStar_Syntax_Syntax.n  in
+          match uu____26062 with
           | FStar_Syntax_Syntax.Tm_type u -> u
-          | uu____25803 ->
+          | uu____26067 ->
               if retry
               then
                 let t2 =
@@ -10094,107 +10164,109 @@ let (level_of_type :
                    in
                 aux false t2
               else
-                (let uu____25809 = FStar_Syntax_Util.type_u ()  in
-                 match uu____25809 with
+                (let uu____26073 = FStar_Syntax_Util.type_u ()  in
+                 match uu____26073 with
                  | (t_u,u) ->
                      let env1 =
-                       let uu___3387_25817 = env  in
+                       let uu___3404_26081 = env  in
                        {
                          FStar_TypeChecker_Env.solver =
-                           (uu___3387_25817.FStar_TypeChecker_Env.solver);
+                           (uu___3404_26081.FStar_TypeChecker_Env.solver);
                          FStar_TypeChecker_Env.range =
-                           (uu___3387_25817.FStar_TypeChecker_Env.range);
+                           (uu___3404_26081.FStar_TypeChecker_Env.range);
                          FStar_TypeChecker_Env.curmodule =
-                           (uu___3387_25817.FStar_TypeChecker_Env.curmodule);
+                           (uu___3404_26081.FStar_TypeChecker_Env.curmodule);
                          FStar_TypeChecker_Env.gamma =
-                           (uu___3387_25817.FStar_TypeChecker_Env.gamma);
+                           (uu___3404_26081.FStar_TypeChecker_Env.gamma);
                          FStar_TypeChecker_Env.gamma_sig =
-                           (uu___3387_25817.FStar_TypeChecker_Env.gamma_sig);
+                           (uu___3404_26081.FStar_TypeChecker_Env.gamma_sig);
                          FStar_TypeChecker_Env.gamma_cache =
-                           (uu___3387_25817.FStar_TypeChecker_Env.gamma_cache);
+                           (uu___3404_26081.FStar_TypeChecker_Env.gamma_cache);
                          FStar_TypeChecker_Env.modules =
-                           (uu___3387_25817.FStar_TypeChecker_Env.modules);
+                           (uu___3404_26081.FStar_TypeChecker_Env.modules);
                          FStar_TypeChecker_Env.expected_typ =
-                           (uu___3387_25817.FStar_TypeChecker_Env.expected_typ);
+                           (uu___3404_26081.FStar_TypeChecker_Env.expected_typ);
                          FStar_TypeChecker_Env.sigtab =
-                           (uu___3387_25817.FStar_TypeChecker_Env.sigtab);
+                           (uu___3404_26081.FStar_TypeChecker_Env.sigtab);
                          FStar_TypeChecker_Env.attrtab =
-                           (uu___3387_25817.FStar_TypeChecker_Env.attrtab);
+                           (uu___3404_26081.FStar_TypeChecker_Env.attrtab);
                          FStar_TypeChecker_Env.is_pattern =
-                           (uu___3387_25817.FStar_TypeChecker_Env.is_pattern);
+                           (uu___3404_26081.FStar_TypeChecker_Env.is_pattern);
                          FStar_TypeChecker_Env.instantiate_imp =
-                           (uu___3387_25817.FStar_TypeChecker_Env.instantiate_imp);
+                           (uu___3404_26081.FStar_TypeChecker_Env.instantiate_imp);
                          FStar_TypeChecker_Env.effects =
-                           (uu___3387_25817.FStar_TypeChecker_Env.effects);
+                           (uu___3404_26081.FStar_TypeChecker_Env.effects);
                          FStar_TypeChecker_Env.generalize =
-                           (uu___3387_25817.FStar_TypeChecker_Env.generalize);
+                           (uu___3404_26081.FStar_TypeChecker_Env.generalize);
                          FStar_TypeChecker_Env.letrecs =
-                           (uu___3387_25817.FStar_TypeChecker_Env.letrecs);
+                           (uu___3404_26081.FStar_TypeChecker_Env.letrecs);
                          FStar_TypeChecker_Env.top_level =
-                           (uu___3387_25817.FStar_TypeChecker_Env.top_level);
+                           (uu___3404_26081.FStar_TypeChecker_Env.top_level);
                          FStar_TypeChecker_Env.check_uvars =
-                           (uu___3387_25817.FStar_TypeChecker_Env.check_uvars);
+                           (uu___3404_26081.FStar_TypeChecker_Env.check_uvars);
                          FStar_TypeChecker_Env.use_eq =
-                           (uu___3387_25817.FStar_TypeChecker_Env.use_eq);
+                           (uu___3404_26081.FStar_TypeChecker_Env.use_eq);
                          FStar_TypeChecker_Env.is_iface =
-                           (uu___3387_25817.FStar_TypeChecker_Env.is_iface);
+                           (uu___3404_26081.FStar_TypeChecker_Env.is_iface);
                          FStar_TypeChecker_Env.admit =
-                           (uu___3387_25817.FStar_TypeChecker_Env.admit);
+                           (uu___3404_26081.FStar_TypeChecker_Env.admit);
                          FStar_TypeChecker_Env.lax = true;
                          FStar_TypeChecker_Env.lax_universes =
-                           (uu___3387_25817.FStar_TypeChecker_Env.lax_universes);
+                           (uu___3404_26081.FStar_TypeChecker_Env.lax_universes);
                          FStar_TypeChecker_Env.phase1 =
-                           (uu___3387_25817.FStar_TypeChecker_Env.phase1);
+                           (uu___3404_26081.FStar_TypeChecker_Env.phase1);
                          FStar_TypeChecker_Env.failhard =
-                           (uu___3387_25817.FStar_TypeChecker_Env.failhard);
+                           (uu___3404_26081.FStar_TypeChecker_Env.failhard);
                          FStar_TypeChecker_Env.nosynth =
-                           (uu___3387_25817.FStar_TypeChecker_Env.nosynth);
+                           (uu___3404_26081.FStar_TypeChecker_Env.nosynth);
                          FStar_TypeChecker_Env.uvar_subtyping =
-                           (uu___3387_25817.FStar_TypeChecker_Env.uvar_subtyping);
+                           (uu___3404_26081.FStar_TypeChecker_Env.uvar_subtyping);
                          FStar_TypeChecker_Env.tc_term =
-                           (uu___3387_25817.FStar_TypeChecker_Env.tc_term);
+                           (uu___3404_26081.FStar_TypeChecker_Env.tc_term);
                          FStar_TypeChecker_Env.type_of =
-                           (uu___3387_25817.FStar_TypeChecker_Env.type_of);
+                           (uu___3404_26081.FStar_TypeChecker_Env.type_of);
                          FStar_TypeChecker_Env.universe_of =
-                           (uu___3387_25817.FStar_TypeChecker_Env.universe_of);
+                           (uu___3404_26081.FStar_TypeChecker_Env.universe_of);
                          FStar_TypeChecker_Env.check_type_of =
-                           (uu___3387_25817.FStar_TypeChecker_Env.check_type_of);
+                           (uu___3404_26081.FStar_TypeChecker_Env.check_type_of);
                          FStar_TypeChecker_Env.use_bv_sorts =
-                           (uu___3387_25817.FStar_TypeChecker_Env.use_bv_sorts);
+                           (uu___3404_26081.FStar_TypeChecker_Env.use_bv_sorts);
                          FStar_TypeChecker_Env.qtbl_name_and_index =
-                           (uu___3387_25817.FStar_TypeChecker_Env.qtbl_name_and_index);
+                           (uu___3404_26081.FStar_TypeChecker_Env.qtbl_name_and_index);
                          FStar_TypeChecker_Env.normalized_eff_names =
-                           (uu___3387_25817.FStar_TypeChecker_Env.normalized_eff_names);
+                           (uu___3404_26081.FStar_TypeChecker_Env.normalized_eff_names);
                          FStar_TypeChecker_Env.fv_delta_depths =
-                           (uu___3387_25817.FStar_TypeChecker_Env.fv_delta_depths);
+                           (uu___3404_26081.FStar_TypeChecker_Env.fv_delta_depths);
                          FStar_TypeChecker_Env.proof_ns =
-                           (uu___3387_25817.FStar_TypeChecker_Env.proof_ns);
+                           (uu___3404_26081.FStar_TypeChecker_Env.proof_ns);
                          FStar_TypeChecker_Env.synth_hook =
-                           (uu___3387_25817.FStar_TypeChecker_Env.synth_hook);
+                           (uu___3404_26081.FStar_TypeChecker_Env.synth_hook);
                          FStar_TypeChecker_Env.splice =
-                           (uu___3387_25817.FStar_TypeChecker_Env.splice);
+                           (uu___3404_26081.FStar_TypeChecker_Env.splice);
                          FStar_TypeChecker_Env.postprocess =
-                           (uu___3387_25817.FStar_TypeChecker_Env.postprocess);
+                           (uu___3404_26081.FStar_TypeChecker_Env.postprocess);
                          FStar_TypeChecker_Env.is_native_tactic =
-                           (uu___3387_25817.FStar_TypeChecker_Env.is_native_tactic);
+                           (uu___3404_26081.FStar_TypeChecker_Env.is_native_tactic);
                          FStar_TypeChecker_Env.identifier_info =
-                           (uu___3387_25817.FStar_TypeChecker_Env.identifier_info);
+                           (uu___3404_26081.FStar_TypeChecker_Env.identifier_info);
                          FStar_TypeChecker_Env.tc_hooks =
-                           (uu___3387_25817.FStar_TypeChecker_Env.tc_hooks);
+                           (uu___3404_26081.FStar_TypeChecker_Env.tc_hooks);
                          FStar_TypeChecker_Env.dsenv =
-                           (uu___3387_25817.FStar_TypeChecker_Env.dsenv);
+                           (uu___3404_26081.FStar_TypeChecker_Env.dsenv);
                          FStar_TypeChecker_Env.nbe =
-                           (uu___3387_25817.FStar_TypeChecker_Env.nbe);
+                           (uu___3404_26081.FStar_TypeChecker_Env.nbe);
                          FStar_TypeChecker_Env.strict_args_tab =
-                           (uu___3387_25817.FStar_TypeChecker_Env.strict_args_tab)
+                           (uu___3404_26081.FStar_TypeChecker_Env.strict_args_tab);
+                         FStar_TypeChecker_Env.erasable_types_tab =
+                           (uu___3404_26081.FStar_TypeChecker_Env.erasable_types_tab)
                        }  in
                      let g = FStar_TypeChecker_Rel.teq env1 t1 t_u  in
                      ((match g.FStar_TypeChecker_Env.guard_f with
                        | FStar_TypeChecker_Common.NonTrivial f ->
-                           let uu____25822 =
+                           let uu____26086 =
                              FStar_Syntax_Print.term_to_string t1  in
-                           level_of_type_fail env1 e uu____25822
-                       | uu____25824 ->
+                           level_of_type_fail env1 e uu____26086
+                       | uu____26088 ->
                            FStar_TypeChecker_Rel.force_trivial_guard env1 g);
                       u))
            in
@@ -10207,61 +10279,61 @@ let rec (universe_of_aux :
   =
   fun env  ->
     fun e  ->
-      let uu____25841 =
-        let uu____25842 = FStar_Syntax_Subst.compress e  in
-        uu____25842.FStar_Syntax_Syntax.n  in
-      match uu____25841 with
-      | FStar_Syntax_Syntax.Tm_bvar uu____25845 -> failwith "Impossible"
+      let uu____26105 =
+        let uu____26106 = FStar_Syntax_Subst.compress e  in
+        uu____26106.FStar_Syntax_Syntax.n  in
+      match uu____26105 with
+      | FStar_Syntax_Syntax.Tm_bvar uu____26109 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_unknown  -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_delayed uu____25848 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_let uu____25872 ->
+      | FStar_Syntax_Syntax.Tm_delayed uu____26112 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_let uu____26136 ->
           let e1 = FStar_TypeChecker_Normalize.normalize [] env e  in
           universe_of_aux env e1
-      | FStar_Syntax_Syntax.Tm_abs (bs,t,uu____25889) ->
+      | FStar_Syntax_Syntax.Tm_abs (bs,t,uu____26153) ->
           level_of_type_fail env e "arrow type"
       | FStar_Syntax_Syntax.Tm_uvar (u,s) ->
           FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ
-      | FStar_Syntax_Syntax.Tm_meta (t,uu____25934) -> universe_of_aux env t
+      | FStar_Syntax_Syntax.Tm_meta (t,uu____26198) -> universe_of_aux env t
       | FStar_Syntax_Syntax.Tm_name n1 -> n1.FStar_Syntax_Syntax.sort
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____25941 =
+          let uu____26205 =
             FStar_TypeChecker_Env.lookup_lid env
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          (match uu____25941 with | ((uu____25950,t),uu____25952) -> t)
+          (match uu____26205 with | ((uu____26214,t),uu____26216) -> t)
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____25958 = FStar_Syntax_Util.unfold_lazy i  in
-          universe_of_aux env uu____25958
+          let uu____26222 = FStar_Syntax_Util.unfold_lazy i  in
+          universe_of_aux env uu____26222
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____25961,(FStar_Util.Inl t,uu____25963),uu____25964) -> t
+          (uu____26225,(FStar_Util.Inl t,uu____26227),uu____26228) -> t
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____26011,(FStar_Util.Inr c,uu____26013),uu____26014) ->
+          (uu____26275,(FStar_Util.Inr c,uu____26277),uu____26278) ->
           FStar_Syntax_Util.comp_result c
       | FStar_Syntax_Syntax.Tm_type u ->
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_succ u))
             FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
-      | FStar_Syntax_Syntax.Tm_quoted uu____26062 -> FStar_Syntax_Util.ktype0
+      | FStar_Syntax_Syntax.Tm_quoted uu____26326 -> FStar_Syntax_Util.ktype0
       | FStar_Syntax_Syntax.Tm_constant sc ->
           tc_constant env e.FStar_Syntax_Syntax.pos sc
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____26071;
-             FStar_Syntax_Syntax.vars = uu____26072;_},us)
+             FStar_Syntax_Syntax.pos = uu____26335;
+             FStar_Syntax_Syntax.vars = uu____26336;_},us)
           ->
-          let uu____26078 =
+          let uu____26342 =
             FStar_TypeChecker_Env.lookup_lid env
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          (match uu____26078 with
-           | ((us',t),uu____26089) ->
+          (match uu____26342 with
+           | ((us',t),uu____26353) ->
                (if (FStar_List.length us) <> (FStar_List.length us')
                 then
-                  (let uu____26096 = FStar_TypeChecker_Env.get_range env  in
+                  (let uu____26360 = FStar_TypeChecker_Env.get_range env  in
                    FStar_Errors.raise_error
                      (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
                        "Unexpected number of universe instantiations")
-                     uu____26096)
+                     uu____26360)
                 else
                   FStar_List.iter2
                     (fun u'  ->
@@ -10269,31 +10341,31 @@ let rec (universe_of_aux :
                          match u' with
                          | FStar_Syntax_Syntax.U_unif u'' ->
                              FStar_Syntax_Unionfind.univ_change u'' u
-                         | uu____26115 -> failwith "Impossible") us' us;
+                         | uu____26379 -> failwith "Impossible") us' us;
                 t))
-      | FStar_Syntax_Syntax.Tm_uinst uu____26117 ->
+      | FStar_Syntax_Syntax.Tm_uinst uu____26381 ->
           failwith "Impossible: Tm_uinst's head must be an fvar"
-      | FStar_Syntax_Syntax.Tm_refine (x,uu____26126) ->
+      | FStar_Syntax_Syntax.Tm_refine (x,uu____26390) ->
           universe_of_aux env x.FStar_Syntax_Syntax.sort
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____26153 = FStar_Syntax_Subst.open_comp bs c  in
-          (match uu____26153 with
+          let uu____26417 = FStar_Syntax_Subst.open_comp bs c  in
+          (match uu____26417 with
            | (bs1,c1) ->
                let us =
                  FStar_List.map
-                   (fun uu____26173  ->
-                      match uu____26173 with
-                      | (b,uu____26181) ->
-                          let uu____26186 =
+                   (fun uu____26437  ->
+                      match uu____26437 with
+                      | (b,uu____26445) ->
+                          let uu____26450 =
                             universe_of_aux env b.FStar_Syntax_Syntax.sort
                              in
                           level_of_type env b.FStar_Syntax_Syntax.sort
-                            uu____26186) bs1
+                            uu____26450) bs1
                   in
                let u_res =
                  let res = FStar_Syntax_Util.comp_result c1  in
-                 let uu____26191 = universe_of_aux env res  in
-                 level_of_type env res uu____26191  in
+                 let uu____26455 = universe_of_aux env res  in
+                 level_of_type env res uu____26455  in
                let u_c =
                  FStar_All.pipe_right c1
                    (FStar_TypeChecker_Util.universe_of_comp env u_res)
@@ -10309,195 +10381,197 @@ let rec (universe_of_aux :
             let hd3 = FStar_Syntax_Subst.compress hd2  in
             match hd3.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Tm_unknown  -> failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_bvar uu____26302 ->
+            | FStar_Syntax_Syntax.Tm_bvar uu____26566 ->
                 failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_delayed uu____26318 ->
+            | FStar_Syntax_Syntax.Tm_delayed uu____26582 ->
                 failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_fvar uu____26356 ->
-                let uu____26357 = universe_of_aux env hd3  in
-                (uu____26357, args1)
-            | FStar_Syntax_Syntax.Tm_name uu____26368 ->
-                let uu____26369 = universe_of_aux env hd3  in
-                (uu____26369, args1)
-            | FStar_Syntax_Syntax.Tm_uvar uu____26380 ->
-                let uu____26393 = universe_of_aux env hd3  in
-                (uu____26393, args1)
-            | FStar_Syntax_Syntax.Tm_uinst uu____26404 ->
-                let uu____26411 = universe_of_aux env hd3  in
-                (uu____26411, args1)
-            | FStar_Syntax_Syntax.Tm_ascribed uu____26422 ->
-                let uu____26449 = universe_of_aux env hd3  in
-                (uu____26449, args1)
-            | FStar_Syntax_Syntax.Tm_refine uu____26460 ->
-                let uu____26467 = universe_of_aux env hd3  in
-                (uu____26467, args1)
-            | FStar_Syntax_Syntax.Tm_constant uu____26478 ->
-                let uu____26479 = universe_of_aux env hd3  in
-                (uu____26479, args1)
-            | FStar_Syntax_Syntax.Tm_arrow uu____26490 ->
-                let uu____26505 = universe_of_aux env hd3  in
-                (uu____26505, args1)
-            | FStar_Syntax_Syntax.Tm_meta uu____26516 ->
-                let uu____26523 = universe_of_aux env hd3  in
-                (uu____26523, args1)
-            | FStar_Syntax_Syntax.Tm_type uu____26534 ->
-                let uu____26535 = universe_of_aux env hd3  in
-                (uu____26535, args1)
-            | FStar_Syntax_Syntax.Tm_match (uu____26546,hd4::uu____26548) ->
-                let uu____26613 = FStar_Syntax_Subst.open_branch hd4  in
-                (match uu____26613 with
-                 | (uu____26628,uu____26629,hd5) ->
-                     let uu____26647 = FStar_Syntax_Util.head_and_args hd5
+            | FStar_Syntax_Syntax.Tm_fvar uu____26620 ->
+                let uu____26621 = universe_of_aux env hd3  in
+                (uu____26621, args1)
+            | FStar_Syntax_Syntax.Tm_name uu____26632 ->
+                let uu____26633 = universe_of_aux env hd3  in
+                (uu____26633, args1)
+            | FStar_Syntax_Syntax.Tm_uvar uu____26644 ->
+                let uu____26657 = universe_of_aux env hd3  in
+                (uu____26657, args1)
+            | FStar_Syntax_Syntax.Tm_uinst uu____26668 ->
+                let uu____26675 = universe_of_aux env hd3  in
+                (uu____26675, args1)
+            | FStar_Syntax_Syntax.Tm_ascribed uu____26686 ->
+                let uu____26713 = universe_of_aux env hd3  in
+                (uu____26713, args1)
+            | FStar_Syntax_Syntax.Tm_refine uu____26724 ->
+                let uu____26731 = universe_of_aux env hd3  in
+                (uu____26731, args1)
+            | FStar_Syntax_Syntax.Tm_constant uu____26742 ->
+                let uu____26743 = universe_of_aux env hd3  in
+                (uu____26743, args1)
+            | FStar_Syntax_Syntax.Tm_arrow uu____26754 ->
+                let uu____26769 = universe_of_aux env hd3  in
+                (uu____26769, args1)
+            | FStar_Syntax_Syntax.Tm_meta uu____26780 ->
+                let uu____26787 = universe_of_aux env hd3  in
+                (uu____26787, args1)
+            | FStar_Syntax_Syntax.Tm_type uu____26798 ->
+                let uu____26799 = universe_of_aux env hd3  in
+                (uu____26799, args1)
+            | FStar_Syntax_Syntax.Tm_match (uu____26810,hd4::uu____26812) ->
+                let uu____26877 = FStar_Syntax_Subst.open_branch hd4  in
+                (match uu____26877 with
+                 | (uu____26892,uu____26893,hd5) ->
+                     let uu____26911 = FStar_Syntax_Util.head_and_args hd5
                         in
-                     (match uu____26647 with
+                     (match uu____26911 with
                       | (hd6,args2) -> type_of_head retry hd6 args2))
-            | uu____26704 when retry ->
+            | uu____26968 when retry ->
                 let e1 =
                   FStar_TypeChecker_Normalize.normalize
                     [FStar_TypeChecker_Env.Beta;
                     FStar_TypeChecker_Env.DoNotUnfoldPureLets] env e
                    in
-                let uu____26706 = FStar_Syntax_Util.head_and_args e1  in
-                (match uu____26706 with
+                let uu____26970 = FStar_Syntax_Util.head_and_args e1  in
+                (match uu____26970 with
                  | (hd4,args2) -> type_of_head false hd4 args2)
-            | uu____26764 ->
-                let uu____26765 =
+            | uu____27028 ->
+                let uu____27029 =
                   FStar_TypeChecker_Env.clear_expected_typ env  in
-                (match uu____26765 with
-                 | (env1,uu____26787) ->
+                (match uu____27029 with
+                 | (env1,uu____27051) ->
                      let env2 =
-                       let uu___3548_26793 = env1  in
+                       let uu___3565_27057 = env1  in
                        {
                          FStar_TypeChecker_Env.solver =
-                           (uu___3548_26793.FStar_TypeChecker_Env.solver);
+                           (uu___3565_27057.FStar_TypeChecker_Env.solver);
                          FStar_TypeChecker_Env.range =
-                           (uu___3548_26793.FStar_TypeChecker_Env.range);
+                           (uu___3565_27057.FStar_TypeChecker_Env.range);
                          FStar_TypeChecker_Env.curmodule =
-                           (uu___3548_26793.FStar_TypeChecker_Env.curmodule);
+                           (uu___3565_27057.FStar_TypeChecker_Env.curmodule);
                          FStar_TypeChecker_Env.gamma =
-                           (uu___3548_26793.FStar_TypeChecker_Env.gamma);
+                           (uu___3565_27057.FStar_TypeChecker_Env.gamma);
                          FStar_TypeChecker_Env.gamma_sig =
-                           (uu___3548_26793.FStar_TypeChecker_Env.gamma_sig);
+                           (uu___3565_27057.FStar_TypeChecker_Env.gamma_sig);
                          FStar_TypeChecker_Env.gamma_cache =
-                           (uu___3548_26793.FStar_TypeChecker_Env.gamma_cache);
+                           (uu___3565_27057.FStar_TypeChecker_Env.gamma_cache);
                          FStar_TypeChecker_Env.modules =
-                           (uu___3548_26793.FStar_TypeChecker_Env.modules);
+                           (uu___3565_27057.FStar_TypeChecker_Env.modules);
                          FStar_TypeChecker_Env.expected_typ =
-                           (uu___3548_26793.FStar_TypeChecker_Env.expected_typ);
+                           (uu___3565_27057.FStar_TypeChecker_Env.expected_typ);
                          FStar_TypeChecker_Env.sigtab =
-                           (uu___3548_26793.FStar_TypeChecker_Env.sigtab);
+                           (uu___3565_27057.FStar_TypeChecker_Env.sigtab);
                          FStar_TypeChecker_Env.attrtab =
-                           (uu___3548_26793.FStar_TypeChecker_Env.attrtab);
+                           (uu___3565_27057.FStar_TypeChecker_Env.attrtab);
                          FStar_TypeChecker_Env.is_pattern =
-                           (uu___3548_26793.FStar_TypeChecker_Env.is_pattern);
+                           (uu___3565_27057.FStar_TypeChecker_Env.is_pattern);
                          FStar_TypeChecker_Env.instantiate_imp =
-                           (uu___3548_26793.FStar_TypeChecker_Env.instantiate_imp);
+                           (uu___3565_27057.FStar_TypeChecker_Env.instantiate_imp);
                          FStar_TypeChecker_Env.effects =
-                           (uu___3548_26793.FStar_TypeChecker_Env.effects);
+                           (uu___3565_27057.FStar_TypeChecker_Env.effects);
                          FStar_TypeChecker_Env.generalize =
-                           (uu___3548_26793.FStar_TypeChecker_Env.generalize);
+                           (uu___3565_27057.FStar_TypeChecker_Env.generalize);
                          FStar_TypeChecker_Env.letrecs =
-                           (uu___3548_26793.FStar_TypeChecker_Env.letrecs);
+                           (uu___3565_27057.FStar_TypeChecker_Env.letrecs);
                          FStar_TypeChecker_Env.top_level = false;
                          FStar_TypeChecker_Env.check_uvars =
-                           (uu___3548_26793.FStar_TypeChecker_Env.check_uvars);
+                           (uu___3565_27057.FStar_TypeChecker_Env.check_uvars);
                          FStar_TypeChecker_Env.use_eq =
-                           (uu___3548_26793.FStar_TypeChecker_Env.use_eq);
+                           (uu___3565_27057.FStar_TypeChecker_Env.use_eq);
                          FStar_TypeChecker_Env.is_iface =
-                           (uu___3548_26793.FStar_TypeChecker_Env.is_iface);
+                           (uu___3565_27057.FStar_TypeChecker_Env.is_iface);
                          FStar_TypeChecker_Env.admit =
-                           (uu___3548_26793.FStar_TypeChecker_Env.admit);
+                           (uu___3565_27057.FStar_TypeChecker_Env.admit);
                          FStar_TypeChecker_Env.lax = true;
                          FStar_TypeChecker_Env.lax_universes =
-                           (uu___3548_26793.FStar_TypeChecker_Env.lax_universes);
+                           (uu___3565_27057.FStar_TypeChecker_Env.lax_universes);
                          FStar_TypeChecker_Env.phase1 =
-                           (uu___3548_26793.FStar_TypeChecker_Env.phase1);
+                           (uu___3565_27057.FStar_TypeChecker_Env.phase1);
                          FStar_TypeChecker_Env.failhard =
-                           (uu___3548_26793.FStar_TypeChecker_Env.failhard);
+                           (uu___3565_27057.FStar_TypeChecker_Env.failhard);
                          FStar_TypeChecker_Env.nosynth =
-                           (uu___3548_26793.FStar_TypeChecker_Env.nosynth);
+                           (uu___3565_27057.FStar_TypeChecker_Env.nosynth);
                          FStar_TypeChecker_Env.uvar_subtyping =
-                           (uu___3548_26793.FStar_TypeChecker_Env.uvar_subtyping);
+                           (uu___3565_27057.FStar_TypeChecker_Env.uvar_subtyping);
                          FStar_TypeChecker_Env.tc_term =
-                           (uu___3548_26793.FStar_TypeChecker_Env.tc_term);
+                           (uu___3565_27057.FStar_TypeChecker_Env.tc_term);
                          FStar_TypeChecker_Env.type_of =
-                           (uu___3548_26793.FStar_TypeChecker_Env.type_of);
+                           (uu___3565_27057.FStar_TypeChecker_Env.type_of);
                          FStar_TypeChecker_Env.universe_of =
-                           (uu___3548_26793.FStar_TypeChecker_Env.universe_of);
+                           (uu___3565_27057.FStar_TypeChecker_Env.universe_of);
                          FStar_TypeChecker_Env.check_type_of =
-                           (uu___3548_26793.FStar_TypeChecker_Env.check_type_of);
+                           (uu___3565_27057.FStar_TypeChecker_Env.check_type_of);
                          FStar_TypeChecker_Env.use_bv_sorts = true;
                          FStar_TypeChecker_Env.qtbl_name_and_index =
-                           (uu___3548_26793.FStar_TypeChecker_Env.qtbl_name_and_index);
+                           (uu___3565_27057.FStar_TypeChecker_Env.qtbl_name_and_index);
                          FStar_TypeChecker_Env.normalized_eff_names =
-                           (uu___3548_26793.FStar_TypeChecker_Env.normalized_eff_names);
+                           (uu___3565_27057.FStar_TypeChecker_Env.normalized_eff_names);
                          FStar_TypeChecker_Env.fv_delta_depths =
-                           (uu___3548_26793.FStar_TypeChecker_Env.fv_delta_depths);
+                           (uu___3565_27057.FStar_TypeChecker_Env.fv_delta_depths);
                          FStar_TypeChecker_Env.proof_ns =
-                           (uu___3548_26793.FStar_TypeChecker_Env.proof_ns);
+                           (uu___3565_27057.FStar_TypeChecker_Env.proof_ns);
                          FStar_TypeChecker_Env.synth_hook =
-                           (uu___3548_26793.FStar_TypeChecker_Env.synth_hook);
+                           (uu___3565_27057.FStar_TypeChecker_Env.synth_hook);
                          FStar_TypeChecker_Env.splice =
-                           (uu___3548_26793.FStar_TypeChecker_Env.splice);
+                           (uu___3565_27057.FStar_TypeChecker_Env.splice);
                          FStar_TypeChecker_Env.postprocess =
-                           (uu___3548_26793.FStar_TypeChecker_Env.postprocess);
+                           (uu___3565_27057.FStar_TypeChecker_Env.postprocess);
                          FStar_TypeChecker_Env.is_native_tactic =
-                           (uu___3548_26793.FStar_TypeChecker_Env.is_native_tactic);
+                           (uu___3565_27057.FStar_TypeChecker_Env.is_native_tactic);
                          FStar_TypeChecker_Env.identifier_info =
-                           (uu___3548_26793.FStar_TypeChecker_Env.identifier_info);
+                           (uu___3565_27057.FStar_TypeChecker_Env.identifier_info);
                          FStar_TypeChecker_Env.tc_hooks =
-                           (uu___3548_26793.FStar_TypeChecker_Env.tc_hooks);
+                           (uu___3565_27057.FStar_TypeChecker_Env.tc_hooks);
                          FStar_TypeChecker_Env.dsenv =
-                           (uu___3548_26793.FStar_TypeChecker_Env.dsenv);
+                           (uu___3565_27057.FStar_TypeChecker_Env.dsenv);
                          FStar_TypeChecker_Env.nbe =
-                           (uu___3548_26793.FStar_TypeChecker_Env.nbe);
+                           (uu___3565_27057.FStar_TypeChecker_Env.nbe);
                          FStar_TypeChecker_Env.strict_args_tab =
-                           (uu___3548_26793.FStar_TypeChecker_Env.strict_args_tab)
+                           (uu___3565_27057.FStar_TypeChecker_Env.strict_args_tab);
+                         FStar_TypeChecker_Env.erasable_types_tab =
+                           (uu___3565_27057.FStar_TypeChecker_Env.erasable_types_tab)
                        }  in
-                     ((let uu____26798 =
+                     ((let uu____27062 =
                          FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug env2)
                            (FStar_Options.Other "UniverseOf")
                           in
-                       if uu____26798
+                       if uu____27062
                        then
-                         let uu____26803 =
-                           let uu____26805 =
+                         let uu____27067 =
+                           let uu____27069 =
                              FStar_TypeChecker_Env.get_range env2  in
-                           FStar_Range.string_of_range uu____26805  in
-                         let uu____26806 =
+                           FStar_Range.string_of_range uu____27069  in
+                         let uu____27070 =
                            FStar_Syntax_Print.term_to_string hd3  in
                          FStar_Util.print2 "%s: About to type-check %s\n"
-                           uu____26803 uu____26806
+                           uu____27067 uu____27070
                        else ());
-                      (let uu____26811 = tc_term env2 hd3  in
-                       match uu____26811 with
-                       | (uu____26832,{
+                      (let uu____27075 = tc_term env2 hd3  in
+                       match uu____27075 with
+                       | (uu____27096,{
                                         FStar_Syntax_Syntax.eff_name =
-                                          uu____26833;
+                                          uu____27097;
                                         FStar_Syntax_Syntax.res_typ = t;
                                         FStar_Syntax_Syntax.cflags =
-                                          uu____26835;
+                                          uu____27099;
                                         FStar_Syntax_Syntax.comp_thunk =
-                                          uu____26836;_},g)
+                                          uu____27100;_},g)
                            ->
-                           ((let uu____26850 =
+                           ((let uu____27114 =
                                FStar_TypeChecker_Rel.solve_deferred_constraints
                                  env2 g
                                 in
-                             FStar_All.pipe_right uu____26850 (fun a1  -> ()));
+                             FStar_All.pipe_right uu____27114 (fun a1  -> ()));
                             (t, args1)))))
              in
-          let uu____26861 = type_of_head true hd1 args  in
-          (match uu____26861 with
+          let uu____27125 = type_of_head true hd1 args  in
+          (match uu____27125 with
            | (t,args1) ->
                let t1 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.UnfoldUntil
                       FStar_Syntax_Syntax.delta_constant] env t
                   in
-               let uu____26900 = FStar_Syntax_Util.arrow_formals_comp t1  in
-               (match uu____26900 with
+               let uu____27164 = FStar_Syntax_Util.arrow_formals_comp t1  in
+               (match uu____27164 with
                 | (bs,res) ->
                     let res1 = FStar_Syntax_Util.comp_result res  in
                     if (FStar_List.length bs) = (FStar_List.length args1)
@@ -10506,14 +10580,14 @@ let rec (universe_of_aux :
                          in
                       FStar_Syntax_Subst.subst subst1 res1
                     else
-                      (let uu____26952 =
+                      (let uu____27216 =
                          FStar_Syntax_Print.term_to_string res1  in
-                       level_of_type_fail env e uu____26952)))
-      | FStar_Syntax_Syntax.Tm_match (uu____26954,hd1::uu____26956) ->
-          let uu____27021 = FStar_Syntax_Subst.open_branch hd1  in
-          (match uu____27021 with
-           | (uu____27022,uu____27023,hd2) -> universe_of_aux env hd2)
-      | FStar_Syntax_Syntax.Tm_match (uu____27041,[]) ->
+                       level_of_type_fail env e uu____27216)))
+      | FStar_Syntax_Syntax.Tm_match (uu____27218,hd1::uu____27220) ->
+          let uu____27285 = FStar_Syntax_Subst.open_branch hd1  in
+          (match uu____27285 with
+           | (uu____27286,uu____27287,hd2) -> universe_of_aux env hd2)
+      | FStar_Syntax_Syntax.Tm_match (uu____27305,[]) ->
           level_of_type_fail env e "empty match cases"
   
 let (universe_of :
@@ -10522,8 +10596,8 @@ let (universe_of :
   =
   fun env  ->
     fun e  ->
-      let uu____27088 = universe_of_aux env e  in
-      level_of_type env e uu____27088
+      let uu____27352 = universe_of_aux env e  in
+      level_of_type env e uu____27352
   
 let (tc_tparams :
   FStar_TypeChecker_Env.env_t ->
@@ -10533,8 +10607,8 @@ let (tc_tparams :
   =
   fun env  ->
     fun tps  ->
-      let uu____27112 = tc_binders env tps  in
-      match uu____27112 with
+      let uu____27376 = tc_binders env tps  in
+      match uu____27376 with
       | (tps1,env1,g,us) ->
           (FStar_TypeChecker_Rel.force_trivial_guard env1 g; (tps1, env1, us))
   
@@ -10551,142 +10625,142 @@ let rec (type_of_well_typed_term :
          in
       let t1 = FStar_Syntax_Subst.compress t  in
       match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed uu____27170 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_bvar uu____27196 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu____27434 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_bvar uu____27460 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_name x ->
           FStar_Pervasives_Native.Some (x.FStar_Syntax_Syntax.sort)
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____27202 = FStar_Syntax_Util.unfold_lazy i  in
-          type_of_well_typed_term env uu____27202
+          let uu____27466 = FStar_Syntax_Util.unfold_lazy i  in
+          type_of_well_typed_term env uu____27466
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____27204 =
+          let uu____27468 =
             FStar_TypeChecker_Env.try_lookup_and_inst_lid env []
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          FStar_Util.bind_opt uu____27204
-            (fun uu____27218  ->
-               match uu____27218 with
-               | (t2,uu____27226) -> FStar_Pervasives_Native.Some t2)
+          FStar_Util.bind_opt uu____27468
+            (fun uu____27482  ->
+               match uu____27482 with
+               | (t2,uu____27490) -> FStar_Pervasives_Native.Some t2)
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____27228;
-             FStar_Syntax_Syntax.vars = uu____27229;_},us)
+             FStar_Syntax_Syntax.pos = uu____27492;
+             FStar_Syntax_Syntax.vars = uu____27493;_},us)
           ->
-          let uu____27235 =
+          let uu____27499 =
             FStar_TypeChecker_Env.try_lookup_and_inst_lid env us
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          FStar_Util.bind_opt uu____27235
-            (fun uu____27249  ->
-               match uu____27249 with
-               | (t2,uu____27257) -> FStar_Pervasives_Native.Some t2)
+          FStar_Util.bind_opt uu____27499
+            (fun uu____27513  ->
+               match uu____27513 with
+               | (t2,uu____27521) -> FStar_Pervasives_Native.Some t2)
       | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify ) ->
           FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reflect
-          uu____27258) -> FStar_Pervasives_Native.None
+          uu____27522) -> FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Tm_constant sc ->
-          let uu____27260 = tc_constant env t1.FStar_Syntax_Syntax.pos sc  in
-          FStar_Pervasives_Native.Some uu____27260
+          let uu____27524 = tc_constant env t1.FStar_Syntax_Syntax.pos sc  in
+          FStar_Pervasives_Native.Some uu____27524
       | FStar_Syntax_Syntax.Tm_type u ->
-          let uu____27262 = mk_tm_type (FStar_Syntax_Syntax.U_succ u)  in
-          FStar_Pervasives_Native.Some uu____27262
+          let uu____27526 = mk_tm_type (FStar_Syntax_Syntax.U_succ u)  in
+          FStar_Pervasives_Native.Some uu____27526
       | FStar_Syntax_Syntax.Tm_abs
           (bs,body,FStar_Pervasives_Native.Some
            { FStar_Syntax_Syntax.residual_effect = eff;
              FStar_Syntax_Syntax.residual_typ = FStar_Pervasives_Native.Some
                tbody;
-             FStar_Syntax_Syntax.residual_flags = uu____27267;_})
+             FStar_Syntax_Syntax.residual_flags = uu____27531;_})
           ->
           let mk_comp =
-            let uu____27311 =
+            let uu____27575 =
               FStar_Ident.lid_equals eff FStar_Parser_Const.effect_Tot_lid
                in
-            if uu____27311
+            if uu____27575
             then FStar_Pervasives_Native.Some FStar_Syntax_Syntax.mk_Total'
             else
-              (let uu____27342 =
+              (let uu____27606 =
                  FStar_Ident.lid_equals eff
                    FStar_Parser_Const.effect_GTot_lid
                   in
-               if uu____27342
+               if uu____27606
                then
                  FStar_Pervasives_Native.Some FStar_Syntax_Syntax.mk_GTotal'
                else FStar_Pervasives_Native.None)
              in
           FStar_Util.bind_opt mk_comp
             (fun f  ->
-               let uu____27412 = universe_of_well_typed_term env tbody  in
-               FStar_Util.bind_opt uu____27412
+               let uu____27676 = universe_of_well_typed_term env tbody  in
+               FStar_Util.bind_opt uu____27676
                  (fun u  ->
-                    let uu____27420 =
-                      let uu____27423 =
-                        let uu____27430 =
-                          let uu____27431 =
-                            let uu____27446 =
+                    let uu____27684 =
+                      let uu____27687 =
+                        let uu____27694 =
+                          let uu____27695 =
+                            let uu____27710 =
                               f tbody (FStar_Pervasives_Native.Some u)  in
-                            (bs, uu____27446)  in
-                          FStar_Syntax_Syntax.Tm_arrow uu____27431  in
-                        FStar_Syntax_Syntax.mk uu____27430  in
-                      uu____27423 FStar_Pervasives_Native.None
+                            (bs, uu____27710)  in
+                          FStar_Syntax_Syntax.Tm_arrow uu____27695  in
+                        FStar_Syntax_Syntax.mk uu____27694  in
+                      uu____27687 FStar_Pervasives_Native.None
                         t1.FStar_Syntax_Syntax.pos
                        in
-                    FStar_Pervasives_Native.Some uu____27420))
+                    FStar_Pervasives_Native.Some uu____27684))
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____27483 = FStar_Syntax_Subst.open_comp bs c  in
-          (match uu____27483 with
+          let uu____27747 = FStar_Syntax_Subst.open_comp bs c  in
+          (match uu____27747 with
            | (bs1,c1) ->
                let rec aux env1 us bs2 =
                  match bs2 with
                  | [] ->
-                     let uu____27542 =
+                     let uu____27806 =
                        universe_of_well_typed_term env1
                          (FStar_Syntax_Util.comp_result c1)
                         in
-                     FStar_Util.bind_opt uu____27542
+                     FStar_Util.bind_opt uu____27806
                        (fun uc  ->
-                          let uu____27550 =
+                          let uu____27814 =
                             mk_tm_type (FStar_Syntax_Syntax.U_max (uc :: us))
                              in
-                          FStar_Pervasives_Native.Some uu____27550)
+                          FStar_Pervasives_Native.Some uu____27814)
                  | (x,imp)::bs3 ->
-                     let uu____27576 =
+                     let uu____27840 =
                        universe_of_well_typed_term env1
                          x.FStar_Syntax_Syntax.sort
                         in
-                     FStar_Util.bind_opt uu____27576
+                     FStar_Util.bind_opt uu____27840
                        (fun u_x  ->
                           let env2 = FStar_TypeChecker_Env.push_bv env1 x  in
                           aux env2 (u_x :: us) bs3)
                   in
                aux env [] bs1)
-      | FStar_Syntax_Syntax.Tm_abs uu____27585 ->
+      | FStar_Syntax_Syntax.Tm_abs uu____27849 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_refine (x,uu____27605) ->
-          let uu____27610 =
+      | FStar_Syntax_Syntax.Tm_refine (x,uu____27869) ->
+          let uu____27874 =
             universe_of_well_typed_term env x.FStar_Syntax_Syntax.sort  in
-          FStar_Util.bind_opt uu____27610
+          FStar_Util.bind_opt uu____27874
             (fun u_x  ->
-               let uu____27618 = mk_tm_type u_x  in
-               FStar_Pervasives_Native.Some uu____27618)
+               let uu____27882 = mk_tm_type u_x  in
+               FStar_Pervasives_Native.Some uu____27882)
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of );
-             FStar_Syntax_Syntax.pos = uu____27623;
-             FStar_Syntax_Syntax.vars = uu____27624;_},a::hd1::rest)
+             FStar_Syntax_Syntax.pos = uu____27887;
+             FStar_Syntax_Syntax.vars = uu____27888;_},a::hd1::rest)
           ->
           let rest1 = hd1 :: rest  in
-          let uu____27703 = FStar_Syntax_Util.head_and_args t1  in
-          (match uu____27703 with
-           | (unary_op1,uu____27723) ->
+          let uu____27967 = FStar_Syntax_Util.head_and_args t1  in
+          (match uu____27967 with
+           | (unary_op1,uu____27987) ->
                let head1 =
-                 let uu____27751 =
+                 let uu____28015 =
                    FStar_Range.union_ranges unary_op1.FStar_Syntax_Syntax.pos
                      (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos
                     in
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_app (unary_op1, [a]))
-                   FStar_Pervasives_Native.None uu____27751
+                   FStar_Pervasives_Native.None uu____28015
                   in
                let t2 =
                  FStar_Syntax_Syntax.mk
@@ -10698,21 +10772,21 @@ let rec (type_of_well_typed_term :
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of );
-             FStar_Syntax_Syntax.pos = uu____27799;
-             FStar_Syntax_Syntax.vars = uu____27800;_},a1::a2::hd1::rest)
+             FStar_Syntax_Syntax.pos = uu____28063;
+             FStar_Syntax_Syntax.vars = uu____28064;_},a1::a2::hd1::rest)
           ->
           let rest1 = hd1 :: rest  in
-          let uu____27896 = FStar_Syntax_Util.head_and_args t1  in
-          (match uu____27896 with
-           | (unary_op1,uu____27916) ->
+          let uu____28160 = FStar_Syntax_Util.head_and_args t1  in
+          (match uu____28160 with
+           | (unary_op1,uu____28180) ->
                let head1 =
-                 let uu____27944 =
+                 let uu____28208 =
                    FStar_Range.union_ranges unary_op1.FStar_Syntax_Syntax.pos
                      (FStar_Pervasives_Native.fst a1).FStar_Syntax_Syntax.pos
                     in
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_app (unary_op1, [a1; a2]))
-                   FStar_Pervasives_Native.None uu____27944
+                   FStar_Pervasives_Native.None uu____28208
                   in
                let t2 =
                  FStar_Syntax_Syntax.mk
@@ -10724,32 +10798,32 @@ let rec (type_of_well_typed_term :
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of );
-             FStar_Syntax_Syntax.pos = uu____28000;
-             FStar_Syntax_Syntax.vars = uu____28001;_},uu____28002::[])
+             FStar_Syntax_Syntax.pos = uu____28264;
+             FStar_Syntax_Syntax.vars = uu____28265;_},uu____28266::[])
           -> FStar_Pervasives_Native.Some FStar_Syntax_Syntax.t_range
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of );
-             FStar_Syntax_Syntax.pos = uu____28041;
-             FStar_Syntax_Syntax.vars = uu____28042;_},(t2,uu____28044)::uu____28045::[])
+             FStar_Syntax_Syntax.pos = uu____28305;
+             FStar_Syntax_Syntax.vars = uu____28306;_},(t2,uu____28308)::uu____28309::[])
           -> type_of_well_typed_term env t2
       | FStar_Syntax_Syntax.Tm_app (hd1,args) ->
           let t_hd = type_of_well_typed_term env hd1  in
           let rec aux t_hd1 =
-            let uu____28141 =
-              let uu____28142 =
+            let uu____28405 =
+              let uu____28406 =
                 FStar_TypeChecker_Normalize.unfold_whnf env t_hd1  in
-              uu____28142.FStar_Syntax_Syntax.n  in
-            match uu____28141 with
+              uu____28406.FStar_Syntax_Syntax.n  in
+            match uu____28405 with
             | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
                 let n_args = FStar_List.length args  in
                 let n_bs = FStar_List.length bs  in
                 let bs_t_opt =
                   if n_args < n_bs
                   then
-                    let uu____28215 = FStar_Util.first_N n_args bs  in
-                    match uu____28215 with
+                    let uu____28479 = FStar_Util.first_N n_args bs  in
+                    match uu____28479 with
                     | (bs1,rest) ->
                         let t2 =
                           FStar_Syntax_Syntax.mk
@@ -10757,24 +10831,24 @@ let rec (type_of_well_typed_term :
                             FStar_Pervasives_Native.None
                             t_hd1.FStar_Syntax_Syntax.pos
                            in
-                        let uu____28303 =
-                          let uu____28308 = FStar_Syntax_Syntax.mk_Total t2
+                        let uu____28567 =
+                          let uu____28572 = FStar_Syntax_Syntax.mk_Total t2
                              in
-                          FStar_Syntax_Subst.open_comp bs1 uu____28308  in
-                        (match uu____28303 with
+                          FStar_Syntax_Subst.open_comp bs1 uu____28572  in
+                        (match uu____28567 with
                          | (bs2,c1) ->
                              FStar_Pervasives_Native.Some
                                (bs2, (FStar_Syntax_Util.comp_result c1)))
                   else
                     if n_args = n_bs
                     then
-                      (let uu____28362 = FStar_Syntax_Subst.open_comp bs c
+                      (let uu____28626 = FStar_Syntax_Subst.open_comp bs c
                           in
-                       match uu____28362 with
+                       match uu____28626 with
                        | (bs1,c1) ->
-                           let uu____28383 =
+                           let uu____28647 =
                              FStar_Syntax_Util.is_tot_or_gtot_comp c1  in
-                           if uu____28383
+                           if uu____28647
                            then
                              FStar_Pervasives_Native.Some
                                (bs1, (FStar_Syntax_Util.comp_result c1))
@@ -10782,8 +10856,8 @@ let rec (type_of_well_typed_term :
                     else FStar_Pervasives_Native.None
                    in
                 FStar_Util.bind_opt bs_t_opt
-                  (fun uu____28465  ->
-                     match uu____28465 with
+                  (fun uu____28729  ->
+                     match uu____28729 with
                      | (bs1,t2) ->
                          let subst1 =
                            FStar_List.map2
@@ -10794,36 +10868,36 @@ let rec (type_of_well_typed_term :
                                       (FStar_Pervasives_Native.fst a))) bs1
                              args
                             in
-                         let uu____28541 = FStar_Syntax_Subst.subst subst1 t2
+                         let uu____28805 = FStar_Syntax_Subst.subst subst1 t2
                             in
-                         FStar_Pervasives_Native.Some uu____28541)
-            | FStar_Syntax_Syntax.Tm_refine (x,uu____28543) ->
+                         FStar_Pervasives_Native.Some uu____28805)
+            | FStar_Syntax_Syntax.Tm_refine (x,uu____28807) ->
                 aux x.FStar_Syntax_Syntax.sort
-            | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____28549,uu____28550) ->
+            | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____28813,uu____28814) ->
                 aux t2
-            | uu____28591 -> FStar_Pervasives_Native.None  in
+            | uu____28855 -> FStar_Pervasives_Native.None  in
           FStar_Util.bind_opt t_hd aux
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____28592,(FStar_Util.Inl t2,uu____28594),uu____28595) ->
+          (uu____28856,(FStar_Util.Inl t2,uu____28858),uu____28859) ->
           FStar_Pervasives_Native.Some t2
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____28642,(FStar_Util.Inr c,uu____28644),uu____28645) ->
+          (uu____28906,(FStar_Util.Inr c,uu____28908),uu____28909) ->
           FStar_Pervasives_Native.Some (FStar_Syntax_Util.comp_result c)
       | FStar_Syntax_Syntax.Tm_uvar (u,s) ->
-          let uu____28710 =
+          let uu____28974 =
             FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ
              in
-          FStar_Pervasives_Native.Some uu____28710
+          FStar_Pervasives_Native.Some uu____28974
       | FStar_Syntax_Syntax.Tm_quoted (tm,qi) ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.t_term
-      | FStar_Syntax_Syntax.Tm_meta (t2,uu____28718) ->
+      | FStar_Syntax_Syntax.Tm_meta (t2,uu____28982) ->
           type_of_well_typed_term env t2
-      | FStar_Syntax_Syntax.Tm_match uu____28723 ->
+      | FStar_Syntax_Syntax.Tm_match uu____28987 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_let uu____28746 ->
+      | FStar_Syntax_Syntax.Tm_let uu____29010 ->
           FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Tm_unknown  -> FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_uinst uu____28760 ->
+      | FStar_Syntax_Syntax.Tm_uinst uu____29024 ->
           FStar_Pervasives_Native.None
 
 and (universe_of_well_typed_term :
@@ -10833,14 +10907,14 @@ and (universe_of_well_typed_term :
   =
   fun env  ->
     fun t  ->
-      let uu____28771 = type_of_well_typed_term env t  in
-      match uu____28771 with
+      let uu____29035 = type_of_well_typed_term env t  in
+      match uu____29035 with
       | FStar_Pervasives_Native.Some
           { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_type u;
-            FStar_Syntax_Syntax.pos = uu____28777;
-            FStar_Syntax_Syntax.vars = uu____28778;_}
+            FStar_Syntax_Syntax.pos = uu____29041;
+            FStar_Syntax_Syntax.vars = uu____29042;_}
           -> FStar_Pervasives_Native.Some u
-      | uu____28781 -> FStar_Pervasives_Native.None
+      | uu____29045 -> FStar_Pervasives_Native.None
 
 let (check_type_of_well_typed_term' :
   Prims.bool ->
@@ -10854,142 +10928,144 @@ let (check_type_of_well_typed_term' :
         fun k  ->
           let env1 = FStar_TypeChecker_Env.set_expected_typ env k  in
           let env2 =
-            let uu___3827_28809 = env1  in
+            let uu___3844_29073 = env1  in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___3827_28809.FStar_TypeChecker_Env.solver);
+                (uu___3844_29073.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___3827_28809.FStar_TypeChecker_Env.range);
+                (uu___3844_29073.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___3827_28809.FStar_TypeChecker_Env.curmodule);
+                (uu___3844_29073.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___3827_28809.FStar_TypeChecker_Env.gamma);
+                (uu___3844_29073.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___3827_28809.FStar_TypeChecker_Env.gamma_sig);
+                (uu___3844_29073.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___3827_28809.FStar_TypeChecker_Env.gamma_cache);
+                (uu___3844_29073.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___3827_28809.FStar_TypeChecker_Env.modules);
+                (uu___3844_29073.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___3827_28809.FStar_TypeChecker_Env.expected_typ);
+                (uu___3844_29073.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___3827_28809.FStar_TypeChecker_Env.sigtab);
+                (uu___3844_29073.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___3827_28809.FStar_TypeChecker_Env.attrtab);
+                (uu___3844_29073.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.is_pattern =
-                (uu___3827_28809.FStar_TypeChecker_Env.is_pattern);
+                (uu___3844_29073.FStar_TypeChecker_Env.is_pattern);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___3827_28809.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___3844_29073.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___3827_28809.FStar_TypeChecker_Env.effects);
+                (uu___3844_29073.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___3827_28809.FStar_TypeChecker_Env.generalize);
+                (uu___3844_29073.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___3827_28809.FStar_TypeChecker_Env.letrecs);
+                (uu___3844_29073.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level =
-                (uu___3827_28809.FStar_TypeChecker_Env.top_level);
+                (uu___3844_29073.FStar_TypeChecker_Env.top_level);
               FStar_TypeChecker_Env.check_uvars =
-                (uu___3827_28809.FStar_TypeChecker_Env.check_uvars);
+                (uu___3844_29073.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___3827_28809.FStar_TypeChecker_Env.use_eq);
+                (uu___3844_29073.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.is_iface =
-                (uu___3827_28809.FStar_TypeChecker_Env.is_iface);
+                (uu___3844_29073.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___3827_28809.FStar_TypeChecker_Env.admit);
+                (uu___3844_29073.FStar_TypeChecker_Env.admit);
               FStar_TypeChecker_Env.lax =
-                (uu___3827_28809.FStar_TypeChecker_Env.lax);
+                (uu___3844_29073.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___3827_28809.FStar_TypeChecker_Env.lax_universes);
+                (uu___3844_29073.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___3827_28809.FStar_TypeChecker_Env.phase1);
+                (uu___3844_29073.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___3827_28809.FStar_TypeChecker_Env.failhard);
+                (uu___3844_29073.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___3827_28809.FStar_TypeChecker_Env.nosynth);
+                (uu___3844_29073.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___3827_28809.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___3844_29073.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___3827_28809.FStar_TypeChecker_Env.tc_term);
+                (uu___3844_29073.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___3827_28809.FStar_TypeChecker_Env.type_of);
+                (uu___3844_29073.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___3827_28809.FStar_TypeChecker_Env.universe_of);
+                (uu___3844_29073.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___3827_28809.FStar_TypeChecker_Env.check_type_of);
+                (uu___3844_29073.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts = true;
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___3827_28809.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___3844_29073.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___3827_28809.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___3844_29073.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___3827_28809.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___3844_29073.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___3827_28809.FStar_TypeChecker_Env.proof_ns);
+                (uu___3844_29073.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___3827_28809.FStar_TypeChecker_Env.synth_hook);
+                (uu___3844_29073.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___3827_28809.FStar_TypeChecker_Env.splice);
+                (uu___3844_29073.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.postprocess =
-                (uu___3827_28809.FStar_TypeChecker_Env.postprocess);
+                (uu___3844_29073.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.is_native_tactic =
-                (uu___3827_28809.FStar_TypeChecker_Env.is_native_tactic);
+                (uu___3844_29073.FStar_TypeChecker_Env.is_native_tactic);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___3827_28809.FStar_TypeChecker_Env.identifier_info);
+                (uu___3844_29073.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___3827_28809.FStar_TypeChecker_Env.tc_hooks);
+                (uu___3844_29073.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___3827_28809.FStar_TypeChecker_Env.dsenv);
+                (uu___3844_29073.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.nbe =
-                (uu___3827_28809.FStar_TypeChecker_Env.nbe);
+                (uu___3844_29073.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___3827_28809.FStar_TypeChecker_Env.strict_args_tab)
+                (uu___3844_29073.FStar_TypeChecker_Env.strict_args_tab);
+              FStar_TypeChecker_Env.erasable_types_tab =
+                (uu___3844_29073.FStar_TypeChecker_Env.erasable_types_tab)
             }  in
-          let slow_check uu____28816 =
+          let slow_check uu____29080 =
             if must_total
             then
-              let uu____28818 = env2.FStar_TypeChecker_Env.type_of env2 t  in
-              match uu____28818 with | (uu____28825,uu____28826,g) -> g
+              let uu____29082 = env2.FStar_TypeChecker_Env.type_of env2 t  in
+              match uu____29082 with | (uu____29089,uu____29090,g) -> g
             else
-              (let uu____28830 = env2.FStar_TypeChecker_Env.tc_term env2 t
+              (let uu____29094 = env2.FStar_TypeChecker_Env.tc_term env2 t
                   in
-               match uu____28830 with | (uu____28837,uu____28838,g) -> g)
+               match uu____29094 with | (uu____29101,uu____29102,g) -> g)
              in
-          let uu____28840 = type_of_well_typed_term env2 t  in
-          match uu____28840 with
+          let uu____29104 = type_of_well_typed_term env2 t  in
+          match uu____29104 with
           | FStar_Pervasives_Native.None  -> slow_check ()
           | FStar_Pervasives_Native.Some k' ->
-              ((let uu____28845 =
+              ((let uu____29109 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2)
                     (FStar_Options.Other "FastImplicits")
                    in
-                if uu____28845
+                if uu____29109
                 then
-                  let uu____28850 =
+                  let uu____29114 =
                     FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos  in
-                  let uu____28852 = FStar_Syntax_Print.term_to_string t  in
-                  let uu____28854 = FStar_Syntax_Print.term_to_string k'  in
-                  let uu____28856 = FStar_Syntax_Print.term_to_string k  in
+                  let uu____29116 = FStar_Syntax_Print.term_to_string t  in
+                  let uu____29118 = FStar_Syntax_Print.term_to_string k'  in
+                  let uu____29120 = FStar_Syntax_Print.term_to_string k  in
                   FStar_Util.print4 "(%s) Fast check  %s : %s <:? %s\n"
-                    uu____28850 uu____28852 uu____28854 uu____28856
+                    uu____29114 uu____29116 uu____29118 uu____29120
                 else ());
                (let g = FStar_TypeChecker_Rel.subtype_nosmt env2 k' k  in
-                (let uu____28865 =
+                (let uu____29129 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2)
                      (FStar_Options.Other "FastImplicits")
                     in
-                 if uu____28865
+                 if uu____29129
                  then
-                   let uu____28870 =
+                   let uu____29134 =
                      FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos
                       in
-                   let uu____28872 = FStar_Syntax_Print.term_to_string t  in
-                   let uu____28874 = FStar_Syntax_Print.term_to_string k'  in
-                   let uu____28876 = FStar_Syntax_Print.term_to_string k  in
+                   let uu____29136 = FStar_Syntax_Print.term_to_string t  in
+                   let uu____29138 = FStar_Syntax_Print.term_to_string k'  in
+                   let uu____29140 = FStar_Syntax_Print.term_to_string k  in
                    FStar_Util.print5 "(%s) Fast check %s: %s : %s <: %s\n"
-                     uu____28870
+                     uu____29134
                      (if FStar_Option.isSome g
                       then "succeeded with guard"
-                      else "failed") uu____28872 uu____28874 uu____28876
+                      else "failed") uu____29136 uu____29138 uu____29140
                  else ());
                 (match g with
                  | FStar_Pervasives_Native.None  -> slow_check ()
@@ -11007,110 +11083,112 @@ let (check_type_of_well_typed_term :
         fun k  ->
           let env1 = FStar_TypeChecker_Env.set_expected_typ env k  in
           let env2 =
-            let uu___3858_28913 = env1  in
+            let uu___3875_29177 = env1  in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___3858_28913.FStar_TypeChecker_Env.solver);
+                (uu___3875_29177.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___3858_28913.FStar_TypeChecker_Env.range);
+                (uu___3875_29177.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___3858_28913.FStar_TypeChecker_Env.curmodule);
+                (uu___3875_29177.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___3858_28913.FStar_TypeChecker_Env.gamma);
+                (uu___3875_29177.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___3858_28913.FStar_TypeChecker_Env.gamma_sig);
+                (uu___3875_29177.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___3858_28913.FStar_TypeChecker_Env.gamma_cache);
+                (uu___3875_29177.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___3858_28913.FStar_TypeChecker_Env.modules);
+                (uu___3875_29177.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___3858_28913.FStar_TypeChecker_Env.expected_typ);
+                (uu___3875_29177.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___3858_28913.FStar_TypeChecker_Env.sigtab);
+                (uu___3875_29177.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___3858_28913.FStar_TypeChecker_Env.attrtab);
+                (uu___3875_29177.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.is_pattern =
-                (uu___3858_28913.FStar_TypeChecker_Env.is_pattern);
+                (uu___3875_29177.FStar_TypeChecker_Env.is_pattern);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___3858_28913.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___3875_29177.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___3858_28913.FStar_TypeChecker_Env.effects);
+                (uu___3875_29177.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___3858_28913.FStar_TypeChecker_Env.generalize);
+                (uu___3875_29177.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___3858_28913.FStar_TypeChecker_Env.letrecs);
+                (uu___3875_29177.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level =
-                (uu___3858_28913.FStar_TypeChecker_Env.top_level);
+                (uu___3875_29177.FStar_TypeChecker_Env.top_level);
               FStar_TypeChecker_Env.check_uvars =
-                (uu___3858_28913.FStar_TypeChecker_Env.check_uvars);
+                (uu___3875_29177.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___3858_28913.FStar_TypeChecker_Env.use_eq);
+                (uu___3875_29177.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.is_iface =
-                (uu___3858_28913.FStar_TypeChecker_Env.is_iface);
+                (uu___3875_29177.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___3858_28913.FStar_TypeChecker_Env.admit);
+                (uu___3875_29177.FStar_TypeChecker_Env.admit);
               FStar_TypeChecker_Env.lax =
-                (uu___3858_28913.FStar_TypeChecker_Env.lax);
+                (uu___3875_29177.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___3858_28913.FStar_TypeChecker_Env.lax_universes);
+                (uu___3875_29177.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___3858_28913.FStar_TypeChecker_Env.phase1);
+                (uu___3875_29177.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___3858_28913.FStar_TypeChecker_Env.failhard);
+                (uu___3875_29177.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___3858_28913.FStar_TypeChecker_Env.nosynth);
+                (uu___3875_29177.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___3858_28913.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___3875_29177.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___3858_28913.FStar_TypeChecker_Env.tc_term);
+                (uu___3875_29177.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___3858_28913.FStar_TypeChecker_Env.type_of);
+                (uu___3875_29177.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___3858_28913.FStar_TypeChecker_Env.universe_of);
+                (uu___3875_29177.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___3858_28913.FStar_TypeChecker_Env.check_type_of);
+                (uu___3875_29177.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts = true;
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___3858_28913.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___3875_29177.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___3858_28913.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___3875_29177.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___3858_28913.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___3875_29177.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___3858_28913.FStar_TypeChecker_Env.proof_ns);
+                (uu___3875_29177.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___3858_28913.FStar_TypeChecker_Env.synth_hook);
+                (uu___3875_29177.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___3858_28913.FStar_TypeChecker_Env.splice);
+                (uu___3875_29177.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.postprocess =
-                (uu___3858_28913.FStar_TypeChecker_Env.postprocess);
+                (uu___3875_29177.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.is_native_tactic =
-                (uu___3858_28913.FStar_TypeChecker_Env.is_native_tactic);
+                (uu___3875_29177.FStar_TypeChecker_Env.is_native_tactic);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___3858_28913.FStar_TypeChecker_Env.identifier_info);
+                (uu___3875_29177.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___3858_28913.FStar_TypeChecker_Env.tc_hooks);
+                (uu___3875_29177.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___3858_28913.FStar_TypeChecker_Env.dsenv);
+                (uu___3875_29177.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.nbe =
-                (uu___3858_28913.FStar_TypeChecker_Env.nbe);
+                (uu___3875_29177.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___3858_28913.FStar_TypeChecker_Env.strict_args_tab)
+                (uu___3875_29177.FStar_TypeChecker_Env.strict_args_tab);
+              FStar_TypeChecker_Env.erasable_types_tab =
+                (uu___3875_29177.FStar_TypeChecker_Env.erasable_types_tab)
             }  in
-          let slow_check uu____28920 =
+          let slow_check uu____29184 =
             if must_total
             then
-              let uu____28922 = env2.FStar_TypeChecker_Env.type_of env2 t  in
-              match uu____28922 with | (uu____28929,uu____28930,g) -> g
+              let uu____29186 = env2.FStar_TypeChecker_Env.type_of env2 t  in
+              match uu____29186 with | (uu____29193,uu____29194,g) -> g
             else
-              (let uu____28934 = env2.FStar_TypeChecker_Env.tc_term env2 t
+              (let uu____29198 = env2.FStar_TypeChecker_Env.tc_term env2 t
                   in
-               match uu____28934 with | (uu____28941,uu____28942,g) -> g)
+               match uu____29198 with | (uu____29205,uu____29206,g) -> g)
              in
-          let uu____28944 =
-            let uu____28946 = FStar_Options.__temp_fast_implicits ()  in
-            FStar_All.pipe_left Prims.op_Negation uu____28946  in
-          if uu____28944
+          let uu____29208 =
+            let uu____29210 = FStar_Options.__temp_fast_implicits ()  in
+            FStar_All.pipe_left Prims.op_Negation uu____29210  in
+          if uu____29208
           then slow_check ()
           else check_type_of_well_typed_term' must_total env2 t k
   

--- a/src/ocaml-output/FStar_TypeChecker_Util.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Util.ml
@@ -4654,8 +4654,11 @@ let (must_erase_for_extraction :
             (match uu____11706 with
              | (bs,c) ->
                  let env1 = FStar_TypeChecker_Env.push_binders env bs  in
-                 (FStar_Syntax_Util.is_pure_or_ghost_comp c) &&
-                   (aux env1 (FStar_Syntax_Util.comp_result c)))
+                 (FStar_Syntax_Util.is_ghost_effect
+                    (FStar_Syntax_Util.comp_effect_name c))
+                   ||
+                   ((FStar_Syntax_Util.is_pure_or_ghost_comp c) &&
+                      (aux env1 (FStar_Syntax_Util.comp_result c))))
         | FStar_Syntax_Syntax.Tm_refine
             ({ FStar_Syntax_Syntax.ppname = uu____11739;
                FStar_Syntax_Syntax.index = uu____11740;

--- a/src/ocaml-output/FStar_Universal.ml
+++ b/src/ocaml-output/FStar_Universal.ml
@@ -104,7 +104,9 @@ let with_dsenv_of_tcenv :
                FStar_TypeChecker_Env.nbe =
                  (uu___8_51.FStar_TypeChecker_Env.nbe);
                FStar_TypeChecker_Env.strict_args_tab =
-                 (uu___8_51.FStar_TypeChecker_Env.strict_args_tab)
+                 (uu___8_51.FStar_TypeChecker_Env.strict_args_tab);
+               FStar_TypeChecker_Env.erasable_types_tab =
+                 (uu___8_51.FStar_TypeChecker_Env.erasable_types_tab)
              }))
   
 let with_tcenv_of_env :
@@ -367,7 +369,9 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
           (uu___72_410.FStar_TypeChecker_Env.dsenv);
         FStar_TypeChecker_Env.nbe = (uu___72_410.FStar_TypeChecker_Env.nbe);
         FStar_TypeChecker_Env.strict_args_tab =
-          (uu___72_410.FStar_TypeChecker_Env.strict_args_tab)
+          (uu___72_410.FStar_TypeChecker_Env.strict_args_tab);
+        FStar_TypeChecker_Env.erasable_types_tab =
+          (uu___72_410.FStar_TypeChecker_Env.erasable_types_tab)
       }  in
     let env2 =
       let uu___75_412 = env1  in
@@ -456,7 +460,9 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
           (uu___75_412.FStar_TypeChecker_Env.dsenv);
         FStar_TypeChecker_Env.nbe = (uu___75_412.FStar_TypeChecker_Env.nbe);
         FStar_TypeChecker_Env.strict_args_tab =
-          (uu___75_412.FStar_TypeChecker_Env.strict_args_tab)
+          (uu___75_412.FStar_TypeChecker_Env.strict_args_tab);
+        FStar_TypeChecker_Env.erasable_types_tab =
+          (uu___75_412.FStar_TypeChecker_Env.erasable_types_tab)
       }  in
     let env3 =
       let uu___78_414 = env2  in
@@ -546,7 +552,9 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
           (uu___78_414.FStar_TypeChecker_Env.dsenv);
         FStar_TypeChecker_Env.nbe = (uu___78_414.FStar_TypeChecker_Env.nbe);
         FStar_TypeChecker_Env.strict_args_tab =
-          (uu___78_414.FStar_TypeChecker_Env.strict_args_tab)
+          (uu___78_414.FStar_TypeChecker_Env.strict_args_tab);
+        FStar_TypeChecker_Env.erasable_types_tab =
+          (uu___78_414.FStar_TypeChecker_Env.erasable_types_tab)
       }  in
     let env4 =
       let uu___81_416 = env3  in
@@ -636,7 +644,9 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
           (uu___81_416.FStar_TypeChecker_Env.dsenv);
         FStar_TypeChecker_Env.nbe = (uu___81_416.FStar_TypeChecker_Env.nbe);
         FStar_TypeChecker_Env.strict_args_tab =
-          (uu___81_416.FStar_TypeChecker_Env.strict_args_tab)
+          (uu___81_416.FStar_TypeChecker_Env.strict_args_tab);
+        FStar_TypeChecker_Env.erasable_types_tab =
+          (uu___81_416.FStar_TypeChecker_Env.erasable_types_tab)
       }  in
     (env4.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.init env4; env4
   

--- a/src/parser/FStar.Parser.Const.fs
+++ b/src/parser/FStar.Parser.Const.fs
@@ -294,6 +294,7 @@ let tcnorm_attr    =  p2l ["FStar"; "Pervasives"; "tcnorm"]
 let dm4f_bind_range_attr = p2l ["FStar"; "Pervasives"; "dm4f_bind_range"]
 let must_erase_for_extraction_attr = psconst "must_erase_for_extraction"
 let strict_on_arguments_attr = p2l ["FStar"; "Pervasives"; "strict_on_arguments"]
+let erasable_attr = p2l ["FStar"; "Pervasives"; "erasable"]
 let comment_attr = p2l ["FStar"; "Pervasives"; "Comment"]
 let fail_attr      = psconst "expect_failure"
 let fail_lax_attr  = psconst "expect_lax_failure"

--- a/src/parser/Makefile
+++ b/src/parser/Makefile
@@ -11,3 +11,5 @@ lex.fs: lex.fsl
 
 clean:
 	rm lex.fs parse.fs
+
+include ../Makefile.boot.common

--- a/src/tactics/FStar.Tactics.Basic.fs
+++ b/src/tactics/FStar.Tactics.Basic.fs
@@ -1791,10 +1791,13 @@ let t_destruct (s_tm : term) : tac<list<(fv * Z.t)>> = wrap_err "destruct" <|
        * user do that (with the returned arity). `.ps` represents inaccesible patterns
        * for the type's parameters.
        *)
+      let erasable = U.has_attribute se.sigattrs FStar.Parser.Const.erasable_attr in
+      failwhen (erasable && not (is_irrelevant g)) "cannot destruct erasable type to solve proof-relevant goal" (fun () ->
 
       (* Instantiate formal universes to the actuals,
        * and substitute accordingly in binders and types *)
       failwhen (List.length a_us <> List.length t_us) "t_us don't match?" (fun () ->
+
 
       (* Not needed currently? *)
       (* let s = Env.mk_univ_subst t_us a_us in *)
@@ -1854,7 +1857,7 @@ let t_destruct (s_tm : term) : tac<list<(fv * Z.t)>> = wrap_err "destruct" <|
                         let cod = goal_type g in
                         let equ = env.universe_of env s_ty in
                         (* Typecheck the pattern, to fill-in the universes and get an expression out of it *)
-                        let _ , _, _, pat_t, _, _guard_pat = TcTerm.tc_pat ({ env with lax = true }) s_ty pat in
+                        let _ , _, _, pat_t, _, _guard_pat, _erasable = TcTerm.tc_pat ({ env with lax = true }) s_ty pat in
                         let eq_b = S.gen_bv "breq" None (U.mk_squash equ (U.mk_eq2 equ s_ty s_tm pat_t)) in
                         let cod = U.arrow [S.mk_binder eq_b] (mk_Total cod) in
 
@@ -1873,7 +1876,7 @@ let t_destruct (s_tm : term) : tac<list<(fv * Z.t)>> = wrap_err "destruct" <|
       let w = mk (Tm_match (s_tm, brs)) None s_tm.pos in
       bind (solve' g w) (fun () ->
       bind (add_goals goals) (fun () ->
-      ret infos))))
+      ret infos)))))
 
     | _ -> fail "not an inductive type"))))
 

--- a/src/typechecker/FStar.TypeChecker.Env.fs
+++ b/src/typechecker/FStar.TypeChecker.Env.fs
@@ -898,7 +898,9 @@ let rec non_informative env t =
     | Tm_uinst (t, _) -> non_informative env t
     | Tm_arrow(_, c) ->
       (is_pure_or_ghost_comp c && non_informative env (comp_result c))
-      || is_ghost_effect (comp_effect_name c)
+      //It would be sound to also add this disjunct below,
+      //But, it leads to regressions in examples/rel/Benton2004.fst
+      //|| is_ghost_effect (comp_effect_name c)
     | _ -> false
 
 let fv_has_strict_args env fv =

--- a/src/typechecker/FStar.TypeChecker.Env.fs
+++ b/src/typechecker/FStar.TypeChecker.Env.fs
@@ -457,7 +457,7 @@ let inst_tscheme_with_range (r:range) (t:tscheme) =
 
 let check_effect_is_not_a_template (ed:eff_decl) rng : unit =
   if List.length ed.univs <> 0 || List.length ed.binders <> 0
-  then 
+  then
     let msg = BU.format2
       "Effect template %s should be applied to arguments for its binders (%s) before it can be used at an effect position"
       (Print.lid_to_string ed.mname)
@@ -847,7 +847,7 @@ let lookup_attrs_of_lid env lid : option<list<attribute>> =
 
 let fv_exists_and_has_attr env fv_lid attr_lid : bool * bool =
     match lookup_attrs_of_lid env fv_lid with
-    | None -> 
+    | None ->
       false, false
     | Some attrs ->
       true,
@@ -876,10 +876,13 @@ let cache_in_fv_tab (tab:BU.smap<'a>) (fv:fv) (f:unit -> (bool * 'a)) : 'a =
 let type_is_erasable env fv =
   let f () =
      let ex, erasable = fv_exists_and_has_attr env fv.fv_name.v Const.erasable_attr in
-     let ex', must_erase_for_extraction_attr =
-       fv_exists_and_has_attr env fv.fv_name.v Const.must_erase_for_extraction_attr in
-     ex || ex',
-     erasable || must_erase_for_extraction_attr
+     ex,erasable
+     //unfortunately, treating the Const.must_erase_for_extraction_attr
+     //in the same way here as erasable_attr leads to regressions in fragile proofs,
+     //notably in FStar.ModifiesGen, since this expands the class of computation types
+     //that can be promoted from ghost to tot. That in turn results in slightly different
+     //smt encodings, leading to breakages. So, sadly, I'm not including must_erase_for_extraction
+     //here. In any case, must_erase_for_extraction is transitionary and should be removed
   in
   cache_in_fv_tab env.erasable_types_tab fv f
 

--- a/src/typechecker/FStar.TypeChecker.Env.fsi
+++ b/src/typechecker/FStar.TypeChecker.Env.fsi
@@ -145,7 +145,8 @@ type env = {
   tc_hooks       : tcenv_hooks;                   (* hooks that the interactive more relies onto for symbol tracking *)
   dsenv          : FStar.Syntax.DsEnv.env;        (* The desugaring environment from the front-end *)
   nbe            : list<step> -> env -> term -> term;  (* Callback to the NBE function *)
-  strict_args_tab:BU.smap<(option<(list<int>)>)>;                (* a dictionary of fv names to strict arguments *)
+  strict_args_tab:BU.smap<(option<(list<int>)>)>;  (* a dictionary of fv names to strict arguments *)
+  erasable_types_tab:BU.smap<bool>;              (* a dictionary of type names to erasable types *)
 }
 
 and solver_depth_t = int * int * int
@@ -247,6 +248,7 @@ val lookup_attrs_of_lid    : env -> lid -> option<list<attribute>>
 val fv_with_lid_has_attr   : env -> fv_lid:lid -> attr_lid:lid -> bool
 val fv_has_attr            : env -> fv -> attr_lid:lid -> bool
 val fv_has_strict_args     : env -> fv -> option<(list<int>)>
+val non_informative        : env -> typ -> bool
 val try_lookup_effect_lid  : env -> lident -> option<term>
 val lookup_effect_lid      : env -> lident -> term
 val lookup_effect_abbrev   : env -> universes -> lident -> option<(binders * comp)>

--- a/src/typechecker/FStar.TypeChecker.Normalize.fs
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fs
@@ -2545,7 +2545,7 @@ let ghost_to_pure env c =
                       ForExtraction //and refinement types
                      ]
               env in
-    let non_info t = non_informative (norm cfg [] [] t) in
+    let non_info t = non_informative env (norm cfg [] [] t) in
     match c.n with
     | Total _ -> c
     | GTotal (t, uopt) when non_info t -> {c with n = Total (t, uopt)}
@@ -2575,7 +2575,7 @@ let ghost_to_pure_lcomp env (lc:lcomp) =
                 ForExtraction //and refinement types
                 ]
         env in
-    let non_info t = non_informative (norm cfg [] [] t) in
+    let non_info t = non_informative env (norm cfg [] [] t) in
     if U.is_ghost_effect lc.eff_name
     && non_info lc.res_typ
     then match downgrade_ghost_effect_name lc.eff_name with

--- a/src/typechecker/FStar.TypeChecker.Tc.fs
+++ b/src/typechecker/FStar.TypeChecker.Tc.fs
@@ -152,8 +152,8 @@ let tc_eff_decl env0 (ed:S.eff_decl) : eff_decl =
   //now open rest of the ed with us and bs
   let ed_univs_subst, ed_univs = SS.univ_var_opening us in
   let ed_bs, ed_bs_subst = SS.open_binders' (SS.subst_binders ed_univs_subst bs) in
-  
-  
+
+
   let ed =
     let op (us, t) =
       let t = SS.subst (SS.shift_subst (List.length ed_bs + List.length us) ed_univs_subst) t in
@@ -224,7 +224,7 @@ let tc_eff_decl env0 (ed:S.eff_decl) : eff_decl =
     BU.print1 "Typechecked signature: %s\n" (Print.tscheme_to_string signature);
 
   (*
-   * AR: return a fresh (in the sense of fresh universe) instance of a:Type and wp sort (closed with the returned a) 
+   * AR: return a fresh (in the sense of fresh universe) instance of a:Type and wp sort (closed with the returned a)
    *)
   let fresh_a_and_wp () =
     let fail t = raise_error (Err.unexpected_signature_for_monad env ed.mname t) (snd ed.signature).pos in
@@ -349,7 +349,7 @@ let tc_eff_decl env0 (ed:S.eff_decl) : eff_decl =
         let k, _, _ = tc_tot_or_gtot_term env k in
         let env = Some (Env.set_range env (snd (ed.return_repr)).pos) in
         check_and_gen' "return_repr" 1 env ed.return_repr (Some k) in
-    
+
       log_combinator "return_repr" return_repr;
 
       let bind_repr =
@@ -372,7 +372,7 @@ let tc_eff_decl env0 (ed:S.eff_decl) : eff_decl =
           if BU.for_some (U.attr_eq U.dm4f_bind_range_attr) ed.eff_attrs
           then [S.null_binder S.t_range; S.null_binder S.t_range]
           else [] in
-       
+
         let k = U.arrow ([S.mk_binder a; S.mk_binder b] @
                          maybe_range_arg @
                          [S.mk_binder wp_f;
@@ -497,7 +497,7 @@ let tc_eff_decl env0 (ed:S.eff_decl) : eff_decl =
     let ts = SS.close_tscheme ed_bs ts in
     let ed_univs_closing = SS.univ_var_closing ed_univs in
     SS.subst_tscheme (SS.shift_subst (List.length ed_bs) ed_univs_closing) ts in
-  
+
   //univs and binders have already been set
   let ed = { ed with
     signature    =cl signature;
@@ -1164,11 +1164,18 @@ let tc_decl' env0 se: list<sigelt> * list<sigelt> * Env.env =
 
   | Sig_bundle(ses, lids) ->
     let env = Env.set_range env r in
+    //propagate attributes from the bundle to its elements
+    let ses = ses |> List.map (fun e -> {e with sigattrs = e.sigattrs@se.sigattrs}) in
     let ses =
       if Options.use_two_phase_tc () && Env.should_verify env then begin
         //we generate extra sigelts even in the first phase, and then throw them away, would be nice to not generate them at all
-        let ses = tc_inductive ({ env with phase1 = true; lax = true }) ses se.sigquals lids |> fst |> N.elim_uvars env |> U.ses_of_sigbundle in
-        if Env.debug env <| Options.Other "TwoPhases" then BU.print1 "Inductive after phase 1: %s\n" (Print.sigelt_to_string ({ se with sigel = Sig_bundle (ses, lids) }));
+        let ses =
+          tc_inductive ({ env with phase1 = true; lax = true }) ses se.sigquals lids
+          |> fst
+          |> N.elim_uvars env
+          |> U.ses_of_sigbundle in
+        if Env.debug env <| Options.Other "TwoPhases"
+        then BU.print1 "Inductive after phase 1: %s\n" (Print.sigelt_to_string ({ se with sigel = Sig_bundle (ses, lids) }));
         ses
       end
       else ses

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fs
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fs
@@ -776,24 +776,35 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
 
     let guard_x = S.new_bv (Some e1.pos) c1.res_typ in
     let t_eqns = eqns |> List.map (tc_eqn guard_x env_branches) in
-    let c_branches, g_branches =
-      let cases, g =
+    let c_branches, g_branches, erasable =
+      let cases, g, erasable =
           List.fold_right
-                (fun (branch, f, eff_label, cflags, c, g) (caccum, gaccum) ->
+                (fun (branch, f, eff_label, cflags, c, g, erasable_branch) (caccum, gaccum, erasable) ->
                      (f, eff_label, cflags, c)::caccum,
-                     Env.conj_guard g gaccum)
+                     Env.conj_guard g gaccum,
+                     erasable || erasable_branch)
                 t_eqns
-                ([], Env.trivial_guard) in
+                ([], Env.trivial_guard, false) in
       (* bind_cases adds an exhaustiveness check *)
-      TcUtil.bind_cases env res_t cases, g
+      TcUtil.bind_cases env res_t cases,
+      g,
+      erasable
     in
 
     let cres = TcUtil.bind e1.pos env (Some e1) c1 (Some guard_x, c_branches) in
+    let cres =
+      if erasable
+      then (* promote cres to ghost *)
+           let e = U.exp_true_bool in
+           let c = mk_GTotal' U.t_bool (Some U_zero) in
+           TcUtil.bind e.pos env (Some e) (U.lcomp_of_comp c) (None, cres)
+      else cres
+    in
     let e =
       let mk_match scrutinee =
         (* TODO (KM) : I have the impression that lifting here is useless/wrong : the scrutinee should always be pure... *)
         (* let scrutinee = TypeChecker.Util.maybe_lift env scrutinee c1.eff_name cres.eff_name c1.res_typ in *)
-        let branches = t_eqns |> List.map (fun ((pat, wopt, br), _, eff_label, _, _, _) ->
+        let branches = t_eqns |> List.map (fun ((pat, wopt, br), _, eff_label, _, _, _, _) ->
               (pat, wopt, TcUtil.maybe_lift env br eff_label cres.eff_name res_t))
         in
         let e = mk (Tm_match(scrutinee, branches)) None top.pos in
@@ -1845,6 +1856,7 @@ and tc_pat env (pat_t:typ) (p0:pat) :
       * term                         (* terms corresponding to the pattern                                          *)
       * term                         (* the same term in normal form                                                *)
       * guard_t                      (* unresolved implicits *)
+      * bool                         (* true if the pattern matches an erasable type *)
       =
     let fail : string -> 'a = fun msg ->
         raise_error (Errors.Fatal_MismatchedPatternType, msg) p0.p
@@ -1934,12 +1946,16 @@ and tc_pat env (pat_t:typ) (p0:pat) :
            let g = Rel.discharge_guard_no_smt env g in
            g
     in
-    let type_of_simple_pat env (e:term) : term * typ * list<bv> * guard_t =
+    let type_of_simple_pat env (e:term) : term * typ * list<bv> * guard_t * bool =
         let head, args = U.head_and_args e in
         match head.n with
         | Tm_fvar f ->
           let us, t_f = Env.lookup_datacon env f.fv_name.v in
           let formals, t = U.arrow_formals t_f in
+          //Data constructors are marked with the "erasable" attribute
+          //if their types are; matching on this constructor incurs
+          //a ghost effect
+          let erasable = Env.non_informative env t in
           if List.length formals <> List.length args
           then fail "Pattern is not a fully-applied data constructor";
           let rec aux (subst, args_out, bvs, guard) formals args =
@@ -1947,7 +1963,7 @@ and tc_pat env (pat_t:typ) (p0:pat) :
             | [], [] ->
               let head = S.mk_Tm_uinst head us in
               let pat_e = S.mk_Tm_app head args_out None e.pos in
-              pat_e, SS.subst subst t, bvs, guard
+              pat_e, SS.subst subst t, bvs, guard, erasable
             | (f, _)::formals, (a, imp_a)::args ->
               let t_f = SS.subst subst f.sort in
               let a, subst, bvs, g =
@@ -1979,7 +1995,8 @@ and tc_pat env (pat_t:typ) (p0:pat) :
         : list<bv>
         * term
         * pat
-        * guard_t =
+        * guard_t
+        * bool =
         if Env.debug env <| Options.Other "Patterns"
         then BU.print2 "Checking pattern %s at type %s\n" (Print.pat_to_string p) (Print.term_to_string t);
         match p.v with
@@ -1991,14 +2008,16 @@ and tc_pat env (pat_t:typ) (p0:pat) :
           [x],
           S.bv_to_name x,
           {p with v=Pat_wild x},
-          Env.trivial_guard
+          Env.trivial_guard,
+          false
 
         | Pat_var x ->
           let x = {x with sort=t} in
           [x],
           S.bv_to_name x,
           {p with v=Pat_var x},
-          Env.trivial_guard
+          Env.trivial_guard,
+          false
 
         | Pat_constant _ ->
           let _, e_c, _, _ = PatternUtils.pat_as_exp false env p in
@@ -2012,7 +2031,8 @@ and tc_pat env (pat_t:typ) (p0:pat) :
           [],
           e_c,
           p,
-          Env.trivial_guard
+          Env.trivial_guard,
+          false
 
         | Pat_cons(fv, sub_pats) ->
           let simple_pat =
@@ -2040,8 +2060,8 @@ and tc_pat env (pat_t:typ) (p0:pat) :
                                           (Print.pat_to_string simple_pat)
                                           (BU.string_of_int (List.length sub_pats))
                                           (BU.string_of_int (List.length simple_bvs)));
-          let simple_pat_e, simple_bvs, g1 =
-              let simple_pat_e, simple_pat_t, simple_bvs, guard =
+          let simple_pat_e, simple_bvs, g1, erasable =
+              let simple_pat_e, simple_pat_t, simple_bvs, guard, erasable =
                   type_of_simple_pat env simple_pat_e
               in
               let g' = pat_typ_ok env simple_pat_t (expected_pat_typ env p0.p t) in
@@ -2052,16 +2072,16 @@ and tc_pat env (pat_t:typ) (p0:pat) :
                             (Print.term_to_string simple_pat_t)
                             (List.map (fun x -> "(" ^ Print.bv_to_string x ^ " : " ^ Print.term_to_string x.sort ^ ")") simple_bvs
                               |> String.concat " ");
-              simple_pat_e, simple_bvs, guard
+              simple_pat_e, simple_bvs, guard, erasable
           in
-          let _env, bvs, checked_sub_pats, subst, g =
+          let _env, bvs, checked_sub_pats, subst, g, erasable =
             List.fold_left2
-              (fun (env, bvs, pats, subst, g) (p, b) x ->
+              (fun (env, bvs, pats, subst, g, erasable) (p, b) x ->
                 let expected_t = SS.subst subst x.sort in
-                let bvs_p, e_p, p, g' = check_nested_pattern env p expected_t in
+                let bvs_p, e_p, p, g', erasable_p = check_nested_pattern env p expected_t in
                 let env = Env.push_bvs env bvs_p in
-                env, bvs@bvs_p, pats@[(p,b)], NT(x, e_p)::subst, Env.conj_guard g g')
-              (env, [], [], [], Env.conj_guard g0 g1)
+                env, bvs@bvs_p, pats@[(p,b)], NT(x, e_p)::subst, Env.conj_guard g g', erasable || erasable_p)
+              (env, [], [], [], Env.conj_guard g0 g1, erasable)
               sub_pats
               simple_bvs
           in
@@ -2097,11 +2117,12 @@ and tc_pat env (pat_t:typ) (p0:pat) :
           bvs,
           pat_e,
           reconstruct_nested_pat simple_pat_elab,
-          g
+          g,
+          erasable
     in
     if Env.debug env <| Options.Other "Patterns"
     then BU.print1 "Checking pattern: %s\n" (Print.pat_to_string p0);
-    let bvs, pat_e, pat, g =
+    let bvs, pat_e, pat, g, erasable =
         check_nested_pattern
             ({(Env.clear_expected_typ env |> fst) with use_eq=true})
             (PatternUtils.elaborate_pat env p0)
@@ -2111,7 +2132,7 @@ and tc_pat env (pat_t:typ) (p0:pat) :
     then BU.print2 "Done checking pattern %s as expression %s\n"
                     (Print.pat_to_string pat)
                     (Print.term_to_string pat_e);
-    pat, bvs, Env.push_bvs env bvs, pat_e, N.normalize [Env.Beta] env pat_e, g
+    pat, bvs, Env.push_bvs env bvs, pat_e, N.normalize [Env.Beta] env pat_e, g, erasable
 
 
 (********************************************************************************************************************)
@@ -2127,8 +2148,10 @@ and tc_eqn scrutinee env branch
         * term       (* the guard condition for taking this branch, used by the caller for the exhaustiveness check *)
         * lident                                                                 (* effect label of the lcomp below *)
         * list<cflag>                                                                       (* flags for each lcomp *)
-        * (bool -> lcomp)                    (* computation type of the branch, with or without a "return" equation *)
-        * guard_t =                                                                    (* well-formedness condition *)
+        * (bool -> lcomp)                     (* computation type of the branch, with or without a "return" equation *)
+        * guard_t                                                                      (* well-formedness condition *)
+        * bool                                                      (* true if the pattern matches an erasable type *)
+        =
   let pattern, when_clause, branch_exp = SS.open_branch branch in
   let cpat, _, cbr = branch in
 
@@ -2137,7 +2160,7 @@ and tc_eqn scrutinee env branch
   let scrutinee_env, _ = Env.push_bv env scrutinee |> Env.clear_expected_typ in
 
   (* 1. Check the pattern *)
-  let pattern, pat_bvs, pat_env, pat_exp, norm_pat_exp, guard_pat =
+  let pattern, pat_bvs, pat_env, pat_exp, norm_pat_exp, guard_pat, erasable =
     tc_pat env pat_t pattern
   in
 
@@ -2373,7 +2396,8 @@ and tc_eqn scrutinee env branch
   effect_label,
   cflags,
   maybe_return_c, //closed already---does not contain free pattern-bound variables
-  TcUtil.close_guard_implicits env (List.map S.mk_binder pat_bvs) guard
+  TcUtil.close_guard_implicits env (List.map S.mk_binder pat_bvs) guard,
+  erasable
 
 (******************************************************************************)
 (* Checking a top-level, non-recursive let-binding:                           *)

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fsi
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fsi
@@ -21,7 +21,7 @@ val tc_binders: env -> binders -> binders * env * guard_t * universes
 val tc_term: env -> term -> term * lcomp * guard_t
 val tc_maybe_toplevel_term: env -> term -> term * lcomp * guard_t
 val tc_comp: env -> comp -> comp * universe * guard_t
-val tc_pat : Env.env -> typ -> pat -> pat * list<bv> * Env.env * term * term * guard_t
+val tc_pat : Env.env -> typ -> pat -> pat * list<bv> * Env.env * term * term * guard_t * bool
 val type_of_tot_term: env -> term -> term * typ * guard_t
 val universe_of: env -> term -> universe
 

--- a/src/typechecker/FStar.TypeChecker.Util.fs
+++ b/src/typechecker/FStar.TypeChecker.Util.fs
@@ -485,7 +485,7 @@ let weaken_comp env (c:comp) (formula:term) : comp =
            None
            r
          in
-         
+
          let w_wp = lift_wp_and_bind_with env pure_assume_wp md u_res_t res_t wp in
          mk_comp md u_res_t res_t w_wp (weaken_flags c.flags)
 
@@ -1008,7 +1008,7 @@ let check_trivial_precondition env c =
     None
     (Env.get_range env)
   in
-  
+
   ct, vc, Env.guard_of_guard_formula <| NonTrivial vc
 
 let maybe_coerce_bool_to_type env (e:term) (lc:lcomp) (t:term) : term * lcomp =
@@ -1875,16 +1875,22 @@ let check_sigelt_quals (env:FStar.TypeChecker.Env.env) se =
       | _ -> ()
 
 let must_erase_for_extraction (g:env) (t:typ) =
-    let rec aux_whnf env t = //t is expected to b in WHNF
-      Env.non_informative env t
-      || (match (SS.compress t).n with
-         | Tm_arrow _ ->
+    let rec descend env t = //t is expected to b in WHNF
+      match (SS.compress t).n with
+      | Tm_arrow _ ->
            let bs, c = U.arrow_formals_comp t in
            let env = FStar.TypeChecker.Env.push_binders env bs in
            (U.is_pure_or_ghost_comp c && aux env (U.comp_result c))
-         | Tm_refine({sort=t}, _) ->
+      | Tm_refine({sort=t}, _) ->
            aux env t
-         | _ -> false)
+      | Tm_app (head, _)
+      | Tm_uinst (head, _) ->
+           descend env head
+      | Tm_fvar fv ->
+           //special treatment for must_erase_for_extraction here
+           //See Env.type_is_erasable for more explanations
+           Env.fv_has_attr env fv C.must_erase_for_extraction_attr
+      | _ -> false
     and aux env t =
         let t = N.normalize [Env.Primops;
                              Env.Weak;
@@ -1896,7 +1902,7 @@ let must_erase_for_extraction (g:env) (t:typ) =
                              Env.Iota;
                              Env.Unascribe] env t in
 //        debug g (fun () -> BU.print1 "aux %s\n" (Print.term_to_string t));
-        let res = aux_whnf env t in
+        let res = Env.non_informative env t || descend env t in
         if Env.debug env <| Options.Other "Extraction"
         then BU.print2 "must_erase=%s: %s\n" (if res then "true" else "false") (Print.term_to_string t);
         res

--- a/src/typechecker/FStar.TypeChecker.Util.fs
+++ b/src/typechecker/FStar.TypeChecker.Util.fs
@@ -1880,7 +1880,8 @@ let must_erase_for_extraction (g:env) (t:typ) =
       | Tm_arrow _ ->
            let bs, c = U.arrow_formals_comp t in
            let env = FStar.TypeChecker.Env.push_binders env bs in
-           (U.is_pure_or_ghost_comp c && aux env (U.comp_result c))
+           (U.is_ghost_effect (U.comp_effect_name c))
+           || (U.is_pure_or_ghost_comp c && aux env (U.comp_result c))
       | Tm_refine({sort=t}, _) ->
            aux env t
       | Tm_app (head, _)

--- a/ulib/FStar.Ghost.fst
+++ b/ulib/FStar.Ghost.fst
@@ -1,0 +1,50 @@
+(*
+   Copyright 2008-2014 Nikhil Swamy and Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
+(*
+   This module provides an erased type
+   to abstract computationally irrelevant values.
+
+   It relies on the GHOST effect defined in Prims.
+
+   [erased a] is decorated with the erasable attribute
+   As such,
+
+   1. The type is considered non-informative.
+      So, [Ghost (erased a)] can be subsumed to [Pure (erased a)]
+
+   2. The compiler extracts [erased a] to [unit]
+
+   The type is [erased a] is in a bijection with [a],
+   as witnessed by the [hide] and [reveal] function.
+
+   Importantly, computationally relevant code cannot use [reveal]
+     (it's marked GTot)
+
+   Just like Coq's prop, it is okay to use erased types
+   freely as long as we produce an erased type.
+
+*)
+module FStar.Ghost
+
+[@erasable]
+type erased (a:Type) =
+  | E of a
+
+let reveal #a (E x) = x
+let hide #a x = E x
+let hide_reveal #a x = ()
+let reveal_hide #a x = ()

--- a/ulib/FStar.Ghost.fsti
+++ b/ulib/FStar.Ghost.fsti
@@ -14,14 +14,15 @@
    limitations under the License.
 *)
 
+
 (*
    This module provides an erased type
    to abstract computationally irrelevant values.
 
    It relies on the GHOST effect defined in Prims.
 
-   [erased a] is an abstract type that receives
-   special treatment in the compiler.
+   [erased a] is decorated with the erasable attribute
+   As such,
 
    1. The type is considered non-informative.
       So, [Ghost (erased a)] can be subsumed to [Pure (erased a)]
@@ -39,6 +40,7 @@
 
 *)
 module FStar.Ghost
+[@erasable]
 val erased : Type u#a -> Type u#a
 val reveal : #a:Type u#a -> erased a -> GTot a
 val hide   : #a:Type u#a -> a -> Tot (erased a)

--- a/ulib/FStar.Pervasives.fst
+++ b/ulib/FStar.Pervasives.fst
@@ -413,6 +413,20 @@ let unifier_hint_injective : unit = ()
 irreducible
 let strict_on_arguments (x:list int) : unit = ()
 
+(**
+ * This attribute can be added to an inductive type definition, 
+ * indicating that it should be erased on extraction to `unit`.
+ * 
+ * However, any pattern matching on the inductive type results 
+ * in a `Ghost` effect, ensuring that computationally relevant
+ * code cannot rely on the values of the erasable type.
+ *
+ * See examples/micro-benchmarks/Erasable.fst, for examples.
+ * Also see https://github.com/FStarLang/FStar/issues/1844
+ *)
+irreducible
+let erasable : unit = ()
+
 (*********************************************************************************)
 (* Marking terms for normalization *)
 (*********************************************************************************)


### PR DESCRIPTION
See issue #1844 for a description of this feature. 

See examples/micro-benchmarks/Erasable.fst
And also ulib/FStar.Ghost.fst for an implementation of the previously assumed FStar.Ghost.fsti.

I have an F* green and am still working on a couple of everest regressions.

In the meantime, I'd be happy to have your comments. 

Note, my first attempt at this tried to generalize the class of noninformative types, but that led to regressions in some brittle proofs, so I had to, regrettably, back those changes out.

I also have yet to remove the special treatment of FStar.Ghost.erased  in the compiler ... I plan to do that before merging this.

