### PR TITLE
Exemple of ulib module documentation : FStar.Classical

### DIFF
--- a/ulib/FStar.Classical.fsti
+++ b/ulib/FStar.Classical.fsti
@@ -34,22 +34,29 @@ module FStar.Classical
 
 (**** Witnesses *)
 
-/// Shows the existence of a type by exhibiting a value of that type. For instance:
-///
-/// ```fstar
-/// let x : n:nat{n <> 0} = 1 in
-/// give_witness x
-/// ```
-val give_witness (#a:Type) (_:a) :Lemma (ensures a)
+(** Demonstrate the existence of a type from a value of that type.
 
-/// Same as before, but squashed version. For instance:
-///  ```fstar
-/// let pf : squash(1+1 = 2) = () in
-/// give_witness pf
-/// ```
-val give_witness_from_squash (#a:Type) (_:squash a) :Lemma (ensures a)
+    Example:
+    {[
+        let x : n:nat{n <> 0} = 1 in
+        give_witness x
+    ]}
 
-/// Returns the equality as a `Type` if it is provable from the context.
+*)
+val give_witness (#a:Type) (_:a) : Lemma (ensures a)
+
+(**
+  Demonstrate the existence of a type from a squashed value. See [give_witness].
+
+  Example:
+  {[
+     let pf : squash(1+1 = 2) = () in
+     give_witness pf
+  ]}
+*)
+val give_witness_from_squash (#a:Type) (_:squash a) : Lemma (ensures a)
+
+(** Produce equality as a [Type] if provable from context. *)
 val get_equality
   (#t:Type)
   (a b: t)
@@ -57,7 +64,7 @@ val get_equality
     (requires (a == b))
     (ensures (fun _ -> True))
 
-/// Returns the forall property as a `Type` if is is provable from the context.
+(** Produce a [forall] property as a [Type] if provable from context. *)
 val get_forall
   (#a:Type)
   (p: a -> GTot Type0)
@@ -65,56 +72,105 @@ val get_forall
     (requires (forall (x: a). p x))
     (ensures (fun _ -> True))
 
-/// Applies an implication to the squashed left-hand side to get the squashed right-hand side.
+(** Get an arrow from an implication. Converse is [arrow_to_impl]. *)
 val impl_to_arrow (#a:Type0) (#b:Type0) (_:(a ==> b)) (_:squash a) :GTot (squash b)
 
-/// Returns the implication as a `Type` given a lemma-like function proving `b` from `a`.
-val arrow_to_impl (#a:Type0) (#b:Type0) (_:(squash a -> GTot (squash b))) :GTot (a ==> b)
+(** Get an implication from an arrow. Converse is [impl_to_arrow].
+
+    Example:
+    {[
+       arrow_to_impl #(foo) #(bar) (fun _ ->
+         // proof of "bar", but now we have "foo" in context
+       )
+    ]}
+    can be used to prove [foo ==> bar].
+*)
+val arrow_to_impl (#a:Type0) (#b:Type0) (_:(squash a -> GTot (squash b))) : GTot (a ==> b)
 
 (**** Universal quantification *)
 
-/// Instantiate a proposition `p` with a certain value `x` in the context.
-val gtot_to_lemma (#a:Type) (#p:(a -> GTot Type)) ($_:(x:a -> GTot (p x))) (x:a) :Lemma (p x)
+(** Introduce a property [p x] from a [GTot] function. *)
+val gtot_to_lemma (#a:Type) (#p:(a -> GTot Type)) ($_:(x:a -> GTot (p x))) (x:a) : Lemma (p x)
 
-/// Same as before, but expects a lemma and provides a `GTot`.
-val lemma_to_squash_gtot (#a:Type) (#p:(a -> GTot Type)) ($_:(x:a -> Lemma (p x))) (x:a) :GTot (squash (p x))
-
+(** Produce a squashed property as a [Type] from a lemma. *)
+val lemma_to_squash_gtot
+  (#a:Type)
+  (#p:(a -> GTot Type))
+  ($_:(x:a -> Lemma (p x)))
+  (x:a)
+  : GTot (squash (p x))
 
 /// The following values are all variations on a same theme: proving a proposition `p` true for all `x` of type `a`.
 
-/// Returns a proof (squashed) that property `p` holds for all `x` of type `a`.
-val forall_intro_gtot (#a:Type) (#p:(a -> GTot Type)) ($_:(x:a -> GTot (p x))) :Tot (squash (forall (x:a). p x))
+(** Produce [forall] property as a [Type] from a [GTot] function. See [lemma_forall_intro_gtot]. *)
+val forall_intro_gtot
+  (#a:Type)
+  (#p:(a -> GTot Type))
+  ($_:(x:a -> GTot (p x)))
+  : Tot (squash (forall (x:a). p x))
 
-/// Same as above, but expressed as a lemma.
-val lemma_forall_intro_gtot (#a:Type) (#p:(a -> GTot Type)) ($_:(x:a -> GTot (p x))) :Lemma (forall (x:a). p x)
+(** Introduce a [forall] property into context from a [GTot] function. *)
+val lemma_forall_intro_gtot
+  (#a:Type)
+  (#p:(a -> GTot Type))
+  ($_:(x:a -> GTot (p x)))
+  : Lemma (forall (x:a). p x)
 
-/// Same as before, but expects a `Gtot` and returns a squashed `Tot`.
-val forall_intro_squash_gtot (#a:Type) (#p:(a -> GTot Type)) ($_:(x:a -> GTot (squash (p x))))
-  :Tot (squash (forall (x:a). p x))
+(** Produce a squashed [forall] property as a [Type] from a [GTot] function. See [forall_intro_squash_gtot_join]. *)
+val forall_intro_squash_gtot
+  (#a:Type)
+  (#p:(a -> GTot Type))
+  ($_:(x:a -> GTot (squash (p x))))
+  : Tot (squash (forall (x:a). p x))
 
-/// Same as before, but expects a `Gtot` and returns a `Tot`.
-val forall_intro_squash_gtot_join (#a:Type) (#p:(a -> GTot Type)) ($_:(x:a -> GTot (squash (p x))))
-  :Tot (forall (x:a). p x)
+(** Produce a [forall] property as a [Type] from a [GTot] function. *)
+//This one seems more generally useful than the one above
+val forall_intro_squash_gtot_join
+  (#a:Type)
+  (#p:(a -> GTot Type))
+  ($_:(x:a -> GTot (squash (p x))))
+  : Tot (forall (x:a). p x)
 
-/// This is the most used form of forall introduction. You can use it in the following way :
-///
-/// ```fstar
-/// let aux (x: a) : Lemma (p x) = ... in
-/// forall_intro aux;
-/// assert(forall (x:a). p x)
-/// ```
+(** Introduce a [forall] property into context from a lemma. See relevant useful [move_requires] to make this even more useful.
+
+    Example:
+    {[
+        let aux x : Lemma (p x) =
+            // proof of [p x]
+        in
+        forall_intro aux // and now we have [forall x. p x]
+    ]}
+
+    Example:
+    {[
+        let aux x : Lemma (requires (p x)) (ensures (q x)) =
+            // proof of [q x] under assumption of [q x]
+        in
+        forall_intro (move_requires aux) // and now we have [forall x. p x ==> q x]
+    ]}
+*)
 val forall_intro (#a:Type) (#p:(a -> GTot Type)) ($_:(x:a -> Lemma (p x))) : Lemma (forall (x:a). p x)
 
-/// Same as above, but with a pattern guarding the trigger of the forall
+(** Introduce a [forall] property with a pattern. See [forall_intro]. *)
 val forall_intro_with_pat (#a:Type) (#c: (x:a -> Type)) (#p:(x:a -> GTot Type0))
   ($pat: (x:a -> Tot (c x)))
   ($_: (x:a -> Lemma (p x)))
-  :Lemma (forall (x:a).{:pattern (pat x)} p x)
+  : Lemma (forall (x:a).{:pattern (pat x)} p x)
 
-/// Same as forall_intro, but without the `$` constraining the unification to be exact.
+(** Introduce a [forall] property. Equivalent to [forall_intro] except for lack of exact unification requirement [$]. *)
 val forall_intro_sub (#a:Type) (#p:(a -> GTot Type)) (_:(x:a -> Lemma (p x))) : Lemma (forall (x:a). p x)
 
-/// Same as `forall_intro` but with two arguments.
+(** Introduce a [forall] property over 2 variables. Similar to [forall_intro].
+
+    Example: A useful way to use it with a lemma that has a non-trivial [requires] clause:
+    {[
+        let aux x y : Lemma (requires (p x y)) (ensures (q x y)) =
+            // proof of [q x y] under assumption of [p x y]
+        in
+        let aux x = move_requires (aux x) in // notice only 1 argument (last argument is pointfree)
+        forall_intro aux // and now we have [forall x. p x y ==> q x y]
+    ]}
+*)
 val forall_intro_2
   (#a:Type)
   (#b:(a -> Type))
@@ -122,7 +178,7 @@ val forall_intro_2
   ($_: (x:a -> y:b x -> Lemma (p x y)))
   : Lemma (forall (x:a) (y:b x). p x y)
 
-/// Same as `forall_intro_with_pat` but with two arguments.
+(** [forall_intro_2] with pattern. *)
 val forall_intro_2_with_pat
   (#a:Type)
   (#b:(a -> Type))
@@ -132,6 +188,18 @@ val forall_intro_2_with_pat
   ($_: (x:a -> y:b x -> Lemma (p x y)))
   : Lemma (forall (x:a) (y:b x).{:pattern (pat x y)} p x y)
 
+(** [forall_intro] for 3 variables.
+
+    Example: Similar to [forall_intro_2], we can use it for non-trivial [requires] clauses:
+    {[
+        let aux x y z : Lemma (requires (p x y z)) (ensures (q x y z)) =
+            // proof of [q x y z] under assumption of [p x y z]
+        in
+        let aux x y = move_requires (aux x y) in
+	// notice only 2 arguments (last argument is pointfree)
+        forall_intro aux // and now we have [forall x. p x y z ==> q x y z]
+    ]}
+*)
 val forall_intro_3
   (#a:Type)
   (#b:(a -> Type))
@@ -140,6 +208,7 @@ val forall_intro_3
   ($_: (x:a -> y:b x -> z:c x y -> Lemma (p x y z)))
   : Lemma (forall (x:a) (y:b x) (z:c x y). p x y z)
 
+(** [forall_intro_3] with pattern. *)
 val forall_intro_3_with_pat
   (#a:Type)
   (#b:(a -> Type))
@@ -150,6 +219,7 @@ val forall_intro_3_with_pat
   ($_: (x:a -> y:b x -> z:c x y -> Lemma (p x y z)))
   : Lemma (forall (x:a) (y:b x) (z:c x y).{:pattern (pat x y z)} p x y z)
 
+(** [forall_intro] for 4 variables. *)
 val forall_intro_4
   (#a:Type)
   (#b:(a -> Type))
@@ -161,31 +231,28 @@ val forall_intro_4
 
 (**** Existential quantification *)
 
-/// This one should be inferred by the SMT in most cases. This is how it should be used:
-///
-/// ```fstar
-/// exists_intro (fun (x: nat) -> x <> 0) 1
-/// ```
+(** Introduce [exists x. p x], given [p] and a [witness]. *)
 val exists_intro (#a:Type) (p:(a -> Type)) (witness:a)
   : Lemma (requires (p witness)) (ensures (exists (x:a). p x))
 
-/// If, forall `x` of type `a`, we have `p x ==> r`, then if there exists such an `x`, `r` holds.
+(** Given a lemma [x:_ -> (p x ==> r)], show that [(exists x. p x) ==> r]. *)
 val forall_to_exists (#a:Type) (#p:(a -> Type)) (#r:Type) ($_:(x:a -> Lemma (p x ==> r)))
   : Lemma ((exists (x:a). p x) ==> r)
 
-/// Same as before but with two arguments.
+(** [forall_to_exists] for two variables. *)
 val forall_to_exists_2 (#a:Type) (#p:(a -> Type)) (#b:Type) (#q:(b -> Type)) (#r:Type)
   ($f:(x:a -> y:b -> Lemma ((p x /\ q y) ==> r)))
   : Lemma (((exists (x:a). p x) /\ (exists (y:b). q y)) ==> r)
 
-/// Main point for introducing the witness of an existential predicate. Should be used like this:
-///
-/// ```fstar
-/// let pf : squash (exists (x:a). p x) = () in
-/// exists_elim goal pf (fun x ->
-///   ...
-/// )
-/// ```
+(** Introduce a (scoped) witness of an existential.
+    Example:
+    {[
+        // if [exists x. p x] is in context, and we are proving [goal]
+        exists_elim goal (fun (x:_{p x}) ->
+          // we now have a witness [x] in context here that we can use to prove [goal]
+        )
+    ]}
+*)
 val exists_elim (goal:Type) (#a:Type) (#p:(a -> Type)) (_:squash (exists (x:a). p x))
   (_:(x:a{p x} -> GTot (squash goal))) : Lemma goal
 
@@ -198,46 +265,90 @@ val exists_elim (goal:Type) (#a:Type) (#p:(a -> Type)) (_:squash (exists (x:a). 
 /// impl_intro aux
 /// ```
 
-val impl_intro_gtot (#p:Type0) (#q:Type0) ($_:p -> GTot q) :GTot (p ==> q)
+(** Introduce an implication using a [GTot] function. [arrow_to_impl] without explicit squash. *)
+val impl_intro_gtot (#p:Type0) (#q:Type0) ($_:p -> GTot q) : GTot (p ==> q)
+
+(** Introduce an implication using a lemma. *)
 val impl_intro (#p:Type0) (#q:Type0) ($_: p -> Lemma q) : Lemma (p ==> q)
 
-/// `move_requires` is very useful when you want to convert a requires/ensures lemma into an
-/// implication. However, it will only work if your lemma takes only one argument and that both its
-/// pre and post conditions are functions applied to this argument. Any more complicated patterns won't
-/// unify, and you will have to use `impl_intro` more painfully instead.
-val move_requires (#a:Type) (#p:a -> Type) (#q:a -> Type)
+(** Convert a requires/ensures lemma into an implication lemma.
+
+    Note: Works only on lemmas with a single argument, but can be made
+    to work with lemmas with more arguments by using the following
+    "trick":
+
+    If we have {[
+       val foo x y z : Lemma
+           (requires (p x y z))
+           (ensures (q x y z))
+    ]} and want {[
+       val bar x y z : Lemma
+           (p x y z ==> q x y z)
+    ]} then we can simply use {[
+       let bar x y z =
+           move_requires (foo x y) z
+    ]}
+*)
+val move_requires
+  (#a:Type)
+  (#p:a -> Type)
+  (#q:a -> Type)
   ($_:(x:a -> Lemma (requires (p x)) (ensures (q x)))) (x:a)
   : Lemma (p x ==> q x)
 
-/// Generative version of `impl_intro`.
+(** A generative version of [impl_intro]. *)
 val impl_intro_gen (#p:Type0) (#q:squash p -> Tot Type0) (_:squash p -> Lemma (q ()))
   : Lemma (p ==> q ())
 
-/// Mixes `forall_intro` and `impl_intro` in a single lemma.
-val forall_impl_intro (#a:Type) (#p:(a -> GTot Type)) (#q:(a -> GTot Type))
+(** Both [impl_intro] and [forall_intro] at once. *)
+val forall_impl_intro
+  (#a:Type)
+  (#p:(a -> GTot Type))
+  (#q:(a -> GTot Type))
   ($_:(x:a -> (squash(p x)) -> Lemma (q x)))
   : Lemma (forall x. p x ==> q x)
 
 
-/// Gost lemma version of `forall_impl_intro`.
+(** Given a [Ghost unit] function with pre/post conditions, convert it into a lemma with [forall] and implication. *)
 val ghost_lemma (#a:Type) (#p:(a -> GTot Type0)) (#q:(a -> unit -> GTot Type0))
   ($_:(x:a -> Ghost unit (p x) (q x)))
   : Lemma (forall (x:a). p x ==> q x ())
 
 (**** Disjunctions *)
 
-/// Eliminates a disjunction. The unificiation is fairly tricky for making this one work so here is how one can use it:
-///
-/// ```fstar
-/// let goal (_ : squash (l \/ r)) = ... in
-/// or_elim #l #r #goal
-///   (fun _ -> ...)
-///   (fun _ -> ...)
-/// ```
+(** Eliminate a disjunction. Useful for splitting proof of goal under two assumptions separately.
+
+    Example:
+    {[
+        // assuming we want to prove [goal] under [l \/ r].
+        let goal (_ : squash (l \/ r)) = ... in
+        or_elim #l #r #goal
+                (fun _ ->
+                     // prove [goal] assuming [l]
+                )
+                (fun _ ->
+                     // prove [goal] assuming [r]
+                )
+        // and now we've proven [goal] under [l \/ r].
+    ]}
+
+    Example:
+    {[
+        // assuming we want to prove [goal].
+        or_elim #_ #_ #(fun () -> goal)
+                (fun (_:squash p) ->
+                     // prove [goal] assuming [p]
+                )
+                (fun (_:squash (~p)) ->
+                     // prove [goal] assuming [~p]
+                )
+       // and now we've proven [goal].
+    ]}
+*)
 val or_elim (#l #r:Type0) (#goal:(squash (l \/ r) -> Tot Type0))
   (hl:squash l -> Lemma (goal ()))
   (hr:squash r -> Lemma (goal ()))
   : Lemma ((l \/ r) ==> goal ())
 
-/// Introduces a disjunction thanks to the excluded middle of classical logic.
-val excluded_middle (p:Type) : Lemma (requires (True)) (ensures (p \/ ~p))
+(** Introduce [p \/ ~p] -- a classic of classical logic. *)
+val excluded_middle (p:Type) :Lemma (requires (True)) (ensures (p \/ ~p))


### PR DESCRIPTION
Work made in collaboration with @jaybosamiya, to produce a doc style that mixes `fslit` and `fsdoc`.