### PR TITLE
`check_with` attribute

### DIFF
--- a/examples/bug-reports/Bug1866.fst
+++ b/examples/bug-reports/Bug1866.fst
@@ -1,0 +1,89 @@
+module Bug1866
+
+open FStar.Tactics
+
+let rec not_do_much e: Tac term =
+  match inspect e with
+  | Tv_App _ _ ->
+      let e, es = collect_app e in
+      let e = not_do_much e in
+      let es = map (fun (e, q) -> not_do_much e, q) es in
+      mk_app e es
+
+  | Tv_Var _ | Tv_BVar _ | Tv_FVar _
+  | Tv_Const _ ->
+    e
+
+  | Tv_Abs b e ->
+      let e = not_do_much e in
+      let e = pack (Tv_Abs b e) in
+      e
+
+  | Tv_Match scrut branches ->
+      let scrut = not_do_much scrut in
+      let pats, es = List.Tot.split branches in
+      let es = map not_do_much es in
+      let branches = zip pats es in
+      pack (Tv_Match scrut branches)
+
+  | Tv_Let r bv e1 e2 ->
+      let e1 = not_do_much e1 in
+      let e2 = not_do_much e2 in
+      let e = pack (Tv_Let r bv e1 e2) in
+      e
+
+  | Tv_AscribedT e t tac ->
+      let e = not_do_much e in
+      let e = pack (Tv_AscribedT e t tac) in
+      e
+
+  | Tv_AscribedC e c tac ->
+      let e = not_do_much e in
+      let e = pack (Tv_AscribedC e c tac) in
+      e
+
+  | Tv_Arrow _ _
+  | Tv_Type _
+  | Tv_Uvar _ _
+  | Tv_Refine _ _
+  | Tv_Unknown ->
+      // Looks like we ended up visiting a type argument of an application.
+      e
+
+
+let base0 =
+    let (x,y,z) = (1,2,3) in
+    x
+
+let base1 =
+    let Mktuple3 x y z = (1,2,3) in
+    x
+
+let base2 =
+    let Mktuple3 #_ #_ #_ x y z = (1,2,3) in
+    x
+
+val base3 : 'a & 'b -> 'a
+let base3 p =
+    let (x, _) = p in
+    x
+
+#set-options "--print_implicits --ugly"
+
+let traverse (name:string) : Tac unit =
+  let d = lookup_typ (cur_env ()) (cur_module () @ [ name ]) in
+  let d = match d with Some d -> d | None -> fail "0" in
+  let d = match inspect_sigelt d with
+    | Sg_Let _ _ _ _ d -> d
+    | _ -> fail "1"
+  in
+  let name = pack_fv (cur_module () @ [ "test_" ^ name ]) in
+  let r = not_do_much d in
+  dump ("r = " ^ term_to_string r);
+  let s = pack_sigelt (Sg_Let false name [] (pack Tv_Unknown) r) in
+  exact (quote [ s ])
+
+%splice[test_base0](traverse "base0")
+%splice[test_base1](traverse "base1")
+%splice[test_base2](traverse "base2")
+(* %splice[test_base3](traverse "base3") *)

--- a/examples/bug-reports/Bug1866.fst
+++ b/examples/bug-reports/Bug1866.fst
@@ -63,27 +63,31 @@ let base2 =
     let Mktuple3 #_ #_ #_ x y z = (1,2,3) in
     x
 
-val base3 : 'a & 'b -> 'a
-let base3 p =
+val base3 : #a:Type -> #b:Type -> a & b -> a
+let base3 #a #b p =
     let (x, _) = p in
     x
 
-#set-options "--print_implicits --ugly"
+val base4 : 'a & 'b -> 'a
+let base4 p =
+    let (x, _) = p in
+    x
 
 let traverse (name:string) : Tac unit =
   let d = lookup_typ (cur_env ()) (cur_module () @ [ name ]) in
   let d = match d with Some d -> d | None -> fail "0" in
-  let d = match inspect_sigelt d with
-    | Sg_Let _ _ _ _ d -> d
+  let d, us = match inspect_sigelt d with
+    | Sg_Let _ _ us _ d -> d, us
     | _ -> fail "1"
   in
   let name = pack_fv (cur_module () @ [ "test_" ^ name ]) in
   let r = not_do_much d in
-  dump ("r = " ^ term_to_string r);
-  let s = pack_sigelt (Sg_Let false name [] (pack Tv_Unknown) r) in
+  (* dump ("r = " ^ term_to_string r); *)
+  let s = pack_sigelt (Sg_Let false name us (pack Tv_Unknown) r) in
   exact (quote [ s ])
 
 %splice[test_base0](traverse "base0")
 %splice[test_base1](traverse "base1")
 %splice[test_base2](traverse "base2")
-(* %splice[test_base3](traverse "base3") *)
+%splice[test_base3](traverse "base3")
+%splice[test_base4](traverse "base4")

--- a/examples/bug-reports/Makefile
+++ b/examples/bug-reports/Makefile
@@ -36,7 +36,7 @@ SHOULD_VERIFY_CLOSED=bug022.fst bug024.fst bug025.fst bug026.fst bug026b.fst bug
   Bug1595.fst Bug1601.fst Bug1602.fst Bug1604.fst Bug1605.fst Bug1621.fst Bug1680.fst Bug1682.fst Bug1694.fst \
   Bug1730b.fst Bug1612.fst Bug1614a.fst Bug1614b.fst Bug1614c.fst Bug1614d.fst Bug1614e.fst Bug1750.fst Bug1750.Aux.fst \
   Bug1622.fst bug1540.fst Bug1784.fst Bug1802.fst Bug1055.fst Bug1818.fst Bug1640.fst Bug1243.fst Bug1841.fst \
-  Bug1847.fst Bug1855.fst Bug1812.fst Bug1840.fst
+  Bug1847.fst Bug1855.fst Bug1812.fst Bug1840.fst Bug1866.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=bug771.fsti bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=bug016.fst

--- a/examples/native_tactics/Printers.fst
+++ b/examples/native_tactics/Printers.fst
@@ -64,7 +64,7 @@ let printer_fun () : Tac unit =
             | Sg_Constructor name t ->
             let pn = String.concat "." name in
             let t_args, _ = collect_arr t in
-            let bv_pats = TD.map (fun ti -> let bv = fresh_bv ti in (bv, Pat_Var bv)) t_args in
+            let bv_pats = TD.map (fun ti -> let bv = fresh_bv ti in (bv, (Pat_Var bv, false))) t_args in
             let bvs, pats = List.Tot.split bv_pats in
             let head = pack (Tv_Const (C_String pn)) in
             let bod = mk_concat (mk_stringlit " ") (head :: TD.map mk_print_binder bvs) in

--- a/examples/tactics/MultiStage.fst
+++ b/examples/tactics/MultiStage.fst
@@ -1,0 +1,26 @@
+module MultiStage
+
+open FStar.Tactics
+
+let tau1 () : Tac unit =
+  let se = pack_sigelt (Sg_Let false (pack_fv (cur_module () @ ["test1"])) []
+                               (`int)
+                               (`(synth (fun () -> dump "Running inner tactic 1"; exact (`42))))) in
+  exact (quote [se])
+
+%splice[test1] (tau1 ())
+
+let _ = assert (test1 == 42)
+
+let tau2 () : Tac unit =
+  let res : term = quote 42 in
+  let se = pack_sigelt (Sg_Let false (pack_fv (cur_module () @ ["test2"])) []
+                               (`int)
+                               (`(synth (fun () -> dump "Running inner tactic 2"; exact (`@res))))) in
+  exact (quote [se])
+
+
+  
+%splice[test2] (tau2 ())
+
+let _ = assert (test2 == 42)

--- a/examples/tactics/MultiStage.fst
+++ b/examples/tactics/MultiStage.fst
@@ -7,9 +7,7 @@ let tau1 () : Tac unit =
                                (`int)
                                (`(synth (fun () -> dump "Running inner tactic 1"; exact (`42))))) in
   exact (quote [se])
-
 %splice[test1] (tau1 ())
-
 let _ = assert (test1 == 42)
 
 let tau2 () : Tac unit =
@@ -18,9 +16,41 @@ let tau2 () : Tac unit =
                                (`int)
                                (`(synth (fun () -> dump "Running inner tactic 2"; exact (`@res))))) in
   exact (quote [se])
-
-
-  
 %splice[test2] (tau2 ())
-
 let _ = assert (test2 == 42)
+
+let tau3 () : Tac unit =
+  let res : term = quote 42 in
+  let se = pack_sigelt (Sg_Let false (pack_fv (cur_module () @ ["test3"])) []
+                               (`int)
+                               (`(_ by (dump "Running inner tactic 3";
+                                        exact (`@res))))) in
+  exact (quote [se])
+%splice[test3] (tau3 ())
+let _ = assert (test3 == 42)
+
+(* This will get stuck, `res` has no definition in the environment where the tactic runs *)
+(* let tau4 () : Tac unit = *)
+(*   let se = pack_sigelt (Sg_Let false (pack_fv (cur_module () @ ["test4"])) [] *)
+(*                                (`int) *)
+(*                                (`(let res : term = quote 42 in *)
+(*                                   _ by (dump "Running inner tactic 4"; *)
+(*                                         let x = 42 in *)
+(*                                         exact (res))))) in *)
+(*   exact (quote [se]) *)
+(* %splice[test4] (tau4 ()) *)
+(* let _ = assert (test4 == 42) *)
+
+let string_of_name = String.concat "."
+
+let tau5 () : Tac unit =
+  let res : term = quote 42 in
+  let f_name : name = ["a";"b";"c"] in
+  let se = pack_sigelt (Sg_Let false (pack_fv (cur_module () @ ["test5"])) []
+                               (`int)
+                               (`(_ by (dump ("Running inner tactic 5: " ^ (string_of_name (`@f_name)));
+                                        let x = 42 in
+                                        exact (quote 42))))) in
+  exact (quote [se])
+%splice[test5] (tau5 ())
+let _ = assert (test5 == 42)

--- a/examples/tactics/Printers.fst
+++ b/examples/tactics/Printers.fst
@@ -84,7 +84,7 @@ let mk_printer_fun (dom : term) : Tac term =
             | Sg_Constructor name t ->
             let pn = String.concat "." name in
             let t_args, _ = collect_arr t in
-            let bv_pats = TU.map (fun ti -> let bv = fresh_bv_named "a" ti in (bv, Pat_Var bv)) t_args in
+            let bv_pats = TU.map (fun ti -> let bv = fresh_bv_named "a" ti in (bv, (Pat_Var bv, false))) t_args in
             let bvs, pats = List.Tot.split bv_pats in
             let head = pack (Tv_Const (C_String pn)) in
             let bod = mk_concat (mk_stringlit " ") (head :: TU.map (mk_print_bv xt_ns fftm) bvs) in

--- a/examples/tactics/SigeltOpts.fst
+++ b/examples/tactics/SigeltOpts.fst
@@ -1,0 +1,37 @@
+module SigeltOpts
+
+open FStar.Tactics
+
+#set-options "--max_fuel 2"
+let sp1 = assert (List.length [1] == 1)
+
+#set-options "--max_fuel 0"
+
+(* Fails without fuel *)
+[@expect_failure]
+let sp2 = assert (List.length [1] == 1)
+
+val add_check_with : optionstate -> sigelt -> Tac sigelt
+let add_check_with opts se =
+  let attrs = sigelt_attrs se in
+  let t = quote (check_with opts) in
+  set_sigelt_attrs (t :: attrs) se
+
+let tau () : Tac unit =
+  match lookup_typ (cur_env ()) ["SigeltOpts"; "sp1"] with
+  | None -> fail "1"
+  | Some se ->
+    match sigelt_opts se with
+    | None -> fail "2"
+    | Some opts ->
+        let se : sigelt = pack_sigelt (Sg_Let false (pack_fv ["SigeltOpts"; "blah"]) [] (`_)
+                                              (`(assert (List.length [2] == 1)))) in
+        let se = add_check_with opts se in
+        exact (quote [se])
+
+(* Splice `blah`, using the options for sp1, i.e. --max_fuel 2 *)
+%splice[blah] (tau ())
+
+(* Outside, still with max_fuel = 0 *)
+[@expect_failure]
+let sp3 = assert (List.length [1] == 1)

--- a/src/basic/FStar.Options.fs
+++ b/src/basic/FStar.Options.fs
@@ -116,7 +116,7 @@ let copy_optionstate m = Util.smap_copy m
 let fstar_options : ref<list<list<optionstate>>> = Util.mk_ref []
 
 let internal_peek () = List.hd (List.hd !fstar_options)
-let peek () = internal_peek()
+let peek () = copy_optionstate (internal_peek())
 let pop  () = // already signal-atomic
     match !fstar_options with
     | []
@@ -146,7 +146,7 @@ let set o =
 let snapshot () = Common.snapshot push fstar_options ()
 let rollback depth = Common.rollback pop fstar_options depth
 
-let set_option k v = Util.smap_add (peek()) k v
+let set_option k v = Util.smap_add (internal_peek()) k v
 let set_option' (k,v) =  set_option k v
 
 let light_off_files : ref<list<string>> = Util.mk_ref []
@@ -290,7 +290,7 @@ let initialize_parse_warn_error f = fst (parse_warn_error_set_get) f
 let parse_warn_error s = snd (parse_warn_error_set_get) () s
 
 let init () =
-   let o = peek () in
+   let o = internal_peek () in
    Util.smap_clear o;
    defaults |> List.iter set_option'                          //initialize it with the default values
 
@@ -303,7 +303,7 @@ let clear () =
 let _run = clear()
 
 let get_option s =
-  match Util.smap_try_find (peek()) s with
+  match Util.smap_try_find (internal_peek()) s with
   | None -> failwith ("Impossible: option " ^s^ " not found")
   | Some s -> s
 

--- a/src/fstar/FStar.Main.fs
+++ b/src/fstar/FStar.Main.fs
@@ -188,6 +188,7 @@ let lazy_chooser k i = match k with
     | FStar.Syntax.Syntax.BadLazy -> failwith "lazy chooser: got a BadLazy"
     | FStar.Syntax.Syntax.Lazy_bv         -> FStar.Reflection.Embeddings.unfold_lazy_bv          i
     | FStar.Syntax.Syntax.Lazy_binder     -> FStar.Reflection.Embeddings.unfold_lazy_binder      i
+    | FStar.Syntax.Syntax.Lazy_optionstate -> FStar.Reflection.Embeddings.unfold_lazy_optionstate i
     | FStar.Syntax.Syntax.Lazy_fvar       -> FStar.Reflection.Embeddings.unfold_lazy_fvar        i
     | FStar.Syntax.Syntax.Lazy_comp       -> FStar.Reflection.Embeddings.unfold_lazy_comp        i
     | FStar.Syntax.Syntax.Lazy_env        -> FStar.Reflection.Embeddings.unfold_lazy_env         i
@@ -202,7 +203,9 @@ let setup_hooks () =
     Options.initialize_parse_warn_error FStar.Parser.ParseIt.parse_warn_error;
     FStar.Syntax.Syntax.lazy_chooser := Some lazy_chooser;
     FStar.Syntax.Util.tts_f := Some FStar.Syntax.Print.term_to_string;
-    FStar.TypeChecker.Normalize.unembed_binder_knot := Some FStar.Reflection.Embeddings.e_binder
+    FStar.TypeChecker.Normalize.unembed_binder_knot := Some FStar.Reflection.Embeddings.e_binder;
+    FStar.TypeChecker.Tc.unembed_optionstate_knot := Some FStar.Reflection.Embeddings.e_optionstate;
+    ()
 
 let handle_error e =
     if FStar.Errors.handleable e then

--- a/src/ocaml-output/FStar_Extraction_ML_Modul.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Modul.ml
@@ -886,40 +886,41 @@ let (extract_bundle_iface :
             FStar_Syntax_Syntax.sigrng = uu____2359;
             FStar_Syntax_Syntax.sigquals = uu____2360;
             FStar_Syntax_Syntax.sigmeta = uu____2361;
-            FStar_Syntax_Syntax.sigattrs = uu____2362;_}::[],uu____2363),(FStar_Syntax_Syntax.ExceptionConstructor
+            FStar_Syntax_Syntax.sigattrs = uu____2362;
+            FStar_Syntax_Syntax.sigopts = uu____2363;_}::[],uu____2364),(FStar_Syntax_Syntax.ExceptionConstructor
          )::[]) ->
-          let uu____2382 = extract_ctor env [] env { dname = l; dtyp = t }
+          let uu____2385 = extract_ctor env [] env { dname = l; dtyp = t }
              in
-          (match uu____2382 with
+          (match uu____2385 with
            | (env1,ctor) -> (env1, (iface_of_bindings [ctor])))
-      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____2415),quals) ->
-          let uu____2429 =
+      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____2418),quals) ->
+          let uu____2432 =
             FStar_Syntax_Util.has_attribute se.FStar_Syntax_Syntax.sigattrs
               FStar_Parser_Const.erasable_attr
              in
-          if uu____2429
+          if uu____2432
           then (env, empty_iface)
           else
-            (let uu____2438 =
+            (let uu____2441 =
                bundle_as_inductive_families env ses quals
                  se.FStar_Syntax_Syntax.sigattrs
                 in
-             match uu____2438 with
+             match uu____2441 with
              | (env1,ifams) ->
-                 let uu____2455 =
+                 let uu____2458 =
                    FStar_Util.fold_map extract_one_family env1 ifams  in
-                 (match uu____2455 with
+                 (match uu____2458 with
                   | (env2,td) ->
-                      let uu____2496 =
-                        let uu____2497 =
-                          let uu____2498 =
+                      let uu____2499 =
+                        let uu____2500 =
+                          let uu____2501 =
                             FStar_List.map (fun x  -> x.ifv) ifams  in
-                          iface_of_type_names uu____2498  in
-                        iface_union uu____2497
+                          iface_of_type_names uu____2501  in
+                        iface_union uu____2500
                           (iface_of_bindings (FStar_List.flatten td))
                          in
-                      (env2, uu____2496)))
-      | uu____2507 -> failwith "Unexpected signature element"
+                      (env2, uu____2499)))
+      | uu____2510 -> failwith "Unexpected signature element"
   
 let (extract_type_declaration :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -937,29 +938,29 @@ let (extract_type_declaration :
         fun attrs  ->
           fun univs1  ->
             fun t  ->
-              let uu____2582 =
-                let uu____2584 =
+              let uu____2585 =
+                let uu____2587 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_some
-                       (fun uu___6_2590  ->
-                          match uu___6_2590 with
+                       (fun uu___6_2593  ->
+                          match uu___6_2593 with
                           | FStar_Syntax_Syntax.Assumption  -> true
-                          | uu____2593 -> false))
+                          | uu____2596 -> false))
                    in
-                Prims.op_Negation uu____2584  in
-              if uu____2582
+                Prims.op_Negation uu____2587  in
+              if uu____2585
               then (g, empty_iface, [])
               else
-                (let uu____2608 = FStar_Syntax_Util.arrow_formals t  in
-                 match uu____2608 with
-                 | (bs,uu____2632) ->
+                (let uu____2611 = FStar_Syntax_Util.arrow_formals t  in
+                 match uu____2611 with
+                 | (bs,uu____2635) ->
                      let fv =
                        FStar_Syntax_Syntax.lid_as_fv lid
                          FStar_Syntax_Syntax.delta_constant
                          FStar_Pervasives_Native.None
                         in
                      let lb =
-                       let uu____2655 =
+                       let uu____2658 =
                          FStar_Syntax_Util.abs bs FStar_Syntax_Syntax.t_unit
                            FStar_Pervasives_Native.None
                           in
@@ -969,7 +970,7 @@ let (extract_type_declaration :
                          FStar_Syntax_Syntax.lbtyp = t;
                          FStar_Syntax_Syntax.lbeff =
                            FStar_Parser_Const.effect_Tot_lid;
-                         FStar_Syntax_Syntax.lbdef = uu____2655;
+                         FStar_Syntax_Syntax.lbdef = uu____2658;
                          FStar_Syntax_Syntax.lbattrs = attrs;
                          FStar_Syntax_Syntax.lbpos =
                            (t.FStar_Syntax_Syntax.pos)
@@ -989,18 +990,18 @@ let (extract_reifiable_effect :
           FStar_Syntax_Syntax.lid_as_fv lid
             FStar_Syntax_Syntax.delta_equational FStar_Pervasives_Native.None
            in
-        let uu____2718 =
+        let uu____2721 =
           FStar_Extraction_ML_UEnv.extend_fv' g1 fv ml_name tysc false false
            in
-        match uu____2718 with
+        match uu____2721 with
         | (g2,mangled_name,exp_binding) ->
-            ((let uu____2740 =
+            ((let uu____2743 =
                 FStar_All.pipe_left
                   (FStar_TypeChecker_Env.debug
                      g2.FStar_Extraction_ML_UEnv.env_tcenv)
                   (FStar_Options.Other "ExtractionReify")
                  in
-              if uu____2740
+              if uu____2743
               then FStar_Util.print1 "Mangled name: %s\n" mangled_name
               else ());
              (let lb =
@@ -1018,80 +1019,80 @@ let (extract_reifiable_effect :
                    (FStar_Extraction_ML_Syntax.NonRec, [lb])))))
          in
       let rec extract_fv tm =
-        (let uu____2776 =
+        (let uu____2779 =
            FStar_All.pipe_left
              (FStar_TypeChecker_Env.debug
                 g.FStar_Extraction_ML_UEnv.env_tcenv)
              (FStar_Options.Other "ExtractionReify")
             in
-         if uu____2776
+         if uu____2779
          then
-           let uu____2781 = FStar_Syntax_Print.term_to_string tm  in
-           FStar_Util.print1 "extract_fv term: %s\n" uu____2781
+           let uu____2784 = FStar_Syntax_Print.term_to_string tm  in
+           FStar_Util.print1 "extract_fv term: %s\n" uu____2784
          else ());
-        (let uu____2786 =
-           let uu____2787 = FStar_Syntax_Subst.compress tm  in
-           uu____2787.FStar_Syntax_Syntax.n  in
-         match uu____2786 with
-         | FStar_Syntax_Syntax.Tm_uinst (tm1,uu____2795) -> extract_fv tm1
+        (let uu____2789 =
+           let uu____2790 = FStar_Syntax_Subst.compress tm  in
+           uu____2790.FStar_Syntax_Syntax.n  in
+         match uu____2789 with
+         | FStar_Syntax_Syntax.Tm_uinst (tm1,uu____2798) -> extract_fv tm1
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              let mlp =
                FStar_Extraction_ML_Syntax.mlpath_of_lident
                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                 in
-             let uu____2802 = FStar_Extraction_ML_UEnv.lookup_fv g fv  in
-             (match uu____2802 with
-              | { FStar_Extraction_ML_UEnv.exp_b_name = uu____2807;
-                  FStar_Extraction_ML_UEnv.exp_b_expr = uu____2808;
+             let uu____2805 = FStar_Extraction_ML_UEnv.lookup_fv g fv  in
+             (match uu____2805 with
+              | { FStar_Extraction_ML_UEnv.exp_b_name = uu____2810;
+                  FStar_Extraction_ML_UEnv.exp_b_expr = uu____2811;
                   FStar_Extraction_ML_UEnv.exp_b_tscheme = tysc;
-                  FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____2810;_} ->
-                  let uu____2813 =
+                  FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____2813;_} ->
+                  let uu____2816 =
                     FStar_All.pipe_left
                       (FStar_Extraction_ML_Syntax.with_ty
                          FStar_Extraction_ML_Syntax.MLTY_Top)
                       (FStar_Extraction_ML_Syntax.MLE_Name mlp)
                      in
-                  (uu____2813, tysc))
-         | uu____2814 ->
-             let uu____2815 =
-               let uu____2817 =
+                  (uu____2816, tysc))
+         | uu____2817 ->
+             let uu____2818 =
+               let uu____2820 =
                  FStar_Range.string_of_range tm.FStar_Syntax_Syntax.pos  in
-               let uu____2819 = FStar_Syntax_Print.term_to_string tm  in
-               FStar_Util.format2 "(%s) Not an fv: %s" uu____2817 uu____2819
+               let uu____2822 = FStar_Syntax_Print.term_to_string tm  in
+               FStar_Util.format2 "(%s) Not an fv: %s" uu____2820 uu____2822
                 in
-             failwith uu____2815)
+             failwith uu____2818)
          in
       let extract_action g1 a =
-        (let uu____2847 =
+        (let uu____2850 =
            FStar_All.pipe_left
              (FStar_TypeChecker_Env.debug
                 g1.FStar_Extraction_ML_UEnv.env_tcenv)
              (FStar_Options.Other "ExtractionReify")
             in
-         if uu____2847
+         if uu____2850
          then
-           let uu____2852 =
+           let uu____2855 =
              FStar_Syntax_Print.term_to_string
                a.FStar_Syntax_Syntax.action_typ
               in
-           let uu____2854 =
+           let uu____2857 =
              FStar_Syntax_Print.term_to_string
                a.FStar_Syntax_Syntax.action_defn
               in
-           FStar_Util.print2 "Action type %s and term %s\n" uu____2852
-             uu____2854
+           FStar_Util.print2 "Action type %s and term %s\n" uu____2855
+             uu____2857
          else ());
-        (let uu____2859 = FStar_Extraction_ML_UEnv.action_name ed a  in
-         match uu____2859 with
+        (let uu____2862 = FStar_Extraction_ML_UEnv.action_name ed a  in
+         match uu____2862 with
          | (a_nm,a_lid) ->
              let lbname =
-               let uu____2879 =
+               let uu____2882 =
                  FStar_Syntax_Syntax.new_bv
                    (FStar_Pervasives_Native.Some
                       ((a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos))
                    FStar_Syntax_Syntax.tun
                   in
-               FStar_Util.Inl uu____2879  in
+               FStar_Util.Inl uu____2882  in
              let lb =
                FStar_Syntax_Syntax.mk_lb
                  (lbname, (a.FStar_Syntax_Syntax.action_univs),
@@ -1108,28 +1109,28 @@ let (extract_reifiable_effect :
                  FStar_Pervasives_Native.None
                  (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
                 in
-             let uu____2909 =
+             let uu____2912 =
                FStar_Extraction_ML_Term.term_as_mlexpr g1 action_lb  in
-             (match uu____2909 with
-              | (a_let,uu____2925,ty) ->
-                  ((let uu____2928 =
+             (match uu____2912 with
+              | (a_let,uu____2928,ty) ->
+                  ((let uu____2931 =
                       FStar_All.pipe_left
                         (FStar_TypeChecker_Env.debug
                            g1.FStar_Extraction_ML_UEnv.env_tcenv)
                         (FStar_Options.Other "ExtractionReify")
                        in
-                    if uu____2928
+                    if uu____2931
                     then
-                      let uu____2933 =
+                      let uu____2936 =
                         FStar_Extraction_ML_Code.string_of_mlexpr a_nm a_let
                          in
                       FStar_Util.print1 "Extracted action term: %s\n"
-                        uu____2933
+                        uu____2936
                     else ());
-                   (let uu____2938 =
+                   (let uu____2941 =
                       match a_let.FStar_Extraction_ML_Syntax.expr with
                       | FStar_Extraction_ML_Syntax.MLE_Let
-                          ((uu____2961,mllb::[]),uu____2963) ->
+                          ((uu____2964,mllb::[]),uu____2966) ->
                           (match mllb.FStar_Extraction_ML_Syntax.mllb_tysc
                            with
                            | FStar_Pervasives_Native.Some tysc ->
@@ -1137,77 +1138,77 @@ let (extract_reifiable_effect :
                                  tysc)
                            | FStar_Pervasives_Native.None  ->
                                failwith "No type scheme")
-                      | uu____3003 -> failwith "Impossible"  in
-                    match uu____2938 with
+                      | uu____3006 -> failwith "Impossible"  in
+                    match uu____2941 with
                     | (exp,tysc) ->
-                        ((let uu____3041 =
+                        ((let uu____3044 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug
                                  g1.FStar_Extraction_ML_UEnv.env_tcenv)
                               (FStar_Options.Other "ExtractionReify")
                              in
-                          if uu____3041
+                          if uu____3044
                           then
-                            ((let uu____3047 =
+                            ((let uu____3050 =
                                 FStar_Extraction_ML_Code.string_of_mlty a_nm
                                   (FStar_Pervasives_Native.snd tysc)
                                  in
                               FStar_Util.print1 "Extracted action type: %s\n"
-                                uu____3047);
+                                uu____3050);
                              FStar_List.iter
                                (fun x  ->
                                   FStar_Util.print1 "and binders: %s\n" x)
                                (FStar_Pervasives_Native.fst tysc))
                           else ());
-                         (let uu____3063 = extend_env g1 a_lid a_nm exp tysc
+                         (let uu____3066 = extend_env g1 a_lid a_nm exp tysc
                              in
-                          match uu____3063 with
+                          match uu____3066 with
                           | (env,iface1,impl) -> (env, (iface1, impl))))))))
          in
-      let uu____3085 =
-        let uu____3092 =
+      let uu____3088 =
+        let uu____3095 =
           extract_fv
             (FStar_Pervasives_Native.snd ed.FStar_Syntax_Syntax.return_repr)
            in
-        match uu____3092 with
+        match uu____3095 with
         | (return_tm,ty_sc) ->
-            let uu____3109 =
+            let uu____3112 =
               FStar_Extraction_ML_UEnv.monad_op_name ed "return"  in
-            (match uu____3109 with
+            (match uu____3112 with
              | (return_nm,return_lid) ->
                  extend_env g return_lid return_nm return_tm ty_sc)
          in
-      match uu____3085 with
+      match uu____3088 with
       | (g1,return_iface,return_decl) ->
-          let uu____3134 =
-            let uu____3141 =
+          let uu____3137 =
+            let uu____3144 =
               extract_fv
                 (FStar_Pervasives_Native.snd ed.FStar_Syntax_Syntax.bind_repr)
                in
-            match uu____3141 with
+            match uu____3144 with
             | (bind_tm,ty_sc) ->
-                let uu____3158 =
+                let uu____3161 =
                   FStar_Extraction_ML_UEnv.monad_op_name ed "bind"  in
-                (match uu____3158 with
+                (match uu____3161 with
                  | (bind_nm,bind_lid) ->
                      extend_env g1 bind_lid bind_nm bind_tm ty_sc)
              in
-          (match uu____3134 with
+          (match uu____3137 with
            | (g2,bind_iface,bind_decl) ->
-               let uu____3183 =
+               let uu____3186 =
                  FStar_Util.fold_map extract_action g2
                    ed.FStar_Syntax_Syntax.actions
                   in
-               (match uu____3183 with
+               (match uu____3186 with
                 | (g3,actions) ->
-                    let uu____3220 = FStar_List.unzip actions  in
-                    (match uu____3220 with
+                    let uu____3223 = FStar_List.unzip actions  in
+                    (match uu____3223 with
                      | (actions_iface,actions1) ->
-                         let uu____3247 =
+                         let uu____3250 =
                            iface_union_l (return_iface :: bind_iface ::
                              actions_iface)
                             in
-                         (g3, uu____3247, (return_decl :: bind_decl ::
+                         (g3, uu____3250, (return_decl :: bind_decl ::
                            actions1)))))
   
 let (extract_let_rec_types :
@@ -1220,55 +1221,55 @@ let (extract_let_rec_types :
   fun se  ->
     fun env  ->
       fun lbs  ->
-        let uu____3278 =
+        let uu____3281 =
           FStar_Util.for_some
             (fun lb  ->
-               let uu____3283 =
+               let uu____3286 =
                  FStar_Extraction_ML_Term.is_arity env
                    lb.FStar_Syntax_Syntax.lbtyp
                   in
-               Prims.op_Negation uu____3283) lbs
+               Prims.op_Negation uu____3286) lbs
            in
-        if uu____3278
+        if uu____3281
         then
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_ExtractionUnsupported,
               "Mutually recursively defined typed and terms cannot yet be extracted")
             se.FStar_Syntax_Syntax.sigrng
         else
-          (let uu____3306 =
+          (let uu____3309 =
              FStar_List.fold_left
-               (fun uu____3341  ->
+               (fun uu____3344  ->
                   fun lb  ->
-                    match uu____3341 with
+                    match uu____3344 with
                     | (env1,iface_opt,impls) ->
-                        let uu____3382 =
+                        let uu____3385 =
                           extract_let_rec_type env1
                             se.FStar_Syntax_Syntax.sigquals
                             se.FStar_Syntax_Syntax.sigattrs lb
                            in
-                        (match uu____3382 with
+                        (match uu____3385 with
                          | (env2,iface1,impl) ->
                              let iface_opt1 =
                                match iface_opt with
                                | FStar_Pervasives_Native.None  ->
                                    FStar_Pervasives_Native.Some iface1
                                | FStar_Pervasives_Native.Some iface' ->
-                                   let uu____3416 = iface_union iface' iface1
+                                   let uu____3419 = iface_union iface' iface1
                                       in
-                                   FStar_Pervasives_Native.Some uu____3416
+                                   FStar_Pervasives_Native.Some uu____3419
                                 in
                              (env2, iface_opt1, (impl :: impls))))
                (env, FStar_Pervasives_Native.None, []) lbs
               in
-           match uu____3306 with
+           match uu____3309 with
            | (env1,iface_opt,impls) ->
-               let uu____3456 = FStar_Option.get iface_opt  in
-               let uu____3457 =
+               let uu____3459 = FStar_Option.get iface_opt  in
+               let uu____3460 =
                  FStar_All.pipe_right (FStar_List.rev impls)
                    FStar_List.flatten
                   in
-               (env1, uu____3456, uu____3457))
+               (env1, uu____3459, uu____3460))
   
 let (extract_sigelt_iface :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1277,84 +1278,84 @@ let (extract_sigelt_iface :
   fun g  ->
     fun se  ->
       match se.FStar_Syntax_Syntax.sigel with
-      | FStar_Syntax_Syntax.Sig_bundle uu____3489 ->
+      | FStar_Syntax_Syntax.Sig_bundle uu____3492 ->
           extract_bundle_iface g se
-      | FStar_Syntax_Syntax.Sig_inductive_typ uu____3498 ->
+      | FStar_Syntax_Syntax.Sig_inductive_typ uu____3501 ->
           extract_bundle_iface g se
-      | FStar_Syntax_Syntax.Sig_datacon uu____3515 ->
+      | FStar_Syntax_Syntax.Sig_datacon uu____3518 ->
           extract_bundle_iface g se
       | FStar_Syntax_Syntax.Sig_declare_typ (lid,univs1,t) when
           FStar_Extraction_ML_Term.is_arity g t ->
-          let uu____3534 =
+          let uu____3537 =
             extract_type_declaration g lid se.FStar_Syntax_Syntax.sigquals
               se.FStar_Syntax_Syntax.sigattrs univs1 t
              in
-          (match uu____3534 with | (env,iface1,uu____3549) -> (env, iface1))
-      | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____3555) when
+          (match uu____3537 with | (env,iface1,uu____3552) -> (env, iface1))
+      | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____3558) when
           FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp ->
-          let uu____3564 =
+          let uu____3567 =
             extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
               se.FStar_Syntax_Syntax.sigattrs lb
              in
-          (match uu____3564 with | (env,iface1,uu____3579) -> (env, iface1))
-      | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____3585) when
+          (match uu____3567 with | (env,iface1,uu____3582) -> (env, iface1))
+      | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____3588) when
           FStar_Util.for_some
             (fun lb  ->
                FStar_Extraction_ML_Term.is_arity g
                  lb.FStar_Syntax_Syntax.lbtyp) lbs
           ->
-          let uu____3598 = extract_let_rec_types se g lbs  in
-          (match uu____3598 with | (env,iface1,uu____3613) -> (env, iface1))
+          let uu____3601 = extract_let_rec_types se g lbs  in
+          (match uu____3601 with | (env,iface1,uu____3616) -> (env, iface1))
       | FStar_Syntax_Syntax.Sig_declare_typ (lid,_univs,t) ->
           let quals = se.FStar_Syntax_Syntax.sigquals  in
-          let uu____3624 =
+          let uu____3627 =
             (FStar_All.pipe_right quals
                (FStar_List.contains FStar_Syntax_Syntax.Assumption))
               &&
-              (let uu____3630 =
+              (let uu____3633 =
                  FStar_TypeChecker_Util.must_erase_for_extraction
                    g.FStar_Extraction_ML_UEnv.env_tcenv t
                   in
-               Prims.op_Negation uu____3630)
+               Prims.op_Negation uu____3633)
              in
-          if uu____3624
+          if uu____3627
           then
-            let uu____3637 =
-              let uu____3648 =
-                let uu____3649 =
-                  let uu____3652 = always_fail lid t  in [uu____3652]  in
-                (false, uu____3649)  in
-              FStar_Extraction_ML_Term.extract_lb_iface g uu____3648  in
-            (match uu____3637 with
+            let uu____3640 =
+              let uu____3651 =
+                let uu____3652 =
+                  let uu____3655 = always_fail lid t  in [uu____3655]  in
+                (false, uu____3652)  in
+              FStar_Extraction_ML_Term.extract_lb_iface g uu____3651  in
+            (match uu____3640 with
              | (g1,bindings) -> (g1, (iface_of_bindings bindings)))
           else (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_let (lbs,uu____3678) ->
-          let uu____3683 = FStar_Extraction_ML_Term.extract_lb_iface g lbs
+      | FStar_Syntax_Syntax.Sig_let (lbs,uu____3681) ->
+          let uu____3686 = FStar_Extraction_ML_Term.extract_lb_iface g lbs
              in
-          (match uu____3683 with
+          (match uu____3686 with
            | (g1,bindings) -> (g1, (iface_of_bindings bindings)))
-      | FStar_Syntax_Syntax.Sig_main uu____3712 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____3713 ->
+      | FStar_Syntax_Syntax.Sig_main uu____3715 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____3716 ->
           (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_assume uu____3714 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_sub_effect uu____3721 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_effect_abbrev uu____3722 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_assume uu____3717 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_sub_effect uu____3724 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_effect_abbrev uu____3725 -> (g, empty_iface)
       | FStar_Syntax_Syntax.Sig_pragma p ->
           (FStar_Syntax_Util.process_pragma p se.FStar_Syntax_Syntax.sigrng;
            (g, empty_iface))
-      | FStar_Syntax_Syntax.Sig_splice uu____3737 ->
+      | FStar_Syntax_Syntax.Sig_splice uu____3740 ->
           failwith "impossible: trying to extract splice"
       | FStar_Syntax_Syntax.Sig_new_effect ed ->
-          let uu____3750 =
+          let uu____3753 =
             (FStar_TypeChecker_Env.is_reifiable_effect
                g.FStar_Extraction_ML_UEnv.env_tcenv
                ed.FStar_Syntax_Syntax.mname)
               && (FStar_List.isEmpty ed.FStar_Syntax_Syntax.binders)
              in
-          if uu____3750
+          if uu____3753
           then
-            let uu____3763 = extract_reifiable_effect g ed  in
-            (match uu____3763 with | (env,iface1,uu____3778) -> (env, iface1))
+            let uu____3766 = extract_reifiable_effect g ed  in
+            (match uu____3766 with | (env,iface1,uu____3781) -> (env, iface1))
           else (g, empty_iface)
   
 let (extract_iface' :
@@ -1363,34 +1364,34 @@ let (extract_iface' :
   =
   fun g  ->
     fun modul  ->
-      let uu____3800 = FStar_Options.interactive ()  in
-      if uu____3800
+      let uu____3803 = FStar_Options.interactive ()  in
+      if uu____3803
       then (g, empty_iface)
       else
-        (let uu____3809 = FStar_Options.restore_cmd_line_options true  in
+        (let uu____3812 = FStar_Options.restore_cmd_line_options true  in
          let decls = modul.FStar_Syntax_Syntax.declarations  in
          let iface1 =
-           let uu___613_3813 = empty_iface  in
+           let uu___614_3816 = empty_iface  in
            {
              iface_module_name = (g.FStar_Extraction_ML_UEnv.currentModule);
-             iface_bindings = (uu___613_3813.iface_bindings);
-             iface_tydefs = (uu___613_3813.iface_tydefs);
-             iface_type_names = (uu___613_3813.iface_type_names)
+             iface_bindings = (uu___614_3816.iface_bindings);
+             iface_tydefs = (uu___614_3816.iface_tydefs);
+             iface_type_names = (uu___614_3816.iface_type_names)
            }  in
          let res =
            FStar_List.fold_left
-             (fun uu____3831  ->
+             (fun uu____3834  ->
                 fun se  ->
-                  match uu____3831 with
+                  match uu____3834 with
                   | (g1,iface2) ->
-                      let uu____3843 = extract_sigelt_iface g1 se  in
-                      (match uu____3843 with
+                      let uu____3846 = extract_sigelt_iface g1 se  in
+                      (match uu____3846 with
                        | (g2,iface') ->
-                           let uu____3854 = iface_union iface2 iface'  in
-                           (g2, uu____3854))) (g, iface1) decls
+                           let uu____3857 = iface_union iface2 iface'  in
+                           (g2, uu____3857))) (g, iface1) decls
             in
-         (let uu____3856 = FStar_Options.restore_cmd_line_options true  in
-          FStar_All.pipe_left (fun a1  -> ()) uu____3856);
+         (let uu____3859 = FStar_Options.restore_cmd_line_options true  in
+          FStar_All.pipe_left (fun a1  -> ()) uu____3859);
          res)
   
 let (extract_iface :
@@ -1399,15 +1400,15 @@ let (extract_iface :
   =
   fun g  ->
     fun modul  ->
-      let uu____3873 = FStar_Options.debug_any ()  in
-      if uu____3873
+      let uu____3876 = FStar_Options.debug_any ()  in
+      if uu____3876
       then
-        let uu____3880 =
+        let uu____3883 =
           FStar_Util.format1 "Extracted interface of %s"
             (modul.FStar_Syntax_Syntax.name).FStar_Ident.str
            in
-        FStar_Util.measure_execution_time uu____3880
-          (fun uu____3888  -> extract_iface' g modul)
+        FStar_Util.measure_execution_time uu____3883
+          (fun uu____3891  -> extract_iface' g modul)
       else extract_iface' g modul
   
 let (extend_with_iface :
@@ -1417,25 +1418,25 @@ let (extend_with_iface :
       let mlident_map =
         FStar_List.fold_left
           (fun acc  ->
-             fun uu____3918  ->
-               match uu____3918 with
-               | (uu____3929,x) ->
+             fun uu____3921  ->
+               match uu____3921 with
+               | (uu____3932,x) ->
                    FStar_Util.psmap_add acc
                      x.FStar_Extraction_ML_UEnv.exp_b_name "")
           g.FStar_Extraction_ML_UEnv.env_mlident_map iface1.iface_bindings
          in
-      let uu___636_3933 = g  in
-      let uu____3934 =
-        let uu____3937 =
-          FStar_List.map (fun _3944  -> FStar_Extraction_ML_UEnv.Fv _3944)
+      let uu___637_3936 = g  in
+      let uu____3937 =
+        let uu____3940 =
+          FStar_List.map (fun _3947  -> FStar_Extraction_ML_UEnv.Fv _3947)
             iface1.iface_bindings
            in
-        FStar_List.append uu____3937 g.FStar_Extraction_ML_UEnv.env_bindings
+        FStar_List.append uu____3940 g.FStar_Extraction_ML_UEnv.env_bindings
          in
       {
         FStar_Extraction_ML_UEnv.env_tcenv =
-          (uu___636_3933.FStar_Extraction_ML_UEnv.env_tcenv);
-        FStar_Extraction_ML_UEnv.env_bindings = uu____3934;
+          (uu___637_3936.FStar_Extraction_ML_UEnv.env_tcenv);
+        FStar_Extraction_ML_UEnv.env_bindings = uu____3937;
         FStar_Extraction_ML_UEnv.env_mlident_map = mlident_map;
         FStar_Extraction_ML_UEnv.tydefs =
           (FStar_List.append iface1.iface_tydefs
@@ -1444,7 +1445,7 @@ let (extend_with_iface :
           (FStar_List.append iface1.iface_type_names
              g.FStar_Extraction_ML_UEnv.type_names);
         FStar_Extraction_ML_UEnv.currentModule =
-          (uu___636_3933.FStar_Extraction_ML_UEnv.currentModule)
+          (uu___637_3936.FStar_Extraction_ML_UEnv.currentModule)
       }
   
 let (extract_bundle :
@@ -1457,10 +1458,10 @@ let (extract_bundle :
     fun se  ->
       let extract_ctor env_iparams ml_tyvars env1 ctor =
         let mlt =
-          let uu____4022 =
+          let uu____4025 =
             FStar_Extraction_ML_Term.term_as_mlty env_iparams ctor.dtyp  in
           FStar_Extraction_ML_Util.eraseTypeDeep
-            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____4022
+            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____4025
            in
         let steps =
           [FStar_TypeChecker_Env.Inlining;
@@ -1469,104 +1470,104 @@ let (extract_bundle :
           FStar_TypeChecker_Env.EraseUniverses;
           FStar_TypeChecker_Env.AllowUnboundUniverses]  in
         let names1 =
-          let uu____4030 =
-            let uu____4031 =
-              let uu____4034 =
+          let uu____4033 =
+            let uu____4034 =
+              let uu____4037 =
                 FStar_TypeChecker_Normalize.normalize steps
                   env_iparams.FStar_Extraction_ML_UEnv.env_tcenv ctor.dtyp
                  in
-              FStar_Syntax_Subst.compress uu____4034  in
-            uu____4031.FStar_Syntax_Syntax.n  in
-          match uu____4030 with
-          | FStar_Syntax_Syntax.Tm_arrow (bs,uu____4039) ->
+              FStar_Syntax_Subst.compress uu____4037  in
+            uu____4034.FStar_Syntax_Syntax.n  in
+          match uu____4033 with
+          | FStar_Syntax_Syntax.Tm_arrow (bs,uu____4042) ->
               FStar_List.map
-                (fun uu____4072  ->
-                   match uu____4072 with
+                (fun uu____4075  ->
+                   match uu____4075 with
                    | ({ FStar_Syntax_Syntax.ppname = ppname;
-                        FStar_Syntax_Syntax.index = uu____4081;
-                        FStar_Syntax_Syntax.sort = uu____4082;_},uu____4083)
+                        FStar_Syntax_Syntax.index = uu____4084;
+                        FStar_Syntax_Syntax.sort = uu____4085;_},uu____4086)
                        -> ppname.FStar_Ident.idText) bs
-          | uu____4091 -> []  in
+          | uu____4094 -> []  in
         let tys = (ml_tyvars, mlt)  in
         let fvv = FStar_Extraction_ML_UEnv.mkFvvar ctor.dname ctor.dtyp  in
-        let uu____4099 =
+        let uu____4102 =
           FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false false  in
-        match uu____4099 with
-        | (env2,uu____4126,uu____4127) ->
-            let uu____4130 =
-              let uu____4143 = lident_as_mlsymbol ctor.dname  in
-              let uu____4145 =
-                let uu____4153 = FStar_Extraction_ML_Util.argTypes mlt  in
-                FStar_List.zip names1 uu____4153  in
-              (uu____4143, uu____4145)  in
-            (env2, uu____4130)
+        match uu____4102 with
+        | (env2,uu____4129,uu____4130) ->
+            let uu____4133 =
+              let uu____4146 = lident_as_mlsymbol ctor.dname  in
+              let uu____4148 =
+                let uu____4156 = FStar_Extraction_ML_Util.argTypes mlt  in
+                FStar_List.zip names1 uu____4156  in
+              (uu____4146, uu____4148)  in
+            (env2, uu____4133)
          in
       let extract_one_family env1 ind =
-        let uu____4214 = binders_as_mlty_binders env1 ind.iparams  in
-        match uu____4214 with
+        let uu____4217 = binders_as_mlty_binders env1 ind.iparams  in
+        match uu____4217 with
         | (env_iparams,vars) ->
-            let uu____4258 =
+            let uu____4261 =
               FStar_All.pipe_right ind.idatas
                 (FStar_Util.fold_map (extract_ctor env_iparams vars) env1)
                in
-            (match uu____4258 with
+            (match uu____4261 with
              | (env2,ctors) ->
-                 let uu____4365 = FStar_Syntax_Util.arrow_formals ind.ityp
+                 let uu____4368 = FStar_Syntax_Util.arrow_formals ind.ityp
                     in
-                 (match uu____4365 with
-                  | (indices,uu____4407) ->
+                 (match uu____4368 with
+                  | (indices,uu____4410) ->
                       let ml_params =
-                        let uu____4432 =
+                        let uu____4435 =
                           FStar_All.pipe_right indices
                             (FStar_List.mapi
                                (fun i  ->
-                                  fun uu____4458  ->
-                                    let uu____4466 =
+                                  fun uu____4461  ->
+                                    let uu____4469 =
                                       FStar_Util.string_of_int i  in
-                                    Prims.op_Hat "'dummyV" uu____4466))
+                                    Prims.op_Hat "'dummyV" uu____4469))
                            in
-                        FStar_List.append vars uu____4432  in
+                        FStar_List.append vars uu____4435  in
                       let tbody =
-                        let uu____4471 =
+                        let uu____4474 =
                           FStar_Util.find_opt
-                            (fun uu___7_4476  ->
-                               match uu___7_4476 with
-                               | FStar_Syntax_Syntax.RecordType uu____4478 ->
+                            (fun uu___7_4479  ->
+                               match uu___7_4479 with
+                               | FStar_Syntax_Syntax.RecordType uu____4481 ->
                                    true
-                               | uu____4488 -> false) ind.iquals
+                               | uu____4491 -> false) ind.iquals
                            in
-                        match uu____4471 with
+                        match uu____4474 with
                         | FStar_Pervasives_Native.Some
                             (FStar_Syntax_Syntax.RecordType (ns,ids)) ->
-                            let uu____4500 = FStar_List.hd ctors  in
-                            (match uu____4500 with
-                             | (uu____4525,c_ty) ->
+                            let uu____4503 = FStar_List.hd ctors  in
+                            (match uu____4503 with
+                             | (uu____4528,c_ty) ->
                                  let fields =
                                    FStar_List.map2
                                      (fun id1  ->
-                                        fun uu____4569  ->
-                                          match uu____4569 with
-                                          | (uu____4580,ty) ->
+                                        fun uu____4572  ->
+                                          match uu____4572 with
+                                          | (uu____4583,ty) ->
                                               let lid =
                                                 FStar_Ident.lid_of_ids
                                                   (FStar_List.append ns [id1])
                                                  in
-                                              let uu____4585 =
+                                              let uu____4588 =
                                                 lident_as_mlsymbol lid  in
-                                              (uu____4585, ty)) ids c_ty
+                                              (uu____4588, ty)) ids c_ty
                                     in
                                  FStar_Extraction_ML_Syntax.MLTD_Record
                                    fields)
-                        | uu____4588 ->
+                        | uu____4591 ->
                             FStar_Extraction_ML_Syntax.MLTD_DType ctors
                          in
-                      let uu____4591 =
-                        let uu____4614 = lident_as_mlsymbol ind.iname  in
-                        (false, uu____4614, FStar_Pervasives_Native.None,
+                      let uu____4594 =
+                        let uu____4617 = lident_as_mlsymbol ind.iname  in
+                        (false, uu____4617, FStar_Pervasives_Native.None,
                           ml_params, (ind.imetadata),
                           (FStar_Pervasives_Native.Some tbody))
                          in
-                      (env2, uu____4591)))
+                      (env2, uu____4594)))
          in
       match ((se.FStar_Syntax_Syntax.sigel),
               (se.FStar_Syntax_Syntax.sigquals))
@@ -1574,36 +1575,37 @@ let (extract_bundle :
       | (FStar_Syntax_Syntax.Sig_bundle
          ({
             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-              (l,uu____4659,t,uu____4661,uu____4662,uu____4663);
-            FStar_Syntax_Syntax.sigrng = uu____4664;
-            FStar_Syntax_Syntax.sigquals = uu____4665;
-            FStar_Syntax_Syntax.sigmeta = uu____4666;
-            FStar_Syntax_Syntax.sigattrs = uu____4667;_}::[],uu____4668),(FStar_Syntax_Syntax.ExceptionConstructor
+              (l,uu____4662,t,uu____4664,uu____4665,uu____4666);
+            FStar_Syntax_Syntax.sigrng = uu____4667;
+            FStar_Syntax_Syntax.sigquals = uu____4668;
+            FStar_Syntax_Syntax.sigmeta = uu____4669;
+            FStar_Syntax_Syntax.sigattrs = uu____4670;
+            FStar_Syntax_Syntax.sigopts = uu____4671;_}::[],uu____4672),(FStar_Syntax_Syntax.ExceptionConstructor
          )::[]) ->
-          let uu____4687 = extract_ctor env [] env { dname = l; dtyp = t }
+          let uu____4693 = extract_ctor env [] env { dname = l; dtyp = t }
              in
-          (match uu____4687 with
+          (match uu____4693 with
            | (env1,ctor) -> (env1, [FStar_Extraction_ML_Syntax.MLM_Exn ctor]))
-      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____4740),quals) ->
-          let uu____4754 =
+      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____4746),quals) ->
+          let uu____4760 =
             FStar_Syntax_Util.has_attribute se.FStar_Syntax_Syntax.sigattrs
               FStar_Parser_Const.erasable_attr
              in
-          if uu____4754
+          if uu____4760
           then (env, [])
           else
-            (let uu____4767 =
+            (let uu____4773 =
                bundle_as_inductive_families env ses quals
                  se.FStar_Syntax_Syntax.sigattrs
                 in
-             match uu____4767 with
+             match uu____4773 with
              | (env1,ifams) ->
-                 let uu____4786 =
+                 let uu____4792 =
                    FStar_Util.fold_map extract_one_family env1 ifams  in
-                 (match uu____4786 with
+                 (match uu____4792 with
                   | (env2,td) ->
                       (env2, [FStar_Extraction_ML_Syntax.MLM_Ty td])))
-      | uu____4895 -> failwith "Unexpected signature element"
+      | uu____4901 -> failwith "Unexpected signature element"
   
 let (maybe_register_plugin :
   env_t ->
@@ -1619,43 +1621,43 @@ let (maybe_register_plugin :
       let plugin_with_arity attrs =
         FStar_Util.find_map attrs
           (fun t  ->
-             let uu____4953 = FStar_Syntax_Util.head_and_args t  in
-             match uu____4953 with
+             let uu____4959 = FStar_Syntax_Util.head_and_args t  in
+             match uu____4959 with
              | (head1,args) ->
-                 let uu____5001 =
-                   let uu____5003 =
+                 let uu____5007 =
+                   let uu____5009 =
                      FStar_Syntax_Util.is_fvar FStar_Parser_Const.plugin_attr
                        head1
                       in
-                   Prims.op_Negation uu____5003  in
-                 if uu____5001
+                   Prims.op_Negation uu____5009  in
+                 if uu____5007
                  then FStar_Pervasives_Native.None
                  else
                    (match args with
                     | ({
                          FStar_Syntax_Syntax.n =
                            FStar_Syntax_Syntax.Tm_constant
-                           (FStar_Const.Const_int (s,uu____5022));
-                         FStar_Syntax_Syntax.pos = uu____5023;
-                         FStar_Syntax_Syntax.vars = uu____5024;_},uu____5025)::[]
+                           (FStar_Const.Const_int (s,uu____5028));
+                         FStar_Syntax_Syntax.pos = uu____5029;
+                         FStar_Syntax_Syntax.vars = uu____5030;_},uu____5031)::[]
                         ->
-                        let uu____5064 =
-                          let uu____5068 = FStar_Util.int_of_string s  in
-                          FStar_Pervasives_Native.Some uu____5068  in
-                        FStar_Pervasives_Native.Some uu____5064
-                    | uu____5074 ->
+                        let uu____5070 =
+                          let uu____5074 = FStar_Util.int_of_string s  in
+                          FStar_Pervasives_Native.Some uu____5074  in
+                        FStar_Pervasives_Native.Some uu____5070
+                    | uu____5080 ->
                         FStar_Pervasives_Native.Some
                           FStar_Pervasives_Native.None))
          in
-      let uu____5089 =
-        let uu____5091 = FStar_Options.codegen ()  in
-        uu____5091 <> (FStar_Pervasives_Native.Some FStar_Options.Plugin)  in
-      if uu____5089
+      let uu____5095 =
+        let uu____5097 = FStar_Options.codegen ()  in
+        uu____5097 <> (FStar_Pervasives_Native.Some FStar_Options.Plugin)  in
+      if uu____5095
       then []
       else
-        (let uu____5101 = plugin_with_arity se.FStar_Syntax_Syntax.sigattrs
+        (let uu____5107 = plugin_with_arity se.FStar_Syntax_Syntax.sigattrs
             in
-         match uu____5101 with
+         match uu____5107 with
          | FStar_Pervasives_Native.None  -> []
          | FStar_Pervasives_Native.Some arity_opt ->
              (match se.FStar_Syntax_Syntax.sigel with
@@ -1668,20 +1670,20 @@ let (maybe_register_plugin :
                        in
                     let fv_t = lb.FStar_Syntax_Syntax.lbtyp  in
                     let ml_name_str =
-                      let uu____5143 =
-                        let uu____5144 = FStar_Ident.string_of_lid fv_lid1
+                      let uu____5149 =
+                        let uu____5150 = FStar_Ident.string_of_lid fv_lid1
                            in
-                        FStar_Extraction_ML_Syntax.MLC_String uu____5144  in
-                      FStar_Extraction_ML_Syntax.MLE_Const uu____5143  in
-                    let uu____5146 =
+                        FStar_Extraction_ML_Syntax.MLC_String uu____5150  in
+                      FStar_Extraction_ML_Syntax.MLE_Const uu____5149  in
+                    let uu____5152 =
                       FStar_Extraction_ML_Util.interpret_plugin_as_term_fun
                         g.FStar_Extraction_ML_UEnv.env_tcenv fv fv_t
                         arity_opt ml_name_str
                        in
-                    match uu____5146 with
+                    match uu____5152 with
                     | FStar_Pervasives_Native.Some
                         (interp,nbe_interp,arity,plugin1) ->
-                        let uu____5179 =
+                        let uu____5185 =
                           if plugin1
                           then
                             ("FStar_Tactics_Native.register_plugin",
@@ -1690,36 +1692,36 @@ let (maybe_register_plugin :
                             ("FStar_Tactics_Native.register_tactic",
                               [interp])
                            in
-                        (match uu____5179 with
+                        (match uu____5185 with
                          | (register,args) ->
                              let h =
-                               let uu____5216 =
-                                 let uu____5217 =
-                                   let uu____5218 =
+                               let uu____5222 =
+                                 let uu____5223 =
+                                   let uu____5224 =
                                      FStar_Ident.lid_of_str register  in
                                    FStar_Extraction_ML_Syntax.mlpath_of_lident
-                                     uu____5218
+                                     uu____5224
                                     in
                                  FStar_Extraction_ML_Syntax.MLE_Name
-                                   uu____5217
+                                   uu____5223
                                   in
                                FStar_All.pipe_left
                                  (FStar_Extraction_ML_Syntax.with_ty
                                     FStar_Extraction_ML_Syntax.MLTY_Top)
-                                 uu____5216
+                                 uu____5222
                                 in
                              let arity1 =
-                               let uu____5220 =
-                                 let uu____5221 =
-                                   let uu____5233 =
+                               let uu____5226 =
+                                 let uu____5227 =
+                                   let uu____5239 =
                                      FStar_Util.string_of_int arity  in
-                                   (uu____5233, FStar_Pervasives_Native.None)
+                                   (uu____5239, FStar_Pervasives_Native.None)
                                     in
                                  FStar_Extraction_ML_Syntax.MLC_Int
-                                   uu____5221
+                                   uu____5227
                                   in
                                FStar_Extraction_ML_Syntax.MLE_Const
-                                 uu____5220
+                                 uu____5226
                                 in
                              let app =
                                FStar_All.pipe_left
@@ -1734,7 +1736,7 @@ let (maybe_register_plugin :
                     | FStar_Pervasives_Native.None  -> []  in
                   FStar_List.collect mk_registration
                     (FStar_Pervasives_Native.snd lbs)
-              | uu____5262 -> []))
+              | uu____5268 -> []))
   
 let rec (extract_sig :
   env_t ->
@@ -1745,59 +1747,59 @@ let rec (extract_sig :
     fun se  ->
       FStar_Extraction_ML_UEnv.debug g
         (fun u  ->
-           let uu____5290 = FStar_Syntax_Print.sigelt_to_string se  in
-           FStar_Util.print1 ">>>> extract_sig %s \n" uu____5290);
+           let uu____5296 = FStar_Syntax_Print.sigelt_to_string se  in
+           FStar_Util.print1 ">>>> extract_sig %s \n" uu____5296);
       (match se.FStar_Syntax_Syntax.sigel with
-       | FStar_Syntax_Syntax.Sig_bundle uu____5299 -> extract_bundle g se
-       | FStar_Syntax_Syntax.Sig_inductive_typ uu____5308 ->
+       | FStar_Syntax_Syntax.Sig_bundle uu____5305 -> extract_bundle g se
+       | FStar_Syntax_Syntax.Sig_inductive_typ uu____5314 ->
            extract_bundle g se
-       | FStar_Syntax_Syntax.Sig_datacon uu____5325 -> extract_bundle g se
+       | FStar_Syntax_Syntax.Sig_datacon uu____5331 -> extract_bundle g se
        | FStar_Syntax_Syntax.Sig_new_effect ed when
            FStar_TypeChecker_Env.is_reifiable_effect
              g.FStar_Extraction_ML_UEnv.env_tcenv
              ed.FStar_Syntax_Syntax.mname
            ->
-           let uu____5342 = extract_reifiable_effect g ed  in
-           (match uu____5342 with | (env,_iface,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_splice uu____5366 ->
+           let uu____5348 = extract_reifiable_effect g ed  in
+           (match uu____5348 with | (env,_iface,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_splice uu____5372 ->
            failwith "impossible: trying to extract splice"
-       | FStar_Syntax_Syntax.Sig_new_effect uu____5380 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_new_effect uu____5386 -> (g, [])
        | FStar_Syntax_Syntax.Sig_declare_typ (lid,univs1,t) when
            FStar_Extraction_ML_Term.is_arity g t ->
-           let uu____5386 =
+           let uu____5392 =
              extract_type_declaration g lid se.FStar_Syntax_Syntax.sigquals
                se.FStar_Syntax_Syntax.sigattrs univs1 t
               in
-           (match uu____5386 with | (env,uu____5402,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____5411) when
+           (match uu____5392 with | (env,uu____5408,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____5417) when
            FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp
            ->
-           let uu____5420 =
+           let uu____5426 =
              extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
                se.FStar_Syntax_Syntax.sigattrs lb
               in
-           (match uu____5420 with | (env,uu____5436,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____5445) when
+           (match uu____5426 with | (env,uu____5442,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____5451) when
            FStar_Util.for_some
              (fun lb  ->
                 FStar_Extraction_ML_Term.is_arity g
                   lb.FStar_Syntax_Syntax.lbtyp) lbs
            ->
-           let uu____5458 = extract_let_rec_types se g lbs  in
-           (match uu____5458 with | (env,uu____5474,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let (lbs,uu____5483) ->
+           let uu____5464 = extract_let_rec_types se g lbs  in
+           (match uu____5464 with | (env,uu____5480,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let (lbs,uu____5489) ->
            let attrs = se.FStar_Syntax_Syntax.sigattrs  in
            let quals = se.FStar_Syntax_Syntax.sigquals  in
-           let uu____5494 =
-             let uu____5503 =
+           let uu____5500 =
+             let uu____5509 =
                FStar_Syntax_Util.extract_attr'
                  FStar_Parser_Const.postprocess_extr_with attrs
                 in
-             match uu____5503 with
+             match uu____5509 with
              | FStar_Pervasives_Native.None  ->
                  (attrs, FStar_Pervasives_Native.None)
              | FStar_Pervasives_Native.Some
-                 (ats,(tau,FStar_Pervasives_Native.None )::uu____5532) ->
+                 (ats,(tau,FStar_Pervasives_Native.None )::uu____5538) ->
                  (ats, (FStar_Pervasives_Native.Some tau))
              | FStar_Pervasives_Native.Some (ats,args) ->
                  (FStar_Errors.log_issue se.FStar_Syntax_Syntax.sigrng
@@ -1805,7 +1807,7 @@ let rec (extract_sig :
                       "Ill-formed application of `postprocess_for_extraction_with`");
                   (attrs, FStar_Pervasives_Native.None))
               in
-           (match uu____5494 with
+           (match uu____5500 with
             | (attrs1,post_tau) ->
                 let postprocess_lb tau lb =
                   let lbdef =
@@ -1814,24 +1816,24 @@ let rec (extract_sig :
                       lb.FStar_Syntax_Syntax.lbtyp
                       lb.FStar_Syntax_Syntax.lbdef
                      in
-                  let uu___867_5618 = lb  in
+                  let uu___869_5624 = lb  in
                   {
                     FStar_Syntax_Syntax.lbname =
-                      (uu___867_5618.FStar_Syntax_Syntax.lbname);
+                      (uu___869_5624.FStar_Syntax_Syntax.lbname);
                     FStar_Syntax_Syntax.lbunivs =
-                      (uu___867_5618.FStar_Syntax_Syntax.lbunivs);
+                      (uu___869_5624.FStar_Syntax_Syntax.lbunivs);
                     FStar_Syntax_Syntax.lbtyp =
-                      (uu___867_5618.FStar_Syntax_Syntax.lbtyp);
+                      (uu___869_5624.FStar_Syntax_Syntax.lbtyp);
                     FStar_Syntax_Syntax.lbeff =
-                      (uu___867_5618.FStar_Syntax_Syntax.lbeff);
+                      (uu___869_5624.FStar_Syntax_Syntax.lbeff);
                     FStar_Syntax_Syntax.lbdef = lbdef;
                     FStar_Syntax_Syntax.lbattrs =
-                      (uu___867_5618.FStar_Syntax_Syntax.lbattrs);
+                      (uu___869_5624.FStar_Syntax_Syntax.lbattrs);
                     FStar_Syntax_Syntax.lbpos =
-                      (uu___867_5618.FStar_Syntax_Syntax.lbpos)
+                      (uu___869_5624.FStar_Syntax_Syntax.lbpos)
                   }  in
                 let lbs1 =
-                  let uu____5627 =
+                  let uu____5633 =
                     match post_tau with
                     | FStar_Pervasives_Native.Some tau ->
                         FStar_List.map (postprocess_lb tau)
@@ -1839,176 +1841,176 @@ let rec (extract_sig :
                     | FStar_Pervasives_Native.None  ->
                         FStar_Pervasives_Native.snd lbs
                      in
-                  ((FStar_Pervasives_Native.fst lbs), uu____5627)  in
-                let uu____5645 =
-                  let uu____5652 =
+                  ((FStar_Pervasives_Native.fst lbs), uu____5633)  in
+                let uu____5651 =
+                  let uu____5658 =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_let
                          (lbs1, FStar_Syntax_Util.exp_false_bool))
                       FStar_Pervasives_Native.None
                       se.FStar_Syntax_Syntax.sigrng
                      in
-                  FStar_Extraction_ML_Term.term_as_mlexpr g uu____5652  in
-                (match uu____5645 with
-                 | (ml_let,uu____5669,uu____5670) ->
+                  FStar_Extraction_ML_Term.term_as_mlexpr g uu____5658  in
+                (match uu____5651 with
+                 | (ml_let,uu____5675,uu____5676) ->
                      (match ml_let.FStar_Extraction_ML_Syntax.expr with
                       | FStar_Extraction_ML_Syntax.MLE_Let
-                          ((flavor,bindings),uu____5679) ->
+                          ((flavor,bindings),uu____5685) ->
                           let flags = FStar_List.choose flag_of_qual quals
                              in
                           let flags' = extract_metadata attrs1  in
-                          let uu____5696 =
+                          let uu____5702 =
                             FStar_List.fold_left2
-                              (fun uu____5722  ->
+                              (fun uu____5728  ->
                                  fun ml_lb  ->
-                                   fun uu____5724  ->
-                                     match (uu____5722, uu____5724) with
+                                   fun uu____5730  ->
+                                     match (uu____5728, uu____5730) with
                                      | ((env,ml_lbs),{
                                                        FStar_Syntax_Syntax.lbname
                                                          = lbname;
                                                        FStar_Syntax_Syntax.lbunivs
-                                                         = uu____5746;
+                                                         = uu____5752;
                                                        FStar_Syntax_Syntax.lbtyp
                                                          = t;
                                                        FStar_Syntax_Syntax.lbeff
-                                                         = uu____5748;
+                                                         = uu____5754;
                                                        FStar_Syntax_Syntax.lbdef
-                                                         = uu____5749;
+                                                         = uu____5755;
                                                        FStar_Syntax_Syntax.lbattrs
-                                                         = uu____5750;
+                                                         = uu____5756;
                                                        FStar_Syntax_Syntax.lbpos
-                                                         = uu____5751;_})
+                                                         = uu____5757;_})
                                          ->
-                                         let uu____5776 =
+                                         let uu____5782 =
                                            FStar_All.pipe_right
                                              ml_lb.FStar_Extraction_ML_Syntax.mllb_meta
                                              (FStar_List.contains
                                                 FStar_Extraction_ML_Syntax.Erased)
                                             in
-                                         if uu____5776
+                                         if uu____5782
                                          then (env, ml_lbs)
                                          else
                                            (let lb_lid =
-                                              let uu____5793 =
-                                                let uu____5796 =
+                                              let uu____5799 =
+                                                let uu____5802 =
                                                   FStar_Util.right lbname  in
-                                                uu____5796.FStar_Syntax_Syntax.fv_name
+                                                uu____5802.FStar_Syntax_Syntax.fv_name
                                                  in
-                                              uu____5793.FStar_Syntax_Syntax.v
+                                              uu____5799.FStar_Syntax_Syntax.v
                                                in
                                             let flags'' =
-                                              let uu____5800 =
-                                                let uu____5801 =
+                                              let uu____5806 =
+                                                let uu____5807 =
                                                   FStar_Syntax_Subst.compress
                                                     t
                                                    in
-                                                uu____5801.FStar_Syntax_Syntax.n
+                                                uu____5807.FStar_Syntax_Syntax.n
                                                  in
-                                              match uu____5800 with
+                                              match uu____5806 with
                                               | FStar_Syntax_Syntax.Tm_arrow
-                                                  (uu____5806,{
+                                                  (uu____5812,{
                                                                 FStar_Syntax_Syntax.n
                                                                   =
                                                                   FStar_Syntax_Syntax.Comp
                                                                   {
                                                                     FStar_Syntax_Syntax.comp_univs
                                                                     =
-                                                                    uu____5807;
+                                                                    uu____5813;
                                                                     FStar_Syntax_Syntax.effect_name
                                                                     = e;
                                                                     FStar_Syntax_Syntax.result_typ
                                                                     =
-                                                                    uu____5809;
+                                                                    uu____5815;
                                                                     FStar_Syntax_Syntax.effect_args
                                                                     =
-                                                                    uu____5810;
+                                                                    uu____5816;
                                                                     FStar_Syntax_Syntax.flags
                                                                     =
-                                                                    uu____5811;_};
+                                                                    uu____5817;_};
                                                                 FStar_Syntax_Syntax.pos
                                                                   =
-                                                                  uu____5812;
+                                                                  uu____5818;
                                                                 FStar_Syntax_Syntax.vars
                                                                   =
-                                                                  uu____5813;_})
+                                                                  uu____5819;_})
                                                   when
-                                                  let uu____5848 =
+                                                  let uu____5854 =
                                                     FStar_Ident.string_of_lid
                                                       e
                                                      in
-                                                  uu____5848 =
+                                                  uu____5854 =
                                                     "FStar.HyperStack.ST.StackInline"
                                                   ->
                                                   [FStar_Extraction_ML_Syntax.StackInline]
-                                              | uu____5852 -> []  in
+                                              | uu____5858 -> []  in
                                             let meta =
                                               FStar_List.append flags
                                                 (FStar_List.append flags'
                                                    flags'')
                                                in
                                             let ml_lb1 =
-                                              let uu___915_5857 = ml_lb  in
+                                              let uu___917_5863 = ml_lb  in
                                               {
                                                 FStar_Extraction_ML_Syntax.mllb_name
                                                   =
-                                                  (uu___915_5857.FStar_Extraction_ML_Syntax.mllb_name);
+                                                  (uu___917_5863.FStar_Extraction_ML_Syntax.mllb_name);
                                                 FStar_Extraction_ML_Syntax.mllb_tysc
                                                   =
-                                                  (uu___915_5857.FStar_Extraction_ML_Syntax.mllb_tysc);
+                                                  (uu___917_5863.FStar_Extraction_ML_Syntax.mllb_tysc);
                                                 FStar_Extraction_ML_Syntax.mllb_add_unit
                                                   =
-                                                  (uu___915_5857.FStar_Extraction_ML_Syntax.mllb_add_unit);
+                                                  (uu___917_5863.FStar_Extraction_ML_Syntax.mllb_add_unit);
                                                 FStar_Extraction_ML_Syntax.mllb_def
                                                   =
-                                                  (uu___915_5857.FStar_Extraction_ML_Syntax.mllb_def);
+                                                  (uu___917_5863.FStar_Extraction_ML_Syntax.mllb_def);
                                                 FStar_Extraction_ML_Syntax.mllb_meta
                                                   = meta;
                                                 FStar_Extraction_ML_Syntax.print_typ
                                                   =
-                                                  (uu___915_5857.FStar_Extraction_ML_Syntax.print_typ)
+                                                  (uu___917_5863.FStar_Extraction_ML_Syntax.print_typ)
                                               }  in
-                                            let uu____5858 =
-                                              let uu____5863 =
+                                            let uu____5864 =
+                                              let uu____5869 =
                                                 FStar_All.pipe_right quals
                                                   (FStar_Util.for_some
-                                                     (fun uu___8_5870  ->
-                                                        match uu___8_5870
+                                                     (fun uu___8_5876  ->
+                                                        match uu___8_5876
                                                         with
                                                         | FStar_Syntax_Syntax.Projector
-                                                            uu____5872 ->
+                                                            uu____5878 ->
                                                             true
-                                                        | uu____5878 -> false))
+                                                        | uu____5884 -> false))
                                                  in
-                                              if uu____5863
+                                              if uu____5869
                                               then
                                                 let mname =
-                                                  let uu____5894 =
+                                                  let uu____5900 =
                                                     mangle_projector_lid
                                                       lb_lid
                                                      in
                                                   FStar_All.pipe_right
-                                                    uu____5894
+                                                    uu____5900
                                                     FStar_Extraction_ML_Syntax.mlpath_of_lident
                                                    in
-                                                let uu____5903 =
-                                                  let uu____5911 =
+                                                let uu____5909 =
+                                                  let uu____5917 =
                                                     FStar_Util.right lbname
                                                      in
-                                                  let uu____5912 =
+                                                  let uu____5918 =
                                                     FStar_Util.must
                                                       ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc
                                                      in
                                                   FStar_Extraction_ML_UEnv.extend_fv'
-                                                    env uu____5911 mname
-                                                    uu____5912
+                                                    env uu____5917 mname
+                                                    uu____5918
                                                     ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit
                                                     false
                                                    in
-                                                match uu____5903 with
-                                                | (env1,uu____5919,uu____5920)
+                                                match uu____5909 with
+                                                | (env1,uu____5925,uu____5926)
                                                     ->
                                                     (env1,
-                                                      (let uu___928_5924 =
+                                                      (let uu___930_5930 =
                                                          ml_lb1  in
                                                        {
                                                          FStar_Extraction_ML_Syntax.mllb_name
@@ -2017,169 +2019,171 @@ let rec (extract_sig :
                                                               mname);
                                                          FStar_Extraction_ML_Syntax.mllb_tysc
                                                            =
-                                                           (uu___928_5924.FStar_Extraction_ML_Syntax.mllb_tysc);
+                                                           (uu___930_5930.FStar_Extraction_ML_Syntax.mllb_tysc);
                                                          FStar_Extraction_ML_Syntax.mllb_add_unit
                                                            =
-                                                           (uu___928_5924.FStar_Extraction_ML_Syntax.mllb_add_unit);
+                                                           (uu___930_5930.FStar_Extraction_ML_Syntax.mllb_add_unit);
                                                          FStar_Extraction_ML_Syntax.mllb_def
                                                            =
-                                                           (uu___928_5924.FStar_Extraction_ML_Syntax.mllb_def);
+                                                           (uu___930_5930.FStar_Extraction_ML_Syntax.mllb_def);
                                                          FStar_Extraction_ML_Syntax.mllb_meta
                                                            =
-                                                           (uu___928_5924.FStar_Extraction_ML_Syntax.mllb_meta);
+                                                           (uu___930_5930.FStar_Extraction_ML_Syntax.mllb_meta);
                                                          FStar_Extraction_ML_Syntax.print_typ
                                                            =
-                                                           (uu___928_5924.FStar_Extraction_ML_Syntax.print_typ)
+                                                           (uu___930_5930.FStar_Extraction_ML_Syntax.print_typ)
                                                        }))
                                               else
-                                                (let uu____5931 =
-                                                   let uu____5939 =
+                                                (let uu____5937 =
+                                                   let uu____5945 =
                                                      FStar_Util.must
                                                        ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc
                                                       in
                                                    FStar_Extraction_ML_UEnv.extend_lb
-                                                     env lbname t uu____5939
+                                                     env lbname t uu____5945
                                                      ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit
                                                      false
                                                     in
-                                                 match uu____5931 with
-                                                 | (env1,uu____5946,uu____5947)
+                                                 match uu____5937 with
+                                                 | (env1,uu____5952,uu____5953)
                                                      -> (env1, ml_lb1))
                                                in
-                                            match uu____5858 with
+                                            match uu____5864 with
                                             | (g1,ml_lb2) ->
                                                 (g1, (ml_lb2 :: ml_lbs))))
                               (g, []) bindings
                               (FStar_Pervasives_Native.snd lbs1)
                              in
-                          (match uu____5696 with
+                          (match uu____5702 with
                            | (g1,ml_lbs') ->
-                               let uu____5977 =
-                                 let uu____5980 =
-                                   let uu____5983 =
-                                     let uu____5984 =
+                               let uu____5983 =
+                                 let uu____5986 =
+                                   let uu____5989 =
+                                     let uu____5990 =
                                        FStar_Extraction_ML_Util.mlloc_of_range
                                          se.FStar_Syntax_Syntax.sigrng
                                         in
                                      FStar_Extraction_ML_Syntax.MLM_Loc
-                                       uu____5984
+                                       uu____5990
                                       in
-                                   [uu____5983;
+                                   [uu____5989;
                                    FStar_Extraction_ML_Syntax.MLM_Let
                                      (flavor, (FStar_List.rev ml_lbs'))]
                                     in
-                                 let uu____5987 = maybe_register_plugin g1 se
+                                 let uu____5993 = maybe_register_plugin g1 se
                                     in
-                                 FStar_List.append uu____5980 uu____5987  in
-                               (g1, uu____5977))
-                      | uu____5992 ->
-                          let uu____5993 =
-                            let uu____5995 =
+                                 FStar_List.append uu____5986 uu____5993  in
+                               (g1, uu____5983))
+                      | uu____5998 ->
+                          let uu____5999 =
+                            let uu____6001 =
                               FStar_Extraction_ML_Code.string_of_mlexpr
                                 g.FStar_Extraction_ML_UEnv.currentModule
                                 ml_let
                                in
                             FStar_Util.format1
                               "Impossible: Translated a let to a non-let: %s"
-                              uu____5995
+                              uu____6001
                              in
-                          failwith uu____5993)))
-       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____6005,t) ->
+                          failwith uu____5999)))
+       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____6011,t) ->
            let quals = se.FStar_Syntax_Syntax.sigquals  in
-           let uu____6010 =
+           let uu____6016 =
              (FStar_All.pipe_right quals
                 (FStar_List.contains FStar_Syntax_Syntax.Assumption))
                &&
-               (let uu____6016 =
+               (let uu____6022 =
                   FStar_TypeChecker_Util.must_erase_for_extraction
                     g.FStar_Extraction_ML_UEnv.env_tcenv t
                    in
-                Prims.op_Negation uu____6016)
+                Prims.op_Negation uu____6022)
               in
-           if uu____6010
+           if uu____6016
            then
              let always_fail1 =
-               let uu___948_6026 = se  in
-               let uu____6027 =
-                 let uu____6028 =
-                   let uu____6035 =
-                     let uu____6036 =
-                       let uu____6039 = always_fail lid t  in [uu____6039]
+               let uu___950_6032 = se  in
+               let uu____6033 =
+                 let uu____6034 =
+                   let uu____6041 =
+                     let uu____6042 =
+                       let uu____6045 = always_fail lid t  in [uu____6045]
                         in
-                     (false, uu____6036)  in
-                   (uu____6035, [])  in
-                 FStar_Syntax_Syntax.Sig_let uu____6028  in
+                     (false, uu____6042)  in
+                   (uu____6041, [])  in
+                 FStar_Syntax_Syntax.Sig_let uu____6034  in
                {
-                 FStar_Syntax_Syntax.sigel = uu____6027;
+                 FStar_Syntax_Syntax.sigel = uu____6033;
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___948_6026.FStar_Syntax_Syntax.sigrng);
+                   (uu___950_6032.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___948_6026.FStar_Syntax_Syntax.sigquals);
+                   (uu___950_6032.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___948_6026.FStar_Syntax_Syntax.sigmeta);
+                   (uu___950_6032.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___948_6026.FStar_Syntax_Syntax.sigattrs)
+                   (uu___950_6032.FStar_Syntax_Syntax.sigattrs);
+                 FStar_Syntax_Syntax.sigopts =
+                   (uu___950_6032.FStar_Syntax_Syntax.sigopts)
                }  in
-             let uu____6046 = extract_sig g always_fail1  in
-             (match uu____6046 with
+             let uu____6052 = extract_sig g always_fail1  in
+             (match uu____6052 with
               | (g1,mlm) ->
-                  let uu____6065 =
+                  let uu____6071 =
                     FStar_Util.find_map quals
-                      (fun uu___9_6070  ->
-                         match uu___9_6070 with
+                      (fun uu___9_6076  ->
+                         match uu___9_6076 with
                          | FStar_Syntax_Syntax.Discriminator l ->
                              FStar_Pervasives_Native.Some l
-                         | uu____6074 -> FStar_Pervasives_Native.None)
+                         | uu____6080 -> FStar_Pervasives_Native.None)
                      in
-                  (match uu____6065 with
+                  (match uu____6071 with
                    | FStar_Pervasives_Native.Some l ->
-                       let uu____6082 =
-                         let uu____6085 =
-                           let uu____6086 =
+                       let uu____6088 =
+                         let uu____6091 =
+                           let uu____6092 =
                              FStar_Extraction_ML_Util.mlloc_of_range
                                se.FStar_Syntax_Syntax.sigrng
                               in
-                           FStar_Extraction_ML_Syntax.MLM_Loc uu____6086  in
-                         let uu____6087 =
-                           let uu____6090 =
+                           FStar_Extraction_ML_Syntax.MLM_Loc uu____6092  in
+                         let uu____6093 =
+                           let uu____6096 =
                              FStar_Extraction_ML_Term.ind_discriminator_body
                                g1 lid l
                               in
-                           [uu____6090]  in
-                         uu____6085 :: uu____6087  in
-                       (g1, uu____6082)
-                   | uu____6093 ->
-                       let uu____6096 =
+                           [uu____6096]  in
+                         uu____6091 :: uu____6093  in
+                       (g1, uu____6088)
+                   | uu____6099 ->
+                       let uu____6102 =
                          FStar_Util.find_map quals
-                           (fun uu___10_6102  ->
-                              match uu___10_6102 with
-                              | FStar_Syntax_Syntax.Projector (l,uu____6106)
+                           (fun uu___10_6108  ->
+                              match uu___10_6108 with
+                              | FStar_Syntax_Syntax.Projector (l,uu____6112)
                                   -> FStar_Pervasives_Native.Some l
-                              | uu____6107 -> FStar_Pervasives_Native.None)
+                              | uu____6113 -> FStar_Pervasives_Native.None)
                           in
-                       (match uu____6096 with
-                        | FStar_Pervasives_Native.Some uu____6114 -> (g1, [])
-                        | uu____6117 -> (g1, mlm))))
+                       (match uu____6102 with
+                        | FStar_Pervasives_Native.Some uu____6120 -> (g1, [])
+                        | uu____6123 -> (g1, mlm))))
            else (g, [])
        | FStar_Syntax_Syntax.Sig_main e ->
-           let uu____6127 = FStar_Extraction_ML_Term.term_as_mlexpr g e  in
-           (match uu____6127 with
-            | (ml_main,uu____6141,uu____6142) ->
-                let uu____6143 =
-                  let uu____6146 =
-                    let uu____6147 =
+           let uu____6133 = FStar_Extraction_ML_Term.term_as_mlexpr g e  in
+           (match uu____6133 with
+            | (ml_main,uu____6147,uu____6148) ->
+                let uu____6149 =
+                  let uu____6152 =
+                    let uu____6153 =
                       FStar_Extraction_ML_Util.mlloc_of_range
                         se.FStar_Syntax_Syntax.sigrng
                        in
-                    FStar_Extraction_ML_Syntax.MLM_Loc uu____6147  in
-                  [uu____6146; FStar_Extraction_ML_Syntax.MLM_Top ml_main]
+                    FStar_Extraction_ML_Syntax.MLM_Loc uu____6153  in
+                  [uu____6152; FStar_Extraction_ML_Syntax.MLM_Top ml_main]
                    in
-                (g, uu____6143))
-       | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____6150 ->
+                (g, uu____6149))
+       | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____6156 ->
            failwith "impossible -- removed by tc.fs"
-       | FStar_Syntax_Syntax.Sig_assume uu____6158 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_sub_effect uu____6167 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____6170 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_assume uu____6164 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_sub_effect uu____6173 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____6176 -> (g, [])
        | FStar_Syntax_Syntax.Sig_pragma p ->
            (FStar_Syntax_Util.process_pragma p se.FStar_Syntax_Syntax.sigrng;
             (g, [])))
@@ -2192,74 +2196,74 @@ let (extract' :
   =
   fun g  ->
     fun m  ->
-      let uu____6212 = FStar_Options.restore_cmd_line_options true  in
+      let uu____6218 = FStar_Options.restore_cmd_line_options true  in
       let name =
         FStar_Extraction_ML_Syntax.mlpath_of_lident
           m.FStar_Syntax_Syntax.name
          in
       let g1 =
-        let uu___991_6216 = g  in
-        let uu____6217 =
+        let uu___993_6222 = g  in
+        let uu____6223 =
           FStar_TypeChecker_Env.set_current_module
             g.FStar_Extraction_ML_UEnv.env_tcenv m.FStar_Syntax_Syntax.name
            in
         {
-          FStar_Extraction_ML_UEnv.env_tcenv = uu____6217;
+          FStar_Extraction_ML_UEnv.env_tcenv = uu____6223;
           FStar_Extraction_ML_UEnv.env_bindings =
-            (uu___991_6216.FStar_Extraction_ML_UEnv.env_bindings);
+            (uu___993_6222.FStar_Extraction_ML_UEnv.env_bindings);
           FStar_Extraction_ML_UEnv.env_mlident_map =
-            (uu___991_6216.FStar_Extraction_ML_UEnv.env_mlident_map);
+            (uu___993_6222.FStar_Extraction_ML_UEnv.env_mlident_map);
           FStar_Extraction_ML_UEnv.tydefs =
-            (uu___991_6216.FStar_Extraction_ML_UEnv.tydefs);
+            (uu___993_6222.FStar_Extraction_ML_UEnv.tydefs);
           FStar_Extraction_ML_UEnv.type_names =
-            (uu___991_6216.FStar_Extraction_ML_UEnv.type_names);
+            (uu___993_6222.FStar_Extraction_ML_UEnv.type_names);
           FStar_Extraction_ML_UEnv.currentModule = name
         }  in
-      let uu____6218 =
+      let uu____6224 =
         FStar_Util.fold_map
           (fun g2  ->
              fun se  ->
-               let uu____6237 =
+               let uu____6243 =
                  FStar_Options.debug_module
                    (m.FStar_Syntax_Syntax.name).FStar_Ident.str
                   in
-               if uu____6237
+               if uu____6243
                then
                  let nm =
-                   let uu____6248 =
+                   let uu____6254 =
                      FStar_All.pipe_right
                        (FStar_Syntax_Util.lids_of_sigelt se)
                        (FStar_List.map FStar_Ident.string_of_lid)
                       in
-                   FStar_All.pipe_right uu____6248 (FStar_String.concat ", ")
+                   FStar_All.pipe_right uu____6254 (FStar_String.concat ", ")
                     in
                  (FStar_Util.print1 "+++About to extract {%s}\n" nm;
-                  (let uu____6265 = FStar_Util.format1 "---Extracted {%s}" nm
+                  (let uu____6271 = FStar_Util.format1 "---Extracted {%s}" nm
                       in
-                   FStar_Util.measure_execution_time uu____6265
-                     (fun uu____6275  -> extract_sig g2 se)))
+                   FStar_Util.measure_execution_time uu____6271
+                     (fun uu____6281  -> extract_sig g2 se)))
                else extract_sig g2 se) g1 m.FStar_Syntax_Syntax.declarations
          in
-      match uu____6218 with
+      match uu____6224 with
       | (g2,sigs) ->
           let mlm = FStar_List.flatten sigs  in
           let is_kremlin =
-            let uu____6297 = FStar_Options.codegen ()  in
-            uu____6297 = (FStar_Pervasives_Native.Some FStar_Options.Kremlin)
+            let uu____6303 = FStar_Options.codegen ()  in
+            uu____6303 = (FStar_Pervasives_Native.Some FStar_Options.Kremlin)
              in
           if
             ((m.FStar_Syntax_Syntax.name).FStar_Ident.str <> "Prims") &&
               (is_kremlin ||
                  (Prims.op_Negation m.FStar_Syntax_Syntax.is_interface))
           then
-            ((let uu____6312 =
-                let uu____6314 = FStar_Options.silent ()  in
-                Prims.op_Negation uu____6314  in
-              if uu____6312
+            ((let uu____6318 =
+                let uu____6320 = FStar_Options.silent ()  in
+                Prims.op_Negation uu____6320  in
+              if uu____6318
               then
-                let uu____6317 =
+                let uu____6323 =
                   FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
-                FStar_Util.print1 "Extracted module %s\n" uu____6317
+                FStar_Util.print1 "Extracted module %s\n" uu____6323
               else ());
              (g2,
                (FStar_Pervasives_Native.Some
@@ -2276,42 +2280,42 @@ let (extract :
   =
   fun g  ->
     fun m  ->
-      (let uu____6392 = FStar_Options.restore_cmd_line_options true  in
-       FStar_All.pipe_left (fun a2  -> ()) uu____6392);
-      (let uu____6395 =
-         let uu____6397 =
+      (let uu____6398 = FStar_Options.restore_cmd_line_options true  in
+       FStar_All.pipe_left (fun a2  -> ()) uu____6398);
+      (let uu____6401 =
+         let uu____6403 =
            FStar_Options.should_extract
              (m.FStar_Syntax_Syntax.name).FStar_Ident.str
             in
-         Prims.op_Negation uu____6397  in
-       if uu____6395
+         Prims.op_Negation uu____6403  in
+       if uu____6401
        then
-         let uu____6400 =
-           let uu____6402 =
+         let uu____6406 =
+           let uu____6408 =
              FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
            FStar_Util.format1
              "Extract called on a module %s that should not be extracted"
-             uu____6402
+             uu____6408
             in
-         failwith uu____6400
+         failwith uu____6406
        else ());
-      (let uu____6407 = FStar_Options.interactive ()  in
-       if uu____6407
+      (let uu____6413 = FStar_Options.interactive ()  in
+       if uu____6413
        then (g, FStar_Pervasives_Native.None)
        else
          (let res =
-            let uu____6427 = FStar_Options.debug_any ()  in
-            if uu____6427
+            let uu____6433 = FStar_Options.debug_any ()  in
+            if uu____6433
             then
               let msg =
-                let uu____6438 =
+                let uu____6444 =
                   FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name
                    in
-                FStar_Util.format1 "Extracting module %s\n" uu____6438  in
+                FStar_Util.format1 "Extracting module %s\n" uu____6444  in
               FStar_Util.measure_execution_time msg
-                (fun uu____6448  -> extract' g m)
+                (fun uu____6454  -> extract' g m)
             else extract' g m  in
-          (let uu____6452 = FStar_Options.restore_cmd_line_options true  in
-           FStar_All.pipe_left (fun a3  -> ()) uu____6452);
+          (let uu____6458 = FStar_Options.restore_cmd_line_options true  in
+           FStar_All.pipe_left (fun a3  -> ()) uu____6458);
           res))
   

--- a/src/ocaml-output/FStar_Interactive_Ide.ml
+++ b/src/ocaml-output/FStar_Interactive_Ide.ml
@@ -2257,40 +2257,41 @@ let run_with_parsed_and_tc_term :
                   FStar_Syntax_Syntax.sigrng = uu____6279;
                   FStar_Syntax_Syntax.sigquals = uu____6280;
                   FStar_Syntax_Syntax.sigmeta = uu____6281;
-                  FStar_Syntax_Syntax.sigattrs = uu____6282;_}::[] ->
+                  FStar_Syntax_Syntax.sigattrs = uu____6282;
+                  FStar_Syntax_Syntax.sigopts = uu____6283;_}::[] ->
                   FStar_Pervasives_Native.Some (univs1, def)
-              | uu____6321 -> FStar_Pervasives_Native.None  in
+              | uu____6324 -> FStar_Pervasives_Native.None  in
             let parse1 frag =
-              let uu____6342 =
+              let uu____6345 =
                 FStar_Parser_ParseIt.parse
                   (FStar_Parser_ParseIt.Toplevel frag)
                  in
-              match uu____6342 with
+              match uu____6345 with
               | FStar_Parser_ParseIt.ASTFragment
-                  (FStar_Util.Inr decls,uu____6348) ->
+                  (FStar_Util.Inr decls,uu____6351) ->
                   FStar_Pervasives_Native.Some decls
-              | uu____6369 -> FStar_Pervasives_Native.None  in
+              | uu____6372 -> FStar_Pervasives_Native.None  in
             let desugar env decls =
-              let uu____6387 =
-                let uu____6392 =
+              let uu____6390 =
+                let uu____6395 =
                   FStar_ToSyntax_ToSyntax.decls_to_sigelts decls  in
-                uu____6392 env.FStar_TypeChecker_Env.dsenv  in
-              FStar_Pervasives_Native.fst uu____6387  in
+                uu____6395 env.FStar_TypeChecker_Env.dsenv  in
+              FStar_Pervasives_Native.fst uu____6390  in
             let typecheck tcenv decls =
-              let uu____6414 = FStar_TypeChecker_Tc.tc_decls tcenv decls  in
-              match uu____6414 with | (ses,uu____6428,uu____6429) -> ses  in
+              let uu____6417 = FStar_TypeChecker_Tc.tc_decls tcenv decls  in
+              match uu____6417 with | (ses,uu____6431,uu____6432) -> ses  in
             run_and_rewind st
               (QueryNOK, (FStar_Util.JsonStr "Computation interrupted"))
               (fun st1  ->
                  let tcenv = st1.FStar_Interactive_JsonHelper.repl_env  in
                  let frag = dummy_let_fragment term  in
-                 let uu____6450 = parse1 frag  in
-                 match uu____6450 with
+                 let uu____6453 = parse1 frag  in
+                 match uu____6453 with
                  | FStar_Pervasives_Native.None  ->
                      (QueryNOK,
                        (FStar_Util.JsonStr "Could not parse this term"))
                  | FStar_Pervasives_Native.Some decls ->
-                     let aux uu____6476 =
+                     let aux uu____6479 =
                        let decls1 = desugar tcenv decls  in
                        let ses = typecheck tcenv decls1  in
                        match find_let_body ses with
@@ -2299,9 +2300,9 @@ let run_with_parsed_and_tc_term :
                              (FStar_Util.JsonStr
                                 "Typechecking yielded an unexpected term"))
                        | FStar_Pervasives_Native.Some (univs1,def) ->
-                           let uu____6512 =
+                           let uu____6515 =
                              FStar_Syntax_Subst.open_univ_vars univs1 def  in
-                           (match uu____6512 with
+                           (match uu____6515 with
                             | (univs2,def1) ->
                                 let tcenv1 =
                                   FStar_TypeChecker_Env.push_univ_vars tcenv
@@ -2309,35 +2310,35 @@ let run_with_parsed_and_tc_term :
                                    in
                                 continuation tcenv1 def1)
                         in
-                     let uu____6524 = FStar_Options.trace_error ()  in
-                     if uu____6524
+                     let uu____6527 = FStar_Options.trace_error ()  in
+                     if uu____6527
                      then aux ()
                      else
                        (try
-                          (fun uu___808_6538  -> match () with | () -> aux ())
+                          (fun uu___809_6541  -> match () with | () -> aux ())
                             ()
                         with
-                        | uu___807_6547 ->
-                            let uu____6552 =
-                              FStar_Errors.issue_of_exn uu___807_6547  in
-                            (match uu____6552 with
+                        | uu___808_6550 ->
+                            let uu____6555 =
+                              FStar_Errors.issue_of_exn uu___808_6550  in
+                            (match uu____6555 with
                              | FStar_Pervasives_Native.Some issue ->
-                                 let uu____6560 =
-                                   let uu____6561 =
+                                 let uu____6563 =
+                                   let uu____6564 =
                                      FStar_Errors.format_issue issue  in
-                                   FStar_Util.JsonStr uu____6561  in
-                                 (QueryNOK, uu____6560)
+                                   FStar_Util.JsonStr uu____6564  in
+                                 (QueryNOK, uu____6563)
                              | FStar_Pervasives_Native.None  ->
-                                 FStar_Exn.raise uu___807_6547)))
+                                 FStar_Exn.raise uu___808_6550)))
   
 let run_compute :
-  'Auu____6576 .
+  'Auu____6579 .
     FStar_Interactive_JsonHelper.repl_state ->
       Prims.string ->
         FStar_TypeChecker_Env.step Prims.list FStar_Pervasives_Native.option
           ->
           ((query_status * FStar_Util.json) *
-            (FStar_Interactive_JsonHelper.repl_state,'Auu____6576)
+            (FStar_Interactive_JsonHelper.repl_state,'Auu____6579)
             FStar_Util.either)
   =
   fun st  ->
@@ -2364,13 +2365,13 @@ let run_compute :
           (fun tcenv  ->
              fun def  ->
                let normalized = normalize_term1 tcenv rules1 def  in
-               let uu____6654 =
-                 let uu____6655 =
+               let uu____6657 =
+                 let uu____6658 =
                    FStar_Interactive_QueryHelper.term_to_string tcenv
                      normalized
                     in
-                 FStar_Util.JsonStr uu____6655  in
-               (QueryOK, uu____6654))
+                 FStar_Util.JsonStr uu____6658  in
+               (QueryOK, uu____6657))
   
 type search_term' =
   | NameContainsStr of Prims.string 
@@ -2380,13 +2381,13 @@ and search_term = {
   st_term: search_term' }
 let (uu___is_NameContainsStr : search_term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NameContainsStr _0 -> true | uu____6690 -> false
+    match projectee with | NameContainsStr _0 -> true | uu____6693 -> false
   
 let (__proj__NameContainsStr__item___0 : search_term' -> Prims.string) =
   fun projectee  -> match projectee with | NameContainsStr _0 -> _0 
 let (uu___is_TypeContainsLid : search_term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | TypeContainsLid _0 -> true | uu____6712 -> false
+    match projectee with | TypeContainsLid _0 -> true | uu____6715 -> false
   
 let (__proj__TypeContainsLid__item___0 : search_term' -> FStar_Ident.lid) =
   fun projectee  -> match projectee with | TypeContainsLid _0 -> _0 
@@ -2397,8 +2398,8 @@ let (__proj__Mksearch_term__item__st_negate : search_term -> Prims.bool) =
 let (__proj__Mksearch_term__item__st_term : search_term -> search_term') =
   fun projectee  -> match projectee with | { st_negate; st_term;_} -> st_term 
 let (st_cost : search_term' -> Prims.int) =
-  fun uu___6_6747  ->
-    match uu___6_6747 with
+  fun uu___6_6750  ->
+    match uu___6_6750 with
     | NameContainsStr str -> - (FStar_String.length str)
     | TypeContainsLid lid -> Prims.int_one
   
@@ -2432,26 +2433,26 @@ let (__proj__Mksearch_candidate__item__sc_fvars :
   
 let (sc_of_lid : FStar_Ident.lid -> search_candidate) =
   fun lid  ->
-    let uu____6881 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
-    let uu____6888 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
-    { sc_lid = lid; sc_typ = uu____6881; sc_fvars = uu____6888 }
+    let uu____6884 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
+    let uu____6891 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
+    { sc_lid = lid; sc_typ = uu____6884; sc_fvars = uu____6891 }
   
 let (sc_typ :
   FStar_TypeChecker_Env.env -> search_candidate -> FStar_Syntax_Syntax.typ) =
   fun tcenv  ->
     fun sc  ->
-      let uu____6912 = FStar_ST.op_Bang sc.sc_typ  in
-      match uu____6912 with
+      let uu____6915 = FStar_ST.op_Bang sc.sc_typ  in
+      match uu____6915 with
       | FStar_Pervasives_Native.Some t -> t
       | FStar_Pervasives_Native.None  ->
           let typ =
-            let uu____6940 =
+            let uu____6943 =
               FStar_TypeChecker_Env.try_lookup_lid tcenv sc.sc_lid  in
-            match uu____6940 with
+            match uu____6943 with
             | FStar_Pervasives_Native.None  ->
                 FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
                   FStar_Pervasives_Native.None FStar_Range.dummyRange
-            | FStar_Pervasives_Native.Some ((uu____6959,typ),uu____6961) ->
+            | FStar_Pervasives_Native.Some ((uu____6962,typ),uu____6964) ->
                 typ
              in
           (FStar_ST.op_Colon_Equals sc.sc_typ
@@ -2464,13 +2465,13 @@ let (sc_fvars :
   =
   fun tcenv  ->
     fun sc  ->
-      let uu____7011 = FStar_ST.op_Bang sc.sc_fvars  in
-      match uu____7011 with
+      let uu____7014 = FStar_ST.op_Bang sc.sc_fvars  in
+      match uu____7014 with
       | FStar_Pervasives_Native.Some fv -> fv
       | FStar_Pervasives_Native.None  ->
           let fv =
-            let uu____7055 = sc_typ tcenv sc  in
-            FStar_Syntax_Free.fvars uu____7055  in
+            let uu____7058 = sc_typ tcenv sc  in
+            FStar_Syntax_Free.fvars uu____7058  in
           (FStar_ST.op_Colon_Equals sc.sc_fvars
              (FStar_Pervasives_Native.Some fv);
            fv)
@@ -2480,39 +2481,39 @@ let (json_of_search_result :
   fun tcenv  ->
     fun sc  ->
       let typ_str =
-        let uu____7099 = sc_typ tcenv sc  in
-        FStar_Interactive_QueryHelper.term_to_string tcenv uu____7099  in
-      let uu____7100 =
-        let uu____7108 =
-          let uu____7114 =
-            let uu____7115 =
-              let uu____7117 =
+        let uu____7102 = sc_typ tcenv sc  in
+        FStar_Interactive_QueryHelper.term_to_string tcenv uu____7102  in
+      let uu____7103 =
+        let uu____7111 =
+          let uu____7117 =
+            let uu____7118 =
+              let uu____7120 =
                 FStar_Syntax_DsEnv.shorten_lid
                   tcenv.FStar_TypeChecker_Env.dsenv sc.sc_lid
                  in
-              uu____7117.FStar_Ident.str  in
-            FStar_Util.JsonStr uu____7115  in
-          ("lid", uu____7114)  in
-        [uu____7108; ("type", (FStar_Util.JsonStr typ_str))]  in
-      FStar_Util.JsonAssoc uu____7100
+              uu____7120.FStar_Ident.str  in
+            FStar_Util.JsonStr uu____7118  in
+          ("lid", uu____7117)  in
+        [uu____7111; ("type", (FStar_Util.JsonStr typ_str))]  in
+      FStar_Util.JsonAssoc uu____7103
   
 exception InvalidSearch of Prims.string 
 let (uu___is_InvalidSearch : Prims.exn -> Prims.bool) =
   fun projectee  ->
     match projectee with
-    | InvalidSearch uu____7150 -> true
-    | uu____7153 -> false
+    | InvalidSearch uu____7153 -> true
+    | uu____7156 -> false
   
 let (__proj__InvalidSearch__item__uu___ : Prims.exn -> Prims.string) =
   fun projectee  ->
-    match projectee with | InvalidSearch uu____7163 -> uu____7163
+    match projectee with | InvalidSearch uu____7166 -> uu____7166
   
 let run_search :
-  'Auu____7172 .
+  'Auu____7175 .
     FStar_Interactive_JsonHelper.repl_state ->
       Prims.string ->
         ((query_status * FStar_Util.json) *
-          (FStar_Interactive_JsonHelper.repl_state,'Auu____7172)
+          (FStar_Interactive_JsonHelper.repl_state,'Auu____7175)
           FStar_Util.either)
   =
   fun st  ->
@@ -2525,8 +2526,8 @@ let run_search :
           | NameContainsStr str ->
               FStar_Util.contains (candidate.sc_lid).FStar_Ident.str str
           | TypeContainsLid lid ->
-              let uu____7219 = sc_fvars tcenv candidate  in
-              FStar_Util.set_mem lid uu____7219
+              let uu____7222 = sc_fvars tcenv candidate  in
+              FStar_Util.set_mem lid uu____7222
            in
         found <> term.st_negate  in
       let parse1 search_str1 =
@@ -2548,32 +2549,32 @@ let run_search :
           let parsed =
             if beg_quote <> end_quote
             then
-              let uu____7278 =
-                let uu____7279 =
+              let uu____7281 =
+                let uu____7282 =
                   FStar_Util.format1 "Improperly quoted search term: %s"
                     term1
                    in
-                InvalidSearch uu____7279  in
-              FStar_Exn.raise uu____7278
+                InvalidSearch uu____7282  in
+              FStar_Exn.raise uu____7281
             else
               if beg_quote
               then
-                (let uu____7285 = strip_quotes term1  in
-                 NameContainsStr uu____7285)
+                (let uu____7288 = strip_quotes term1  in
+                 NameContainsStr uu____7288)
               else
                 (let lid = FStar_Ident.lid_of_str term1  in
-                 let uu____7290 =
+                 let uu____7293 =
                    FStar_Syntax_DsEnv.resolve_to_fully_qualified_name
                      tcenv.FStar_TypeChecker_Env.dsenv lid
                     in
-                 match uu____7290 with
+                 match uu____7293 with
                  | FStar_Pervasives_Native.None  ->
-                     let uu____7293 =
-                       let uu____7294 =
+                     let uu____7296 =
+                       let uu____7297 =
                          FStar_Util.format1 "Unknown identifier: %s" term1
                           in
-                       InvalidSearch uu____7294  in
-                     FStar_Exn.raise uu____7293
+                       InvalidSearch uu____7297  in
+                     FStar_Exn.raise uu____7296
                  | FStar_Pervasives_Native.Some lid1 -> TypeContainsLid lid1)
              in
           { st_negate = negate; st_term = parsed }  in
@@ -2582,15 +2583,15 @@ let run_search :
         let cmp x y = (st_cost x.st_term) - (st_cost y.st_term)  in
         FStar_Util.sort_with cmp terms  in
       let pprint_one term =
-        let uu____7322 =
+        let uu____7325 =
           match term.st_term with
           | NameContainsStr s -> FStar_Util.format1 "\"%s\"" s
           | TypeContainsLid l -> FStar_Util.format1 "%s" l.FStar_Ident.str
            in
-        Prims.op_Hat (if term.st_negate then "-" else "") uu____7322  in
+        Prims.op_Hat (if term.st_negate then "-" else "") uu____7325  in
       let results =
         try
-          (fun uu___921_7356  ->
+          (fun uu___922_7359  ->
              match () with
              | () ->
                  let terms = parse1 search_str  in
@@ -2611,16 +2612,16 @@ let run_search :
                  (match results with
                   | [] ->
                       let kwds =
-                        let uu____7404 = FStar_List.map pprint_one terms  in
-                        FStar_Util.concat_l " " uu____7404  in
-                      let uu____7410 =
-                        let uu____7411 =
+                        let uu____7407 = FStar_List.map pprint_one terms  in
+                        FStar_Util.concat_l " " uu____7407  in
+                      let uu____7413 =
+                        let uu____7414 =
                           FStar_Util.format1
                             "No results found for query [%s]" kwds
                            in
-                        InvalidSearch uu____7411  in
-                      FStar_Exn.raise uu____7410
-                  | uu____7418 -> (QueryOK, (FStar_Util.JsonList js)))) ()
+                        InvalidSearch uu____7414  in
+                      FStar_Exn.raise uu____7413
+                  | uu____7421 -> (QueryOK, (FStar_Util.JsonList js)))) ()
         with | InvalidSearch s -> (QueryNOK, (FStar_Util.JsonStr s))  in
       (results, (FStar_Util.Inl st))
   
@@ -2657,8 +2658,8 @@ let (validate_query :
       match q.qq with
       | Push
           { push_kind = FStar_Interactive_PushHelper.SyntaxCheck ;
-            push_code = uu____7549; push_line = uu____7550;
-            push_column = uu____7551; push_peek_only = false ;_}
+            push_code = uu____7552; push_line = uu____7553;
+            push_column = uu____7554; push_peek_only = false ;_}
           ->
           {
             qq =
@@ -2666,12 +2667,12 @@ let (validate_query :
                  "Cannot use 'kind': 'syntax' with 'query': 'push'");
             qid = (q.qid)
           }
-      | uu____7557 ->
+      | uu____7560 ->
           (match st.FStar_Interactive_JsonHelper.repl_curmod with
            | FStar_Pervasives_Native.None  when
                query_needs_current_module q.qq ->
                { qq = (GenericError "Current module unset"); qid = (q.qid) }
-           | uu____7559 -> q)
+           | uu____7562 -> q)
   
 let (validate_and_run_query :
   FStar_Interactive_JsonHelper.repl_state ->
@@ -2695,8 +2696,8 @@ let (js_repl_eval :
   =
   fun st  ->
     fun query  ->
-      let uu____7632 = validate_and_run_query st query  in
-      match uu____7632 with
+      let uu____7635 = validate_and_run_query st query  in
+      match uu____7635 with
       | ((status,response),st_opt) ->
           let js_response = json_of_response query.qid status response  in
           (js_response, st_opt)
@@ -2709,8 +2710,8 @@ let (js_repl_eval_js :
   =
   fun st  ->
     fun query_js  ->
-      let uu____7698 = deserialize_interactive_query query_js  in
-      js_repl_eval st uu____7698
+      let uu____7701 = deserialize_interactive_query query_js  in
+      js_repl_eval st uu____7701
   
 let (js_repl_eval_str :
   FStar_Interactive_JsonHelper.repl_state ->
@@ -2720,18 +2721,18 @@ let (js_repl_eval_str :
   =
   fun st  ->
     fun query_str  ->
-      let uu____7722 =
-        let uu____7732 = parse_interactive_query query_str  in
-        js_repl_eval st uu____7732  in
-      match uu____7722 with
+      let uu____7725 =
+        let uu____7735 = parse_interactive_query query_str  in
+        js_repl_eval st uu____7735  in
+      match uu____7725 with
       | (js_response,st_opt) ->
-          let uu____7755 = FStar_Util.string_of_json js_response  in
-          (uu____7755, st_opt)
+          let uu____7758 = FStar_Util.string_of_json js_response  in
+          (uu____7758, st_opt)
   
 let (js_repl_init_opts : unit -> unit) =
-  fun uu____7768  ->
-    let uu____7769 = FStar_Options.parse_cmd_line ()  in
-    match uu____7769 with
+  fun uu____7771  ->
+    let uu____7772 = FStar_Options.parse_cmd_line ()  in
+    match uu____7772 with
     | (res,fnames) ->
         (match res with
          | FStar_Getopt.Error msg ->
@@ -2742,17 +2743,17 @@ let (js_repl_init_opts : unit -> unit) =
               | [] ->
                   failwith
                     "repl_init: No file name given in --ide invocation"
-              | h::uu____7792::uu____7793 ->
+              | h::uu____7795::uu____7796 ->
                   failwith
                     "repl_init: Too many file names given in --ide invocation"
-              | uu____7802 -> ()))
+              | uu____7805 -> ()))
   
 let rec (go : FStar_Interactive_JsonHelper.repl_state -> Prims.int) =
   fun st  ->
     let query =
       read_interactive_query st.FStar_Interactive_JsonHelper.repl_stdin  in
-    let uu____7815 = validate_and_run_query st query  in
-    match uu____7815 with
+    let uu____7818 = validate_and_run_query st query  in
+    match uu____7818 with
     | ((status,response),state_opt) ->
         (write_response query.qid status response;
          (match state_opt with
@@ -2762,21 +2763,21 @@ let rec (go : FStar_Interactive_JsonHelper.repl_state -> Prims.int) =
 let (interactive_error_handler : FStar_Errors.error_handler) =
   let issues = FStar_Util.mk_ref []  in
   let add_one1 e =
-    let uu____7868 =
-      let uu____7871 = FStar_ST.op_Bang issues  in e :: uu____7871  in
-    FStar_ST.op_Colon_Equals issues uu____7868  in
-  let count_errors uu____7925 =
-    let uu____7926 =
-      let uu____7929 = FStar_ST.op_Bang issues  in
+    let uu____7871 =
+      let uu____7874 = FStar_ST.op_Bang issues  in e :: uu____7874  in
+    FStar_ST.op_Colon_Equals issues uu____7871  in
+  let count_errors uu____7928 =
+    let uu____7929 =
+      let uu____7932 = FStar_ST.op_Bang issues  in
       FStar_List.filter
         (fun e  -> e.FStar_Errors.issue_level = FStar_Errors.EError)
-        uu____7929
+        uu____7932
        in
-    FStar_List.length uu____7926  in
-  let report uu____7964 =
-    let uu____7965 = FStar_ST.op_Bang issues  in
-    FStar_List.sortWith FStar_Errors.compare_issues uu____7965  in
-  let clear1 uu____7996 = FStar_ST.op_Colon_Equals issues []  in
+    FStar_List.length uu____7929  in
+  let report uu____7967 =
+    let uu____7968 = FStar_ST.op_Bang issues  in
+    FStar_List.sortWith FStar_Errors.compare_issues uu____7968  in
+  let clear1 uu____7999 = FStar_ST.op_Colon_Equals issues []  in
   {
     FStar_Errors.eh_add_one = add_one1;
     FStar_Errors.eh_count_errors = count_errors;
@@ -2796,8 +2797,8 @@ let (interactive_printer : (FStar_Util.json -> unit) -> FStar_Util.printer) =
         (fun label  ->
            fun get_string  ->
              fun get_json  ->
-               let uu____8057 = get_json ()  in
-               forward_message printer label uu____8057)
+               let uu____8060 = get_json ()  in
+               forward_message printer label uu____8060)
     }
   
 let (install_ide_mode_hooks : (FStar_Util.json -> unit) -> unit) =
@@ -2806,15 +2807,15 @@ let (install_ide_mode_hooks : (FStar_Util.json -> unit) -> unit) =
     FStar_Errors.set_handler interactive_error_handler
   
 let (initial_range : FStar_Range.range) =
-  let uu____8071 = FStar_Range.mk_pos Prims.int_one Prims.int_zero  in
   let uu____8074 = FStar_Range.mk_pos Prims.int_one Prims.int_zero  in
-  FStar_Range.mk_range "<input>" uu____8071 uu____8074 
+  let uu____8077 = FStar_Range.mk_pos Prims.int_one Prims.int_zero  in
+  FStar_Range.mk_range "<input>" uu____8074 uu____8077 
 let (build_initial_repl_state :
   Prims.string -> FStar_Interactive_JsonHelper.repl_state) =
   fun filename  ->
     let env = FStar_Universal.init_env FStar_Parser_Dep.empty_deps  in
     let env1 = FStar_TypeChecker_Env.set_range env initial_range  in
-    let uu____8088 = FStar_Util.open_stdin ()  in
+    let uu____8091 = FStar_Util.open_stdin ()  in
     {
       FStar_Interactive_JsonHelper.repl_line = Prims.int_one;
       FStar_Interactive_JsonHelper.repl_column = Prims.int_zero;
@@ -2822,25 +2823,25 @@ let (build_initial_repl_state :
       FStar_Interactive_JsonHelper.repl_deps_stack = [];
       FStar_Interactive_JsonHelper.repl_curmod = FStar_Pervasives_Native.None;
       FStar_Interactive_JsonHelper.repl_env = env1;
-      FStar_Interactive_JsonHelper.repl_stdin = uu____8088;
+      FStar_Interactive_JsonHelper.repl_stdin = uu____8091;
       FStar_Interactive_JsonHelper.repl_names =
         FStar_Interactive_CompletionTable.empty
     }
   
 let interactive_mode' :
-  'Auu____8104 . FStar_Interactive_JsonHelper.repl_state -> 'Auu____8104 =
+  'Auu____8107 . FStar_Interactive_JsonHelper.repl_state -> 'Auu____8107 =
   fun init_st  ->
     write_hello ();
     (let exit_code =
-       let uu____8113 =
+       let uu____8116 =
          (FStar_Options.record_hints ()) || (FStar_Options.use_hints ())  in
-       if uu____8113
+       if uu____8116
        then
-         let uu____8117 =
-           let uu____8119 = FStar_Options.file_list ()  in
-           FStar_List.hd uu____8119  in
-         FStar_SMTEncoding_Solver.with_hints_db uu____8117
-           (fun uu____8126  -> go init_st)
+         let uu____8120 =
+           let uu____8122 = FStar_Options.file_list ()  in
+           FStar_List.hd uu____8122  in
+         FStar_SMTEncoding_Solver.with_hints_db uu____8120
+           (fun uu____8129  -> go init_st)
        else go init_st  in
      FStar_All.exit exit_code)
   
@@ -2848,24 +2849,24 @@ let (interactive_mode : Prims.string -> unit) =
   fun filename  ->
     install_ide_mode_hooks FStar_Interactive_JsonHelper.write_json;
     FStar_Util.set_sigint_handler FStar_Util.sigint_ignore;
-    (let uu____8140 =
-       let uu____8142 = FStar_Options.codegen ()  in
-       FStar_Option.isSome uu____8142  in
-     if uu____8140
+    (let uu____8143 =
+       let uu____8145 = FStar_Options.codegen ()  in
+       FStar_Option.isSome uu____8145  in
+     if uu____8143
      then
        FStar_Errors.log_issue FStar_Range.dummyRange
          (FStar_Errors.Warning_IDEIgnoreCodeGen, "--ide: ignoring --codegen")
      else ());
     (let init1 = build_initial_repl_state filename  in
-     let uu____8151 = FStar_Options.trace_error ()  in
-     if uu____8151
+     let uu____8154 = FStar_Options.trace_error ()  in
+     if uu____8154
      then interactive_mode' init1
      else
        (try
-          (fun uu___1069_8157  ->
+          (fun uu___1070_8160  ->
              match () with | () -> interactive_mode' init1) ()
         with
-        | uu___1068_8160 ->
+        | uu___1069_8163 ->
             (FStar_Errors.set_handler FStar_Errors.default_handler;
-             FStar_Exn.raise uu___1068_8160)))
+             FStar_Exn.raise uu___1069_8163)))
   

--- a/src/ocaml-output/FStar_Main.ml
+++ b/src/ocaml-output/FStar_Main.ml
@@ -274,6 +274,8 @@ let (lazy_chooser :
           FStar_Reflection_Embeddings.unfold_lazy_bv i
       | FStar_Syntax_Syntax.Lazy_binder  ->
           FStar_Reflection_Embeddings.unfold_lazy_binder i
+      | FStar_Syntax_Syntax.Lazy_optionstate  ->
+          FStar_Reflection_Embeddings.unfold_lazy_optionstate i
       | FStar_Syntax_Syntax.Lazy_fvar  ->
           FStar_Reflection_Embeddings.unfold_lazy_fvar i
       | FStar_Syntax_Syntax.Lazy_comp  ->
@@ -300,72 +302,74 @@ let (setup_hooks : unit -> unit) =
     FStar_ST.op_Colon_Equals FStar_Syntax_Util.tts_f
       (FStar_Pervasives_Native.Some FStar_Syntax_Print.term_to_string);
     FStar_ST.op_Colon_Equals FStar_TypeChecker_Normalize.unembed_binder_knot
-      (FStar_Pervasives_Native.Some FStar_Reflection_Embeddings.e_binder)
+      (FStar_Pervasives_Native.Some FStar_Reflection_Embeddings.e_binder);
+    FStar_ST.op_Colon_Equals FStar_TypeChecker_Tc.unembed_optionstate_knot
+      (FStar_Pervasives_Native.Some FStar_Reflection_Embeddings.e_optionstate)
   
 let (handle_error : Prims.exn -> unit) =
   fun e  ->
     if FStar_Errors.handleable e then FStar_Errors.err_exn e else ();
-    (let uu____744 = FStar_Options.trace_error ()  in
-     if uu____744
+    (let uu____775 = FStar_Options.trace_error ()  in
+     if uu____775
      then
-       let uu____747 = FStar_Util.message_of_exn e  in
-       let uu____749 = FStar_Util.trace_of_exn e  in
-       FStar_Util.print2_error "Unexpected error\n%s\n%s\n" uu____747
-         uu____749
+       let uu____778 = FStar_Util.message_of_exn e  in
+       let uu____780 = FStar_Util.trace_of_exn e  in
+       FStar_Util.print2_error "Unexpected error\n%s\n%s\n" uu____778
+         uu____780
      else
        if Prims.op_Negation (FStar_Errors.handleable e)
        then
-         (let uu____755 = FStar_Util.message_of_exn e  in
+         (let uu____786 = FStar_Util.message_of_exn e  in
           FStar_Util.print1_error
             "Unexpected error; please file a bug report, ideally with a minimized version of the source program that triggered the error.\n%s\n"
-            uu____755)
+            uu____786)
        else ());
     cleanup ();
     report_errors []
   
 let (main : unit -> unit) =
-  fun uu____771  ->
+  fun uu____802  ->
     try
-      (fun uu___121_781  ->
+      (fun uu___124_812  ->
          match () with
          | () ->
              (setup_hooks ();
-              (let uu____783 = FStar_Util.record_time go  in
-               match uu____783 with
-               | (uu____789,time) ->
-                   let uu____793 =
+              (let uu____814 = FStar_Util.record_time go  in
+               match uu____814 with
+               | (uu____820,time) ->
+                   let uu____824 =
                      (FStar_Options.print ()) ||
                        (FStar_Options.print_in_place ())
                       in
-                   if uu____793
+                   if uu____824
                    then
-                     let uu____796 = FStar_ST.op_Bang fstar_files  in
-                     (match uu____796 with
+                     let uu____827 = FStar_ST.op_Bang fstar_files  in
+                     (match uu____827 with
                       | FStar_Pervasives_Native.Some filenames ->
                           let printing_mode =
-                            let uu____839 = FStar_Options.print ()  in
-                            if uu____839
+                            let uu____870 = FStar_Options.print ()  in
+                            if uu____870
                             then FStar_Prettyprint.FromTempToStdout
                             else FStar_Prettyprint.FromTempToFile  in
                           FStar_Prettyprint.generate printing_mode filenames
                       | FStar_Pervasives_Native.None  ->
                           (FStar_Util.print_error
                              "Internal error: List of source files not properly set";
-                           (let uu____850 = FStar_Options.query_stats ()  in
-                            if uu____850
+                           (let uu____881 = FStar_Options.query_stats ()  in
+                            if uu____881
                             then
-                              let uu____853 = FStar_Util.string_of_int time
+                              let uu____884 = FStar_Util.string_of_int time
                                  in
-                              let uu____855 =
-                                let uu____857 = FStar_Getopt.cmdline ()  in
-                                FStar_String.concat " " uu____857  in
+                              let uu____886 =
+                                let uu____888 = FStar_Getopt.cmdline ()  in
+                                FStar_String.concat " " uu____888  in
                               FStar_Util.print2 "TOTAL TIME %s ms: %s\n"
-                                uu____853 uu____855
+                                uu____884 uu____886
                             else ());
                            cleanup ();
                            FStar_All.exit Prims.int_zero))
                    else ()))) ()
     with
-    | uu___120_871 ->
-        (handle_error uu___120_871; FStar_All.exit Prims.int_one)
+    | uu___123_902 ->
+        (handle_error uu___123_902; FStar_All.exit Prims.int_one)
   

--- a/src/ocaml-output/FStar_Options.ml
+++ b/src/ocaml-output/FStar_Options.ml
@@ -171,91 +171,95 @@ let (internal_peek : unit -> optionstate) =
       FStar_List.hd uu____592  in
     FStar_List.hd uu____589
   
-let (peek : unit -> optionstate) = fun uu____631  -> internal_peek () 
+let (peek : unit -> optionstate) =
+  fun uu____631  ->
+    let uu____632 = internal_peek ()  in copy_optionstate uu____632
+  
 let (pop : unit -> unit) =
-  fun uu____637  ->
-    let uu____638 = FStar_ST.op_Bang fstar_options  in
-    match uu____638 with
+  fun uu____640  ->
+    let uu____641 = FStar_ST.op_Bang fstar_options  in
+    match uu____641 with
     | [] -> failwith "TOO MANY POPS!"
-    | uu____673::[] -> failwith "TOO MANY POPS!"
-    | uu____681::tl1 -> FStar_ST.op_Colon_Equals fstar_options tl1
+    | uu____676::[] -> failwith "TOO MANY POPS!"
+    | uu____684::tl1 -> FStar_ST.op_Colon_Equals fstar_options tl1
   
 let (push : unit -> unit) =
-  fun uu____723  ->
-    let uu____724 =
-      let uu____729 =
-        let uu____732 =
-          let uu____735 = FStar_ST.op_Bang fstar_options  in
-          FStar_List.hd uu____735  in
-        FStar_List.map copy_optionstate uu____732  in
-      let uu____769 = FStar_ST.op_Bang fstar_options  in uu____729 ::
-        uu____769
+  fun uu____726  ->
+    let uu____727 =
+      let uu____732 =
+        let uu____735 =
+          let uu____738 = FStar_ST.op_Bang fstar_options  in
+          FStar_List.hd uu____738  in
+        FStar_List.map copy_optionstate uu____735  in
+      let uu____772 = FStar_ST.op_Bang fstar_options  in uu____732 ::
+        uu____772
        in
-    FStar_ST.op_Colon_Equals fstar_options uu____724
+    FStar_ST.op_Colon_Equals fstar_options uu____727
   
 let (internal_pop : unit -> Prims.bool) =
-  fun uu____836  ->
+  fun uu____839  ->
     let curstack =
-      let uu____840 = FStar_ST.op_Bang fstar_options  in
-      FStar_List.hd uu____840  in
+      let uu____843 = FStar_ST.op_Bang fstar_options  in
+      FStar_List.hd uu____843  in
     match curstack with
     | [] -> failwith "impossible: empty current option stack"
-    | uu____877::[] -> false
-    | uu____879::tl1 ->
-        ((let uu____884 =
-            let uu____889 =
-              let uu____894 = FStar_ST.op_Bang fstar_options  in
-              FStar_List.tl uu____894  in
-            tl1 :: uu____889  in
-          FStar_ST.op_Colon_Equals fstar_options uu____884);
+    | uu____880::[] -> false
+    | uu____882::tl1 ->
+        ((let uu____887 =
+            let uu____892 =
+              let uu____897 = FStar_ST.op_Bang fstar_options  in
+              FStar_List.tl uu____897  in
+            tl1 :: uu____892  in
+          FStar_ST.op_Colon_Equals fstar_options uu____887);
          true)
   
 let (internal_push : unit -> unit) =
-  fun uu____963  ->
+  fun uu____966  ->
     let curstack =
-      let uu____967 = FStar_ST.op_Bang fstar_options  in
-      FStar_List.hd uu____967  in
+      let uu____970 = FStar_ST.op_Bang fstar_options  in
+      FStar_List.hd uu____970  in
     let stack' =
-      let uu____1004 =
-        let uu____1005 = FStar_List.hd curstack  in
-        copy_optionstate uu____1005  in
-      uu____1004 :: curstack  in
-    let uu____1008 =
-      let uu____1013 =
-        let uu____1018 = FStar_ST.op_Bang fstar_options  in
-        FStar_List.tl uu____1018  in
-      stack' :: uu____1013  in
-    FStar_ST.op_Colon_Equals fstar_options uu____1008
+      let uu____1007 =
+        let uu____1008 = FStar_List.hd curstack  in
+        copy_optionstate uu____1008  in
+      uu____1007 :: curstack  in
+    let uu____1011 =
+      let uu____1016 =
+        let uu____1021 = FStar_ST.op_Bang fstar_options  in
+        FStar_List.tl uu____1021  in
+      stack' :: uu____1016  in
+    FStar_ST.op_Colon_Equals fstar_options uu____1011
   
 let (set : optionstate -> unit) =
   fun o  ->
-    let uu____1087 = FStar_ST.op_Bang fstar_options  in
-    match uu____1087 with
+    let uu____1090 = FStar_ST.op_Bang fstar_options  in
+    match uu____1090 with
     | [] -> failwith "set on empty option stack"
-    | []::uu____1122 -> failwith "set on empty current option stack"
-    | (uu____1130::tl1)::os ->
+    | []::uu____1125 -> failwith "set on empty current option stack"
+    | (uu____1133::tl1)::os ->
         FStar_ST.op_Colon_Equals fstar_options ((o :: tl1) :: os)
   
 let (snapshot : unit -> (Prims.int * unit)) =
-  fun uu____1180  -> FStar_Common.snapshot push fstar_options () 
+  fun uu____1183  -> FStar_Common.snapshot push fstar_options () 
 let (rollback : Prims.int FStar_Pervasives_Native.option -> unit) =
   fun depth  -> FStar_Common.rollback pop fstar_options depth 
 let (set_option : Prims.string -> option_val -> unit) =
   fun k  ->
     fun v1  ->
-      let uu____1210 = peek ()  in FStar_Util.smap_add uu____1210 k v1
+      let uu____1213 = internal_peek ()  in
+      FStar_Util.smap_add uu____1213 k v1
   
 let (set_option' : (Prims.string * option_val) -> unit) =
-  fun uu____1223  -> match uu____1223 with | (k,v1) -> set_option k v1 
+  fun uu____1226  -> match uu____1226 with | (k,v1) -> set_option k v1 
 let (light_off_files : Prims.string Prims.list FStar_ST.ref) =
   FStar_Util.mk_ref [] 
 let (add_light_off_file : Prims.string -> unit) =
   fun filename  ->
-    let uu____1251 =
-      let uu____1255 = FStar_ST.op_Bang light_off_files  in filename ::
-        uu____1255
+    let uu____1254 =
+      let uu____1258 = FStar_ST.op_Bang light_off_files  in filename ::
+        uu____1258
        in
-    FStar_ST.op_Colon_Equals light_off_files uu____1251
+    FStar_ST.op_Colon_Equals light_off_files uu____1254
   
 let (defaults : (Prims.string * option_val) Prims.list) =
   [("__temp_no_proj", (List []));
@@ -376,14 +380,14 @@ let (parse_warn_error_set_get :
   =
   let r = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
   let set1 f =
-    let uu____2253 = FStar_ST.op_Bang r  in
-    match uu____2253 with
+    let uu____2256 = FStar_ST.op_Bang r  in
+    match uu____2256 with
     | FStar_Pervasives_Native.None  ->
         FStar_ST.op_Colon_Equals r (FStar_Pervasives_Native.Some f)
-    | uu____2344 -> failwith "Multiple initialization of FStar.Options"  in
-  let get1 uu____2365 =
-    let uu____2366 = FStar_ST.op_Bang r  in
-    match uu____2366 with
+    | uu____2347 -> failwith "Multiple initialization of FStar.Options"  in
+  let get1 uu____2368 =
+    let uu____2369 = FStar_ST.op_Bang r  in
+    match uu____2369 with
     | FStar_Pervasives_Native.Some f -> f
     | FStar_Pervasives_Native.None  ->
         failwith "FStar.Options is improperly initialized"
@@ -394,18 +398,18 @@ let (initialize_parse_warn_error :
   fun f  -> FStar_Pervasives_Native.fst parse_warn_error_set_get f 
 let (parse_warn_error : Prims.string -> error_flag Prims.list) =
   fun s  ->
-    let uu____2505 = FStar_Pervasives_Native.snd parse_warn_error_set_get ()
+    let uu____2508 = FStar_Pervasives_Native.snd parse_warn_error_set_get ()
        in
-    uu____2505 s
+    uu____2508 s
   
 let (init : unit -> unit) =
-  fun uu____2536  ->
-    let o = peek ()  in
+  fun uu____2539  ->
+    let o = internal_peek ()  in
     FStar_Util.smap_clear o;
     FStar_All.pipe_right defaults (FStar_List.iter set_option')
   
 let (clear : unit -> unit) =
-  fun uu____2556  ->
+  fun uu____2559  ->
     let o = FStar_Util.smap_create (Prims.of_int (50))  in
     FStar_ST.op_Colon_Equals fstar_options [[o]];
     FStar_ST.op_Colon_Equals light_off_files [];
@@ -414,259 +418,260 @@ let (clear : unit -> unit) =
 let (_run : unit) = clear () 
 let (get_option : Prims.string -> option_val) =
   fun s  ->
-    let uu____2629 =
-      let uu____2632 = peek ()  in FStar_Util.smap_try_find uu____2632 s  in
-    match uu____2629 with
+    let uu____2632 =
+      let uu____2635 = internal_peek ()  in
+      FStar_Util.smap_try_find uu____2635 s  in
+    match uu____2632 with
     | FStar_Pervasives_Native.None  ->
-        let uu____2635 =
-          let uu____2637 = FStar_String.op_Hat s " not found"  in
-          FStar_String.op_Hat "Impossible: option " uu____2637  in
-        failwith uu____2635
+        let uu____2638 =
+          let uu____2640 = FStar_String.op_Hat s " not found"  in
+          FStar_String.op_Hat "Impossible: option " uu____2640  in
+        failwith uu____2638
     | FStar_Pervasives_Native.Some s1 -> s1
   
 let lookup_opt :
-  'Auu____2649 . Prims.string -> (option_val -> 'Auu____2649) -> 'Auu____2649
-  = fun s  -> fun c  -> let uu____2667 = get_option s  in c uu____2667 
+  'Auu____2652 . Prims.string -> (option_val -> 'Auu____2652) -> 'Auu____2652
+  = fun s  -> fun c  -> let uu____2670 = get_option s  in c uu____2670 
 let (get_abort_on : unit -> Prims.int) =
-  fun uu____2674  -> lookup_opt "abort_on" as_int 
+  fun uu____2677  -> lookup_opt "abort_on" as_int 
 let (get_admit_smt_queries : unit -> Prims.bool) =
-  fun uu____2683  -> lookup_opt "admit_smt_queries" as_bool 
+  fun uu____2686  -> lookup_opt "admit_smt_queries" as_bool 
 let (get_admit_except : unit -> Prims.string FStar_Pervasives_Native.option)
-  = fun uu____2694  -> lookup_opt "admit_except" (as_option as_string) 
+  = fun uu____2697  -> lookup_opt "admit_except" (as_option as_string) 
 let (get_already_cached :
   unit -> Prims.string Prims.list FStar_Pervasives_Native.option) =
-  fun uu____2710  ->
+  fun uu____2713  ->
     lookup_opt "already_cached" (as_option (as_list as_string))
   
 let (get_cache_checked_modules : unit -> Prims.bool) =
-  fun uu____2727  -> lookup_opt "cache_checked_modules" as_bool 
+  fun uu____2730  -> lookup_opt "cache_checked_modules" as_bool 
 let (get_cache_dir : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____2738  -> lookup_opt "cache_dir" (as_option as_string) 
+  fun uu____2741  -> lookup_opt "cache_dir" (as_option as_string) 
 let (get_cache_off : unit -> Prims.bool) =
-  fun uu____2750  -> lookup_opt "cache_off" as_bool 
+  fun uu____2753  -> lookup_opt "cache_off" as_bool 
 let (get_cmi : unit -> Prims.bool) =
-  fun uu____2759  -> lookup_opt "cmi" as_bool 
+  fun uu____2762  -> lookup_opt "cmi" as_bool 
 let (get_codegen : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____2770  -> lookup_opt "codegen" (as_option as_string) 
+  fun uu____2773  -> lookup_opt "codegen" (as_option as_string) 
 let (get_codegen_lib : unit -> Prims.string Prims.list) =
-  fun uu____2784  -> lookup_opt "codegen-lib" (as_list as_string) 
+  fun uu____2787  -> lookup_opt "codegen-lib" (as_list as_string) 
 let (get_debug : unit -> Prims.string Prims.list) =
-  fun uu____2798  -> lookup_opt "debug" (as_list as_string) 
+  fun uu____2801  -> lookup_opt "debug" (as_list as_string) 
 let (get_debug_level : unit -> Prims.string Prims.list) =
-  fun uu____2812  -> lookup_opt "debug_level" as_comma_string_list 
+  fun uu____2815  -> lookup_opt "debug_level" as_comma_string_list 
 let (get_defensive : unit -> Prims.string) =
-  fun uu____2823  -> lookup_opt "defensive" as_string 
+  fun uu____2826  -> lookup_opt "defensive" as_string 
 let (get_dep : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____2834  -> lookup_opt "dep" (as_option as_string) 
+  fun uu____2837  -> lookup_opt "dep" (as_option as_string) 
 let (get_detail_errors : unit -> Prims.bool) =
-  fun uu____2846  -> lookup_opt "detail_errors" as_bool 
+  fun uu____2849  -> lookup_opt "detail_errors" as_bool 
 let (get_detail_hint_replay : unit -> Prims.bool) =
-  fun uu____2855  -> lookup_opt "detail_hint_replay" as_bool 
+  fun uu____2858  -> lookup_opt "detail_hint_replay" as_bool 
 let (get_doc : unit -> Prims.bool) =
-  fun uu____2864  -> lookup_opt "doc" as_bool 
+  fun uu____2867  -> lookup_opt "doc" as_bool 
 let (get_dump_module : unit -> Prims.string Prims.list) =
-  fun uu____2875  -> lookup_opt "dump_module" (as_list as_string) 
+  fun uu____2878  -> lookup_opt "dump_module" (as_list as_string) 
 let (get_eager_subtyping : unit -> Prims.bool) =
-  fun uu____2887  -> lookup_opt "eager_subtyping" as_bool 
+  fun uu____2890  -> lookup_opt "eager_subtyping" as_bool 
 let (get_expose_interfaces : unit -> Prims.bool) =
-  fun uu____2896  -> lookup_opt "expose_interfaces" as_bool 
+  fun uu____2899  -> lookup_opt "expose_interfaces" as_bool 
 let (get_extract :
   unit -> Prims.string Prims.list FStar_Pervasives_Native.option) =
-  fun uu____2909  -> lookup_opt "extract" (as_option (as_list as_string)) 
+  fun uu____2912  -> lookup_opt "extract" (as_option (as_list as_string)) 
 let (get_extract_module : unit -> Prims.string Prims.list) =
-  fun uu____2928  -> lookup_opt "extract_module" (as_list as_string) 
+  fun uu____2931  -> lookup_opt "extract_module" (as_list as_string) 
 let (get_extract_namespace : unit -> Prims.string Prims.list) =
-  fun uu____2942  -> lookup_opt "extract_namespace" (as_list as_string) 
+  fun uu____2945  -> lookup_opt "extract_namespace" (as_list as_string) 
 let (get_fs_typ_app : unit -> Prims.bool) =
-  fun uu____2954  -> lookup_opt "fs_typ_app" as_bool 
+  fun uu____2957  -> lookup_opt "fs_typ_app" as_bool 
 let (get_hide_uvar_nums : unit -> Prims.bool) =
-  fun uu____2963  -> lookup_opt "hide_uvar_nums" as_bool 
+  fun uu____2966  -> lookup_opt "hide_uvar_nums" as_bool 
 let (get_hint_info : unit -> Prims.bool) =
-  fun uu____2972  -> lookup_opt "hint_info" as_bool 
+  fun uu____2975  -> lookup_opt "hint_info" as_bool 
 let (get_hint_dir : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____2983  -> lookup_opt "hint_dir" (as_option as_string) 
+  fun uu____2986  -> lookup_opt "hint_dir" (as_option as_string) 
 let (get_hint_file : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____2997  -> lookup_opt "hint_file" (as_option as_string) 
+  fun uu____3000  -> lookup_opt "hint_file" (as_option as_string) 
 let (get_in : unit -> Prims.bool) =
-  fun uu____3009  -> lookup_opt "in" as_bool 
+  fun uu____3012  -> lookup_opt "in" as_bool 
 let (get_ide : unit -> Prims.bool) =
-  fun uu____3018  -> lookup_opt "ide" as_bool 
+  fun uu____3021  -> lookup_opt "ide" as_bool 
 let (get_lsp : unit -> Prims.bool) =
-  fun uu____3027  -> lookup_opt "lsp" as_bool 
+  fun uu____3030  -> lookup_opt "lsp" as_bool 
 let (get_include : unit -> Prims.string Prims.list) =
-  fun uu____3038  -> lookup_opt "include" (as_list as_string) 
+  fun uu____3041  -> lookup_opt "include" (as_list as_string) 
 let (get_print : unit -> Prims.bool) =
-  fun uu____3050  -> lookup_opt "print" as_bool 
+  fun uu____3053  -> lookup_opt "print" as_bool 
 let (get_print_in_place : unit -> Prims.bool) =
-  fun uu____3059  -> lookup_opt "print_in_place" as_bool 
+  fun uu____3062  -> lookup_opt "print_in_place" as_bool 
 let (get_initial_fuel : unit -> Prims.int) =
-  fun uu____3068  -> lookup_opt "initial_fuel" as_int 
+  fun uu____3071  -> lookup_opt "initial_fuel" as_int 
 let (get_initial_ifuel : unit -> Prims.int) =
-  fun uu____3077  -> lookup_opt "initial_ifuel" as_int 
+  fun uu____3080  -> lookup_opt "initial_ifuel" as_int 
 let (get_keep_query_captions : unit -> Prims.bool) =
-  fun uu____3086  -> lookup_opt "keep_query_captions" as_bool 
+  fun uu____3089  -> lookup_opt "keep_query_captions" as_bool 
 let (get_lax : unit -> Prims.bool) =
-  fun uu____3095  -> lookup_opt "lax" as_bool 
+  fun uu____3098  -> lookup_opt "lax" as_bool 
 let (get_load : unit -> Prims.string Prims.list) =
-  fun uu____3106  -> lookup_opt "load" (as_list as_string) 
+  fun uu____3109  -> lookup_opt "load" (as_list as_string) 
 let (get_log_queries : unit -> Prims.bool) =
-  fun uu____3118  -> lookup_opt "log_queries" as_bool 
+  fun uu____3121  -> lookup_opt "log_queries" as_bool 
 let (get_log_types : unit -> Prims.bool) =
-  fun uu____3127  -> lookup_opt "log_types" as_bool 
+  fun uu____3130  -> lookup_opt "log_types" as_bool 
 let (get_max_fuel : unit -> Prims.int) =
-  fun uu____3136  -> lookup_opt "max_fuel" as_int 
+  fun uu____3139  -> lookup_opt "max_fuel" as_int 
 let (get_max_ifuel : unit -> Prims.int) =
-  fun uu____3145  -> lookup_opt "max_ifuel" as_int 
+  fun uu____3148  -> lookup_opt "max_ifuel" as_int 
 let (get_min_fuel : unit -> Prims.int) =
-  fun uu____3154  -> lookup_opt "min_fuel" as_int 
+  fun uu____3157  -> lookup_opt "min_fuel" as_int 
 let (get_MLish : unit -> Prims.bool) =
-  fun uu____3163  -> lookup_opt "MLish" as_bool 
+  fun uu____3166  -> lookup_opt "MLish" as_bool 
 let (get_no_default_includes : unit -> Prims.bool) =
-  fun uu____3172  -> lookup_opt "no_default_includes" as_bool 
+  fun uu____3175  -> lookup_opt "no_default_includes" as_bool 
 let (get_no_extract : unit -> Prims.string Prims.list) =
-  fun uu____3183  -> lookup_opt "no_extract" (as_list as_string) 
+  fun uu____3186  -> lookup_opt "no_extract" (as_list as_string) 
 let (get_no_location_info : unit -> Prims.bool) =
-  fun uu____3195  -> lookup_opt "no_location_info" as_bool 
+  fun uu____3198  -> lookup_opt "no_location_info" as_bool 
 let (get_no_plugins : unit -> Prims.bool) =
-  fun uu____3204  -> lookup_opt "no_plugins" as_bool 
+  fun uu____3207  -> lookup_opt "no_plugins" as_bool 
 let (get_no_smt : unit -> Prims.bool) =
-  fun uu____3213  -> lookup_opt "no_smt" as_bool 
+  fun uu____3216  -> lookup_opt "no_smt" as_bool 
 let (get_normalize_pure_terms_for_extraction : unit -> Prims.bool) =
-  fun uu____3222  -> lookup_opt "normalize_pure_terms_for_extraction" as_bool 
+  fun uu____3225  -> lookup_opt "normalize_pure_terms_for_extraction" as_bool 
 let (get_odir : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____3233  -> lookup_opt "odir" (as_option as_string) 
+  fun uu____3236  -> lookup_opt "odir" (as_option as_string) 
 let (get_ugly : unit -> Prims.bool) =
-  fun uu____3245  -> lookup_opt "ugly" as_bool 
+  fun uu____3248  -> lookup_opt "ugly" as_bool 
 let (get_prims : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____3256  -> lookup_opt "prims" (as_option as_string) 
+  fun uu____3259  -> lookup_opt "prims" (as_option as_string) 
 let (get_print_bound_var_types : unit -> Prims.bool) =
-  fun uu____3268  -> lookup_opt "print_bound_var_types" as_bool 
+  fun uu____3271  -> lookup_opt "print_bound_var_types" as_bool 
 let (get_print_effect_args : unit -> Prims.bool) =
-  fun uu____3277  -> lookup_opt "print_effect_args" as_bool 
+  fun uu____3280  -> lookup_opt "print_effect_args" as_bool 
 let (get_print_full_names : unit -> Prims.bool) =
-  fun uu____3286  -> lookup_opt "print_full_names" as_bool 
+  fun uu____3289  -> lookup_opt "print_full_names" as_bool 
 let (get_print_implicits : unit -> Prims.bool) =
-  fun uu____3295  -> lookup_opt "print_implicits" as_bool 
+  fun uu____3298  -> lookup_opt "print_implicits" as_bool 
 let (get_print_universes : unit -> Prims.bool) =
-  fun uu____3304  -> lookup_opt "print_universes" as_bool 
+  fun uu____3307  -> lookup_opt "print_universes" as_bool 
 let (get_print_z3_statistics : unit -> Prims.bool) =
-  fun uu____3313  -> lookup_opt "print_z3_statistics" as_bool 
+  fun uu____3316  -> lookup_opt "print_z3_statistics" as_bool 
 let (get_prn : unit -> Prims.bool) =
-  fun uu____3322  -> lookup_opt "prn" as_bool 
+  fun uu____3325  -> lookup_opt "prn" as_bool 
 let (get_query_stats : unit -> Prims.bool) =
-  fun uu____3331  -> lookup_opt "query_stats" as_bool 
+  fun uu____3334  -> lookup_opt "query_stats" as_bool 
 let (get_record_hints : unit -> Prims.bool) =
-  fun uu____3340  -> lookup_opt "record_hints" as_bool 
+  fun uu____3343  -> lookup_opt "record_hints" as_bool 
 let (get_reuse_hint_for :
   unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____3351  -> lookup_opt "reuse_hint_for" (as_option as_string) 
+  fun uu____3354  -> lookup_opt "reuse_hint_for" (as_option as_string) 
 let (get_silent : unit -> Prims.bool) =
-  fun uu____3363  -> lookup_opt "silent" as_bool 
+  fun uu____3366  -> lookup_opt "silent" as_bool 
 let (get_smt : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____3374  -> lookup_opt "smt" (as_option as_string) 
+  fun uu____3377  -> lookup_opt "smt" (as_option as_string) 
 let (get_smtencoding_elim_box : unit -> Prims.bool) =
-  fun uu____3386  -> lookup_opt "smtencoding.elim_box" as_bool 
+  fun uu____3389  -> lookup_opt "smtencoding.elim_box" as_bool 
 let (get_smtencoding_nl_arith_repr : unit -> Prims.string) =
-  fun uu____3395  -> lookup_opt "smtencoding.nl_arith_repr" as_string 
+  fun uu____3398  -> lookup_opt "smtencoding.nl_arith_repr" as_string 
 let (get_smtencoding_l_arith_repr : unit -> Prims.string) =
-  fun uu____3404  -> lookup_opt "smtencoding.l_arith_repr" as_string 
+  fun uu____3407  -> lookup_opt "smtencoding.l_arith_repr" as_string 
 let (get_smtencoding_valid_intro : unit -> Prims.bool) =
-  fun uu____3413  -> lookup_opt "smtencoding.valid_intro" as_bool 
+  fun uu____3416  -> lookup_opt "smtencoding.valid_intro" as_bool 
 let (get_smtencoding_valid_elim : unit -> Prims.bool) =
-  fun uu____3422  -> lookup_opt "smtencoding.valid_elim" as_bool 
+  fun uu____3425  -> lookup_opt "smtencoding.valid_elim" as_bool 
 let (get_tactic_raw_binders : unit -> Prims.bool) =
-  fun uu____3431  -> lookup_opt "tactic_raw_binders" as_bool 
+  fun uu____3434  -> lookup_opt "tactic_raw_binders" as_bool 
 let (get_tactics_failhard : unit -> Prims.bool) =
-  fun uu____3440  -> lookup_opt "tactics_failhard" as_bool 
+  fun uu____3443  -> lookup_opt "tactics_failhard" as_bool 
 let (get_tactics_info : unit -> Prims.bool) =
-  fun uu____3449  -> lookup_opt "tactics_info" as_bool 
+  fun uu____3452  -> lookup_opt "tactics_info" as_bool 
 let (get_tactic_trace : unit -> Prims.bool) =
-  fun uu____3458  -> lookup_opt "tactic_trace" as_bool 
+  fun uu____3461  -> lookup_opt "tactic_trace" as_bool 
 let (get_tactic_trace_d : unit -> Prims.int) =
-  fun uu____3467  -> lookup_opt "tactic_trace_d" as_int 
+  fun uu____3470  -> lookup_opt "tactic_trace_d" as_int 
 let (get_tactics_nbe : unit -> Prims.bool) =
-  fun uu____3476  -> lookup_opt "__tactics_nbe" as_bool 
+  fun uu____3479  -> lookup_opt "__tactics_nbe" as_bool 
 let (get_tcnorm : unit -> Prims.bool) =
-  fun uu____3485  -> lookup_opt "tcnorm" as_bool 
+  fun uu____3488  -> lookup_opt "tcnorm" as_bool 
 let (get_timing : unit -> Prims.bool) =
-  fun uu____3494  -> lookup_opt "timing" as_bool 
+  fun uu____3497  -> lookup_opt "timing" as_bool 
 let (get_trace_error : unit -> Prims.bool) =
-  fun uu____3503  -> lookup_opt "trace_error" as_bool 
+  fun uu____3506  -> lookup_opt "trace_error" as_bool 
 let (get_unthrottle_inductives : unit -> Prims.bool) =
-  fun uu____3512  -> lookup_opt "unthrottle_inductives" as_bool 
+  fun uu____3515  -> lookup_opt "unthrottle_inductives" as_bool 
 let (get_unsafe_tactic_exec : unit -> Prims.bool) =
-  fun uu____3521  -> lookup_opt "unsafe_tactic_exec" as_bool 
+  fun uu____3524  -> lookup_opt "unsafe_tactic_exec" as_bool 
 let (get_use_eq_at_higher_order : unit -> Prims.bool) =
-  fun uu____3530  -> lookup_opt "use_eq_at_higher_order" as_bool 
+  fun uu____3533  -> lookup_opt "use_eq_at_higher_order" as_bool 
 let (get_use_hints : unit -> Prims.bool) =
-  fun uu____3539  -> lookup_opt "use_hints" as_bool 
+  fun uu____3542  -> lookup_opt "use_hints" as_bool 
 let (get_use_hint_hashes : unit -> Prims.bool) =
-  fun uu____3548  -> lookup_opt "use_hint_hashes" as_bool 
+  fun uu____3551  -> lookup_opt "use_hint_hashes" as_bool 
 let (get_use_native_tactics :
   unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____3559  -> lookup_opt "use_native_tactics" (as_option as_string) 
+  fun uu____3562  -> lookup_opt "use_native_tactics" (as_option as_string) 
 let (get_use_tactics : unit -> Prims.bool) =
-  fun uu____3571  ->
-    let uu____3572 = lookup_opt "no_tactics" as_bool  in
-    Prims.op_Negation uu____3572
+  fun uu____3574  ->
+    let uu____3575 = lookup_opt "no_tactics" as_bool  in
+    Prims.op_Negation uu____3575
   
 let (get_using_facts_from :
   unit -> Prims.string Prims.list FStar_Pervasives_Native.option) =
-  fun uu____3586  ->
+  fun uu____3589  ->
     lookup_opt "using_facts_from" (as_option (as_list as_string))
   
 let (get_vcgen_optimize_bind_as_seq :
   unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____3605  ->
+  fun uu____3608  ->
     lookup_opt "vcgen.optimize_bind_as_seq" (as_option as_string)
   
 let (get_verify_module : unit -> Prims.string Prims.list) =
-  fun uu____3619  -> lookup_opt "verify_module" (as_list as_string) 
+  fun uu____3622  -> lookup_opt "verify_module" (as_list as_string) 
 let (get___temp_no_proj : unit -> Prims.string Prims.list) =
-  fun uu____3633  -> lookup_opt "__temp_no_proj" (as_list as_string) 
+  fun uu____3636  -> lookup_opt "__temp_no_proj" (as_list as_string) 
 let (get_version : unit -> Prims.bool) =
-  fun uu____3645  -> lookup_opt "version" as_bool 
+  fun uu____3648  -> lookup_opt "version" as_bool 
 let (get_warn_default_effects : unit -> Prims.bool) =
-  fun uu____3654  -> lookup_opt "warn_default_effects" as_bool 
+  fun uu____3657  -> lookup_opt "warn_default_effects" as_bool 
 let (get_z3cliopt : unit -> Prims.string Prims.list) =
-  fun uu____3665  -> lookup_opt "z3cliopt" (as_list as_string) 
+  fun uu____3668  -> lookup_opt "z3cliopt" (as_list as_string) 
 let (get_z3refresh : unit -> Prims.bool) =
-  fun uu____3677  -> lookup_opt "z3refresh" as_bool 
+  fun uu____3680  -> lookup_opt "z3refresh" as_bool 
 let (get_z3rlimit : unit -> Prims.int) =
-  fun uu____3686  -> lookup_opt "z3rlimit" as_int 
+  fun uu____3689  -> lookup_opt "z3rlimit" as_int 
 let (get_z3rlimit_factor : unit -> Prims.int) =
-  fun uu____3695  -> lookup_opt "z3rlimit_factor" as_int 
+  fun uu____3698  -> lookup_opt "z3rlimit_factor" as_int 
 let (get_z3seed : unit -> Prims.int) =
-  fun uu____3704  -> lookup_opt "z3seed" as_int 
+  fun uu____3707  -> lookup_opt "z3seed" as_int 
 let (get_use_two_phase_tc : unit -> Prims.bool) =
-  fun uu____3713  -> lookup_opt "use_two_phase_tc" as_bool 
+  fun uu____3716  -> lookup_opt "use_two_phase_tc" as_bool 
 let (get_no_positivity : unit -> Prims.bool) =
-  fun uu____3722  -> lookup_opt "__no_positivity" as_bool 
+  fun uu____3725  -> lookup_opt "__no_positivity" as_bool 
 let (get_ml_no_eta_expand_coertions : unit -> Prims.bool) =
-  fun uu____3731  -> lookup_opt "__ml_no_eta_expand_coertions" as_bool 
+  fun uu____3734  -> lookup_opt "__ml_no_eta_expand_coertions" as_bool 
 let (get_warn_error : unit -> Prims.string Prims.list) =
-  fun uu____3742  -> lookup_opt "warn_error" (as_list as_string) 
+  fun uu____3745  -> lookup_opt "warn_error" (as_list as_string) 
 let (get_use_extracted_interfaces : unit -> Prims.bool) =
-  fun uu____3754  -> lookup_opt "use_extracted_interfaces" as_bool 
+  fun uu____3757  -> lookup_opt "use_extracted_interfaces" as_bool 
 let (get_use_nbe : unit -> Prims.bool) =
-  fun uu____3763  -> lookup_opt "use_nbe" as_bool 
+  fun uu____3766  -> lookup_opt "use_nbe" as_bool 
 let (get_trivial_pre_for_unannotated_effectful_fns : unit -> Prims.bool) =
-  fun uu____3772  ->
+  fun uu____3775  ->
     lookup_opt "trivial_pre_for_unannotated_effectful_fns" as_bool
   
 let (get_profile :
   unit -> Prims.string Prims.list FStar_Pervasives_Native.option) =
-  fun uu____3785  -> lookup_opt "profile" (as_option (as_list as_string)) 
+  fun uu____3788  -> lookup_opt "profile" (as_option (as_list as_string)) 
 let (get_profile_group_by_decl : unit -> Prims.bool) =
-  fun uu____3802  -> lookup_opt "profile_group_by_decl" as_bool 
+  fun uu____3805  -> lookup_opt "profile_group_by_decl" as_bool 
 let (get_profile_component :
   unit -> Prims.string Prims.list FStar_Pervasives_Native.option) =
-  fun uu____3815  ->
+  fun uu____3818  ->
     lookup_opt "profile_component" (as_option (as_list as_string))
   
 let (dlevel : Prims.string -> debug_level_t) =
-  fun uu___6_3832  ->
-    match uu___6_3832 with
+  fun uu___6_3835  ->
+    match uu___6_3835 with
     | "Low" -> Low
     | "Medium" -> Medium
     | "High" -> High
@@ -677,7 +682,7 @@ let (one_debug_level_geq : debug_level_t -> debug_level_t -> Prims.bool) =
   fun l1  ->
     fun l2  ->
       match l1 with
-      | Other uu____3853 -> l1 = l2
+      | Other uu____3856 -> l1 = l2
       | Low  -> l1 = l2
       | Medium  -> (l2 = Low) || (l2 = Medium)
       | High  -> ((l2 = Low) || (l2 = Medium)) || (l2 = High)
@@ -686,8 +691,8 @@ let (one_debug_level_geq : debug_level_t -> debug_level_t -> Prims.bool) =
   
 let (debug_level_geq : debug_level_t -> Prims.bool) =
   fun l2  ->
-    let uu____3862 = get_debug_level ()  in
-    FStar_All.pipe_right uu____3862
+    let uu____3865 = get_debug_level ()  in
+    FStar_All.pipe_right uu____3865
       (FStar_Util.for_some (fun l1  -> one_debug_level_geq (dlevel l1) l2))
   
 let (universe_include_path_base_dirs : Prims.string Prims.list) =
@@ -695,14 +700,14 @@ let (universe_include_path_base_dirs : Prims.string Prims.list) =
   FStar_All.pipe_right ["/ulib"; "/lib/fstar"]
     (FStar_List.collect
        (fun d  ->
-          let uu____3906 =
+          let uu____3909 =
             FStar_All.pipe_right sub_dirs
               (FStar_List.map
                  (fun s  ->
-                    let uu____3922 = FStar_String.op_Hat "/" s  in
-                    FStar_String.op_Hat d uu____3922))
+                    let uu____3925 = FStar_String.op_Hat "/" s  in
+                    FStar_String.op_Hat d uu____3925))
              in
-          d :: uu____3906))
+          d :: uu____3909))
   
 let (_version : Prims.string FStar_ST.ref) = FStar_Util.mk_ref "" 
 let (_platform : Prims.string FStar_ST.ref) = FStar_Util.mk_ref "" 
@@ -710,77 +715,77 @@ let (_compiler : Prims.string FStar_ST.ref) = FStar_Util.mk_ref ""
 let (_date : Prims.string FStar_ST.ref) = FStar_Util.mk_ref "<not set>" 
 let (_commit : Prims.string FStar_ST.ref) = FStar_Util.mk_ref "" 
 let (display_version : unit -> unit) =
-  fun uu____3961  ->
-    let uu____3962 =
-      let uu____3964 = FStar_ST.op_Bang _version  in
-      let uu____3987 = FStar_ST.op_Bang _platform  in
-      let uu____4010 = FStar_ST.op_Bang _compiler  in
-      let uu____4033 = FStar_ST.op_Bang _date  in
-      let uu____4056 = FStar_ST.op_Bang _commit  in
+  fun uu____3964  ->
+    let uu____3965 =
+      let uu____3967 = FStar_ST.op_Bang _version  in
+      let uu____3990 = FStar_ST.op_Bang _platform  in
+      let uu____4013 = FStar_ST.op_Bang _compiler  in
+      let uu____4036 = FStar_ST.op_Bang _date  in
+      let uu____4059 = FStar_ST.op_Bang _commit  in
       FStar_Util.format5
-        "F* %s\nplatform=%s\ncompiler=%s\ndate=%s\ncommit=%s\n" uu____3964
-        uu____3987 uu____4010 uu____4033 uu____4056
+        "F* %s\nplatform=%s\ncompiler=%s\ndate=%s\ncommit=%s\n" uu____3967
+        uu____3990 uu____4013 uu____4036 uu____4059
        in
-    FStar_Util.print_string uu____3962
+    FStar_Util.print_string uu____3965
   
 let display_usage_aux :
-  'Auu____4087 'Auu____4088 .
-    ('Auu____4087 * Prims.string * 'Auu____4088 FStar_Getopt.opt_variant *
+  'Auu____4090 'Auu____4091 .
+    ('Auu____4090 * Prims.string * 'Auu____4091 FStar_Getopt.opt_variant *
       Prims.string) Prims.list -> unit
   =
   fun specs  ->
     FStar_Util.print_string "fstar.exe [options] file[s]\n";
     FStar_List.iter
-      (fun uu____4143  ->
-         match uu____4143 with
-         | (uu____4156,flag,p,doc) ->
+      (fun uu____4146  ->
+         match uu____4146 with
+         | (uu____4159,flag,p,doc) ->
              (match p with
               | FStar_Getopt.ZeroArgs ig ->
                   if doc = ""
                   then
-                    let uu____4175 =
-                      let uu____4177 = FStar_Util.colorize_bold flag  in
-                      FStar_Util.format1 "  --%s\n" uu____4177  in
-                    FStar_Util.print_string uu____4175
+                    let uu____4178 =
+                      let uu____4180 = FStar_Util.colorize_bold flag  in
+                      FStar_Util.format1 "  --%s\n" uu____4180  in
+                    FStar_Util.print_string uu____4178
                   else
-                    (let uu____4182 =
-                       let uu____4184 = FStar_Util.colorize_bold flag  in
-                       FStar_Util.format2 "  --%s  %s\n" uu____4184 doc  in
-                     FStar_Util.print_string uu____4182)
-              | FStar_Getopt.OneArg (uu____4187,argname) ->
+                    (let uu____4185 =
+                       let uu____4187 = FStar_Util.colorize_bold flag  in
+                       FStar_Util.format2 "  --%s  %s\n" uu____4187 doc  in
+                     FStar_Util.print_string uu____4185)
+              | FStar_Getopt.OneArg (uu____4190,argname) ->
                   if doc = ""
                   then
-                    let uu____4202 =
-                      let uu____4204 = FStar_Util.colorize_bold flag  in
-                      let uu____4206 = FStar_Util.colorize_bold argname  in
-                      FStar_Util.format2 "  --%s %s\n" uu____4204 uu____4206
+                    let uu____4205 =
+                      let uu____4207 = FStar_Util.colorize_bold flag  in
+                      let uu____4209 = FStar_Util.colorize_bold argname  in
+                      FStar_Util.format2 "  --%s %s\n" uu____4207 uu____4209
                        in
-                    FStar_Util.print_string uu____4202
+                    FStar_Util.print_string uu____4205
                   else
-                    (let uu____4211 =
-                       let uu____4213 = FStar_Util.colorize_bold flag  in
-                       let uu____4215 = FStar_Util.colorize_bold argname  in
-                       FStar_Util.format3 "  --%s %s  %s\n" uu____4213
-                         uu____4215 doc
+                    (let uu____4214 =
+                       let uu____4216 = FStar_Util.colorize_bold flag  in
+                       let uu____4218 = FStar_Util.colorize_bold argname  in
+                       FStar_Util.format3 "  --%s %s  %s\n" uu____4216
+                         uu____4218 doc
                         in
-                     FStar_Util.print_string uu____4211))) specs
+                     FStar_Util.print_string uu____4214))) specs
   
 let (mk_spec :
   (FStar_BaseTypes.char * Prims.string * option_val FStar_Getopt.opt_variant
     * Prims.string) -> FStar_Getopt.opt)
   =
   fun o  ->
-    let uu____4250 = o  in
-    match uu____4250 with
+    let uu____4253 = o  in
+    match uu____4253 with
     | (ns,name,arg,desc) ->
         let arg1 =
           match arg with
           | FStar_Getopt.ZeroArgs f ->
-              let g uu____4292 =
-                let uu____4293 = f ()  in set_option name uu____4293  in
+              let g uu____4295 =
+                let uu____4296 = f ()  in set_option name uu____4296  in
               FStar_Getopt.ZeroArgs g
           | FStar_Getopt.OneArg (f,d) ->
-              let g x = let uu____4314 = f x  in set_option name uu____4314
+              let g x = let uu____4317 = f x  in set_option name uu____4317
                  in
               FStar_Getopt.OneArg (g, d)
            in
@@ -790,30 +795,30 @@ let (accumulated_option : Prims.string -> option_val -> option_val) =
   fun name  ->
     fun value  ->
       let prev_values =
-        let uu____4341 = lookup_opt name (as_option as_list')  in
-        FStar_Util.dflt [] uu____4341  in
+        let uu____4344 = lookup_opt name (as_option as_list')  in
+        FStar_Util.dflt [] uu____4344  in
       List (value :: prev_values)
   
 let (reverse_accumulated_option : Prims.string -> option_val -> option_val) =
   fun name  ->
     fun value  ->
       let prev_values =
-        let uu____4370 = lookup_opt name (as_option as_list')  in
-        FStar_Util.dflt [] uu____4370  in
+        let uu____4373 = lookup_opt name (as_option as_list')  in
+        FStar_Util.dflt [] uu____4373  in
       List (FStar_List.append prev_values [value])
   
 let accumulate_string :
-  'Auu____4392 .
-    Prims.string -> ('Auu____4392 -> Prims.string) -> 'Auu____4392 -> unit
+  'Auu____4395 .
+    Prims.string -> ('Auu____4395 -> Prims.string) -> 'Auu____4395 -> unit
   =
   fun name  ->
     fun post_processor  ->
       fun value  ->
-        let uu____4417 =
-          let uu____4418 =
-            let uu____4419 = post_processor value  in String uu____4419  in
-          accumulated_option name uu____4418  in
-        set_option name uu____4417
+        let uu____4420 =
+          let uu____4421 =
+            let uu____4422 = post_processor value  in String uu____4422  in
+          accumulated_option name uu____4421  in
+        set_option name uu____4420
   
 let (add_extract_module : Prims.string -> unit) =
   fun s  -> accumulate_string "extract_module" FStar_String.lowercase s 
@@ -835,55 +840,55 @@ type opt_type =
   | WithSideEffect of ((unit -> unit) * opt_type) 
 let (uu___is_Const : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Const _0 -> true | uu____4541 -> false
+    match projectee with | Const _0 -> true | uu____4544 -> false
   
 let (__proj__Const__item___0 : opt_type -> option_val) =
   fun projectee  -> match projectee with | Const _0 -> _0 
 let (uu___is_IntStr : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | IntStr _0 -> true | uu____4561 -> false
+    match projectee with | IntStr _0 -> true | uu____4564 -> false
   
 let (__proj__IntStr__item___0 : opt_type -> Prims.string) =
   fun projectee  -> match projectee with | IntStr _0 -> _0 
 let (uu___is_BoolStr : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | BoolStr  -> true | uu____4582 -> false
+    match projectee with | BoolStr  -> true | uu____4585 -> false
   
 let (uu___is_PathStr : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | PathStr _0 -> true | uu____4595 -> false
+    match projectee with | PathStr _0 -> true | uu____4598 -> false
   
 let (__proj__PathStr__item___0 : opt_type -> Prims.string) =
   fun projectee  -> match projectee with | PathStr _0 -> _0 
 let (uu___is_SimpleStr : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | SimpleStr _0 -> true | uu____4618 -> false
+    match projectee with | SimpleStr _0 -> true | uu____4621 -> false
   
 let (__proj__SimpleStr__item___0 : opt_type -> Prims.string) =
   fun projectee  -> match projectee with | SimpleStr _0 -> _0 
 let (uu___is_EnumStr : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | EnumStr _0 -> true | uu____4643 -> false
+    match projectee with | EnumStr _0 -> true | uu____4646 -> false
   
 let (__proj__EnumStr__item___0 : opt_type -> Prims.string Prims.list) =
   fun projectee  -> match projectee with | EnumStr _0 -> _0 
 let (uu___is_OpenEnumStr : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | OpenEnumStr _0 -> true | uu____4679 -> false
+    match projectee with | OpenEnumStr _0 -> true | uu____4682 -> false
   
 let (__proj__OpenEnumStr__item___0 :
   opt_type -> (Prims.string Prims.list * Prims.string)) =
   fun projectee  -> match projectee with | OpenEnumStr _0 -> _0 
 let (uu___is_PostProcessed : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | PostProcessed _0 -> true | uu____4729 -> false
+    match projectee with | PostProcessed _0 -> true | uu____4732 -> false
   
 let (__proj__PostProcessed__item___0 :
   opt_type -> ((option_val -> option_val) * opt_type)) =
   fun projectee  -> match projectee with | PostProcessed _0 -> _0 
 let (uu___is_Accumulated : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Accumulated _0 -> true | uu____4769 -> false
+    match projectee with | Accumulated _0 -> true | uu____4772 -> false
   
 let (__proj__Accumulated__item___0 : opt_type -> opt_type) =
   fun projectee  -> match projectee with | Accumulated _0 -> _0 
@@ -891,13 +896,13 @@ let (uu___is_ReverseAccumulated : opt_type -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | ReverseAccumulated _0 -> true
-    | uu____4788 -> false
+    | uu____4791 -> false
   
 let (__proj__ReverseAccumulated__item___0 : opt_type -> opt_type) =
   fun projectee  -> match projectee with | ReverseAccumulated _0 -> _0 
 let (uu___is_WithSideEffect : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | WithSideEffect _0 -> true | uu____4814 -> false
+    match projectee with | WithSideEffect _0 -> true | uu____4817 -> false
   
 let (__proj__WithSideEffect__item___0 :
   opt_type -> ((unit -> unit) * opt_type)) =
@@ -906,12 +911,12 @@ exception InvalidArgument of Prims.string
 let (uu___is_InvalidArgument : Prims.exn -> Prims.bool) =
   fun projectee  ->
     match projectee with
-    | InvalidArgument uu____4857 -> true
-    | uu____4860 -> false
+    | InvalidArgument uu____4860 -> true
+    | uu____4863 -> false
   
 let (__proj__InvalidArgument__item__uu___ : Prims.exn -> Prims.string) =
   fun projectee  ->
-    match projectee with | InvalidArgument uu____4870 -> uu____4870
+    match projectee with | InvalidArgument uu____4873 -> uu____4873
   
 let rec (parse_opt_val :
   Prims.string -> opt_type -> Prims.string -> option_val) =
@@ -919,20 +924,20 @@ let rec (parse_opt_val :
     fun typ  ->
       fun str_val  ->
         try
-          (fun uu___302_4894  ->
+          (fun uu___302_4897  ->
              match () with
              | () ->
                  (match typ with
                   | Const c -> c
-                  | IntStr uu____4896 ->
-                      let uu____4898 = FStar_Util.safe_int_of_string str_val
+                  | IntStr uu____4899 ->
+                      let uu____4901 = FStar_Util.safe_int_of_string str_val
                          in
-                      (match uu____4898 with
+                      (match uu____4901 with
                        | FStar_Pervasives_Native.Some v1 -> Int v1
                        | FStar_Pervasives_Native.None  ->
                            FStar_Exn.raise (InvalidArgument opt_name))
                   | BoolStr  ->
-                      let uu____4906 =
+                      let uu____4909 =
                         if str_val = "true"
                         then true
                         else
@@ -940,18 +945,18 @@ let rec (parse_opt_val :
                           then false
                           else FStar_Exn.raise (InvalidArgument opt_name)
                          in
-                      Bool uu____4906
-                  | PathStr uu____4923 -> Path str_val
-                  | SimpleStr uu____4925 -> String str_val
+                      Bool uu____4909
+                  | PathStr uu____4926 -> Path str_val
+                  | SimpleStr uu____4928 -> String str_val
                   | EnumStr strs ->
                       if FStar_List.mem str_val strs
                       then String str_val
                       else FStar_Exn.raise (InvalidArgument opt_name)
-                  | OpenEnumStr uu____4935 -> String str_val
+                  | OpenEnumStr uu____4938 -> String str_val
                   | PostProcessed (pp,elem_spec) ->
-                      let uu____4952 =
+                      let uu____4955 =
                         parse_opt_val opt_name elem_spec str_val  in
-                      pp uu____4952
+                      pp uu____4955
                   | Accumulated elem_spec ->
                       let v1 = parse_opt_val opt_name elem_spec str_val  in
                       accumulated_option opt_name v1
@@ -963,19 +968,19 @@ let rec (parse_opt_val :
                        parse_opt_val opt_name elem_spec str_val))) ()
         with
         | InvalidArgument opt_name1 ->
-            let uu____4972 =
+            let uu____4975 =
               FStar_Util.format1 "Invalid argument to --%s" opt_name1  in
-            failwith uu____4972
+            failwith uu____4975
   
 let rec (desc_of_opt_type :
   opt_type -> Prims.string FStar_Pervasives_Native.option) =
   fun typ  ->
     let desc_of_enum cases =
-      let uu____5002 =
-        let uu____5004 =
+      let uu____5005 =
+        let uu____5007 =
           FStar_String.op_Hat (FStar_String.concat "|" cases) "]"  in
-        FStar_String.op_Hat "[" uu____5004  in
-      FStar_Pervasives_Native.Some uu____5002  in
+        FStar_String.op_Hat "[" uu____5007  in
+      FStar_Pervasives_Native.Some uu____5005  in
     match typ with
     | Const c -> FStar_Pervasives_Native.None
     | IntStr desc -> FStar_Pervasives_Native.Some desc
@@ -984,20 +989,20 @@ let rec (desc_of_opt_type :
     | SimpleStr desc -> FStar_Pervasives_Native.Some desc
     | EnumStr strs -> desc_of_enum strs
     | OpenEnumStr (strs,desc) -> desc_of_enum (FStar_List.append strs [desc])
-    | PostProcessed (uu____5046,elem_spec) -> desc_of_opt_type elem_spec
+    | PostProcessed (uu____5049,elem_spec) -> desc_of_opt_type elem_spec
     | Accumulated elem_spec -> desc_of_opt_type elem_spec
     | ReverseAccumulated elem_spec -> desc_of_opt_type elem_spec
-    | WithSideEffect (uu____5056,elem_spec) -> desc_of_opt_type elem_spec
+    | WithSideEffect (uu____5059,elem_spec) -> desc_of_opt_type elem_spec
   
 let rec (arg_spec_of_opt_type :
   Prims.string -> opt_type -> option_val FStar_Getopt.opt_variant) =
   fun opt_name  ->
     fun typ  ->
       let parser = parse_opt_val opt_name typ  in
-      let uu____5087 = desc_of_opt_type typ  in
-      match uu____5087 with
+      let uu____5090 = desc_of_opt_type typ  in
+      match uu____5090 with
       | FStar_Pervasives_Native.None  ->
-          FStar_Getopt.ZeroArgs ((fun uu____5095  -> parser ""))
+          FStar_Getopt.ZeroArgs ((fun uu____5098  -> parser ""))
       | FStar_Pervasives_Native.Some desc ->
           FStar_Getopt.OneArg (parser, desc)
   
@@ -1005,9 +1010,9 @@ let (pp_validate_dir : option_val -> option_val) =
   fun p  -> let pp = as_string p  in FStar_Util.mkdir false pp; p 
 let (pp_lowercase : option_val -> option_val) =
   fun s  ->
-    let uu____5121 =
-      let uu____5123 = as_string s  in FStar_String.lowercase uu____5123  in
-    String uu____5121
+    let uu____5124 =
+      let uu____5126 = as_string s  in FStar_String.lowercase uu____5126  in
+    String uu____5124
   
 let (abort_counter : Prims.int FStar_ST.ref) =
   FStar_Util.mk_ref Prims.int_zero 
@@ -1016,11 +1021,11 @@ let rec (specs_with_types :
     (FStar_BaseTypes.char * Prims.string * opt_type * Prims.string)
       Prims.list)
   =
-  fun uu____5158  ->
+  fun uu____5161  ->
     [(FStar_Getopt.noshort, "abort_on",
        (PostProcessed
-          (((fun uu___7_5193  ->
-               match uu___7_5193 with
+          (((fun uu___7_5196  ->
+               match uu___7_5196 with
                | Int x -> (FStar_ST.op_Colon_Equals abort_counter x; Int x)
                | x -> failwith "?")), (IntStr "non-negative integer"))),
        "Abort on the n-th error or warning raised. Useful in combination with --trace_error. Count starts at 1, use 0 to disable. (default 0)");
@@ -1228,7 +1233,7 @@ let rec (specs_with_types :
       "Don't use this option yet");
     (118, "version",
       (WithSideEffect
-         (((fun uu____6813  ->
+         (((fun uu____6816  ->
               display_version (); FStar_All.exit Prims.int_zero)),
            (Const (Bool true)))), "Display version number");
     (FStar_Getopt.noshort, "warn_default_effects", (Const (Bool true)),
@@ -1260,12 +1265,12 @@ let rec (specs_with_types :
       "Enforce trivial preconditions for unannotated effectful functions (default 'true')");
     (FStar_Getopt.noshort, "__debug_embedding",
       (WithSideEffect
-         (((fun uu____7054  -> FStar_ST.op_Colon_Equals debug_embedding true)),
+         (((fun uu____7057  -> FStar_ST.op_Colon_Equals debug_embedding true)),
            (Const (Bool true)))),
       "Debug messages for embeddings/unembeddings of natively compiled terms");
     (FStar_Getopt.noshort, "eager_embedding",
       (WithSideEffect
-         (((fun uu____7098  -> FStar_ST.op_Colon_Equals eager_embedding true)),
+         (((fun uu____7101  -> FStar_ST.op_Colon_Equals eager_embedding true)),
            (Const (Bool true)))),
       "Eagerly embed and unembed terms to primitive operations and plugins: not recommended except for benchmarking");
     (FStar_Getopt.noshort, "profile_group_by_decl", (Const (Bool true)),
@@ -1282,26 +1287,26 @@ let rec (specs_with_types :
       "\n\tProfiling can be enabled when the compiler is processing a given set of source modules.\n\tPass `--profile FStar.Pervasives` to enable profiling when the compiler is processing any module in FStar.Pervasives.\n\tThis option is a module or namespace selector, like many other options (e.g., `--extract`)");
     (104, "help",
       (WithSideEffect
-         (((fun uu____7195  ->
-              (let uu____7197 = specs ()  in display_usage_aux uu____7197);
+         (((fun uu____7198  ->
+              (let uu____7200 = specs ()  in display_usage_aux uu____7200);
               FStar_All.exit Prims.int_zero)), (Const (Bool true)))),
       "Display this information")]
 
 and (specs : unit -> FStar_Getopt.opt Prims.list) =
-  fun uu____7228  ->
-    let uu____7231 = specs_with_types ()  in
+  fun uu____7231  ->
+    let uu____7234 = specs_with_types ()  in
     FStar_List.map
-      (fun uu____7262  ->
-         match uu____7262 with
+      (fun uu____7265  ->
+         match uu____7265 with
          | (short,long,typ,doc) ->
-             let uu____7284 =
-               let uu____7298 = arg_spec_of_opt_type long typ  in
-               (short, long, uu____7298, doc)  in
-             mk_spec uu____7284) uu____7231
+             let uu____7287 =
+               let uu____7301 = arg_spec_of_opt_type long typ  in
+               (short, long, uu____7301, doc)  in
+             mk_spec uu____7287) uu____7234
 
 let (settable : Prims.string -> Prims.bool) =
-  fun uu___8_7313  ->
-    match uu___8_7313 with
+  fun uu___8_7316  ->
+    match uu___8_7316 with
     | "abort_on" -> true
     | "admit_except" -> true
     | "admit_smt_queries" -> true
@@ -1371,7 +1376,7 @@ let (settable : Prims.string -> Prims.bool) =
     | "profile_group_by_decl" -> true
     | "profile_component" -> true
     | "profile" -> true
-    | uu____7454 -> false
+    | uu____7457 -> false
   
 let (all_specs : FStar_Getopt.opt Prims.list) = specs () 
 let (all_specs_with_types :
@@ -1383,30 +1388,30 @@ let (settable_specs :
   =
   FStar_All.pipe_right all_specs
     (FStar_List.filter
-       (fun uu____7538  ->
-          match uu____7538 with
-          | (uu____7553,x,uu____7555,uu____7556) -> settable x))
+       (fun uu____7541  ->
+          match uu____7541 with
+          | (uu____7556,x,uu____7558,uu____7559) -> settable x))
   
 let (display_usage : unit -> unit) =
-  fun uu____7572  ->
-    let uu____7573 = specs ()  in display_usage_aux uu____7573
+  fun uu____7575  ->
+    let uu____7576 = specs ()  in display_usage_aux uu____7576
   
 let (fstar_bin_directory : Prims.string) = FStar_Util.get_exec_dir () 
 exception File_argument of Prims.string 
 let (uu___is_File_argument : Prims.exn -> Prims.bool) =
   fun projectee  ->
     match projectee with
-    | File_argument uu____7605 -> true
-    | uu____7608 -> false
+    | File_argument uu____7608 -> true
+    | uu____7611 -> false
   
 let (__proj__File_argument__item__uu___ : Prims.exn -> Prims.string) =
   fun projectee  ->
-    match projectee with | File_argument uu____7618 -> uu____7618
+    match projectee with | File_argument uu____7621 -> uu____7621
   
 let (set_options : Prims.string -> FStar_Getopt.parse_cmdline_res) =
   fun s  ->
     try
-      (fun uu___478_7629  ->
+      (fun uu___478_7632  ->
          match () with
          | () ->
              if s = ""
@@ -1416,66 +1421,66 @@ let (set_options : Prims.string -> FStar_Getopt.parse_cmdline_res) =
                  (fun s1  -> FStar_Exn.raise (File_argument s1)) s) ()
     with
     | File_argument s1 ->
-        let uu____7646 =
+        let uu____7649 =
           FStar_Util.format1 "File %s is not a valid option" s1  in
-        FStar_Getopt.Error uu____7646
+        FStar_Getopt.Error uu____7649
   
 let (file_list_ : Prims.string Prims.list FStar_ST.ref) =
   FStar_Util.mk_ref [] 
 let (parse_cmd_line :
   unit -> (FStar_Getopt.parse_cmdline_res * Prims.string Prims.list)) =
-  fun uu____7671  ->
+  fun uu____7674  ->
     let res =
       FStar_Getopt.parse_cmdline all_specs
         (fun i  ->
-           let uu____7677 =
-             let uu____7681 = FStar_ST.op_Bang file_list_  in
-             FStar_List.append uu____7681 [i]  in
-           FStar_ST.op_Colon_Equals file_list_ uu____7677)
+           let uu____7680 =
+             let uu____7684 = FStar_ST.op_Bang file_list_  in
+             FStar_List.append uu____7684 [i]  in
+           FStar_ST.op_Colon_Equals file_list_ uu____7680)
        in
-    let uu____7738 =
-      let uu____7742 = FStar_ST.op_Bang file_list_  in
-      FStar_List.map FStar_Common.try_convert_file_name_to_mixed uu____7742
+    let uu____7741 =
+      let uu____7745 = FStar_ST.op_Bang file_list_  in
+      FStar_List.map FStar_Common.try_convert_file_name_to_mixed uu____7745
        in
-    (res, uu____7738)
+    (res, uu____7741)
   
 let (file_list : unit -> Prims.string Prims.list) =
-  fun uu____7784  -> FStar_ST.op_Bang file_list_ 
+  fun uu____7787  -> FStar_ST.op_Bang file_list_ 
 let (restore_cmd_line_options : Prims.bool -> FStar_Getopt.parse_cmdline_res)
   =
   fun should_clear  ->
     let old_verify_module = get_verify_module ()  in
     if should_clear then clear () else init ();
     (let r =
-       let uu____7827 = specs ()  in
-       FStar_Getopt.parse_cmdline uu____7827 (fun x  -> ())  in
-     (let uu____7834 =
-        let uu____7840 =
-          let uu____7841 =
-            FStar_List.map (fun _7845  -> String _7845) old_verify_module  in
-          List uu____7841  in
-        ("verify_module", uu____7840)  in
-      set_option' uu____7834);
+       let uu____7830 = specs ()  in
+       FStar_Getopt.parse_cmdline uu____7830 (fun x  -> ())  in
+     (let uu____7837 =
+        let uu____7843 =
+          let uu____7844 =
+            FStar_List.map (fun _7848  -> String _7848) old_verify_module  in
+          List uu____7844  in
+        ("verify_module", uu____7843)  in
+      set_option' uu____7837);
      r)
   
 let (module_name_of_file_name : Prims.string -> Prims.string) =
   fun f  ->
     let f1 = FStar_Util.basename f  in
     let f2 =
-      let uu____7861 =
-        let uu____7863 =
-          let uu____7865 =
-            let uu____7867 = FStar_Util.get_file_extension f1  in
-            FStar_String.length uu____7867  in
-          (FStar_String.length f1) - uu____7865  in
-        uu____7863 - Prims.int_one  in
-      FStar_String.substring f1 Prims.int_zero uu____7861  in
+      let uu____7864 =
+        let uu____7866 =
+          let uu____7868 =
+            let uu____7870 = FStar_Util.get_file_extension f1  in
+            FStar_String.length uu____7870  in
+          (FStar_String.length f1) - uu____7868  in
+        uu____7866 - Prims.int_one  in
+      FStar_String.substring f1 Prims.int_zero uu____7864  in
     FStar_String.lowercase f2
   
 let (should_verify : Prims.string -> Prims.bool) =
   fun m  ->
-    let uu____7880 = get_lax ()  in
-    if uu____7880
+    let uu____7883 = get_lax ()  in
+    if uu____7883
     then false
     else
       (let l = get_verify_module ()  in
@@ -1483,7 +1488,7 @@ let (should_verify : Prims.string -> Prims.bool) =
   
 let (should_verify_file : Prims.string -> Prims.bool) =
   fun fn  ->
-    let uu____7901 = module_name_of_file_name fn  in should_verify uu____7901
+    let uu____7904 = module_name_of_file_name fn  in should_verify uu____7904
   
 let (module_name_eq : Prims.string -> Prims.string -> Prims.bool) =
   fun m1  ->
@@ -1491,73 +1496,73 @@ let (module_name_eq : Prims.string -> Prims.string -> Prims.bool) =
   
 let (dont_gen_projectors : Prims.string -> Prims.bool) =
   fun m  ->
-    let uu____7929 = get___temp_no_proj ()  in
-    FStar_All.pipe_right uu____7929 (FStar_List.existsb (module_name_eq m))
+    let uu____7932 = get___temp_no_proj ()  in
+    FStar_All.pipe_right uu____7932 (FStar_List.existsb (module_name_eq m))
   
 let (should_print_message : Prims.string -> Prims.bool) =
   fun m  ->
-    let uu____7947 = should_verify m  in
-    if uu____7947 then m <> "Prims" else false
+    let uu____7950 = should_verify m  in
+    if uu____7950 then m <> "Prims" else false
   
 let (include_path : unit -> Prims.string Prims.list) =
-  fun uu____7964  ->
+  fun uu____7967  ->
     let cache_dir =
-      let uu____7969 = get_cache_dir ()  in
-      match uu____7969 with
+      let uu____7972 = get_cache_dir ()  in
+      match uu____7972 with
       | FStar_Pervasives_Native.None  -> []
       | FStar_Pervasives_Native.Some c -> [c]  in
-    let uu____7983 = get_no_default_includes ()  in
-    if uu____7983
+    let uu____7986 = get_no_default_includes ()  in
+    if uu____7986
     then
-      let uu____7989 = get_include ()  in
-      FStar_List.append cache_dir uu____7989
+      let uu____7992 = get_include ()  in
+      FStar_List.append cache_dir uu____7992
     else
       (let lib_paths =
-         let uu____8000 = FStar_Util.expand_environment_variable "FSTAR_LIB"
+         let uu____8003 = FStar_Util.expand_environment_variable "FSTAR_LIB"
             in
-         match uu____8000 with
+         match uu____8003 with
          | FStar_Pervasives_Native.None  ->
              let fstar_home = FStar_String.op_Hat fstar_bin_directory "/.."
                 in
              let defs = universe_include_path_base_dirs  in
-             let uu____8016 =
+             let uu____8019 =
                FStar_All.pipe_right defs
                  (FStar_List.map (fun x  -> FStar_String.op_Hat fstar_home x))
                 in
-             FStar_All.pipe_right uu____8016
+             FStar_All.pipe_right uu____8019
                (FStar_List.filter FStar_Util.file_exists)
          | FStar_Pervasives_Native.Some s -> [s]  in
-       let uu____8043 =
-         let uu____8047 =
-           let uu____8051 = get_include ()  in
-           FStar_List.append uu____8051 ["."]  in
-         FStar_List.append lib_paths uu____8047  in
-       FStar_List.append cache_dir uu____8043)
+       let uu____8046 =
+         let uu____8050 =
+           let uu____8054 = get_include ()  in
+           FStar_List.append uu____8054 ["."]  in
+         FStar_List.append lib_paths uu____8050  in
+       FStar_List.append cache_dir uu____8046)
   
 let (find_file : Prims.string -> Prims.string FStar_Pervasives_Native.option)
   =
   let file_map = FStar_Util.smap_create (Prims.of_int (100))  in
   fun filename  ->
-    let uu____8082 = FStar_Util.smap_try_find file_map filename  in
-    match uu____8082 with
+    let uu____8085 = FStar_Util.smap_try_find file_map filename  in
+    match uu____8085 with
     | FStar_Pervasives_Native.Some f -> f
     | FStar_Pervasives_Native.None  ->
         let result =
           try
-            (fun uu___529_8113  ->
+            (fun uu___529_8116  ->
                match () with
                | () ->
-                   let uu____8117 = FStar_Util.is_path_absolute filename  in
-                   if uu____8117
+                   let uu____8120 = FStar_Util.is_path_absolute filename  in
+                   if uu____8120
                    then
                      (if FStar_Util.file_exists filename
                       then FStar_Pervasives_Native.Some filename
                       else FStar_Pervasives_Native.None)
                    else
-                     (let uu____8133 =
-                        let uu____8137 = include_path ()  in
-                        FStar_List.rev uu____8137  in
-                      FStar_Util.find_map uu____8133
+                     (let uu____8136 =
+                        let uu____8140 = include_path ()  in
+                        FStar_List.rev uu____8140  in
+                      FStar_Util.find_map uu____8136
                         (fun p  ->
                            let path =
                              if p = "."
@@ -1566,81 +1571,81 @@ let (find_file : Prims.string -> Prims.string FStar_Pervasives_Native.option)
                            if FStar_Util.file_exists path
                            then FStar_Pervasives_Native.Some path
                            else FStar_Pervasives_Native.None))) ()
-          with | uu___528_8165 -> FStar_Pervasives_Native.None  in
+          with | uu___528_8168 -> FStar_Pervasives_Native.None  in
         (if FStar_Option.isSome result
          then FStar_Util.smap_add file_map filename result
          else ();
          result)
   
 let (prims : unit -> Prims.string) =
-  fun uu____8184  ->
-    let uu____8185 = get_prims ()  in
-    match uu____8185 with
+  fun uu____8187  ->
+    let uu____8188 = get_prims ()  in
+    match uu____8188 with
     | FStar_Pervasives_Native.None  ->
         let filename = "prims.fst"  in
-        let uu____8194 = find_file filename  in
-        (match uu____8194 with
+        let uu____8197 = find_file filename  in
+        (match uu____8197 with
          | FStar_Pervasives_Native.Some result -> result
          | FStar_Pervasives_Native.None  ->
-             let uu____8203 =
+             let uu____8206 =
                FStar_Util.format1
                  "unable to find required file \"%s\" in the module search path.\n"
                  filename
                 in
-             failwith uu____8203)
+             failwith uu____8206)
     | FStar_Pervasives_Native.Some x -> x
   
 let (prims_basename : unit -> Prims.string) =
-  fun uu____8216  ->
-    let uu____8217 = prims ()  in FStar_Util.basename uu____8217
+  fun uu____8219  ->
+    let uu____8220 = prims ()  in FStar_Util.basename uu____8220
   
 let (pervasives : unit -> Prims.string) =
-  fun uu____8225  ->
+  fun uu____8228  ->
     let filename = "FStar.Pervasives.fst"  in
-    let uu____8229 = find_file filename  in
-    match uu____8229 with
+    let uu____8232 = find_file filename  in
+    match uu____8232 with
     | FStar_Pervasives_Native.Some result -> result
     | FStar_Pervasives_Native.None  ->
-        let uu____8238 =
+        let uu____8241 =
           FStar_Util.format1
             "unable to find required file \"%s\" in the module search path.\n"
             filename
            in
-        failwith uu____8238
+        failwith uu____8241
   
 let (pervasives_basename : unit -> Prims.string) =
-  fun uu____8248  ->
-    let uu____8249 = pervasives ()  in FStar_Util.basename uu____8249
+  fun uu____8251  ->
+    let uu____8252 = pervasives ()  in FStar_Util.basename uu____8252
   
 let (pervasives_native_basename : unit -> Prims.string) =
-  fun uu____8257  ->
+  fun uu____8260  ->
     let filename = "FStar.Pervasives.Native.fst"  in
-    let uu____8261 = find_file filename  in
-    match uu____8261 with
+    let uu____8264 = find_file filename  in
+    match uu____8264 with
     | FStar_Pervasives_Native.Some result -> FStar_Util.basename result
     | FStar_Pervasives_Native.None  ->
-        let uu____8270 =
+        let uu____8273 =
           FStar_Util.format1
             "unable to find required file \"%s\" in the module search path.\n"
             filename
            in
-        failwith uu____8270
+        failwith uu____8273
   
 let (prepend_output_dir : Prims.string -> Prims.string) =
   fun fname  ->
-    let uu____8283 = get_odir ()  in
-    match uu____8283 with
+    let uu____8286 = get_odir ()  in
+    match uu____8286 with
     | FStar_Pervasives_Native.None  -> fname
     | FStar_Pervasives_Native.Some x -> FStar_Util.join_paths x fname
   
 let (prepend_cache_dir : Prims.string -> Prims.string) =
   fun fpath  ->
-    let uu____8301 = get_cache_dir ()  in
-    match uu____8301 with
+    let uu____8304 = get_cache_dir ()  in
+    match uu____8304 with
     | FStar_Pervasives_Native.None  -> fpath
     | FStar_Pervasives_Native.Some x ->
-        let uu____8310 = FStar_Util.basename fpath  in
-        FStar_Util.join_paths x uu____8310
+        let uu____8313 = FStar_Util.basename fpath  in
+        FStar_Util.join_paths x uu____8313
   
 let (path_of_text : Prims.string -> Prims.string Prims.list) =
   fun text  -> FStar_String.split [46] text 
@@ -1651,8 +1656,8 @@ let (parse_settings :
   fun ns  ->
     let cache = FStar_Util.smap_create (Prims.of_int (31))  in
     let with_cache f s =
-      let uu____8432 = FStar_Util.smap_try_find cache s  in
-      match uu____8432 with
+      let uu____8435 = FStar_Util.smap_try_find cache s  in
+      match uu____8435 with
       | FStar_Pervasives_Native.Some s1 -> s1
       | FStar_Pervasives_Native.None  ->
           let res = f s  in (FStar_Util.smap_add cache s res; res)
@@ -1667,8 +1672,8 @@ let (parse_settings :
           if FStar_Util.starts_with s "-"
           then
             (let path =
-               let uu____8586 = FStar_Util.substring_from s Prims.int_one  in
-               path_of_text uu____8586  in
+               let uu____8589 = FStar_Util.substring_from s Prims.int_one  in
+               path_of_text uu____8589  in
              (path, false))
           else
             (let s1 =
@@ -1677,7 +1682,7 @@ let (parse_settings :
                else s  in
              ((path_of_text s1), true))
        in
-    let uu____8609 =
+    let uu____8612 =
       FStar_All.pipe_right ns
         (FStar_List.collect
            (fun s  ->
@@ -1688,35 +1693,35 @@ let (parse_settings :
                 with_cache
                   (fun s2  ->
                      let s3 = FStar_Util.replace_char s2 32 44  in
-                     let uu____8683 =
-                       let uu____8687 =
+                     let uu____8686 =
+                       let uu____8690 =
                          FStar_All.pipe_right (FStar_Util.splitlines s3)
                            (FStar_List.concatMap
                               (fun s4  -> FStar_Util.split s4 ","))
                           in
-                       FStar_All.pipe_right uu____8687
+                       FStar_All.pipe_right uu____8690
                          (FStar_List.filter (fun s4  -> s4 <> ""))
                         in
-                     FStar_All.pipe_right uu____8683
+                     FStar_All.pipe_right uu____8686
                        (FStar_List.map parse_one_setting)) s1))
        in
-    FStar_All.pipe_right uu____8609 FStar_List.rev
+    FStar_All.pipe_right uu____8612 FStar_List.rev
   
 let (__temp_no_proj : Prims.string -> Prims.bool) =
   fun s  ->
-    let uu____8774 = get___temp_no_proj ()  in
-    FStar_All.pipe_right uu____8774 (FStar_List.contains s)
+    let uu____8777 = get___temp_no_proj ()  in
+    FStar_All.pipe_right uu____8777 (FStar_List.contains s)
   
 let (__temp_fast_implicits : unit -> Prims.bool) =
-  fun uu____8789  -> lookup_opt "__temp_fast_implicits" as_bool 
+  fun uu____8792  -> lookup_opt "__temp_fast_implicits" as_bool 
 let (admit_smt_queries : unit -> Prims.bool) =
-  fun uu____8798  -> get_admit_smt_queries () 
+  fun uu____8801  -> get_admit_smt_queries () 
 let (admit_except : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____8807  -> get_admit_except () 
+  fun uu____8810  -> get_admit_except () 
 let (cache_checked_modules : unit -> Prims.bool) =
-  fun uu____8814  -> get_cache_checked_modules () 
-let (cache_off : unit -> Prims.bool) = fun uu____8821  -> get_cache_off () 
-let (cmi : unit -> Prims.bool) = fun uu____8828  -> get_cmi () 
+  fun uu____8817  -> get_cache_checked_modules () 
+let (cache_off : unit -> Prims.bool) = fun uu____8824  -> get_cache_off () 
+let (cmi : unit -> Prims.bool) = fun uu____8831  -> get_cmi () 
 type codegen_t =
   | OCaml 
   | FSharp 
@@ -1724,302 +1729,302 @@ type codegen_t =
   | Plugin 
 let (uu___is_OCaml : codegen_t -> Prims.bool) =
   fun projectee  ->
-    match projectee with | OCaml  -> true | uu____8838 -> false
+    match projectee with | OCaml  -> true | uu____8841 -> false
   
 let (uu___is_FSharp : codegen_t -> Prims.bool) =
   fun projectee  ->
-    match projectee with | FSharp  -> true | uu____8849 -> false
+    match projectee with | FSharp  -> true | uu____8852 -> false
   
 let (uu___is_Kremlin : codegen_t -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Kremlin  -> true | uu____8860 -> false
+    match projectee with | Kremlin  -> true | uu____8863 -> false
   
 let (uu___is_Plugin : codegen_t -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Plugin  -> true | uu____8871 -> false
+    match projectee with | Plugin  -> true | uu____8874 -> false
   
 let (codegen : unit -> codegen_t FStar_Pervasives_Native.option) =
-  fun uu____8880  ->
-    let uu____8881 = get_codegen ()  in
-    FStar_Util.map_opt uu____8881
-      (fun uu___9_8887  ->
-         match uu___9_8887 with
+  fun uu____8883  ->
+    let uu____8884 = get_codegen ()  in
+    FStar_Util.map_opt uu____8884
+      (fun uu___9_8890  ->
+         match uu___9_8890 with
          | "OCaml" -> OCaml
          | "FSharp" -> FSharp
          | "Kremlin" -> Kremlin
          | "Plugin" -> Plugin
-         | uu____8893 -> failwith "Impossible")
+         | uu____8896 -> failwith "Impossible")
   
 let (codegen_libs : unit -> Prims.string Prims.list Prims.list) =
-  fun uu____8906  ->
-    let uu____8907 = get_codegen_lib ()  in
-    FStar_All.pipe_right uu____8907
+  fun uu____8909  ->
+    let uu____8910 = get_codegen_lib ()  in
+    FStar_All.pipe_right uu____8910
       (FStar_List.map (fun x  -> FStar_Util.split x "."))
   
 let (debug_any : unit -> Prims.bool) =
-  fun uu____8933  -> let uu____8934 = get_debug ()  in uu____8934 <> [] 
+  fun uu____8936  -> let uu____8937 = get_debug ()  in uu____8937 <> [] 
 let (debug_module : Prims.string -> Prims.bool) =
   fun modul  ->
-    let uu____8951 = get_debug ()  in
-    FStar_All.pipe_right uu____8951
+    let uu____8954 = get_debug ()  in
+    FStar_All.pipe_right uu____8954
       (FStar_List.existsb (module_name_eq modul))
   
 let (debug_at_level : Prims.string -> debug_level_t -> Prims.bool) =
   fun modul  ->
     fun level  ->
-      (let uu____8976 = get_debug ()  in
-       FStar_All.pipe_right uu____8976
+      (let uu____8979 = get_debug ()  in
+       FStar_All.pipe_right uu____8979
          (FStar_List.existsb (module_name_eq modul)))
         && (debug_level_geq level)
   
 let (profile_group_by_decls : unit -> Prims.bool) =
-  fun uu____8991  -> get_profile_group_by_decl () 
+  fun uu____8994  -> get_profile_group_by_decl () 
 let (defensive : unit -> Prims.bool) =
-  fun uu____8998  -> let uu____8999 = get_defensive ()  in uu____8999 <> "no" 
+  fun uu____9001  -> let uu____9002 = get_defensive ()  in uu____9002 <> "no" 
 let (defensive_fail : unit -> Prims.bool) =
-  fun uu____9009  ->
-    let uu____9010 = get_defensive ()  in uu____9010 = "fail"
+  fun uu____9012  ->
+    let uu____9013 = get_defensive ()  in uu____9013 = "fail"
   
 let (dep : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____9022  -> get_dep () 
+  fun uu____9025  -> get_dep () 
 let (detail_errors : unit -> Prims.bool) =
-  fun uu____9029  -> get_detail_errors () 
+  fun uu____9032  -> get_detail_errors () 
 let (detail_hint_replay : unit -> Prims.bool) =
-  fun uu____9036  -> get_detail_hint_replay () 
-let (doc : unit -> Prims.bool) = fun uu____9043  -> get_doc () 
+  fun uu____9039  -> get_detail_hint_replay () 
+let (doc : unit -> Prims.bool) = fun uu____9046  -> get_doc () 
 let (dump_module : Prims.string -> Prims.bool) =
   fun s  ->
-    let uu____9053 = get_dump_module ()  in
-    FStar_All.pipe_right uu____9053 (FStar_List.existsb (module_name_eq s))
+    let uu____9056 = get_dump_module ()  in
+    FStar_All.pipe_right uu____9056 (FStar_List.existsb (module_name_eq s))
   
 let (eager_subtyping : unit -> Prims.bool) =
-  fun uu____9068  -> get_eager_subtyping () 
+  fun uu____9071  -> get_eager_subtyping () 
 let (expose_interfaces : unit -> Prims.bool) =
-  fun uu____9075  -> get_expose_interfaces () 
+  fun uu____9078  -> get_expose_interfaces () 
 let (fs_typ_app : Prims.string -> Prims.bool) =
   fun filename  ->
-    let uu____9085 = FStar_ST.op_Bang light_off_files  in
-    FStar_List.contains filename uu____9085
+    let uu____9088 = FStar_ST.op_Bang light_off_files  in
+    FStar_List.contains filename uu____9088
   
-let (full_context_dependency : unit -> Prims.bool) = fun uu____9121  -> true 
+let (full_context_dependency : unit -> Prims.bool) = fun uu____9124  -> true 
 let (hide_uvar_nums : unit -> Prims.bool) =
-  fun uu____9129  -> get_hide_uvar_nums () 
+  fun uu____9132  -> get_hide_uvar_nums () 
 let (hint_info : unit -> Prims.bool) =
-  fun uu____9136  -> (get_hint_info ()) || (get_query_stats ()) 
+  fun uu____9139  -> (get_hint_info ()) || (get_query_stats ()) 
 let (hint_dir : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____9145  -> get_hint_dir () 
+  fun uu____9148  -> get_hint_dir () 
 let (hint_file : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____9154  -> get_hint_file () 
+  fun uu____9157  -> get_hint_file () 
 let (hint_file_for_src : Prims.string -> Prims.string) =
   fun src_filename  ->
-    let uu____9164 = hint_file ()  in
-    match uu____9164 with
+    let uu____9167 = hint_file ()  in
+    match uu____9167 with
     | FStar_Pervasives_Native.Some fn -> fn
     | FStar_Pervasives_Native.None  ->
         let file_name =
-          let uu____9175 = hint_dir ()  in
-          match uu____9175 with
+          let uu____9178 = hint_dir ()  in
+          match uu____9178 with
           | FStar_Pervasives_Native.Some dir ->
-              let uu____9183 = FStar_Util.basename src_filename  in
-              FStar_Util.concat_dir_filename dir uu____9183
-          | uu____9185 -> src_filename  in
+              let uu____9186 = FStar_Util.basename src_filename  in
+              FStar_Util.concat_dir_filename dir uu____9186
+          | uu____9188 -> src_filename  in
         FStar_Util.format1 "%s.hints" file_name
   
-let (ide : unit -> Prims.bool) = fun uu____9196  -> get_ide () 
-let (print : unit -> Prims.bool) = fun uu____9203  -> get_print () 
+let (ide : unit -> Prims.bool) = fun uu____9199  -> get_ide () 
+let (print : unit -> Prims.bool) = fun uu____9206  -> get_print () 
 let (print_in_place : unit -> Prims.bool) =
-  fun uu____9210  -> get_print_in_place () 
+  fun uu____9213  -> get_print_in_place () 
 let (initial_fuel : unit -> Prims.int) =
-  fun uu____9217  ->
-    let uu____9218 = get_initial_fuel ()  in
-    let uu____9220 = get_max_fuel ()  in Prims.min uu____9218 uu____9220
+  fun uu____9220  ->
+    let uu____9221 = get_initial_fuel ()  in
+    let uu____9223 = get_max_fuel ()  in Prims.min uu____9221 uu____9223
   
 let (initial_ifuel : unit -> Prims.int) =
-  fun uu____9228  ->
-    let uu____9229 = get_initial_ifuel ()  in
-    let uu____9231 = get_max_ifuel ()  in Prims.min uu____9229 uu____9231
+  fun uu____9231  ->
+    let uu____9232 = get_initial_ifuel ()  in
+    let uu____9234 = get_max_ifuel ()  in Prims.min uu____9232 uu____9234
   
 let (interactive : unit -> Prims.bool) =
-  fun uu____9239  -> (get_in ()) || (get_ide ()) 
-let (lax : unit -> Prims.bool) = fun uu____9246  -> get_lax () 
-let (load : unit -> Prims.string Prims.list) = fun uu____9255  -> get_load () 
-let (legacy_interactive : unit -> Prims.bool) = fun uu____9262  -> get_in () 
-let (lsp_server : unit -> Prims.bool) = fun uu____9269  -> get_lsp () 
+  fun uu____9242  -> (get_in ()) || (get_ide ()) 
+let (lax : unit -> Prims.bool) = fun uu____9249  -> get_lax () 
+let (load : unit -> Prims.string Prims.list) = fun uu____9258  -> get_load () 
+let (legacy_interactive : unit -> Prims.bool) = fun uu____9265  -> get_in () 
+let (lsp_server : unit -> Prims.bool) = fun uu____9272  -> get_lsp () 
 let (log_queries : unit -> Prims.bool) =
-  fun uu____9276  -> get_log_queries () 
+  fun uu____9279  -> get_log_queries () 
 let (keep_query_captions : unit -> Prims.bool) =
-  fun uu____9283  -> (log_queries ()) && (get_keep_query_captions ()) 
-let (log_types : unit -> Prims.bool) = fun uu____9290  -> get_log_types () 
-let (max_fuel : unit -> Prims.int) = fun uu____9297  -> get_max_fuel () 
-let (max_ifuel : unit -> Prims.int) = fun uu____9304  -> get_max_ifuel () 
-let (min_fuel : unit -> Prims.int) = fun uu____9311  -> get_min_fuel () 
-let (ml_ish : unit -> Prims.bool) = fun uu____9318  -> get_MLish () 
+  fun uu____9286  -> (log_queries ()) && (get_keep_query_captions ()) 
+let (log_types : unit -> Prims.bool) = fun uu____9293  -> get_log_types () 
+let (max_fuel : unit -> Prims.int) = fun uu____9300  -> get_max_fuel () 
+let (max_ifuel : unit -> Prims.int) = fun uu____9307  -> get_max_ifuel () 
+let (min_fuel : unit -> Prims.int) = fun uu____9314  -> get_min_fuel () 
+let (ml_ish : unit -> Prims.bool) = fun uu____9321  -> get_MLish () 
 let (set_ml_ish : unit -> unit) =
-  fun uu____9324  -> set_option "MLish" (Bool true) 
+  fun uu____9327  -> set_option "MLish" (Bool true) 
 let (no_default_includes : unit -> Prims.bool) =
-  fun uu____9333  -> get_no_default_includes () 
+  fun uu____9336  -> get_no_default_includes () 
 let (no_extract : Prims.string -> Prims.bool) =
   fun s  ->
-    let uu____9343 = get_no_extract ()  in
-    FStar_All.pipe_right uu____9343 (FStar_List.existsb (module_name_eq s))
+    let uu____9346 = get_no_extract ()  in
+    FStar_All.pipe_right uu____9346 (FStar_List.existsb (module_name_eq s))
   
 let (normalize_pure_terms_for_extraction : unit -> Prims.bool) =
-  fun uu____9358  -> get_normalize_pure_terms_for_extraction () 
+  fun uu____9361  -> get_normalize_pure_terms_for_extraction () 
 let (no_location_info : unit -> Prims.bool) =
-  fun uu____9365  -> get_no_location_info () 
-let (no_plugins : unit -> Prims.bool) = fun uu____9372  -> get_no_plugins () 
-let (no_smt : unit -> Prims.bool) = fun uu____9379  -> get_no_smt () 
+  fun uu____9368  -> get_no_location_info () 
+let (no_plugins : unit -> Prims.bool) = fun uu____9375  -> get_no_plugins () 
+let (no_smt : unit -> Prims.bool) = fun uu____9382  -> get_no_smt () 
 let (output_dir : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____9388  -> get_odir () 
-let (ugly : unit -> Prims.bool) = fun uu____9395  -> get_ugly () 
+  fun uu____9391  -> get_odir () 
+let (ugly : unit -> Prims.bool) = fun uu____9398  -> get_ugly () 
 let (print_bound_var_types : unit -> Prims.bool) =
-  fun uu____9402  -> get_print_bound_var_types () 
+  fun uu____9405  -> get_print_bound_var_types () 
 let (print_effect_args : unit -> Prims.bool) =
-  fun uu____9409  -> get_print_effect_args () 
+  fun uu____9412  -> get_print_effect_args () 
 let (print_implicits : unit -> Prims.bool) =
-  fun uu____9416  -> get_print_implicits () 
+  fun uu____9419  -> get_print_implicits () 
 let (print_real_names : unit -> Prims.bool) =
-  fun uu____9423  -> (get_prn ()) || (get_print_full_names ()) 
+  fun uu____9426  -> (get_prn ()) || (get_print_full_names ()) 
 let (print_universes : unit -> Prims.bool) =
-  fun uu____9430  -> get_print_universes () 
+  fun uu____9433  -> get_print_universes () 
 let (print_z3_statistics : unit -> Prims.bool) =
-  fun uu____9437  -> get_print_z3_statistics () 
+  fun uu____9440  -> get_print_z3_statistics () 
 let (query_stats : unit -> Prims.bool) =
-  fun uu____9444  -> get_query_stats () 
+  fun uu____9447  -> get_query_stats () 
 let (record_hints : unit -> Prims.bool) =
-  fun uu____9451  -> get_record_hints () 
+  fun uu____9454  -> get_record_hints () 
 let (reuse_hint_for : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____9460  -> get_reuse_hint_for () 
-let (silent : unit -> Prims.bool) = fun uu____9467  -> get_silent () 
+  fun uu____9463  -> get_reuse_hint_for () 
+let (silent : unit -> Prims.bool) = fun uu____9470  -> get_silent () 
 let (smtencoding_elim_box : unit -> Prims.bool) =
-  fun uu____9474  -> get_smtencoding_elim_box () 
+  fun uu____9477  -> get_smtencoding_elim_box () 
 let (smtencoding_nl_arith_native : unit -> Prims.bool) =
-  fun uu____9481  ->
-    let uu____9482 = get_smtencoding_nl_arith_repr ()  in
-    uu____9482 = "native"
+  fun uu____9484  ->
+    let uu____9485 = get_smtencoding_nl_arith_repr ()  in
+    uu____9485 = "native"
   
 let (smtencoding_nl_arith_wrapped : unit -> Prims.bool) =
-  fun uu____9492  ->
-    let uu____9493 = get_smtencoding_nl_arith_repr ()  in
-    uu____9493 = "wrapped"
+  fun uu____9495  ->
+    let uu____9496 = get_smtencoding_nl_arith_repr ()  in
+    uu____9496 = "wrapped"
   
 let (smtencoding_nl_arith_default : unit -> Prims.bool) =
-  fun uu____9503  ->
-    let uu____9504 = get_smtencoding_nl_arith_repr ()  in
-    uu____9504 = "boxwrap"
+  fun uu____9506  ->
+    let uu____9507 = get_smtencoding_nl_arith_repr ()  in
+    uu____9507 = "boxwrap"
   
 let (smtencoding_l_arith_native : unit -> Prims.bool) =
-  fun uu____9514  ->
-    let uu____9515 = get_smtencoding_l_arith_repr ()  in
-    uu____9515 = "native"
+  fun uu____9517  ->
+    let uu____9518 = get_smtencoding_l_arith_repr ()  in
+    uu____9518 = "native"
   
 let (smtencoding_l_arith_default : unit -> Prims.bool) =
-  fun uu____9525  ->
-    let uu____9526 = get_smtencoding_l_arith_repr ()  in
-    uu____9526 = "boxwrap"
+  fun uu____9528  ->
+    let uu____9529 = get_smtencoding_l_arith_repr ()  in
+    uu____9529 = "boxwrap"
   
 let (smtencoding_valid_intro : unit -> Prims.bool) =
-  fun uu____9536  -> get_smtencoding_valid_intro () 
+  fun uu____9539  -> get_smtencoding_valid_intro () 
 let (smtencoding_valid_elim : unit -> Prims.bool) =
-  fun uu____9543  -> get_smtencoding_valid_elim () 
+  fun uu____9546  -> get_smtencoding_valid_elim () 
 let (tactic_raw_binders : unit -> Prims.bool) =
-  fun uu____9550  -> get_tactic_raw_binders () 
+  fun uu____9553  -> get_tactic_raw_binders () 
 let (tactics_failhard : unit -> Prims.bool) =
-  fun uu____9557  -> get_tactics_failhard () 
+  fun uu____9560  -> get_tactics_failhard () 
 let (tactics_info : unit -> Prims.bool) =
-  fun uu____9564  -> get_tactics_info () 
+  fun uu____9567  -> get_tactics_info () 
 let (tactic_trace : unit -> Prims.bool) =
-  fun uu____9571  -> get_tactic_trace () 
+  fun uu____9574  -> get_tactic_trace () 
 let (tactic_trace_d : unit -> Prims.int) =
-  fun uu____9578  -> get_tactic_trace_d () 
+  fun uu____9581  -> get_tactic_trace_d () 
 let (tactics_nbe : unit -> Prims.bool) =
-  fun uu____9585  -> get_tactics_nbe () 
-let (tcnorm : unit -> Prims.bool) = fun uu____9592  -> get_tcnorm () 
-let (timing : unit -> Prims.bool) = fun uu____9599  -> get_timing () 
+  fun uu____9588  -> get_tactics_nbe () 
+let (tcnorm : unit -> Prims.bool) = fun uu____9595  -> get_tcnorm () 
+let (timing : unit -> Prims.bool) = fun uu____9602  -> get_timing () 
 let (trace_error : unit -> Prims.bool) =
-  fun uu____9606  -> get_trace_error () 
+  fun uu____9609  -> get_trace_error () 
 let (unthrottle_inductives : unit -> Prims.bool) =
-  fun uu____9613  -> get_unthrottle_inductives () 
+  fun uu____9616  -> get_unthrottle_inductives () 
 let (unsafe_tactic_exec : unit -> Prims.bool) =
-  fun uu____9620  -> get_unsafe_tactic_exec () 
+  fun uu____9623  -> get_unsafe_tactic_exec () 
 let (use_eq_at_higher_order : unit -> Prims.bool) =
-  fun uu____9627  -> get_use_eq_at_higher_order () 
-let (use_hints : unit -> Prims.bool) = fun uu____9634  -> get_use_hints () 
+  fun uu____9630  -> get_use_eq_at_higher_order () 
+let (use_hints : unit -> Prims.bool) = fun uu____9637  -> get_use_hints () 
 let (use_hint_hashes : unit -> Prims.bool) =
-  fun uu____9641  -> get_use_hint_hashes () 
+  fun uu____9644  -> get_use_hint_hashes () 
 let (use_native_tactics :
   unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____9650  -> get_use_native_tactics () 
+  fun uu____9653  -> get_use_native_tactics () 
 let (use_tactics : unit -> Prims.bool) =
-  fun uu____9657  -> get_use_tactics () 
+  fun uu____9660  -> get_use_tactics () 
 let (using_facts_from :
   unit -> (Prims.string Prims.list * Prims.bool) Prims.list) =
-  fun uu____9673  ->
-    let uu____9674 = get_using_facts_from ()  in
-    match uu____9674 with
+  fun uu____9676  ->
+    let uu____9677 = get_using_facts_from ()  in
+    match uu____9677 with
     | FStar_Pervasives_Native.None  -> [([], true)]
     | FStar_Pervasives_Native.Some ns -> parse_settings ns
   
 let (vcgen_optimize_bind_as_seq : unit -> Prims.bool) =
-  fun uu____9728  ->
-    let uu____9729 = get_vcgen_optimize_bind_as_seq ()  in
-    FStar_Option.isSome uu____9729
+  fun uu____9731  ->
+    let uu____9732 = get_vcgen_optimize_bind_as_seq ()  in
+    FStar_Option.isSome uu____9732
   
 let (vcgen_decorate_with_type : unit -> Prims.bool) =
-  fun uu____9740  ->
-    let uu____9741 = get_vcgen_optimize_bind_as_seq ()  in
-    match uu____9741 with
+  fun uu____9743  ->
+    let uu____9744 = get_vcgen_optimize_bind_as_seq ()  in
+    match uu____9744 with
     | FStar_Pervasives_Native.Some "with_type" -> true
-    | uu____9749 -> false
+    | uu____9752 -> false
   
 let (warn_default_effects : unit -> Prims.bool) =
-  fun uu____9760  -> get_warn_default_effects () 
+  fun uu____9763  -> get_warn_default_effects () 
 let (z3_exe : unit -> Prims.string) =
-  fun uu____9767  ->
-    let uu____9768 = get_smt ()  in
-    match uu____9768 with
+  fun uu____9770  ->
+    let uu____9771 = get_smt ()  in
+    match uu____9771 with
     | FStar_Pervasives_Native.None  -> FStar_Platform.exe "z3"
     | FStar_Pervasives_Native.Some s -> s
   
 let (z3_cliopt : unit -> Prims.string Prims.list) =
-  fun uu____9786  -> get_z3cliopt () 
-let (z3_refresh : unit -> Prims.bool) = fun uu____9793  -> get_z3refresh () 
-let (z3_rlimit : unit -> Prims.int) = fun uu____9800  -> get_z3rlimit () 
+  fun uu____9789  -> get_z3cliopt () 
+let (z3_refresh : unit -> Prims.bool) = fun uu____9796  -> get_z3refresh () 
+let (z3_rlimit : unit -> Prims.int) = fun uu____9803  -> get_z3rlimit () 
 let (z3_rlimit_factor : unit -> Prims.int) =
-  fun uu____9807  -> get_z3rlimit_factor () 
-let (z3_seed : unit -> Prims.int) = fun uu____9814  -> get_z3seed () 
+  fun uu____9810  -> get_z3rlimit_factor () 
+let (z3_seed : unit -> Prims.int) = fun uu____9817  -> get_z3seed () 
 let (use_two_phase_tc : unit -> Prims.bool) =
-  fun uu____9821  ->
+  fun uu____9824  ->
     (get_use_two_phase_tc ()) &&
-      (let uu____9823 = lax ()  in Prims.op_Negation uu____9823)
+      (let uu____9826 = lax ()  in Prims.op_Negation uu____9826)
   
 let (no_positivity : unit -> Prims.bool) =
-  fun uu____9831  -> get_no_positivity () 
+  fun uu____9834  -> get_no_positivity () 
 let (ml_no_eta_expand_coertions : unit -> Prims.bool) =
-  fun uu____9838  -> get_ml_no_eta_expand_coertions () 
+  fun uu____9841  -> get_ml_no_eta_expand_coertions () 
 let (warn_error : unit -> Prims.string) =
-  fun uu____9845  ->
-    let uu____9846 = get_warn_error ()  in FStar_String.concat "" uu____9846
+  fun uu____9848  ->
+    let uu____9849 = get_warn_error ()  in FStar_String.concat "" uu____9849
   
 let (use_extracted_interfaces : unit -> Prims.bool) =
-  fun uu____9857  -> get_use_extracted_interfaces () 
-let (use_nbe : unit -> Prims.bool) = fun uu____9864  -> get_use_nbe () 
+  fun uu____9860  -> get_use_extracted_interfaces () 
+let (use_nbe : unit -> Prims.bool) = fun uu____9867  -> get_use_nbe () 
 let (trivial_pre_for_unannotated_effectful_fns : unit -> Prims.bool) =
-  fun uu____9871  -> get_trivial_pre_for_unannotated_effectful_fns () 
+  fun uu____9874  -> get_trivial_pre_for_unannotated_effectful_fns () 
 let with_saved_options : 'a . (unit -> 'a) -> 'a =
   fun f  ->
-    let uu____9888 =
-      let uu____9890 = trace_error ()  in Prims.op_Negation uu____9890  in
-    if uu____9888
+    let uu____9891 =
+      let uu____9893 = trace_error ()  in Prims.op_Negation uu____9893  in
+    if uu____9891
     then
       (push ();
        (let r =
           try
-            (fun uu___732_9905  ->
+            (fun uu___732_9908  ->
                match () with
-               | () -> let uu____9910 = f ()  in FStar_Util.Inr uu____9910)
+               | () -> let uu____9913 = f ()  in FStar_Util.Inr uu____9913)
               ()
-          with | uu___731_9912 -> FStar_Util.Inl uu___731_9912  in
+          with | uu___731_9915 -> FStar_Util.Inl uu___731_9915  in
         pop ();
         (match r with
          | FStar_Util.Inr v1 -> v1
@@ -2035,28 +2040,28 @@ let (module_matches_namespace_filter :
       let m_components = path_of_text m1  in
       let rec matches_path m_components1 path =
         match (m_components1, path) with
-        | (uu____9993,[]) -> true
+        | (uu____9996,[]) -> true
         | (m2::ms,p::ps) ->
             (m2 = (FStar_String.lowercase p)) && (matches_path ms ps)
-        | uu____10026 -> false  in
-      let uu____10038 =
+        | uu____10029 -> false  in
+      let uu____10041 =
         FStar_All.pipe_right setting
           (FStar_Util.try_find
-             (fun uu____10080  ->
-                match uu____10080 with
-                | (path,uu____10091) -> matches_path m_components path))
+             (fun uu____10083  ->
+                match uu____10083 with
+                | (path,uu____10094) -> matches_path m_components path))
          in
-      match uu____10038 with
+      match uu____10041 with
       | FStar_Pervasives_Native.None  -> false
-      | FStar_Pervasives_Native.Some (uu____10110,flag) -> flag
+      | FStar_Pervasives_Native.Some (uu____10113,flag) -> flag
   
 let (matches_namespace_filter_opt :
   Prims.string ->
     Prims.string Prims.list FStar_Pervasives_Native.option -> Prims.bool)
   =
   fun m  ->
-    fun uu___10_10145  ->
-      match uu___10_10145 with
+    fun uu___10_10148  ->
+      match uu___10_10148 with
       | FStar_Pervasives_Native.None  -> false
       | FStar_Pervasives_Native.Some filter1 ->
           module_matches_namespace_filter m filter1
@@ -2064,24 +2069,24 @@ let (matches_namespace_filter_opt :
 let (should_extract : Prims.string -> Prims.bool) =
   fun m  ->
     let m1 = FStar_String.lowercase m  in
-    let uu____10175 = get_extract ()  in
-    match uu____10175 with
+    let uu____10178 = get_extract ()  in
+    match uu____10178 with
     | FStar_Pervasives_Native.Some extract_setting ->
-        ((let uu____10190 =
-            let uu____10206 = get_no_extract ()  in
-            let uu____10210 = get_extract_namespace ()  in
-            let uu____10214 = get_extract_module ()  in
-            (uu____10206, uu____10210, uu____10214)  in
-          match uu____10190 with
+        ((let uu____10193 =
+            let uu____10209 = get_no_extract ()  in
+            let uu____10213 = get_extract_namespace ()  in
+            let uu____10217 = get_extract_module ()  in
+            (uu____10209, uu____10213, uu____10217)  in
+          match uu____10193 with
           | ([],[],[]) -> ()
-          | uu____10239 ->
+          | uu____10242 ->
               failwith
                 "Incompatible options: --extract cannot be used with --no_extract, --extract_namespace or --extract_module");
          module_matches_namespace_filter m1 extract_setting)
     | FStar_Pervasives_Native.None  ->
         let should_extract_namespace m2 =
-          let uu____10268 = get_extract_namespace ()  in
-          match uu____10268 with
+          let uu____10271 = get_extract_namespace ()  in
+          match uu____10271 with
           | [] -> false
           | ns ->
               FStar_All.pipe_right ns
@@ -2090,39 +2095,39 @@ let (should_extract : Prims.string -> Prims.bool) =
                       FStar_Util.starts_with m2 (FStar_String.lowercase n1)))
            in
         let should_extract_module m2 =
-          let uu____10296 = get_extract_module ()  in
-          match uu____10296 with
+          let uu____10299 = get_extract_module ()  in
+          match uu____10299 with
           | [] -> false
           | l ->
               FStar_All.pipe_right l
                 (FStar_Util.for_some
                    (fun n1  -> (FStar_String.lowercase n1) = m2))
            in
-        (let uu____10318 = no_extract m1  in Prims.op_Negation uu____10318)
+        (let uu____10321 = no_extract m1  in Prims.op_Negation uu____10321)
           &&
-          (let uu____10321 =
-             let uu____10332 = get_extract_namespace ()  in
-             let uu____10336 = get_extract_module ()  in
-             (uu____10332, uu____10336)  in
-           (match uu____10321 with
+          (let uu____10324 =
+             let uu____10335 = get_extract_namespace ()  in
+             let uu____10339 = get_extract_module ()  in
+             (uu____10335, uu____10339)  in
+           (match uu____10324 with
             | ([],[]) -> true
-            | uu____10356 ->
+            | uu____10359 ->
                 (should_extract_namespace m1) || (should_extract_module m1)))
   
 let (should_be_already_cached : Prims.string -> Prims.bool) =
   fun m  ->
-    let uu____10376 = get_already_cached ()  in
-    match uu____10376 with
+    let uu____10379 = get_already_cached ()  in
+    match uu____10379 with
     | FStar_Pervasives_Native.None  -> false
     | FStar_Pervasives_Native.Some already_cached_setting ->
         module_matches_namespace_filter m already_cached_setting
   
 let (error_flags : unit -> error_flag Prims.list) =
   let cache = FStar_Util.smap_create (Prims.of_int (10))  in
-  fun uu____10409  ->
+  fun uu____10412  ->
     let we = warn_error ()  in
-    let uu____10412 = FStar_Util.smap_try_find cache we  in
-    match uu____10412 with
+    let uu____10415 = FStar_Util.smap_try_find cache we  in
+    match uu____10415 with
     | FStar_Pervasives_Native.None  ->
         let r = parse_warn_error we  in (FStar_Util.smap_add cache we r; r)
     | FStar_Pervasives_Native.Some r -> r
@@ -2134,11 +2139,11 @@ let (profile_enabled :
     fun phase  ->
       match modul_opt with
       | FStar_Pervasives_Native.None  ->
-          let uu____10456 = get_profile_component ()  in
-          matches_namespace_filter_opt phase uu____10456
+          let uu____10459 = get_profile_component ()  in
+          matches_namespace_filter_opt phase uu____10459
       | FStar_Pervasives_Native.Some modul ->
-          (let uu____10467 = get_profile ()  in
-           matches_namespace_filter_opt modul uu____10467) &&
-            (let uu____10474 = get_profile_component ()  in
-             matches_namespace_filter_opt phase uu____10474)
+          (let uu____10470 = get_profile ()  in
+           matches_namespace_filter_opt modul uu____10470) &&
+            (let uu____10477 = get_profile_component ()  in
+             matches_namespace_filter_opt phase uu____10477)
   

--- a/src/ocaml-output/FStar_Parser_Const.ml
+++ b/src/ocaml-output/FStar_Parser_Const.ml
@@ -254,15 +254,19 @@ let (postprocess_with : FStar_Ident.lident) =
   p2l ["FStar"; "Tactics"; "Effect"; "postprocess_with"] 
 let (postprocess_extr_with : FStar_Ident.lident) =
   p2l ["FStar"; "Tactics"; "Effect"; "postprocess_for_extraction_with"] 
+let (check_with_lid : FStar_Ident.lident) =
+  FStar_Ident.lid_of_path ["FStar"; "Reflection"; "Basic"; "check_with"]
+    FStar_Range.dummyRange
+  
 let (gen_reset : ((unit -> Prims.int) * (unit -> unit))) =
   let x = FStar_Util.mk_ref Prims.int_zero  in
-  let gen1 uu____905 = FStar_Util.incr x; FStar_Util.read x  in
-  let reset uu____913 = FStar_Util.write x Prims.int_zero  in (gen1, reset) 
+  let gen1 uu____915 = FStar_Util.incr x; FStar_Util.read x  in
+  let reset uu____923 = FStar_Util.write x Prims.int_zero  in (gen1, reset) 
 let (next_id : unit -> Prims.int) = FStar_Pervasives_Native.fst gen_reset 
 let (sli : FStar_Ident.lident -> Prims.string) =
   fun l  ->
-    let uu____944 = FStar_Options.print_real_names ()  in
-    if uu____944
+    let uu____954 = FStar_Options.print_real_names ()  in
+    if uu____954
     then l.FStar_Ident.str
     else (l.FStar_Ident.ident).FStar_Ident.idText
   
@@ -274,28 +278,28 @@ let (const_to_string : FStar_Const.sconst -> Prims.string) =
     | FStar_Const.Const_bool b -> if b then "true" else "false"
     | FStar_Const.Const_real r -> FStar_String.op_Hat r "R"
     | FStar_Const.Const_float x1 -> FStar_Util.string_of_float x1
-    | FStar_Const.Const_string (s,uu____973) -> FStar_Util.format1 "\"%s\"" s
-    | FStar_Const.Const_bytearray uu____977 -> "<bytearray>"
-    | FStar_Const.Const_int (x1,uu____986) -> x1
+    | FStar_Const.Const_string (s,uu____983) -> FStar_Util.format1 "\"%s\"" s
+    | FStar_Const.Const_bytearray uu____987 -> "<bytearray>"
+    | FStar_Const.Const_int (x1,uu____996) -> x1
     | FStar_Const.Const_char c ->
-        let uu____1003 =
+        let uu____1013 =
           FStar_String.op_Hat (FStar_Util.string_of_char c) "'"  in
-        FStar_String.op_Hat "'" uu____1003
+        FStar_String.op_Hat "'" uu____1013
     | FStar_Const.Const_range r -> FStar_Range.string_of_range r
     | FStar_Const.Const_range_of  -> "range_of"
     | FStar_Const.Const_set_range_of  -> "set_range_of"
     | FStar_Const.Const_reify  -> "reify"
     | FStar_Const.Const_reflect l ->
-        let uu____1012 = sli l  in
-        FStar_Util.format1 "[[%s.reflect]]" uu____1012
+        let uu____1022 = sli l  in
+        FStar_Util.format1 "[[%s.reflect]]" uu____1022
   
 let (mk_tuple_lid : Prims.int -> FStar_Range.range -> FStar_Ident.lident) =
   fun n1  ->
     fun r  ->
       let t =
-        let uu____1030 = FStar_Util.string_of_int n1  in
-        FStar_Util.format1 "tuple%s" uu____1030  in
-      let uu____1033 = psnconst t  in FStar_Ident.set_lid_range uu____1033 r
+        let uu____1040 = FStar_Util.string_of_int n1  in
+        FStar_Util.format1 "tuple%s" uu____1040  in
+      let uu____1043 = psnconst t  in FStar_Ident.set_lid_range uu____1043 r
   
 let (lid_tuple2 : FStar_Ident.lident) =
   mk_tuple_lid (Prims.of_int (2)) FStar_Range.dummyRange 
@@ -303,17 +307,17 @@ let (is_tuple_constructor_string : Prims.string -> Prims.bool) =
   fun s  -> FStar_Util.starts_with s "FStar.Pervasives.Native.tuple" 
 let (is_tuple_constructor_lid : FStar_Ident.ident -> Prims.bool) =
   fun lid  ->
-    let uu____1054 = FStar_Ident.text_of_id lid  in
-    is_tuple_constructor_string uu____1054
+    let uu____1064 = FStar_Ident.text_of_id lid  in
+    is_tuple_constructor_string uu____1064
   
 let (mk_tuple_data_lid :
   Prims.int -> FStar_Range.range -> FStar_Ident.lident) =
   fun n1  ->
     fun r  ->
       let t =
-        let uu____1071 = FStar_Util.string_of_int n1  in
-        FStar_Util.format1 "Mktuple%s" uu____1071  in
-      let uu____1074 = psnconst t  in FStar_Ident.set_lid_range uu____1074 r
+        let uu____1081 = FStar_Util.string_of_int n1  in
+        FStar_Util.format1 "Mktuple%s" uu____1081  in
+      let uu____1084 = psnconst t  in FStar_Ident.set_lid_range uu____1084 r
   
 let (lid_Mktuple2 : FStar_Ident.lident) =
   mk_tuple_data_lid (Prims.of_int (2)) FStar_Range.dummyRange 
@@ -322,8 +326,8 @@ let (is_tuple_datacon_string : Prims.string -> Prims.bool) =
 let (is_tuple_data_lid : FStar_Ident.lident -> Prims.int -> Prims.bool) =
   fun f  ->
     fun n1  ->
-      let uu____1102 = mk_tuple_data_lid n1 FStar_Range.dummyRange  in
-      FStar_Ident.lid_equals f uu____1102
+      let uu____1112 = mk_tuple_data_lid n1 FStar_Range.dummyRange  in
+      FStar_Ident.lid_equals f uu____1112
   
 let (is_tuple_data_lid' : FStar_Ident.lident -> Prims.bool) =
   fun f  -> is_tuple_datacon_string f.FStar_Ident.str 
@@ -333,11 +337,11 @@ let (mk_dtuple_lid : Prims.int -> FStar_Range.range -> FStar_Ident.lident) =
   fun n1  ->
     fun r  ->
       let t =
-        let uu____1150 = FStar_Util.string_of_int n1  in
-        FStar_Util.format1 "dtuple%s" uu____1150  in
-      let uu____1153 = let uu____1154 = mod_prefix_dtuple n1  in uu____1154 t
+        let uu____1160 = FStar_Util.string_of_int n1  in
+        FStar_Util.format1 "dtuple%s" uu____1160  in
+      let uu____1163 = let uu____1164 = mod_prefix_dtuple n1  in uu____1164 t
          in
-      FStar_Ident.set_lid_range uu____1153 r
+      FStar_Ident.set_lid_range uu____1163 r
   
 let (is_dtuple_constructor_string : Prims.string -> Prims.bool) =
   fun s  ->
@@ -351,11 +355,11 @@ let (mk_dtuple_data_lid :
   fun n1  ->
     fun r  ->
       let t =
-        let uu____1195 = FStar_Util.string_of_int n1  in
-        FStar_Util.format1 "Mkdtuple%s" uu____1195  in
-      let uu____1198 = let uu____1199 = mod_prefix_dtuple n1  in uu____1199 t
+        let uu____1205 = FStar_Util.string_of_int n1  in
+        FStar_Util.format1 "Mkdtuple%s" uu____1205  in
+      let uu____1208 = let uu____1209 = mod_prefix_dtuple n1  in uu____1209 t
          in
-      FStar_Ident.set_lid_range uu____1198 r
+      FStar_Ident.set_lid_range uu____1208 r
   
 let (is_dtuple_datacon_string : Prims.string -> Prims.bool) =
   fun s  ->
@@ -365,13 +369,13 @@ let (is_dtuple_datacon_string : Prims.string -> Prims.bool) =
 let (is_dtuple_data_lid : FStar_Ident.lident -> Prims.int -> Prims.bool) =
   fun f  ->
     fun n1  ->
-      let uu____1232 = mk_dtuple_data_lid n1 FStar_Range.dummyRange  in
-      FStar_Ident.lid_equals f uu____1232
+      let uu____1242 = mk_dtuple_data_lid n1 FStar_Range.dummyRange  in
+      FStar_Ident.lid_equals f uu____1242
   
 let (is_dtuple_data_lid' : FStar_Ident.lident -> Prims.bool) =
   fun f  ->
-    let uu____1240 = FStar_Ident.text_of_lid f  in
-    is_dtuple_datacon_string uu____1240
+    let uu____1250 = FStar_Ident.text_of_lid f  in
+    is_dtuple_datacon_string uu____1250
   
 let (is_name : FStar_Ident.lident -> Prims.bool) =
   fun lid  ->

--- a/src/ocaml-output/FStar_Reflection_Basic.ml
+++ b/src/ocaml-output/FStar_Reflection_Basic.ml
@@ -538,7 +538,9 @@ let (set_sigelt_attrs :
           (uu___372_1672.FStar_Syntax_Syntax.sigquals);
         FStar_Syntax_Syntax.sigmeta =
           (uu___372_1672.FStar_Syntax_Syntax.sigmeta);
-        FStar_Syntax_Syntax.sigattrs = attrs
+        FStar_Syntax_Syntax.sigattrs = attrs;
+        FStar_Syntax_Syntax.sigopts =
+          (uu___372_1672.FStar_Syntax_Syntax.sigopts)
       }
   
 let (sigelt_quals :
@@ -559,24 +561,30 @@ let (set_sigelt_quals :
         FStar_Syntax_Syntax.sigmeta =
           (uu___377_1698.FStar_Syntax_Syntax.sigmeta);
         FStar_Syntax_Syntax.sigattrs =
-          (uu___377_1698.FStar_Syntax_Syntax.sigattrs)
+          (uu___377_1698.FStar_Syntax_Syntax.sigattrs);
+        FStar_Syntax_Syntax.sigopts =
+          (uu___377_1698.FStar_Syntax_Syntax.sigopts)
       }
   
+let (sigelt_opts :
+  FStar_Syntax_Syntax.sigelt ->
+    FStar_Options.optionstate FStar_Pervasives_Native.option)
+  = fun se  -> se.FStar_Syntax_Syntax.sigopts 
 let (inspect_sigelt :
   FStar_Syntax_Syntax.sigelt -> FStar_Reflection_Data.sigelt_view) =
   fun se  ->
     match se.FStar_Syntax_Syntax.sigel with
-    | FStar_Syntax_Syntax.Sig_let ((r,lb::[]),uu____1707) ->
+    | FStar_Syntax_Syntax.Sig_let ((r,lb::[]),uu____1717) ->
         let fv =
           match lb.FStar_Syntax_Syntax.lbname with
           | FStar_Util.Inr fv -> fv
-          | FStar_Util.Inl uu____1718 ->
+          | FStar_Util.Inl uu____1728 ->
               failwith "impossible: global Sig_let has bv"
            in
-        let uu____1720 =
+        let uu____1730 =
           FStar_Syntax_Subst.univ_var_opening lb.FStar_Syntax_Syntax.lbunivs
            in
-        (match uu____1720 with
+        (match uu____1730 with
          | (s,us) ->
              let typ =
                FStar_Syntax_Subst.subst s lb.FStar_Syntax_Syntax.lbtyp  in
@@ -586,29 +594,29 @@ let (inspect_sigelt :
                (r, fv, (lb.FStar_Syntax_Syntax.lbunivs),
                  (lb.FStar_Syntax_Syntax.lbtyp),
                  (lb.FStar_Syntax_Syntax.lbdef)))
-    | FStar_Syntax_Syntax.Sig_inductive_typ (lid,us,bs,ty,uu____1748,c_lids)
+    | FStar_Syntax_Syntax.Sig_inductive_typ (lid,us,bs,ty,uu____1758,c_lids)
         ->
         let nm = FStar_Ident.path_of_lid lid  in
-        let uu____1759 = FStar_Syntax_Subst.univ_var_opening us  in
-        (match uu____1759 with
+        let uu____1769 = FStar_Syntax_Subst.univ_var_opening us  in
+        (match uu____1769 with
          | (s,us1) ->
              let bs1 = FStar_Syntax_Subst.subst_binders s bs  in
              let ty1 = FStar_Syntax_Subst.subst s ty  in
-             let uu____1780 =
-               let uu____1797 = FStar_List.map FStar_Ident.path_of_lid c_lids
+             let uu____1790 =
+               let uu____1807 = FStar_List.map FStar_Ident.path_of_lid c_lids
                   in
-               (nm, us1, bs1, ty1, uu____1797)  in
-             FStar_Reflection_Data.Sg_Inductive uu____1780)
-    | FStar_Syntax_Syntax.Sig_datacon (lid,us,ty,uu____1809,n1,uu____1811) ->
-        let uu____1818 = FStar_Syntax_Subst.univ_var_opening us  in
-        (match uu____1818 with
+               (nm, us1, bs1, ty1, uu____1807)  in
+             FStar_Reflection_Data.Sg_Inductive uu____1790)
+    | FStar_Syntax_Syntax.Sig_datacon (lid,us,ty,uu____1819,n1,uu____1821) ->
+        let uu____1828 = FStar_Syntax_Subst.univ_var_opening us  in
+        (match uu____1828 with
          | (s,us1) ->
              let ty1 = FStar_Syntax_Subst.subst s ty  in
-             let uu____1838 =
-               let uu____1843 = FStar_Ident.path_of_lid lid  in
-               (uu____1843, ty1)  in
-             FStar_Reflection_Data.Sg_Constructor uu____1838)
-    | uu____1844 -> FStar_Reflection_Data.Unk
+             let uu____1848 =
+               let uu____1853 = FStar_Ident.path_of_lid lid  in
+               (uu____1853, ty1)  in
+             FStar_Reflection_Data.Sg_Constructor uu____1848)
+    | uu____1854 -> FStar_Reflection_Data.Unk
   
 let (pack_sigelt :
   FStar_Reflection_Data.sigelt_view -> FStar_Syntax_Syntax.sigelt) =
@@ -623,42 +631,42 @@ let (pack_sigelt :
             FStar_Parser_Const.effect_Tot_lid def1 []
             def1.FStar_Syntax_Syntax.pos
            in
-        let uu____1870 =
-          let uu____1871 =
-            let uu____1878 =
-              let uu____1881 = FStar_Syntax_Syntax.lid_of_fv fv  in
-              [uu____1881]  in
-            ((r, [lb]), uu____1878)  in
-          FStar_Syntax_Syntax.Sig_let uu____1871  in
-        FStar_All.pipe_left FStar_Syntax_Syntax.mk_sigelt uu____1870
-    | FStar_Reflection_Data.Sg_Constructor uu____1887 ->
+        let uu____1880 =
+          let uu____1881 =
+            let uu____1888 =
+              let uu____1891 = FStar_Syntax_Syntax.lid_of_fv fv  in
+              [uu____1891]  in
+            ((r, [lb]), uu____1888)  in
+          FStar_Syntax_Syntax.Sig_let uu____1881  in
+        FStar_All.pipe_left FStar_Syntax_Syntax.mk_sigelt uu____1880
+    | FStar_Reflection_Data.Sg_Constructor uu____1897 ->
         failwith "packing Sg_Constructor, sorry"
-    | FStar_Reflection_Data.Sg_Inductive uu____1893 ->
+    | FStar_Reflection_Data.Sg_Inductive uu____1903 ->
         failwith "packing Sg_Inductive, sorry"
     | FStar_Reflection_Data.Unk  -> failwith "packing Unk, sorry"
   
 let (inspect_bv : FStar_Syntax_Syntax.bv -> FStar_Reflection_Data.bv_view) =
   fun bv  ->
-    let uu____1918 =
+    let uu____1928 =
       FStar_Ident.string_of_ident bv.FStar_Syntax_Syntax.ppname  in
-    let uu____1920 = FStar_BigInt.of_int_fs bv.FStar_Syntax_Syntax.index  in
+    let uu____1930 = FStar_BigInt.of_int_fs bv.FStar_Syntax_Syntax.index  in
     {
-      FStar_Reflection_Data.bv_ppname = uu____1918;
-      FStar_Reflection_Data.bv_index = uu____1920;
+      FStar_Reflection_Data.bv_ppname = uu____1928;
+      FStar_Reflection_Data.bv_index = uu____1930;
       FStar_Reflection_Data.bv_sort = (bv.FStar_Syntax_Syntax.sort)
     }
   
 let (pack_bv : FStar_Reflection_Data.bv_view -> FStar_Syntax_Syntax.bv) =
   fun bvv  ->
-    let uu____1927 =
+    let uu____1937 =
       FStar_Ident.mk_ident
         ((bvv.FStar_Reflection_Data.bv_ppname), FStar_Range.dummyRange)
        in
-    let uu____1929 =
+    let uu____1939 =
       FStar_BigInt.to_int_fs bvv.FStar_Reflection_Data.bv_index  in
     {
-      FStar_Syntax_Syntax.ppname = uu____1927;
-      FStar_Syntax_Syntax.index = uu____1929;
+      FStar_Syntax_Syntax.ppname = uu____1937;
+      FStar_Syntax_Syntax.index = uu____1939;
       FStar_Syntax_Syntax.sort = (bvv.FStar_Reflection_Data.bv_sort)
     }
   
@@ -667,28 +675,28 @@ let (inspect_binder :
     (FStar_Syntax_Syntax.bv * FStar_Reflection_Data.aqualv))
   =
   fun b  ->
-    let uu____1945 = b  in
-    match uu____1945 with
-    | (bv,aq) -> let uu____1956 = inspect_aqual aq  in (bv, uu____1956)
+    let uu____1955 = b  in
+    match uu____1955 with
+    | (bv,aq) -> let uu____1966 = inspect_aqual aq  in (bv, uu____1966)
   
 let (pack_binder :
   FStar_Syntax_Syntax.bv ->
     FStar_Reflection_Data.aqualv -> FStar_Syntax_Syntax.binder)
   =
-  fun bv  -> fun aqv  -> let uu____1968 = pack_aqual aqv  in (bv, uu____1968) 
+  fun bv  -> fun aqv  -> let uu____1978 = pack_aqual aqv  in (bv, uu____1978) 
 let (moduleof : FStar_TypeChecker_Env.env -> Prims.string Prims.list) =
   fun e  -> FStar_Ident.path_of_lid e.FStar_TypeChecker_Env.curmodule 
 let (env_open_modules :
   FStar_TypeChecker_Env.env -> FStar_Reflection_Data.name Prims.list) =
   fun e  ->
-    let uu____1995 =
+    let uu____2005 =
       FStar_Syntax_DsEnv.open_modules e.FStar_TypeChecker_Env.dsenv  in
     FStar_List.map
-      (fun uu____2013  ->
-         match uu____2013 with
+      (fun uu____2023  ->
+         match uu____2023 with
          | (l,m) ->
-             let uu____2023 = FStar_Ident.ids_of_lid l  in
-             FStar_List.map FStar_Ident.text_of_id uu____2023) uu____1995
+             let uu____2033 = FStar_Ident.ids_of_lid l  in
+             FStar_List.map FStar_Ident.text_of_id uu____2033) uu____2005
   
 let (binders_of_env :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.binders) =
@@ -697,9 +705,9 @@ let (term_eq :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t1  ->
     fun t2  ->
-      let uu____2045 = FStar_Syntax_Util.un_uinst t1  in
-      let uu____2046 = FStar_Syntax_Util.un_uinst t2  in
-      FStar_Syntax_Util.term_eq uu____2045 uu____2046
+      let uu____2055 = FStar_Syntax_Util.un_uinst t1  in
+      let uu____2056 = FStar_Syntax_Util.un_uinst t2  in
+      FStar_Syntax_Util.term_eq uu____2055 uu____2056
   
 let (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
   fun t  -> FStar_Syntax_Print.term_to_string t 

--- a/src/ocaml-output/FStar_Reflection_Basic.ml
+++ b/src/ocaml-output/FStar_Reflection_Basic.ml
@@ -203,13 +203,15 @@ let rec (inspect_ln :
               FStar_Reflection_Data.Pat_Constant uu____668
           | FStar_Syntax_Syntax.Pat_cons (fv,ps) ->
               let uu____689 =
-                let uu____696 =
+                let uu____701 =
                   FStar_List.map
-                    (fun uu____709  ->
-                       match uu____709 with
-                       | (p1,uu____718) -> inspect_pat p1) ps
+                    (fun uu____725  ->
+                       match uu____725 with
+                       | (p1,b) ->
+                           let uu____746 = inspect_pat p1  in (uu____746, b))
+                    ps
                    in
-                (fv, uu____696)  in
+                (fv, uu____701)  in
               FStar_Reflection_Data.Pat_Cons uu____689
           | FStar_Syntax_Syntax.Pat_var bv ->
               FStar_Reflection_Data.Pat_Var bv
@@ -220,57 +222,57 @@ let rec (inspect_ln :
            in
         let brs1 =
           FStar_List.map
-            (fun uu___0_769  ->
-               match uu___0_769 with
-               | (pat,uu____791,t5) ->
-                   let uu____809 = inspect_pat pat  in (uu____809, t5)) brs
+            (fun uu___0_797  ->
+               match uu___0_797 with
+               | (pat,uu____819,t5) ->
+                   let uu____837 = inspect_pat pat  in (uu____837, t5)) brs
            in
         FStar_Reflection_Data.Tv_Match (t4, brs1)
     | FStar_Syntax_Syntax.Tm_unknown  -> FStar_Reflection_Data.Tv_Unknown
-    | uu____814 ->
-        ((let uu____816 =
-            let uu____822 =
-              let uu____824 = FStar_Syntax_Print.tag_of_term t3  in
-              let uu____826 = FStar_Syntax_Print.term_to_string t3  in
+    | uu____842 ->
+        ((let uu____844 =
+            let uu____850 =
+              let uu____852 = FStar_Syntax_Print.tag_of_term t3  in
+              let uu____854 = FStar_Syntax_Print.term_to_string t3  in
               FStar_Util.format2
-                "inspect_ln: outside of expected syntax (%s, %s)\n" uu____824
-                uu____826
+                "inspect_ln: outside of expected syntax (%s, %s)\n" uu____852
+                uu____854
                in
-            (FStar_Errors.Warning_CantInspect, uu____822)  in
-          FStar_Errors.log_issue t3.FStar_Syntax_Syntax.pos uu____816);
+            (FStar_Errors.Warning_CantInspect, uu____850)  in
+          FStar_Errors.log_issue t3.FStar_Syntax_Syntax.pos uu____844);
          FStar_Reflection_Data.Tv_Unknown)
   
 let (inspect_comp :
   FStar_Syntax_Syntax.comp -> FStar_Reflection_Data.comp_view) =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total (t,uu____837) ->
+    | FStar_Syntax_Syntax.Total (t,uu____865) ->
         FStar_Reflection_Data.C_Total (t, FStar_Pervasives_Native.None)
     | FStar_Syntax_Syntax.Comp ct ->
-        let uu____849 =
+        let uu____877 =
           FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
             FStar_Parser_Const.effect_Lemma_lid
            in
-        if uu____849
+        if uu____877
         then
           (match ct.FStar_Syntax_Syntax.effect_args with
-           | (pre,uu____853)::(post,uu____855)::uu____856 ->
+           | (pre,uu____881)::(post,uu____883)::uu____884 ->
                FStar_Reflection_Data.C_Lemma (pre, post)
-           | uu____899 ->
+           | uu____927 ->
                failwith "inspect_comp: Lemma does not have enough arguments?")
         else
-          (let uu____913 =
+          (let uu____941 =
              FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
                FStar_Parser_Const.effect_Tot_lid
               in
-           if uu____913
+           if uu____941
            then
              let maybe_dec =
                FStar_List.tryFind
-                 (fun uu___1_921  ->
-                    match uu___1_921 with
-                    | FStar_Syntax_Syntax.DECREASES uu____923 -> true
-                    | uu____927 -> false) ct.FStar_Syntax_Syntax.flags
+                 (fun uu___1_949  ->
+                    match uu___1_949 with
+                    | FStar_Syntax_Syntax.DECREASES uu____951 -> true
+                    | uu____955 -> false) ct.FStar_Syntax_Syntax.flags
                 in
              let md =
                match maybe_dec with
@@ -278,36 +280,36 @@ let (inspect_comp :
                    FStar_Pervasives_Native.None
                | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.DECREASES
                    t) -> FStar_Pervasives_Native.Some t
-               | uu____937 -> failwith "impossible"  in
+               | uu____965 -> failwith "impossible"  in
              FStar_Reflection_Data.C_Total
                ((ct.FStar_Syntax_Syntax.result_typ), md)
            else FStar_Reflection_Data.C_Unknown)
-    | FStar_Syntax_Syntax.GTotal uu____947 -> FStar_Reflection_Data.C_Unknown
+    | FStar_Syntax_Syntax.GTotal uu____975 -> FStar_Reflection_Data.C_Unknown
   
 let (pack_comp : FStar_Reflection_Data.comp_view -> FStar_Syntax_Syntax.comp)
   =
   fun cv  ->
     match cv with
-    | FStar_Reflection_Data.C_Total (t,uu____963) ->
+    | FStar_Reflection_Data.C_Total (t,uu____991) ->
         FStar_Syntax_Syntax.mk_Total t
     | FStar_Reflection_Data.C_Lemma (pre,post) ->
         let ct =
-          let uu____971 =
-            let uu____982 = FStar_Syntax_Syntax.as_arg pre  in
-            let uu____991 =
-              let uu____1002 = FStar_Syntax_Syntax.as_arg post  in
-              [uu____1002]  in
-            uu____982 :: uu____991  in
+          let uu____999 =
+            let uu____1010 = FStar_Syntax_Syntax.as_arg pre  in
+            let uu____1019 =
+              let uu____1030 = FStar_Syntax_Syntax.as_arg post  in
+              [uu____1030]  in
+            uu____1010 :: uu____1019  in
           {
             FStar_Syntax_Syntax.comp_univs = [];
             FStar_Syntax_Syntax.effect_name =
               FStar_Parser_Const.effect_Lemma_lid;
             FStar_Syntax_Syntax.result_typ = FStar_Syntax_Syntax.t_unit;
-            FStar_Syntax_Syntax.effect_args = uu____971;
+            FStar_Syntax_Syntax.effect_args = uu____999;
             FStar_Syntax_Syntax.flags = []
           }  in
         FStar_Syntax_Syntax.mk_Comp ct
-    | uu____1035 -> failwith "cannot pack a C_Unknown"
+    | uu____1063 -> failwith "cannot pack a C_Unknown"
   
 let (pack_const : FStar_Reflection_Data.vconst -> FStar_Syntax_Syntax.sconst)
   =
@@ -315,10 +317,10 @@ let (pack_const : FStar_Reflection_Data.vconst -> FStar_Syntax_Syntax.sconst)
     match c with
     | FStar_Reflection_Data.C_Unit  -> FStar_Const.Const_unit
     | FStar_Reflection_Data.C_Int i ->
-        let uu____1044 =
-          let uu____1056 = FStar_BigInt.string_of_big_int i  in
-          (uu____1056, FStar_Pervasives_Native.None)  in
-        FStar_Const.Const_int uu____1044
+        let uu____1072 =
+          let uu____1084 = FStar_BigInt.string_of_big_int i  in
+          (uu____1084, FStar_Pervasives_Native.None)  in
+        FStar_Const.Const_int uu____1072
     | FStar_Reflection_Data.C_True  -> FStar_Const.Const_bool true
     | FStar_Reflection_Data.C_False  -> FStar_Const.Const_bool false
     | FStar_Reflection_Data.C_String s ->
@@ -326,9 +328,9 @@ let (pack_const : FStar_Reflection_Data.vconst -> FStar_Syntax_Syntax.sconst)
     | FStar_Reflection_Data.C_Range r -> FStar_Const.Const_range r
     | FStar_Reflection_Data.C_Reify  -> FStar_Const.Const_reify
     | FStar_Reflection_Data.C_Reflect ns ->
-        let uu____1076 = FStar_Ident.lid_of_path ns FStar_Range.dummyRange
+        let uu____1104 = FStar_Ident.lid_of_path ns FStar_Range.dummyRange
            in
-        FStar_Const.Const_reflect uu____1076
+        FStar_Const.Const_reflect uu____1104
   
 let (pack_ln : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term) =
   fun tv  ->
@@ -344,12 +346,12 @@ let (pack_ln : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term) =
     | FStar_Reflection_Data.Tv_Type () -> FStar_Syntax_Util.ktype
     | FStar_Reflection_Data.Tv_Refine (bv,t) -> FStar_Syntax_Util.refine bv t
     | FStar_Reflection_Data.Tv_Const c ->
-        let uu____1141 =
-          let uu____1148 =
-            let uu____1149 = pack_const c  in
-            FStar_Syntax_Syntax.Tm_constant uu____1149  in
-          FStar_Syntax_Syntax.mk uu____1148  in
-        uu____1141 FStar_Pervasives_Native.None FStar_Range.dummyRange
+        let uu____1169 =
+          let uu____1176 =
+            let uu____1177 = pack_const c  in
+            FStar_Syntax_Syntax.Tm_constant uu____1177  in
+          FStar_Syntax_Syntax.mk uu____1176  in
+        uu____1169 FStar_Pervasives_Native.None FStar_Range.dummyRange
     | FStar_Reflection_Data.Tv_Uvar (u,ctx_u_s) ->
         FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_uvar ctx_u_s)
           FStar_Pervasives_Native.None FStar_Range.dummyRange
@@ -380,22 +382,24 @@ let (pack_ln : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term) =
         let rec pack_pat p =
           match p with
           | FStar_Reflection_Data.Pat_Constant c ->
-              let uu____1215 =
-                let uu____1216 = pack_const c  in
-                FStar_Syntax_Syntax.Pat_constant uu____1216  in
-              FStar_All.pipe_left wrap uu____1215
+              let uu____1243 =
+                let uu____1244 = pack_const c  in
+                FStar_Syntax_Syntax.Pat_constant uu____1244  in
+              FStar_All.pipe_left wrap uu____1243
           | FStar_Reflection_Data.Pat_Cons (fv,ps) ->
-              let uu____1223 =
-                let uu____1224 =
-                  let uu____1238 =
+              let uu____1261 =
+                let uu____1262 =
+                  let uu____1276 =
                     FStar_List.map
-                      (fun p1  ->
-                         let uu____1256 = pack_pat p1  in (uu____1256, false))
+                      (fun uu____1300  ->
+                         match uu____1300 with
+                         | (p1,b) ->
+                             let uu____1315 = pack_pat p1  in (uu____1315, b))
                       ps
                      in
-                  (fv, uu____1238)  in
-                FStar_Syntax_Syntax.Pat_cons uu____1224  in
-              FStar_All.pipe_left wrap uu____1223
+                  (fv, uu____1276)  in
+                FStar_Syntax_Syntax.Pat_cons uu____1262  in
+              FStar_All.pipe_left wrap uu____1261
           | FStar_Reflection_Data.Pat_Var bv ->
               FStar_All.pipe_left wrap (FStar_Syntax_Syntax.Pat_var bv)
           | FStar_Reflection_Data.Pat_Wild bv ->
@@ -406,11 +410,11 @@ let (pack_ln : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term) =
            in
         let brs1 =
           FStar_List.map
-            (fun uu___2_1305  ->
-               match uu___2_1305 with
+            (fun uu___2_1363  ->
+               match uu___2_1363 with
                | (pat,t1) ->
-                   let uu____1322 = pack_pat pat  in
-                   (uu____1322, FStar_Pervasives_Native.None, t1)) brs
+                   let uu____1380 = pack_pat pat  in
+                   (uu____1380, FStar_Pervasives_Native.None, t1)) brs
            in
         FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_match (t, brs1))
           FStar_Pervasives_Native.None FStar_Range.dummyRange
@@ -446,39 +450,39 @@ let (lookup_attr :
   =
   fun attr  ->
     fun env  ->
-      let uu____1483 =
-        let uu____1484 = FStar_Syntax_Subst.compress attr  in
-        uu____1484.FStar_Syntax_Syntax.n  in
-      match uu____1483 with
+      let uu____1541 =
+        let uu____1542 = FStar_Syntax_Subst.compress attr  in
+        uu____1542.FStar_Syntax_Syntax.n  in
+      match uu____1541 with
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           let ses =
-            let uu____1493 =
-              let uu____1495 = FStar_Syntax_Syntax.lid_of_fv fv  in
-              FStar_Ident.text_of_lid uu____1495  in
-            FStar_TypeChecker_Env.lookup_attr env uu____1493  in
+            let uu____1551 =
+              let uu____1553 = FStar_Syntax_Syntax.lid_of_fv fv  in
+              FStar_Ident.text_of_lid uu____1553  in
+            FStar_TypeChecker_Env.lookup_attr env uu____1551  in
           FStar_List.concatMap
             (fun se  ->
-               let uu____1499 = FStar_Syntax_Util.lid_of_sigelt se  in
-               match uu____1499 with
+               let uu____1557 = FStar_Syntax_Util.lid_of_sigelt se  in
+               match uu____1557 with
                | FStar_Pervasives_Native.None  -> []
                | FStar_Pervasives_Native.Some l ->
-                   let uu____1505 =
+                   let uu____1563 =
                      FStar_Syntax_Syntax.lid_as_fv l
                        (FStar_Syntax_Syntax.Delta_constant_at_level
                           (Prims.of_int (999))) FStar_Pervasives_Native.None
                       in
-                   [uu____1505]) ses
-      | uu____1507 -> []
+                   [uu____1563]) ses
+      | uu____1565 -> []
   
 let (all_defs_in_env :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.fv Prims.list) =
   fun env  ->
-    let uu____1518 = FStar_TypeChecker_Env.lidents env  in
+    let uu____1576 = FStar_TypeChecker_Env.lidents env  in
     FStar_List.map
       (fun l  ->
          FStar_Syntax_Syntax.lid_as_fv l
            (FStar_Syntax_Syntax.Delta_constant_at_level (Prims.of_int (999)))
-           FStar_Pervasives_Native.None) uu____1518
+           FStar_Pervasives_Native.None) uu____1576
   
 let (defs_in_module :
   FStar_TypeChecker_Env.env ->
@@ -486,25 +490,25 @@ let (defs_in_module :
   =
   fun env  ->
     fun modul  ->
-      let uu____1539 = FStar_TypeChecker_Env.lidents env  in
+      let uu____1597 = FStar_TypeChecker_Env.lidents env  in
       FStar_List.concatMap
         (fun l  ->
            let ns =
-             let uu____1547 =
-               let uu____1550 = FStar_Ident.ids_of_lid l  in
-               FStar_All.pipe_right uu____1550 init  in
-             FStar_All.pipe_right uu____1547
+             let uu____1605 =
+               let uu____1608 = FStar_Ident.ids_of_lid l  in
+               FStar_All.pipe_right uu____1608 init  in
+             FStar_All.pipe_right uu____1605
                (FStar_List.map FStar_Ident.string_of_ident)
               in
            if ns = modul
            then
-             let uu____1563 =
+             let uu____1621 =
                FStar_Syntax_Syntax.lid_as_fv l
                  (FStar_Syntax_Syntax.Delta_constant_at_level
                     (Prims.of_int (999))) FStar_Pervasives_Native.None
                 in
-             [uu____1563]
-           else []) uu____1539
+             [uu____1621]
+           else []) uu____1597
   
 let (lookup_typ :
   FStar_TypeChecker_Env.env ->
@@ -525,15 +529,15 @@ let (set_sigelt_attrs :
   =
   fun attrs  ->
     fun se  ->
-      let uu___370_1614 = se  in
+      let uu___372_1672 = se  in
       {
-        FStar_Syntax_Syntax.sigel = (uu___370_1614.FStar_Syntax_Syntax.sigel);
+        FStar_Syntax_Syntax.sigel = (uu___372_1672.FStar_Syntax_Syntax.sigel);
         FStar_Syntax_Syntax.sigrng =
-          (uu___370_1614.FStar_Syntax_Syntax.sigrng);
+          (uu___372_1672.FStar_Syntax_Syntax.sigrng);
         FStar_Syntax_Syntax.sigquals =
-          (uu___370_1614.FStar_Syntax_Syntax.sigquals);
+          (uu___372_1672.FStar_Syntax_Syntax.sigquals);
         FStar_Syntax_Syntax.sigmeta =
-          (uu___370_1614.FStar_Syntax_Syntax.sigmeta);
+          (uu___372_1672.FStar_Syntax_Syntax.sigmeta);
         FStar_Syntax_Syntax.sigattrs = attrs
       }
   
@@ -546,33 +550,33 @@ let (set_sigelt_quals :
   =
   fun quals  ->
     fun se  ->
-      let uu___375_1640 = se  in
+      let uu___377_1698 = se  in
       {
-        FStar_Syntax_Syntax.sigel = (uu___375_1640.FStar_Syntax_Syntax.sigel);
+        FStar_Syntax_Syntax.sigel = (uu___377_1698.FStar_Syntax_Syntax.sigel);
         FStar_Syntax_Syntax.sigrng =
-          (uu___375_1640.FStar_Syntax_Syntax.sigrng);
+          (uu___377_1698.FStar_Syntax_Syntax.sigrng);
         FStar_Syntax_Syntax.sigquals = quals;
         FStar_Syntax_Syntax.sigmeta =
-          (uu___375_1640.FStar_Syntax_Syntax.sigmeta);
+          (uu___377_1698.FStar_Syntax_Syntax.sigmeta);
         FStar_Syntax_Syntax.sigattrs =
-          (uu___375_1640.FStar_Syntax_Syntax.sigattrs)
+          (uu___377_1698.FStar_Syntax_Syntax.sigattrs)
       }
   
 let (inspect_sigelt :
   FStar_Syntax_Syntax.sigelt -> FStar_Reflection_Data.sigelt_view) =
   fun se  ->
     match se.FStar_Syntax_Syntax.sigel with
-    | FStar_Syntax_Syntax.Sig_let ((r,lb::[]),uu____1649) ->
+    | FStar_Syntax_Syntax.Sig_let ((r,lb::[]),uu____1707) ->
         let fv =
           match lb.FStar_Syntax_Syntax.lbname with
           | FStar_Util.Inr fv -> fv
-          | FStar_Util.Inl uu____1660 ->
+          | FStar_Util.Inl uu____1718 ->
               failwith "impossible: global Sig_let has bv"
            in
-        let uu____1662 =
+        let uu____1720 =
           FStar_Syntax_Subst.univ_var_opening lb.FStar_Syntax_Syntax.lbunivs
            in
-        (match uu____1662 with
+        (match uu____1720 with
          | (s,us) ->
              let typ =
                FStar_Syntax_Subst.subst s lb.FStar_Syntax_Syntax.lbtyp  in
@@ -582,29 +586,29 @@ let (inspect_sigelt :
                (r, fv, (lb.FStar_Syntax_Syntax.lbunivs),
                  (lb.FStar_Syntax_Syntax.lbtyp),
                  (lb.FStar_Syntax_Syntax.lbdef)))
-    | FStar_Syntax_Syntax.Sig_inductive_typ (lid,us,bs,ty,uu____1690,c_lids)
+    | FStar_Syntax_Syntax.Sig_inductive_typ (lid,us,bs,ty,uu____1748,c_lids)
         ->
         let nm = FStar_Ident.path_of_lid lid  in
-        let uu____1701 = FStar_Syntax_Subst.univ_var_opening us  in
-        (match uu____1701 with
+        let uu____1759 = FStar_Syntax_Subst.univ_var_opening us  in
+        (match uu____1759 with
          | (s,us1) ->
              let bs1 = FStar_Syntax_Subst.subst_binders s bs  in
              let ty1 = FStar_Syntax_Subst.subst s ty  in
-             let uu____1722 =
-               let uu____1739 = FStar_List.map FStar_Ident.path_of_lid c_lids
+             let uu____1780 =
+               let uu____1797 = FStar_List.map FStar_Ident.path_of_lid c_lids
                   in
-               (nm, us1, bs1, ty1, uu____1739)  in
-             FStar_Reflection_Data.Sg_Inductive uu____1722)
-    | FStar_Syntax_Syntax.Sig_datacon (lid,us,ty,uu____1751,n1,uu____1753) ->
-        let uu____1760 = FStar_Syntax_Subst.univ_var_opening us  in
-        (match uu____1760 with
+               (nm, us1, bs1, ty1, uu____1797)  in
+             FStar_Reflection_Data.Sg_Inductive uu____1780)
+    | FStar_Syntax_Syntax.Sig_datacon (lid,us,ty,uu____1809,n1,uu____1811) ->
+        let uu____1818 = FStar_Syntax_Subst.univ_var_opening us  in
+        (match uu____1818 with
          | (s,us1) ->
              let ty1 = FStar_Syntax_Subst.subst s ty  in
-             let uu____1780 =
-               let uu____1785 = FStar_Ident.path_of_lid lid  in
-               (uu____1785, ty1)  in
-             FStar_Reflection_Data.Sg_Constructor uu____1780)
-    | uu____1786 -> FStar_Reflection_Data.Unk
+             let uu____1838 =
+               let uu____1843 = FStar_Ident.path_of_lid lid  in
+               (uu____1843, ty1)  in
+             FStar_Reflection_Data.Sg_Constructor uu____1838)
+    | uu____1844 -> FStar_Reflection_Data.Unk
   
 let (pack_sigelt :
   FStar_Reflection_Data.sigelt_view -> FStar_Syntax_Syntax.sigelt) =
@@ -619,42 +623,42 @@ let (pack_sigelt :
             FStar_Parser_Const.effect_Tot_lid def1 []
             def1.FStar_Syntax_Syntax.pos
            in
-        let uu____1812 =
-          let uu____1813 =
-            let uu____1820 =
-              let uu____1823 = FStar_Syntax_Syntax.lid_of_fv fv  in
-              [uu____1823]  in
-            ((r, [lb]), uu____1820)  in
-          FStar_Syntax_Syntax.Sig_let uu____1813  in
-        FStar_All.pipe_left FStar_Syntax_Syntax.mk_sigelt uu____1812
-    | FStar_Reflection_Data.Sg_Constructor uu____1829 ->
+        let uu____1870 =
+          let uu____1871 =
+            let uu____1878 =
+              let uu____1881 = FStar_Syntax_Syntax.lid_of_fv fv  in
+              [uu____1881]  in
+            ((r, [lb]), uu____1878)  in
+          FStar_Syntax_Syntax.Sig_let uu____1871  in
+        FStar_All.pipe_left FStar_Syntax_Syntax.mk_sigelt uu____1870
+    | FStar_Reflection_Data.Sg_Constructor uu____1887 ->
         failwith "packing Sg_Constructor, sorry"
-    | FStar_Reflection_Data.Sg_Inductive uu____1835 ->
+    | FStar_Reflection_Data.Sg_Inductive uu____1893 ->
         failwith "packing Sg_Inductive, sorry"
     | FStar_Reflection_Data.Unk  -> failwith "packing Unk, sorry"
   
 let (inspect_bv : FStar_Syntax_Syntax.bv -> FStar_Reflection_Data.bv_view) =
   fun bv  ->
-    let uu____1860 =
+    let uu____1918 =
       FStar_Ident.string_of_ident bv.FStar_Syntax_Syntax.ppname  in
-    let uu____1862 = FStar_BigInt.of_int_fs bv.FStar_Syntax_Syntax.index  in
+    let uu____1920 = FStar_BigInt.of_int_fs bv.FStar_Syntax_Syntax.index  in
     {
-      FStar_Reflection_Data.bv_ppname = uu____1860;
-      FStar_Reflection_Data.bv_index = uu____1862;
+      FStar_Reflection_Data.bv_ppname = uu____1918;
+      FStar_Reflection_Data.bv_index = uu____1920;
       FStar_Reflection_Data.bv_sort = (bv.FStar_Syntax_Syntax.sort)
     }
   
 let (pack_bv : FStar_Reflection_Data.bv_view -> FStar_Syntax_Syntax.bv) =
   fun bvv  ->
-    let uu____1869 =
+    let uu____1927 =
       FStar_Ident.mk_ident
         ((bvv.FStar_Reflection_Data.bv_ppname), FStar_Range.dummyRange)
        in
-    let uu____1871 =
+    let uu____1929 =
       FStar_BigInt.to_int_fs bvv.FStar_Reflection_Data.bv_index  in
     {
-      FStar_Syntax_Syntax.ppname = uu____1869;
-      FStar_Syntax_Syntax.index = uu____1871;
+      FStar_Syntax_Syntax.ppname = uu____1927;
+      FStar_Syntax_Syntax.index = uu____1929;
       FStar_Syntax_Syntax.sort = (bvv.FStar_Reflection_Data.bv_sort)
     }
   
@@ -663,28 +667,28 @@ let (inspect_binder :
     (FStar_Syntax_Syntax.bv * FStar_Reflection_Data.aqualv))
   =
   fun b  ->
-    let uu____1887 = b  in
-    match uu____1887 with
-    | (bv,aq) -> let uu____1898 = inspect_aqual aq  in (bv, uu____1898)
+    let uu____1945 = b  in
+    match uu____1945 with
+    | (bv,aq) -> let uu____1956 = inspect_aqual aq  in (bv, uu____1956)
   
 let (pack_binder :
   FStar_Syntax_Syntax.bv ->
     FStar_Reflection_Data.aqualv -> FStar_Syntax_Syntax.binder)
   =
-  fun bv  -> fun aqv  -> let uu____1910 = pack_aqual aqv  in (bv, uu____1910) 
+  fun bv  -> fun aqv  -> let uu____1968 = pack_aqual aqv  in (bv, uu____1968) 
 let (moduleof : FStar_TypeChecker_Env.env -> Prims.string Prims.list) =
   fun e  -> FStar_Ident.path_of_lid e.FStar_TypeChecker_Env.curmodule 
 let (env_open_modules :
   FStar_TypeChecker_Env.env -> FStar_Reflection_Data.name Prims.list) =
   fun e  ->
-    let uu____1937 =
+    let uu____1995 =
       FStar_Syntax_DsEnv.open_modules e.FStar_TypeChecker_Env.dsenv  in
     FStar_List.map
-      (fun uu____1955  ->
-         match uu____1955 with
+      (fun uu____2013  ->
+         match uu____2013 with
          | (l,m) ->
-             let uu____1965 = FStar_Ident.ids_of_lid l  in
-             FStar_List.map FStar_Ident.text_of_id uu____1965) uu____1937
+             let uu____2023 = FStar_Ident.ids_of_lid l  in
+             FStar_List.map FStar_Ident.text_of_id uu____2023) uu____1995
   
 let (binders_of_env :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.binders) =
@@ -693,9 +697,9 @@ let (term_eq :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t1  ->
     fun t2  ->
-      let uu____1987 = FStar_Syntax_Util.un_uinst t1  in
-      let uu____1988 = FStar_Syntax_Util.un_uinst t2  in
-      FStar_Syntax_Util.term_eq uu____1987 uu____1988
+      let uu____2045 = FStar_Syntax_Util.un_uinst t1  in
+      let uu____2046 = FStar_Syntax_Util.un_uinst t2  in
+      FStar_Syntax_Util.term_eq uu____2045 uu____2046
   
 let (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
   fun t  -> FStar_Syntax_Print.term_to_string t 

--- a/src/ocaml-output/FStar_Reflection_Data.ml
+++ b/src/ocaml-output/FStar_Reflection_Data.ml
@@ -53,38 +53,39 @@ let (__proj__C_Reflect__item___0 : vconst -> name) =
   fun projectee  -> match projectee with | C_Reflect _0 -> _0 
 type pattern =
   | Pat_Constant of vconst 
-  | Pat_Cons of (FStar_Syntax_Syntax.fv * pattern Prims.list) 
+  | Pat_Cons of (FStar_Syntax_Syntax.fv * (pattern * Prims.bool) Prims.list)
+  
   | Pat_Var of FStar_Syntax_Syntax.bv 
   | Pat_Wild of FStar_Syntax_Syntax.bv 
   | Pat_Dot_Term of (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term) 
 let (uu___is_Pat_Constant : pattern -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Pat_Constant _0 -> true | uu____200 -> false
+    match projectee with | Pat_Constant _0 -> true | uu____205 -> false
   
 let (__proj__Pat_Constant__item___0 : pattern -> vconst) =
   fun projectee  -> match projectee with | Pat_Constant _0 -> _0 
 let (uu___is_Pat_Cons : pattern -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Pat_Cons _0 -> true | uu____225 -> false
+    match projectee with | Pat_Cons _0 -> true | uu____235 -> false
   
 let (__proj__Pat_Cons__item___0 :
-  pattern -> (FStar_Syntax_Syntax.fv * pattern Prims.list)) =
+  pattern -> (FStar_Syntax_Syntax.fv * (pattern * Prims.bool) Prims.list)) =
   fun projectee  -> match projectee with | Pat_Cons _0 -> _0 
 let (uu___is_Pat_Var : pattern -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Pat_Var _0 -> true | uu____262 -> false
+    match projectee with | Pat_Var _0 -> true | uu____287 -> false
   
 let (__proj__Pat_Var__item___0 : pattern -> FStar_Syntax_Syntax.bv) =
   fun projectee  -> match projectee with | Pat_Var _0 -> _0 
 let (uu___is_Pat_Wild : pattern -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Pat_Wild _0 -> true | uu____281 -> false
+    match projectee with | Pat_Wild _0 -> true | uu____306 -> false
   
 let (__proj__Pat_Wild__item___0 : pattern -> FStar_Syntax_Syntax.bv) =
   fun projectee  -> match projectee with | Pat_Wild _0 -> _0 
 let (uu___is_Pat_Dot_Term : pattern -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Pat_Dot_Term _0 -> true | uu____304 -> false
+    match projectee with | Pat_Dot_Term _0 -> true | uu____329 -> false
   
 let (__proj__Pat_Dot_Term__item___0 :
   pattern -> (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term)) =
@@ -96,15 +97,15 @@ type aqualv =
   | Q_Meta of FStar_Syntax_Syntax.term 
 let (uu___is_Q_Implicit : aqualv -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Q_Implicit  -> true | uu____343 -> false
+    match projectee with | Q_Implicit  -> true | uu____368 -> false
   
 let (uu___is_Q_Explicit : aqualv -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Q_Explicit  -> true | uu____354 -> false
+    match projectee with | Q_Explicit  -> true | uu____379 -> false
   
 let (uu___is_Q_Meta : aqualv -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Q_Meta _0 -> true | uu____366 -> false
+    match projectee with | Q_Meta _0 -> true | uu____391 -> false
   
 let (__proj__Q_Meta__item___0 : aqualv -> FStar_Syntax_Syntax.term) =
   fun projectee  -> match projectee with | Q_Meta _0 -> _0 
@@ -130,71 +131,71 @@ type term_view =
   | Tv_Unknown 
 let (uu___is_Tv_Var : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_Var _0 -> true | uu____510 -> false
+    match projectee with | Tv_Var _0 -> true | uu____535 -> false
   
 let (__proj__Tv_Var__item___0 : term_view -> FStar_Syntax_Syntax.bv) =
   fun projectee  -> match projectee with | Tv_Var _0 -> _0 
 let (uu___is_Tv_BVar : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_BVar _0 -> true | uu____529 -> false
+    match projectee with | Tv_BVar _0 -> true | uu____554 -> false
   
 let (__proj__Tv_BVar__item___0 : term_view -> FStar_Syntax_Syntax.bv) =
   fun projectee  -> match projectee with | Tv_BVar _0 -> _0 
 let (uu___is_Tv_FVar : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_FVar _0 -> true | uu____548 -> false
+    match projectee with | Tv_FVar _0 -> true | uu____573 -> false
   
 let (__proj__Tv_FVar__item___0 : term_view -> FStar_Syntax_Syntax.fv) =
   fun projectee  -> match projectee with | Tv_FVar _0 -> _0 
 let (uu___is_Tv_App : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_App _0 -> true | uu____571 -> false
+    match projectee with | Tv_App _0 -> true | uu____596 -> false
   
 let (__proj__Tv_App__item___0 :
   term_view -> (FStar_Syntax_Syntax.term * argv)) =
   fun projectee  -> match projectee with | Tv_App _0 -> _0 
 let (uu___is_Tv_Abs : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_Abs _0 -> true | uu____606 -> false
+    match projectee with | Tv_Abs _0 -> true | uu____631 -> false
   
 let (__proj__Tv_Abs__item___0 :
   term_view -> (FStar_Syntax_Syntax.binder * FStar_Syntax_Syntax.term)) =
   fun projectee  -> match projectee with | Tv_Abs _0 -> _0 
 let (uu___is_Tv_Arrow : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_Arrow _0 -> true | uu____641 -> false
+    match projectee with | Tv_Arrow _0 -> true | uu____666 -> false
   
 let (__proj__Tv_Arrow__item___0 :
   term_view -> (FStar_Syntax_Syntax.binder * FStar_Syntax_Syntax.comp)) =
   fun projectee  -> match projectee with | Tv_Arrow _0 -> _0 
 let (uu___is_Tv_Type : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_Type _0 -> true | uu____672 -> false
+    match projectee with | Tv_Type _0 -> true | uu____697 -> false
   
 
 let (uu___is_Tv_Refine : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_Refine _0 -> true | uu____689 -> false
+    match projectee with | Tv_Refine _0 -> true | uu____714 -> false
   
 let (__proj__Tv_Refine__item___0 :
   term_view -> (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term)) =
   fun projectee  -> match projectee with | Tv_Refine _0 -> _0 
 let (uu___is_Tv_Const : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_Const _0 -> true | uu____720 -> false
+    match projectee with | Tv_Const _0 -> true | uu____745 -> false
   
 let (__proj__Tv_Const__item___0 : term_view -> vconst) =
   fun projectee  -> match projectee with | Tv_Const _0 -> _0 
 let (uu___is_Tv_Uvar : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_Uvar _0 -> true | uu____743 -> false
+    match projectee with | Tv_Uvar _0 -> true | uu____768 -> false
   
 let (__proj__Tv_Uvar__item___0 :
   term_view -> (FStar_BigInt.t * FStar_Syntax_Syntax.ctx_uvar_and_subst)) =
   fun projectee  -> match projectee with | Tv_Uvar _0 -> _0 
 let (uu___is_Tv_Let : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_Let _0 -> true | uu____783 -> false
+    match projectee with | Tv_Let _0 -> true | uu____808 -> false
   
 let (__proj__Tv_Let__item___0 :
   term_view ->
@@ -203,14 +204,14 @@ let (__proj__Tv_Let__item___0 :
   = fun projectee  -> match projectee with | Tv_Let _0 -> _0 
 let (uu___is_Tv_Match : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_Match _0 -> true | uu____835 -> false
+    match projectee with | Tv_Match _0 -> true | uu____860 -> false
   
 let (__proj__Tv_Match__item___0 :
   term_view -> (FStar_Syntax_Syntax.term * branch Prims.list)) =
   fun projectee  -> match projectee with | Tv_Match _0 -> _0 
 let (uu___is_Tv_AscribedT : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_AscribedT _0 -> true | uu____880 -> false
+    match projectee with | Tv_AscribedT _0 -> true | uu____905 -> false
   
 let (__proj__Tv_AscribedT__item___0 :
   term_view ->
@@ -219,7 +220,7 @@ let (__proj__Tv_AscribedT__item___0 :
   = fun projectee  -> match projectee with | Tv_AscribedT _0 -> _0 
 let (uu___is_Tv_AscribedC : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_AscribedC _0 -> true | uu____931 -> false
+    match projectee with | Tv_AscribedC _0 -> true | uu____956 -> false
   
 let (__proj__Tv_AscribedC__item___0 :
   term_view ->
@@ -228,7 +229,7 @@ let (__proj__Tv_AscribedC__item___0 :
   = fun projectee  -> match projectee with | Tv_AscribedC _0 -> _0 
 let (uu___is_Tv_Unknown : term_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tv_Unknown  -> true | uu____973 -> false
+    match projectee with | Tv_Unknown  -> true | uu____998 -> false
   
 type bv_view =
   {
@@ -255,7 +256,7 @@ type comp_view =
   | C_Unknown 
 let (uu___is_C_Total : comp_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | C_Total _0 -> true | uu____1063 -> false
+    match projectee with | C_Total _0 -> true | uu____1088 -> false
   
 let (__proj__C_Total__item___0 :
   comp_view ->
@@ -263,14 +264,14 @@ let (__proj__C_Total__item___0 :
   = fun projectee  -> match projectee with | C_Total _0 -> _0 
 let (uu___is_C_Lemma : comp_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | C_Lemma _0 -> true | uu____1104 -> false
+    match projectee with | C_Lemma _0 -> true | uu____1129 -> false
   
 let (__proj__C_Lemma__item___0 :
   comp_view -> (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term)) =
   fun projectee  -> match projectee with | C_Lemma _0 -> _0 
 let (uu___is_C_Unknown : comp_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | C_Unknown  -> true | uu____1134 -> false
+    match projectee with | C_Unknown  -> true | uu____1159 -> false
   
 type sigelt_view =
   | Sg_Let of (Prims.bool * FStar_Syntax_Syntax.fv *
@@ -282,7 +283,7 @@ type sigelt_view =
   | Unk 
 let (uu___is_Sg_Let : sigelt_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Sg_Let _0 -> true | uu____1207 -> false
+    match projectee with | Sg_Let _0 -> true | uu____1232 -> false
   
 let (__proj__Sg_Let__item___0 :
   sigelt_view ->
@@ -291,7 +292,7 @@ let (__proj__Sg_Let__item___0 :
   = fun projectee  -> match projectee with | Sg_Let _0 -> _0 
 let (uu___is_Sg_Inductive : sigelt_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Sg_Inductive _0 -> true | uu____1281 -> false
+    match projectee with | Sg_Inductive _0 -> true | uu____1306 -> false
   
 let (__proj__Sg_Inductive__item___0 :
   sigelt_view ->
@@ -300,12 +301,12 @@ let (__proj__Sg_Inductive__item___0 :
   = fun projectee  -> match projectee with | Sg_Inductive _0 -> _0 
 let (uu___is_Sg_Constructor : sigelt_view -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Sg_Constructor _0 -> true | uu____1352 -> false
+    match projectee with | Sg_Constructor _0 -> true | uu____1377 -> false
   
 let (__proj__Sg_Constructor__item___0 : sigelt_view -> (name * typ)) =
   fun projectee  -> match projectee with | Sg_Constructor _0 -> _0 
 let (uu___is_Unk : sigelt_view -> Prims.bool) =
-  fun projectee  -> match projectee with | Unk  -> true | uu____1382 -> false 
+  fun projectee  -> match projectee with | Unk  -> true | uu____1407 -> false 
 type var = FStar_BigInt.t
 type exp =
   | Unit 
@@ -313,17 +314,17 @@ type exp =
   | Mult of (exp * exp) 
 let (uu___is_Unit : exp -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Unit  -> true | uu____1407 -> false
+    match projectee with | Unit  -> true | uu____1432 -> false
   
 let (uu___is_Var : exp -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Var _0 -> true | uu____1419 -> false
+    match projectee with | Var _0 -> true | uu____1444 -> false
   
 let (__proj__Var__item___0 : exp -> var) =
   fun projectee  -> match projectee with | Var _0 -> _0 
 let (uu___is_Mult : exp -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Mult _0 -> true | uu____1442 -> false
+    match projectee with | Mult _0 -> true | uu____1467 -> false
   
 let (__proj__Mult__item___0 : exp -> (exp * exp)) =
   fun projectee  -> match projectee with | Mult _0 -> _0 
@@ -360,42 +361,42 @@ let (fstar_refl_data_lid : Prims.string -> FStar_Ident.lident) =
 let (fstar_refl_data_const : Prims.string -> refl_constant) =
   fun s  ->
     let lid = fstar_refl_data_lid s  in
-    let uu____1592 =
+    let uu____1617 =
       FStar_Syntax_Syntax.lid_as_fv lid FStar_Syntax_Syntax.delta_constant
         (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
        in
-    let uu____1593 = FStar_Syntax_Syntax.tdataconstr lid  in
-    { lid; fv = uu____1592; t = uu____1593 }
+    let uu____1618 = FStar_Syntax_Syntax.tdataconstr lid  in
+    { lid; fv = uu____1617; t = uu____1618 }
   
 let (mk_refl_types_lid_as_term : Prims.string -> FStar_Syntax_Syntax.term) =
   fun s  ->
-    let uu____1602 = fstar_refl_types_lid s  in
-    FStar_Syntax_Syntax.tconst uu____1602
+    let uu____1627 = fstar_refl_types_lid s  in
+    FStar_Syntax_Syntax.tconst uu____1627
   
 let (mk_refl_types_lid_as_fv : Prims.string -> FStar_Syntax_Syntax.fv) =
   fun s  ->
-    let uu____1611 = fstar_refl_types_lid s  in
-    FStar_Syntax_Syntax.fvconst uu____1611
+    let uu____1636 = fstar_refl_types_lid s  in
+    FStar_Syntax_Syntax.fvconst uu____1636
   
 let (mk_refl_syntax_lid_as_term : Prims.string -> FStar_Syntax_Syntax.term) =
   fun s  ->
-    let uu____1620 = fstar_refl_syntax_lid s  in
-    FStar_Syntax_Syntax.tconst uu____1620
+    let uu____1645 = fstar_refl_syntax_lid s  in
+    FStar_Syntax_Syntax.tconst uu____1645
   
 let (mk_refl_syntax_lid_as_fv : Prims.string -> FStar_Syntax_Syntax.fv) =
   fun s  ->
-    let uu____1629 = fstar_refl_syntax_lid s  in
-    FStar_Syntax_Syntax.fvconst uu____1629
+    let uu____1654 = fstar_refl_syntax_lid s  in
+    FStar_Syntax_Syntax.fvconst uu____1654
   
 let (mk_refl_data_lid_as_term : Prims.string -> FStar_Syntax_Syntax.term) =
   fun s  ->
-    let uu____1638 = fstar_refl_data_lid s  in
-    FStar_Syntax_Syntax.tconst uu____1638
+    let uu____1663 = fstar_refl_data_lid s  in
+    FStar_Syntax_Syntax.tconst uu____1663
   
 let (mk_refl_data_lid_as_fv : Prims.string -> FStar_Syntax_Syntax.fv) =
   fun s  ->
-    let uu____1647 = fstar_refl_data_lid s  in
-    FStar_Syntax_Syntax.fvconst uu____1647
+    let uu____1672 = fstar_refl_data_lid s  in
+    FStar_Syntax_Syntax.fvconst uu____1672
   
 let (mk_inspect_pack_pair : Prims.string -> (refl_constant * refl_constant))
   =
@@ -413,11 +414,11 @@ let (mk_inspect_pack_pair : Prims.string -> (refl_constant * refl_constant))
         FStar_Pervasives_Native.None
        in
     let inspect =
-      let uu____1669 = FStar_Syntax_Syntax.fv_to_tm inspect_fv  in
-      { lid = inspect_lid; fv = inspect_fv; t = uu____1669 }  in
+      let uu____1694 = FStar_Syntax_Syntax.fv_to_tm inspect_fv  in
+      { lid = inspect_lid; fv = inspect_fv; t = uu____1694 }  in
     let pack =
-      let uu____1671 = FStar_Syntax_Syntax.fv_to_tm pack_fv  in
-      { lid = pack_lid; fv = pack_fv; t = uu____1671 }  in
+      let uu____1696 = FStar_Syntax_Syntax.fv_to_tm pack_fv  in
+      { lid = pack_lid; fv = pack_fv; t = uu____1696 }  in
     (inspect, pack)
   
 let (uu___71 : (refl_constant * refl_constant)) = mk_inspect_pack_pair "_ln" 
@@ -552,28 +553,28 @@ let (fstar_refl_qualifier_fv : FStar_Syntax_Syntax.fv) =
 let (ref_Mk_bv : refl_constant) =
   let lid = fstar_refl_data_lid "Mkbv_view"  in
   let attr =
-    let uu____1824 =
-      let uu____1831 = fstar_refl_data_lid "bv_view"  in
-      let uu____1833 =
-        let uu____1836 =
+    let uu____1849 =
+      let uu____1856 = fstar_refl_data_lid "bv_view"  in
+      let uu____1858 =
+        let uu____1861 =
           FStar_Ident.mk_ident ("bv_ppname", FStar_Range.dummyRange)  in
-        let uu____1839 =
-          let uu____1842 =
+        let uu____1864 =
+          let uu____1867 =
             FStar_Ident.mk_ident ("bv_index", FStar_Range.dummyRange)  in
-          let uu____1845 =
-            let uu____1848 =
+          let uu____1870 =
+            let uu____1873 =
               FStar_Ident.mk_ident ("bv_sort", FStar_Range.dummyRange)  in
-            [uu____1848]  in
-          uu____1842 :: uu____1845  in
-        uu____1836 :: uu____1839  in
-      (uu____1831, uu____1833)  in
-    FStar_Syntax_Syntax.Record_ctor uu____1824  in
+            [uu____1873]  in
+          uu____1867 :: uu____1870  in
+        uu____1861 :: uu____1864  in
+      (uu____1856, uu____1858)  in
+    FStar_Syntax_Syntax.Record_ctor uu____1849  in
   let fv =
     FStar_Syntax_Syntax.lid_as_fv lid FStar_Syntax_Syntax.delta_constant
       (FStar_Pervasives_Native.Some attr)
      in
-  let uu____1854 = FStar_Syntax_Syntax.fv_to_tm fv  in
-  { lid; fv; t = uu____1854 } 
+  let uu____1879 = FStar_Syntax_Syntax.fv_to_tm fv  in
+  { lid; fv; t = uu____1879 } 
 let (ref_Q_Explicit : refl_constant) = fstar_refl_data_const "Q_Explicit" 
 let (ref_Q_Implicit : refl_constant) = fstar_refl_data_const "Q_Implicit" 
 let (ref_Q_Meta : refl_constant) = fstar_refl_data_const "Q_Meta" 
@@ -653,11 +654,11 @@ let (ref_E_Unit : refl_constant) = fstar_refl_data_const "Unit"
 let (ref_E_Var : refl_constant) = fstar_refl_data_const "Var" 
 let (ref_E_Mult : refl_constant) = fstar_refl_data_const "Mult" 
 let (t_exp : FStar_Syntax_Syntax.term) =
-  let uu____1986 =
+  let uu____2011 =
     FStar_Ident.lid_of_path ["FStar"; "Reflection"; "Data"; "exp"]
       FStar_Range.dummyRange
      in
-  FStar_Syntax_Syntax.tconst uu____1986 
+  FStar_Syntax_Syntax.tconst uu____2011 
 let (ord_Lt_lid : FStar_Ident.lident) =
   FStar_Ident.lid_of_path ["FStar"; "Order"; "Lt"] FStar_Range.dummyRange 
 let (ord_Eq_lid : FStar_Ident.lident) =

--- a/src/ocaml-output/FStar_Reflection_Data.ml
+++ b/src/ocaml-output/FStar_Reflection_Data.ml
@@ -510,6 +510,10 @@ let (fstar_refl_univ_name : FStar_Syntax_Syntax.term) =
   mk_refl_types_lid_as_term "univ_name" 
 let (fstar_refl_univ_name_fv : FStar_Syntax_Syntax.fv) =
   mk_refl_types_lid_as_fv "univ_name" 
+let (fstar_refl_optionstate : FStar_Syntax_Syntax.term) =
+  mk_refl_types_lid_as_term "optionstate" 
+let (fstar_refl_optionstate_fv : FStar_Syntax_Syntax.fv) =
+  mk_refl_types_lid_as_fv "optionstate" 
 let (fstar_refl_aqualv : FStar_Syntax_Syntax.term) =
   mk_refl_data_lid_as_term "aqualv" 
 let (fstar_refl_aqualv_fv : FStar_Syntax_Syntax.fv) =
@@ -553,28 +557,28 @@ let (fstar_refl_qualifier_fv : FStar_Syntax_Syntax.fv) =
 let (ref_Mk_bv : refl_constant) =
   let lid = fstar_refl_data_lid "Mkbv_view"  in
   let attr =
-    let uu____1849 =
-      let uu____1856 = fstar_refl_data_lid "bv_view"  in
-      let uu____1858 =
-        let uu____1861 =
+    let uu____1853 =
+      let uu____1860 = fstar_refl_data_lid "bv_view"  in
+      let uu____1862 =
+        let uu____1865 =
           FStar_Ident.mk_ident ("bv_ppname", FStar_Range.dummyRange)  in
-        let uu____1864 =
-          let uu____1867 =
+        let uu____1868 =
+          let uu____1871 =
             FStar_Ident.mk_ident ("bv_index", FStar_Range.dummyRange)  in
-          let uu____1870 =
-            let uu____1873 =
+          let uu____1874 =
+            let uu____1877 =
               FStar_Ident.mk_ident ("bv_sort", FStar_Range.dummyRange)  in
-            [uu____1873]  in
-          uu____1867 :: uu____1870  in
-        uu____1861 :: uu____1864  in
-      (uu____1856, uu____1858)  in
-    FStar_Syntax_Syntax.Record_ctor uu____1849  in
+            [uu____1877]  in
+          uu____1871 :: uu____1874  in
+        uu____1865 :: uu____1868  in
+      (uu____1860, uu____1862)  in
+    FStar_Syntax_Syntax.Record_ctor uu____1853  in
   let fv =
     FStar_Syntax_Syntax.lid_as_fv lid FStar_Syntax_Syntax.delta_constant
       (FStar_Pervasives_Native.Some attr)
      in
-  let uu____1879 = FStar_Syntax_Syntax.fv_to_tm fv  in
-  { lid; fv; t = uu____1879 } 
+  let uu____1883 = FStar_Syntax_Syntax.fv_to_tm fv  in
+  { lid; fv; t = uu____1883 } 
 let (ref_Q_Explicit : refl_constant) = fstar_refl_data_const "Q_Explicit" 
 let (ref_Q_Implicit : refl_constant) = fstar_refl_data_const "Q_Implicit" 
 let (ref_Q_Meta : refl_constant) = fstar_refl_data_const "Q_Meta" 
@@ -654,11 +658,11 @@ let (ref_E_Unit : refl_constant) = fstar_refl_data_const "Unit"
 let (ref_E_Var : refl_constant) = fstar_refl_data_const "Var" 
 let (ref_E_Mult : refl_constant) = fstar_refl_data_const "Mult" 
 let (t_exp : FStar_Syntax_Syntax.term) =
-  let uu____2011 =
+  let uu____2015 =
     FStar_Ident.lid_of_path ["FStar"; "Reflection"; "Data"; "exp"]
       FStar_Range.dummyRange
      in
-  FStar_Syntax_Syntax.tconst uu____2011 
+  FStar_Syntax_Syntax.tconst uu____2015 
 let (ord_Lt_lid : FStar_Ident.lident) =
   FStar_Ident.lid_of_path ["FStar"; "Order"; "Lt"] FStar_Range.dummyRange 
 let (ord_Eq_lid : FStar_Ident.lident) =

--- a/src/ocaml-output/FStar_Reflection_Embeddings.ml
+++ b/src/ocaml-output/FStar_Reflection_Embeddings.ml
@@ -104,6 +104,42 @@ let (e_binder : FStar_Syntax_Syntax.binder FStar_Syntax_Embeddings.embedding)
          FStar_Pervasives_Native.None)
      in
   mk_emb embed_binder unembed_binder FStar_Reflection_Data.fstar_refl_binder 
+let (e_optionstate :
+  FStar_Options.optionstate FStar_Syntax_Embeddings.embedding) =
+  let embed_optionstate rng b =
+    FStar_Syntax_Util.mk_lazy b FStar_Reflection_Data.fstar_refl_optionstate
+      FStar_Syntax_Syntax.Lazy_optionstate (FStar_Pervasives_Native.Some rng)
+     in
+  let unembed_optionstate w t =
+    let uu____299 =
+      let uu____300 = FStar_Syntax_Subst.compress t  in
+      uu____300.FStar_Syntax_Syntax.n  in
+    match uu____299 with
+    | FStar_Syntax_Syntax.Tm_lazy
+        { FStar_Syntax_Syntax.blob = b;
+          FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_optionstate ;
+          FStar_Syntax_Syntax.ltyp = uu____306;
+          FStar_Syntax_Syntax.rng = uu____307;_}
+        ->
+        let uu____310 = FStar_Dyn.undyn b  in
+        FStar_Pervasives_Native.Some uu____310
+    | uu____311 ->
+        (if w
+         then
+           (let uu____314 =
+              let uu____320 =
+                let uu____322 = FStar_Syntax_Print.term_to_string t  in
+                FStar_Util.format1 "Not an embedded optionstate: %s"
+                  uu____322
+                 in
+              (FStar_Errors.Warning_NotEmbedded, uu____320)  in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____314)
+         else ();
+         FStar_Pervasives_Native.None)
+     in
+  mk_emb embed_optionstate unembed_optionstate
+    FStar_Reflection_Data.fstar_refl_optionstate
+  
 let rec mapM_opt :
   'a 'b .
     ('a -> 'b FStar_Pervasives_Native.option) ->
@@ -114,11 +150,11 @@ let rec mapM_opt :
       match l with
       | [] -> FStar_Pervasives_Native.Some []
       | x::xs ->
-          let uu____314 = f x  in
-          FStar_Util.bind_opt uu____314
+          let uu____374 = f x  in
+          FStar_Util.bind_opt uu____374
             (fun x1  ->
-               let uu____322 = mapM_opt f xs  in
-               FStar_Util.bind_opt uu____322
+               let uu____382 = mapM_opt f xs  in
+               FStar_Util.bind_opt uu____382
                  (fun xs1  -> FStar_Pervasives_Native.Some (x1 :: xs1)))
   
 let (e_term_aq :
@@ -137,38 +173,38 @@ let (e_term_aq :
        in
     let rec unembed_term w t =
       let apply_antiquotes t1 aq1 =
-        let uu____391 =
+        let uu____451 =
           mapM_opt
-            (fun uu____404  ->
-               match uu____404 with
+            (fun uu____464  ->
+               match uu____464 with
                | (bv,e) ->
-                   let uu____413 = unembed_term w e  in
-                   FStar_Util.bind_opt uu____413
+                   let uu____473 = unembed_term w e  in
+                   FStar_Util.bind_opt uu____473
                      (fun e1  ->
                         FStar_Pervasives_Native.Some
                           (FStar_Syntax_Syntax.NT (bv, e1)))) aq1
            in
-        FStar_Util.bind_opt uu____391
+        FStar_Util.bind_opt uu____451
           (fun s  ->
-             let uu____427 = FStar_Syntax_Subst.subst s t1  in
-             FStar_Pervasives_Native.Some uu____427)
+             let uu____487 = FStar_Syntax_Subst.subst s t1  in
+             FStar_Pervasives_Native.Some uu____487)
          in
       let t1 = FStar_Syntax_Util.unmeta t  in
-      let uu____429 =
-        let uu____430 = FStar_Syntax_Subst.compress t1  in
-        uu____430.FStar_Syntax_Syntax.n  in
-      match uu____429 with
+      let uu____489 =
+        let uu____490 = FStar_Syntax_Subst.compress t1  in
+        uu____490.FStar_Syntax_Syntax.n  in
+      match uu____489 with
       | FStar_Syntax_Syntax.Tm_quoted (tm,qi) ->
           apply_antiquotes tm qi.FStar_Syntax_Syntax.antiquotes
-      | uu____441 ->
+      | uu____501 ->
           (if w
            then
-             (let uu____444 =
-                let uu____450 =
-                  let uu____452 = FStar_Syntax_Print.term_to_string t1  in
-                  FStar_Util.format1 "Not an embedded term: %s" uu____452  in
-                (FStar_Errors.Warning_NotEmbedded, uu____450)  in
-              FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____444)
+             (let uu____504 =
+                let uu____510 =
+                  let uu____512 = FStar_Syntax_Print.term_to_string t1  in
+                  FStar_Util.format1 "Not an embedded term: %s" uu____512  in
+                (FStar_Errors.Warning_NotEmbedded, uu____510)  in
+              FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____504)
            else ();
            FStar_Pervasives_Native.None)
        in
@@ -186,35 +222,35 @@ let (e_aqualv :
       | FStar_Reflection_Data.Q_Implicit  ->
           FStar_Reflection_Data.ref_Q_Implicit.FStar_Reflection_Data.t
       | FStar_Reflection_Data.Q_Meta t ->
-          let uu____487 =
-            let uu____492 =
-              let uu____493 =
-                let uu____502 = embed e_term rng t  in
-                FStar_Syntax_Syntax.as_arg uu____502  in
-              [uu____493]  in
+          let uu____547 =
+            let uu____552 =
+              let uu____553 =
+                let uu____562 = embed e_term rng t  in
+                FStar_Syntax_Syntax.as_arg uu____562  in
+              [uu____553]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Q_Meta.FStar_Reflection_Data.t
-              uu____492
+              uu____552
              in
-          uu____487 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____547 FStar_Pervasives_Native.None FStar_Range.dummyRange
        in
-    let uu___88_519 = r  in
+    let uu___103_579 = r  in
     {
-      FStar_Syntax_Syntax.n = (uu___88_519.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___103_579.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___88_519.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___103_579.FStar_Syntax_Syntax.vars)
     }  in
   let unembed_aqualv w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____540 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____540 with
+    let uu____600 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____600 with
     | (hd1,args) ->
-        let uu____585 =
-          let uu____600 =
-            let uu____601 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____601.FStar_Syntax_Syntax.n  in
-          (uu____600, args)  in
-        (match uu____585 with
+        let uu____645 =
+          let uu____660 =
+            let uu____661 = FStar_Syntax_Util.un_uinst hd1  in
+            uu____661.FStar_Syntax_Syntax.n  in
+          (uu____660, args)  in
+        (match uu____645 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Q_Explicit.FStar_Reflection_Data.lid
@@ -223,26 +259,26 @@ let (e_aqualv :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Q_Implicit.FStar_Reflection_Data.lid
              -> FStar_Pervasives_Native.Some FStar_Reflection_Data.Q_Implicit
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(t2,uu____656)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(t2,uu____716)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Q_Meta.FStar_Reflection_Data.lid
              ->
-             let uu____691 = unembed' w e_term t2  in
-             FStar_Util.bind_opt uu____691
+             let uu____751 = unembed' w e_term t2  in
+             FStar_Util.bind_opt uu____751
                (fun t3  ->
                   FStar_Pervasives_Native.Some
                     (FStar_Reflection_Data.Q_Meta t3))
-         | uu____696 ->
+         | uu____756 ->
              (if w
               then
-                (let uu____713 =
-                   let uu____719 =
-                     let uu____721 = FStar_Syntax_Print.term_to_string t1  in
+                (let uu____773 =
+                   let uu____779 =
+                     let uu____781 = FStar_Syntax_Print.term_to_string t1  in
                      FStar_Util.format1 "Not an embedded aqualv: %s"
-                       uu____721
+                       uu____781
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____719)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____713)
+                   (FStar_Errors.Warning_NotEmbedded, uu____779)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____773)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -256,44 +292,13 @@ let (e_fv : FStar_Syntax_Syntax.fv FStar_Syntax_Embeddings.embedding) =
       FStar_Syntax_Syntax.Lazy_fvar (FStar_Pervasives_Native.Some rng)
      in
   let unembed_fv w t =
-    let uu____761 =
-      let uu____762 = FStar_Syntax_Subst.compress t  in
-      uu____762.FStar_Syntax_Syntax.n  in
-    match uu____761 with
-    | FStar_Syntax_Syntax.Tm_lazy
-        { FStar_Syntax_Syntax.blob = b;
-          FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_fvar ;
-          FStar_Syntax_Syntax.ltyp = uu____768;
-          FStar_Syntax_Syntax.rng = uu____769;_}
-        ->
-        let uu____772 = FStar_Dyn.undyn b  in
-        FStar_Pervasives_Native.Some uu____772
-    | uu____773 ->
-        (if w
-         then
-           (let uu____776 =
-              let uu____782 =
-                let uu____784 = FStar_Syntax_Print.term_to_string t  in
-                FStar_Util.format1 "Not an embedded fvar: %s" uu____784  in
-              (FStar_Errors.Warning_NotEmbedded, uu____782)  in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____776)
-         else ();
-         FStar_Pervasives_Native.None)
-     in
-  mk_emb embed_fv unembed_fv FStar_Reflection_Data.fstar_refl_fv 
-let (e_comp : FStar_Syntax_Syntax.comp FStar_Syntax_Embeddings.embedding) =
-  let embed_comp rng c =
-    FStar_Syntax_Util.mk_lazy c FStar_Reflection_Data.fstar_refl_comp
-      FStar_Syntax_Syntax.Lazy_comp (FStar_Pervasives_Native.Some rng)
-     in
-  let unembed_comp w t =
     let uu____821 =
       let uu____822 = FStar_Syntax_Subst.compress t  in
       uu____822.FStar_Syntax_Syntax.n  in
     match uu____821 with
     | FStar_Syntax_Syntax.Tm_lazy
         { FStar_Syntax_Syntax.blob = b;
-          FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_comp ;
+          FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_fvar ;
           FStar_Syntax_Syntax.ltyp = uu____828;
           FStar_Syntax_Syntax.rng = uu____829;_}
         ->
@@ -305,26 +310,26 @@ let (e_comp : FStar_Syntax_Syntax.comp FStar_Syntax_Embeddings.embedding) =
            (let uu____836 =
               let uu____842 =
                 let uu____844 = FStar_Syntax_Print.term_to_string t  in
-                FStar_Util.format1 "Not an embedded comp: %s" uu____844  in
+                FStar_Util.format1 "Not an embedded fvar: %s" uu____844  in
               (FStar_Errors.Warning_NotEmbedded, uu____842)  in
             FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____836)
          else ();
          FStar_Pervasives_Native.None)
      in
-  mk_emb embed_comp unembed_comp FStar_Reflection_Data.fstar_refl_comp 
-let (e_env : FStar_TypeChecker_Env.env FStar_Syntax_Embeddings.embedding) =
-  let embed_env rng e =
-    FStar_Syntax_Util.mk_lazy e FStar_Reflection_Data.fstar_refl_env
-      FStar_Syntax_Syntax.Lazy_env (FStar_Pervasives_Native.Some rng)
+  mk_emb embed_fv unembed_fv FStar_Reflection_Data.fstar_refl_fv 
+let (e_comp : FStar_Syntax_Syntax.comp FStar_Syntax_Embeddings.embedding) =
+  let embed_comp rng c =
+    FStar_Syntax_Util.mk_lazy c FStar_Reflection_Data.fstar_refl_comp
+      FStar_Syntax_Syntax.Lazy_comp (FStar_Pervasives_Native.Some rng)
      in
-  let unembed_env w t =
+  let unembed_comp w t =
     let uu____881 =
       let uu____882 = FStar_Syntax_Subst.compress t  in
       uu____882.FStar_Syntax_Syntax.n  in
     match uu____881 with
     | FStar_Syntax_Syntax.Tm_lazy
         { FStar_Syntax_Syntax.blob = b;
-          FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_env ;
+          FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_comp ;
           FStar_Syntax_Syntax.ltyp = uu____888;
           FStar_Syntax_Syntax.rng = uu____889;_}
         ->
@@ -336,9 +341,40 @@ let (e_env : FStar_TypeChecker_Env.env FStar_Syntax_Embeddings.embedding) =
            (let uu____896 =
               let uu____902 =
                 let uu____904 = FStar_Syntax_Print.term_to_string t  in
-                FStar_Util.format1 "Not an embedded env: %s" uu____904  in
+                FStar_Util.format1 "Not an embedded comp: %s" uu____904  in
               (FStar_Errors.Warning_NotEmbedded, uu____902)  in
             FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____896)
+         else ();
+         FStar_Pervasives_Native.None)
+     in
+  mk_emb embed_comp unembed_comp FStar_Reflection_Data.fstar_refl_comp 
+let (e_env : FStar_TypeChecker_Env.env FStar_Syntax_Embeddings.embedding) =
+  let embed_env rng e =
+    FStar_Syntax_Util.mk_lazy e FStar_Reflection_Data.fstar_refl_env
+      FStar_Syntax_Syntax.Lazy_env (FStar_Pervasives_Native.Some rng)
+     in
+  let unembed_env w t =
+    let uu____941 =
+      let uu____942 = FStar_Syntax_Subst.compress t  in
+      uu____942.FStar_Syntax_Syntax.n  in
+    match uu____941 with
+    | FStar_Syntax_Syntax.Tm_lazy
+        { FStar_Syntax_Syntax.blob = b;
+          FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_env ;
+          FStar_Syntax_Syntax.ltyp = uu____948;
+          FStar_Syntax_Syntax.rng = uu____949;_}
+        ->
+        let uu____952 = FStar_Dyn.undyn b  in
+        FStar_Pervasives_Native.Some uu____952
+    | uu____953 ->
+        (if w
+         then
+           (let uu____956 =
+              let uu____962 =
+                let uu____964 = FStar_Syntax_Print.term_to_string t  in
+                FStar_Util.format1 "Not an embedded env: %s" uu____964  in
+              (FStar_Errors.Warning_NotEmbedded, uu____962)  in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____956)
          else ();
          FStar_Pervasives_Native.None)
      in
@@ -355,78 +391,78 @@ let (e_const :
       | FStar_Reflection_Data.C_False  ->
           FStar_Reflection_Data.ref_C_False.FStar_Reflection_Data.t
       | FStar_Reflection_Data.C_Int i ->
-          let uu____930 =
-            let uu____935 =
-              let uu____936 =
-                let uu____945 =
-                  let uu____946 = FStar_BigInt.string_of_big_int i  in
-                  FStar_Syntax_Util.exp_int uu____946  in
-                FStar_Syntax_Syntax.as_arg uu____945  in
-              [uu____936]  in
+          let uu____990 =
+            let uu____995 =
+              let uu____996 =
+                let uu____1005 =
+                  let uu____1006 = FStar_BigInt.string_of_big_int i  in
+                  FStar_Syntax_Util.exp_int uu____1006  in
+                FStar_Syntax_Syntax.as_arg uu____1005  in
+              [uu____996]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_C_Int.FStar_Reflection_Data.t
-              uu____935
+              uu____995
              in
-          uu____930 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____990 FStar_Pervasives_Native.None FStar_Range.dummyRange
       | FStar_Reflection_Data.C_String s ->
-          let uu____966 =
-            let uu____971 =
-              let uu____972 =
-                let uu____981 = embed FStar_Syntax_Embeddings.e_string rng s
+          let uu____1026 =
+            let uu____1031 =
+              let uu____1032 =
+                let uu____1041 = embed FStar_Syntax_Embeddings.e_string rng s
                    in
-                FStar_Syntax_Syntax.as_arg uu____981  in
-              [uu____972]  in
+                FStar_Syntax_Syntax.as_arg uu____1041  in
+              [uu____1032]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_C_String.FStar_Reflection_Data.t
-              uu____971
+              uu____1031
              in
-          uu____966 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____1026 FStar_Pervasives_Native.None FStar_Range.dummyRange
       | FStar_Reflection_Data.C_Range r ->
-          let uu____1000 =
-            let uu____1005 =
-              let uu____1006 =
-                let uu____1015 = embed FStar_Syntax_Embeddings.e_range rng r
+          let uu____1060 =
+            let uu____1065 =
+              let uu____1066 =
+                let uu____1075 = embed FStar_Syntax_Embeddings.e_range rng r
                    in
-                FStar_Syntax_Syntax.as_arg uu____1015  in
-              [uu____1006]  in
+                FStar_Syntax_Syntax.as_arg uu____1075  in
+              [uu____1066]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_C_Range.FStar_Reflection_Data.t
-              uu____1005
+              uu____1065
              in
-          uu____1000 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____1060 FStar_Pervasives_Native.None FStar_Range.dummyRange
       | FStar_Reflection_Data.C_Reify  ->
           FStar_Reflection_Data.ref_C_Reify.FStar_Reflection_Data.t
       | FStar_Reflection_Data.C_Reflect ns ->
-          let uu____1033 =
-            let uu____1038 =
-              let uu____1039 =
-                let uu____1048 =
+          let uu____1093 =
+            let uu____1098 =
+              let uu____1099 =
+                let uu____1108 =
                   embed FStar_Syntax_Embeddings.e_string_list rng ns  in
-                FStar_Syntax_Syntax.as_arg uu____1048  in
-              [uu____1039]  in
+                FStar_Syntax_Syntax.as_arg uu____1108  in
+              [uu____1099]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_C_Reflect.FStar_Reflection_Data.t
-              uu____1038
+              uu____1098
              in
-          uu____1033 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____1093 FStar_Pervasives_Native.None FStar_Range.dummyRange
        in
-    let uu___177_1068 = r  in
+    let uu___192_1128 = r  in
     {
-      FStar_Syntax_Syntax.n = (uu___177_1068.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___192_1128.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___177_1068.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___192_1128.FStar_Syntax_Syntax.vars)
     }  in
   let unembed_const w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____1089 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____1089 with
+    let uu____1149 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____1149 with
     | (hd1,args) ->
-        let uu____1134 =
-          let uu____1149 =
-            let uu____1150 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____1150.FStar_Syntax_Syntax.n  in
-          (uu____1149, args)  in
-        (match uu____1134 with
+        let uu____1194 =
+          let uu____1209 =
+            let uu____1210 = FStar_Syntax_Util.un_uinst hd1  in
+            uu____1210.FStar_Syntax_Syntax.n  in
+          (uu____1209, args)  in
+        (match uu____1194 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Unit.FStar_Reflection_Data.lid
@@ -439,246 +475,246 @@ let (e_const :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_False.FStar_Reflection_Data.lid
              -> FStar_Pervasives_Native.Some FStar_Reflection_Data.C_False
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(i,uu____1224)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(i,uu____1284)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Int.FStar_Reflection_Data.lid
              ->
-             let uu____1259 = unembed' w FStar_Syntax_Embeddings.e_int i  in
-             FStar_Util.bind_opt uu____1259
+             let uu____1319 = unembed' w FStar_Syntax_Embeddings.e_int i  in
+             FStar_Util.bind_opt uu____1319
                (fun i1  ->
                   FStar_All.pipe_left
-                    (fun _1266  -> FStar_Pervasives_Native.Some _1266)
+                    (fun _1326  -> FStar_Pervasives_Native.Some _1326)
                     (FStar_Reflection_Data.C_Int i1))
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(s,uu____1269)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(s,uu____1329)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_String.FStar_Reflection_Data.lid
              ->
-             let uu____1304 = unembed' w FStar_Syntax_Embeddings.e_string s
+             let uu____1364 = unembed' w FStar_Syntax_Embeddings.e_string s
                 in
-             FStar_Util.bind_opt uu____1304
+             FStar_Util.bind_opt uu____1364
                (fun s1  ->
                   FStar_All.pipe_left
-                    (fun _1315  -> FStar_Pervasives_Native.Some _1315)
+                    (fun _1375  -> FStar_Pervasives_Native.Some _1375)
                     (FStar_Reflection_Data.C_String s1))
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(r,uu____1318)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(r,uu____1378)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Range.FStar_Reflection_Data.lid
              ->
-             let uu____1353 = unembed' w FStar_Syntax_Embeddings.e_range r
+             let uu____1413 = unembed' w FStar_Syntax_Embeddings.e_range r
                 in
-             FStar_Util.bind_opt uu____1353
+             FStar_Util.bind_opt uu____1413
                (fun r1  ->
                   FStar_All.pipe_left
-                    (fun _1360  -> FStar_Pervasives_Native.Some _1360)
+                    (fun _1420  -> FStar_Pervasives_Native.Some _1420)
                     (FStar_Reflection_Data.C_Range r1))
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Reify.FStar_Reflection_Data.lid
              ->
              FStar_All.pipe_left
-               (fun _1382  -> FStar_Pervasives_Native.Some _1382)
+               (fun _1442  -> FStar_Pervasives_Native.Some _1442)
                FStar_Reflection_Data.C_Reify
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(ns,uu____1385)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(ns,uu____1445)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Reflect.FStar_Reflection_Data.lid
              ->
-             let uu____1420 =
+             let uu____1480 =
                unembed' w FStar_Syntax_Embeddings.e_string_list ns  in
-             FStar_Util.bind_opt uu____1420
+             FStar_Util.bind_opt uu____1480
                (fun ns1  ->
                   FStar_All.pipe_left
-                    (fun _1439  -> FStar_Pervasives_Native.Some _1439)
+                    (fun _1499  -> FStar_Pervasives_Native.Some _1499)
                     (FStar_Reflection_Data.C_Reflect ns1))
-         | uu____1440 ->
+         | uu____1500 ->
              (if w
               then
-                (let uu____1457 =
-                   let uu____1463 =
-                     let uu____1465 = FStar_Syntax_Print.term_to_string t1
+                (let uu____1517 =
+                   let uu____1523 =
+                     let uu____1525 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.format1 "Not an embedded vconst: %s"
-                       uu____1465
+                       uu____1525
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____1463)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____1457)
+                   (FStar_Errors.Warning_NotEmbedded, uu____1523)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____1517)
               else ();
               FStar_Pervasives_Native.None))
      in
   mk_emb embed_const unembed_const FStar_Reflection_Data.fstar_refl_vconst 
 let rec (e_pattern' :
   unit -> FStar_Reflection_Data.pattern FStar_Syntax_Embeddings.embedding) =
-  fun uu____1478  ->
+  fun uu____1538  ->
     let rec embed_pattern rng p =
       match p with
       | FStar_Reflection_Data.Pat_Constant c ->
-          let uu____1491 =
-            let uu____1496 =
-              let uu____1497 =
-                let uu____1506 = embed e_const rng c  in
-                FStar_Syntax_Syntax.as_arg uu____1506  in
-              [uu____1497]  in
+          let uu____1551 =
+            let uu____1556 =
+              let uu____1557 =
+                let uu____1566 = embed e_const rng c  in
+                FStar_Syntax_Syntax.as_arg uu____1566  in
+              [uu____1557]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Pat_Constant.FStar_Reflection_Data.t
-              uu____1496
+              uu____1556
              in
-          uu____1491 FStar_Pervasives_Native.None rng
+          uu____1551 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Pat_Cons (fv,ps) ->
-          let uu____1539 =
-            let uu____1544 =
-              let uu____1545 =
-                let uu____1554 = embed e_fv rng fv  in
-                FStar_Syntax_Syntax.as_arg uu____1554  in
-              let uu____1555 =
-                let uu____1566 =
-                  let uu____1575 =
-                    let uu____1576 =
-                      let uu____1586 =
-                        let uu____1594 = e_pattern' ()  in
-                        FStar_Syntax_Embeddings.e_tuple2 uu____1594
+          let uu____1599 =
+            let uu____1604 =
+              let uu____1605 =
+                let uu____1614 = embed e_fv rng fv  in
+                FStar_Syntax_Syntax.as_arg uu____1614  in
+              let uu____1615 =
+                let uu____1626 =
+                  let uu____1635 =
+                    let uu____1636 =
+                      let uu____1646 =
+                        let uu____1654 = e_pattern' ()  in
+                        FStar_Syntax_Embeddings.e_tuple2 uu____1654
                           FStar_Syntax_Embeddings.e_bool
                          in
-                      FStar_Syntax_Embeddings.e_list uu____1586  in
-                    embed uu____1576 rng ps  in
-                  FStar_Syntax_Syntax.as_arg uu____1575  in
-                [uu____1566]  in
-              uu____1545 :: uu____1555  in
+                      FStar_Syntax_Embeddings.e_list uu____1646  in
+                    embed uu____1636 rng ps  in
+                  FStar_Syntax_Syntax.as_arg uu____1635  in
+                [uu____1626]  in
+              uu____1605 :: uu____1615  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Pat_Cons.FStar_Reflection_Data.t
-              uu____1544
+              uu____1604
              in
-          uu____1539 FStar_Pervasives_Native.None rng
+          uu____1599 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Pat_Var bv ->
-          let uu____1635 =
-            let uu____1640 =
-              let uu____1641 =
-                let uu____1650 = embed e_bv rng bv  in
-                FStar_Syntax_Syntax.as_arg uu____1650  in
-              [uu____1641]  in
+          let uu____1695 =
+            let uu____1700 =
+              let uu____1701 =
+                let uu____1710 = embed e_bv rng bv  in
+                FStar_Syntax_Syntax.as_arg uu____1710  in
+              [uu____1701]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Pat_Var.FStar_Reflection_Data.t
-              uu____1640
+              uu____1700
              in
-          uu____1635 FStar_Pervasives_Native.None rng
+          uu____1695 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Pat_Wild bv ->
-          let uu____1668 =
-            let uu____1673 =
-              let uu____1674 =
-                let uu____1683 = embed e_bv rng bv  in
-                FStar_Syntax_Syntax.as_arg uu____1683  in
-              [uu____1674]  in
+          let uu____1728 =
+            let uu____1733 =
+              let uu____1734 =
+                let uu____1743 = embed e_bv rng bv  in
+                FStar_Syntax_Syntax.as_arg uu____1743  in
+              [uu____1734]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Pat_Wild.FStar_Reflection_Data.t
-              uu____1673
+              uu____1733
              in
-          uu____1668 FStar_Pervasives_Native.None rng
+          uu____1728 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Pat_Dot_Term (bv,t) ->
-          let uu____1702 =
-            let uu____1707 =
-              let uu____1708 =
-                let uu____1717 = embed e_bv rng bv  in
-                FStar_Syntax_Syntax.as_arg uu____1717  in
-              let uu____1718 =
-                let uu____1729 =
-                  let uu____1738 = embed e_term rng t  in
-                  FStar_Syntax_Syntax.as_arg uu____1738  in
-                [uu____1729]  in
-              uu____1708 :: uu____1718  in
+          let uu____1762 =
+            let uu____1767 =
+              let uu____1768 =
+                let uu____1777 = embed e_bv rng bv  in
+                FStar_Syntax_Syntax.as_arg uu____1777  in
+              let uu____1778 =
+                let uu____1789 =
+                  let uu____1798 = embed e_term rng t  in
+                  FStar_Syntax_Syntax.as_arg uu____1798  in
+                [uu____1789]  in
+              uu____1768 :: uu____1778  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Pat_Dot_Term.FStar_Reflection_Data.t
-              uu____1707
+              uu____1767
              in
-          uu____1702 FStar_Pervasives_Native.None rng
+          uu____1762 FStar_Pervasives_Native.None rng
        in
     let rec unembed_pattern w t =
       let t1 = FStar_Syntax_Util.unascribe t  in
-      let uu____1781 = FStar_Syntax_Util.head_and_args t1  in
-      match uu____1781 with
+      let uu____1841 = FStar_Syntax_Util.head_and_args t1  in
+      match uu____1841 with
       | (hd1,args) ->
-          let uu____1826 =
-            let uu____1839 =
-              let uu____1840 = FStar_Syntax_Util.un_uinst hd1  in
-              uu____1840.FStar_Syntax_Syntax.n  in
-            (uu____1839, args)  in
-          (match uu____1826 with
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(c,uu____1855)::[]) when
+          let uu____1886 =
+            let uu____1899 =
+              let uu____1900 = FStar_Syntax_Util.un_uinst hd1  in
+              uu____1900.FStar_Syntax_Syntax.n  in
+            (uu____1899, args)  in
+          (match uu____1886 with
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(c,uu____1915)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Constant.FStar_Reflection_Data.lid
                ->
-               let uu____1880 = unembed' w e_const c  in
-               FStar_Util.bind_opt uu____1880
+               let uu____1940 = unembed' w e_const c  in
+               FStar_Util.bind_opt uu____1940
                  (fun c1  ->
                     FStar_All.pipe_left
-                      (fun _1887  -> FStar_Pervasives_Native.Some _1887)
+                      (fun _1947  -> FStar_Pervasives_Native.Some _1947)
                       (FStar_Reflection_Data.Pat_Constant c1))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(f,uu____1890)::(ps,uu____1892)::[]) when
+              fv,(f,uu____1950)::(ps,uu____1952)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Cons.FStar_Reflection_Data.lid
                ->
-               let uu____1927 = unembed' w e_fv f  in
-               FStar_Util.bind_opt uu____1927
+               let uu____1987 = unembed' w e_fv f  in
+               FStar_Util.bind_opt uu____1987
                  (fun f1  ->
-                    let uu____1933 =
-                      let uu____1943 =
-                        let uu____1953 =
-                          let uu____1961 = e_pattern' ()  in
-                          FStar_Syntax_Embeddings.e_tuple2 uu____1961
+                    let uu____1993 =
+                      let uu____2003 =
+                        let uu____2013 =
+                          let uu____2021 = e_pattern' ()  in
+                          FStar_Syntax_Embeddings.e_tuple2 uu____2021
                             FStar_Syntax_Embeddings.e_bool
                            in
-                        FStar_Syntax_Embeddings.e_list uu____1953  in
-                      unembed' w uu____1943 ps  in
-                    FStar_Util.bind_opt uu____1933
+                        FStar_Syntax_Embeddings.e_list uu____2013  in
+                      unembed' w uu____2003 ps  in
+                    FStar_Util.bind_opt uu____1993
                       (fun ps1  ->
                          FStar_All.pipe_left
-                           (fun _1995  -> FStar_Pervasives_Native.Some _1995)
+                           (fun _2055  -> FStar_Pervasives_Native.Some _2055)
                            (FStar_Reflection_Data.Pat_Cons (f1, ps1))))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(bv,uu____2005)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(bv,uu____2065)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Var.FStar_Reflection_Data.lid
                ->
-               let uu____2030 = unembed' w e_bv bv  in
-               FStar_Util.bind_opt uu____2030
+               let uu____2090 = unembed' w e_bv bv  in
+               FStar_Util.bind_opt uu____2090
                  (fun bv1  ->
                     FStar_All.pipe_left
-                      (fun _2037  -> FStar_Pervasives_Native.Some _2037)
+                      (fun _2097  -> FStar_Pervasives_Native.Some _2097)
                       (FStar_Reflection_Data.Pat_Var bv1))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(bv,uu____2040)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(bv,uu____2100)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Wild.FStar_Reflection_Data.lid
                ->
-               let uu____2065 = unembed' w e_bv bv  in
-               FStar_Util.bind_opt uu____2065
+               let uu____2125 = unembed' w e_bv bv  in
+               FStar_Util.bind_opt uu____2125
                  (fun bv1  ->
                     FStar_All.pipe_left
-                      (fun _2072  -> FStar_Pervasives_Native.Some _2072)
+                      (fun _2132  -> FStar_Pervasives_Native.Some _2132)
                       (FStar_Reflection_Data.Pat_Wild bv1))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(bv,uu____2075)::(t2,uu____2077)::[]) when
+              fv,(bv,uu____2135)::(t2,uu____2137)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Dot_Term.FStar_Reflection_Data.lid
                ->
-               let uu____2112 = unembed' w e_bv bv  in
-               FStar_Util.bind_opt uu____2112
+               let uu____2172 = unembed' w e_bv bv  in
+               FStar_Util.bind_opt uu____2172
                  (fun bv1  ->
-                    let uu____2118 = unembed' w e_term t2  in
-                    FStar_Util.bind_opt uu____2118
+                    let uu____2178 = unembed' w e_term t2  in
+                    FStar_Util.bind_opt uu____2178
                       (fun t3  ->
                          FStar_All.pipe_left
-                           (fun _2125  -> FStar_Pervasives_Native.Some _2125)
+                           (fun _2185  -> FStar_Pervasives_Native.Some _2185)
                            (FStar_Reflection_Data.Pat_Dot_Term (bv1, t3))))
-           | uu____2126 ->
+           | uu____2186 ->
                (if w
                 then
-                  (let uu____2141 =
-                     let uu____2147 =
-                       let uu____2149 = FStar_Syntax_Print.term_to_string t1
+                  (let uu____2201 =
+                     let uu____2207 =
+                       let uu____2209 = FStar_Syntax_Print.term_to_string t1
                           in
                        FStar_Util.format1 "Not an embedded pattern: %s"
-                         uu____2149
+                         uu____2209
                         in
-                     (FStar_Errors.Warning_NotEmbedded, uu____2147)  in
+                     (FStar_Errors.Warning_NotEmbedded, uu____2207)  in
                    FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos
-                     uu____2141)
+                     uu____2201)
                 else ();
                 FStar_Pervasives_Native.None))
        in
@@ -699,8 +735,8 @@ let (e_branch_aq :
       FStar_Syntax_Embeddings.embedding)
   =
   fun aq  ->
-    let uu____2176 = e_term_aq aq  in
-    FStar_Syntax_Embeddings.e_tuple2 e_pattern uu____2176
+    let uu____2236 = e_term_aq aq  in
+    FStar_Syntax_Embeddings.e_tuple2 e_pattern uu____2236
   
 let (e_argv_aq :
   FStar_Syntax_Syntax.antiquotations ->
@@ -708,8 +744,8 @@ let (e_argv_aq :
       FStar_Syntax_Embeddings.embedding)
   =
   fun aq  ->
-    let uu____2191 = e_term_aq aq  in
-    FStar_Syntax_Embeddings.e_tuple2 uu____2191 e_aqualv
+    let uu____2251 = e_term_aq aq  in
+    FStar_Syntax_Embeddings.e_tuple2 uu____2251 e_aqualv
   
 let (e_term_view_aq :
   FStar_Syntax_Syntax.antiquotations ->
@@ -719,506 +755,506 @@ let (e_term_view_aq :
     let embed_term_view rng t =
       match t with
       | FStar_Reflection_Data.Tv_FVar fv ->
-          let uu____2214 =
-            let uu____2219 =
-              let uu____2220 =
-                let uu____2229 = embed e_fv rng fv  in
-                FStar_Syntax_Syntax.as_arg uu____2229  in
-              [uu____2220]  in
+          let uu____2274 =
+            let uu____2279 =
+              let uu____2280 =
+                let uu____2289 = embed e_fv rng fv  in
+                FStar_Syntax_Syntax.as_arg uu____2289  in
+              [uu____2280]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_FVar.FStar_Reflection_Data.t
-              uu____2219
+              uu____2279
              in
-          uu____2214 FStar_Pervasives_Native.None rng
+          uu____2274 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_BVar fv ->
-          let uu____2247 =
-            let uu____2252 =
-              let uu____2253 =
-                let uu____2262 = embed e_bv rng fv  in
-                FStar_Syntax_Syntax.as_arg uu____2262  in
-              [uu____2253]  in
+          let uu____2307 =
+            let uu____2312 =
+              let uu____2313 =
+                let uu____2322 = embed e_bv rng fv  in
+                FStar_Syntax_Syntax.as_arg uu____2322  in
+              [uu____2313]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_BVar.FStar_Reflection_Data.t
-              uu____2252
+              uu____2312
              in
-          uu____2247 FStar_Pervasives_Native.None rng
+          uu____2307 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Var bv ->
-          let uu____2280 =
-            let uu____2285 =
-              let uu____2286 =
-                let uu____2295 = embed e_bv rng bv  in
-                FStar_Syntax_Syntax.as_arg uu____2295  in
-              [uu____2286]  in
+          let uu____2340 =
+            let uu____2345 =
+              let uu____2346 =
+                let uu____2355 = embed e_bv rng bv  in
+                FStar_Syntax_Syntax.as_arg uu____2355  in
+              [uu____2346]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_Var.FStar_Reflection_Data.t
-              uu____2285
+              uu____2345
              in
-          uu____2280 FStar_Pervasives_Native.None rng
+          uu____2340 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_App (hd1,a) ->
-          let uu____2314 =
-            let uu____2319 =
-              let uu____2320 =
-                let uu____2329 =
-                  let uu____2330 = e_term_aq aq  in embed uu____2330 rng hd1
+          let uu____2374 =
+            let uu____2379 =
+              let uu____2380 =
+                let uu____2389 =
+                  let uu____2390 = e_term_aq aq  in embed uu____2390 rng hd1
                    in
-                FStar_Syntax_Syntax.as_arg uu____2329  in
-              let uu____2333 =
-                let uu____2344 =
-                  let uu____2353 =
-                    let uu____2354 = e_argv_aq aq  in embed uu____2354 rng a
+                FStar_Syntax_Syntax.as_arg uu____2389  in
+              let uu____2393 =
+                let uu____2404 =
+                  let uu____2413 =
+                    let uu____2414 = e_argv_aq aq  in embed uu____2414 rng a
                      in
-                  FStar_Syntax_Syntax.as_arg uu____2353  in
-                [uu____2344]  in
-              uu____2320 :: uu____2333  in
+                  FStar_Syntax_Syntax.as_arg uu____2413  in
+                [uu____2404]  in
+              uu____2380 :: uu____2393  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_App.FStar_Reflection_Data.t
-              uu____2319
+              uu____2379
              in
-          uu____2314 FStar_Pervasives_Native.None rng
+          uu____2374 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Abs (b,t1) ->
-          let uu____2391 =
-            let uu____2396 =
-              let uu____2397 =
-                let uu____2406 = embed e_binder rng b  in
-                FStar_Syntax_Syntax.as_arg uu____2406  in
-              let uu____2407 =
-                let uu____2418 =
-                  let uu____2427 =
-                    let uu____2428 = e_term_aq aq  in embed uu____2428 rng t1
+          let uu____2451 =
+            let uu____2456 =
+              let uu____2457 =
+                let uu____2466 = embed e_binder rng b  in
+                FStar_Syntax_Syntax.as_arg uu____2466  in
+              let uu____2467 =
+                let uu____2478 =
+                  let uu____2487 =
+                    let uu____2488 = e_term_aq aq  in embed uu____2488 rng t1
                      in
-                  FStar_Syntax_Syntax.as_arg uu____2427  in
-                [uu____2418]  in
-              uu____2397 :: uu____2407  in
+                  FStar_Syntax_Syntax.as_arg uu____2487  in
+                [uu____2478]  in
+              uu____2457 :: uu____2467  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_Abs.FStar_Reflection_Data.t
-              uu____2396
+              uu____2456
              in
-          uu____2391 FStar_Pervasives_Native.None rng
+          uu____2451 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Arrow (b,c) ->
-          let uu____2457 =
-            let uu____2462 =
-              let uu____2463 =
-                let uu____2472 = embed e_binder rng b  in
-                FStar_Syntax_Syntax.as_arg uu____2472  in
-              let uu____2473 =
-                let uu____2484 =
-                  let uu____2493 = embed e_comp rng c  in
-                  FStar_Syntax_Syntax.as_arg uu____2493  in
-                [uu____2484]  in
-              uu____2463 :: uu____2473  in
+          let uu____2517 =
+            let uu____2522 =
+              let uu____2523 =
+                let uu____2532 = embed e_binder rng b  in
+                FStar_Syntax_Syntax.as_arg uu____2532  in
+              let uu____2533 =
+                let uu____2544 =
+                  let uu____2553 = embed e_comp rng c  in
+                  FStar_Syntax_Syntax.as_arg uu____2553  in
+                [uu____2544]  in
+              uu____2523 :: uu____2533  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_Arrow.FStar_Reflection_Data.t
-              uu____2462
+              uu____2522
              in
-          uu____2457 FStar_Pervasives_Native.None rng
+          uu____2517 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Type u ->
-          let uu____2519 =
-            let uu____2524 =
-              let uu____2525 =
-                let uu____2534 = embed FStar_Syntax_Embeddings.e_unit rng ()
+          let uu____2579 =
+            let uu____2584 =
+              let uu____2585 =
+                let uu____2594 = embed FStar_Syntax_Embeddings.e_unit rng ()
                    in
-                FStar_Syntax_Syntax.as_arg uu____2534  in
-              [uu____2525]  in
+                FStar_Syntax_Syntax.as_arg uu____2594  in
+              [uu____2585]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_Type.FStar_Reflection_Data.t
-              uu____2524
+              uu____2584
              in
-          uu____2519 FStar_Pervasives_Native.None rng
+          uu____2579 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Refine (bv,t1) ->
-          let uu____2553 =
-            let uu____2558 =
-              let uu____2559 =
-                let uu____2568 = embed e_bv rng bv  in
-                FStar_Syntax_Syntax.as_arg uu____2568  in
-              let uu____2569 =
-                let uu____2580 =
-                  let uu____2589 =
-                    let uu____2590 = e_term_aq aq  in embed uu____2590 rng t1
+          let uu____2613 =
+            let uu____2618 =
+              let uu____2619 =
+                let uu____2628 = embed e_bv rng bv  in
+                FStar_Syntax_Syntax.as_arg uu____2628  in
+              let uu____2629 =
+                let uu____2640 =
+                  let uu____2649 =
+                    let uu____2650 = e_term_aq aq  in embed uu____2650 rng t1
                      in
-                  FStar_Syntax_Syntax.as_arg uu____2589  in
-                [uu____2580]  in
-              uu____2559 :: uu____2569  in
+                  FStar_Syntax_Syntax.as_arg uu____2649  in
+                [uu____2640]  in
+              uu____2619 :: uu____2629  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_Refine.FStar_Reflection_Data.t
-              uu____2558
+              uu____2618
              in
-          uu____2553 FStar_Pervasives_Native.None rng
+          uu____2613 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Const c ->
-          let uu____2618 =
-            let uu____2623 =
-              let uu____2624 =
-                let uu____2633 = embed e_const rng c  in
-                FStar_Syntax_Syntax.as_arg uu____2633  in
-              [uu____2624]  in
+          let uu____2678 =
+            let uu____2683 =
+              let uu____2684 =
+                let uu____2693 = embed e_const rng c  in
+                FStar_Syntax_Syntax.as_arg uu____2693  in
+              [uu____2684]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_Const.FStar_Reflection_Data.t
-              uu____2623
+              uu____2683
              in
-          uu____2618 FStar_Pervasives_Native.None rng
+          uu____2678 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Uvar (u,d) ->
-          let uu____2652 =
-            let uu____2657 =
-              let uu____2658 =
-                let uu____2667 = embed FStar_Syntax_Embeddings.e_int rng u
+          let uu____2712 =
+            let uu____2717 =
+              let uu____2718 =
+                let uu____2727 = embed FStar_Syntax_Embeddings.e_int rng u
                    in
-                FStar_Syntax_Syntax.as_arg uu____2667  in
-              let uu____2668 =
-                let uu____2679 =
-                  let uu____2688 =
+                FStar_Syntax_Syntax.as_arg uu____2727  in
+              let uu____2728 =
+                let uu____2739 =
+                  let uu____2748 =
                     FStar_Syntax_Util.mk_lazy (u, d)
                       FStar_Syntax_Util.t_ctx_uvar_and_sust
                       FStar_Syntax_Syntax.Lazy_uvar
                       FStar_Pervasives_Native.None
                      in
-                  FStar_Syntax_Syntax.as_arg uu____2688  in
-                [uu____2679]  in
-              uu____2658 :: uu____2668  in
+                  FStar_Syntax_Syntax.as_arg uu____2748  in
+                [uu____2739]  in
+              uu____2718 :: uu____2728  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_Uvar.FStar_Reflection_Data.t
-              uu____2657
+              uu____2717
              in
-          uu____2652 FStar_Pervasives_Native.None rng
+          uu____2712 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Let (r,b,t1,t2) ->
-          let uu____2723 =
-            let uu____2728 =
-              let uu____2729 =
-                let uu____2738 = embed FStar_Syntax_Embeddings.e_bool rng r
+          let uu____2783 =
+            let uu____2788 =
+              let uu____2789 =
+                let uu____2798 = embed FStar_Syntax_Embeddings.e_bool rng r
                    in
-                FStar_Syntax_Syntax.as_arg uu____2738  in
-              let uu____2740 =
-                let uu____2751 =
-                  let uu____2760 = embed e_bv rng b  in
-                  FStar_Syntax_Syntax.as_arg uu____2760  in
-                let uu____2761 =
-                  let uu____2772 =
-                    let uu____2781 =
-                      let uu____2782 = e_term_aq aq  in
-                      embed uu____2782 rng t1  in
-                    FStar_Syntax_Syntax.as_arg uu____2781  in
-                  let uu____2785 =
-                    let uu____2796 =
-                      let uu____2805 =
-                        let uu____2806 = e_term_aq aq  in
-                        embed uu____2806 rng t2  in
-                      FStar_Syntax_Syntax.as_arg uu____2805  in
-                    [uu____2796]  in
-                  uu____2772 :: uu____2785  in
-                uu____2751 :: uu____2761  in
-              uu____2729 :: uu____2740  in
+                FStar_Syntax_Syntax.as_arg uu____2798  in
+              let uu____2800 =
+                let uu____2811 =
+                  let uu____2820 = embed e_bv rng b  in
+                  FStar_Syntax_Syntax.as_arg uu____2820  in
+                let uu____2821 =
+                  let uu____2832 =
+                    let uu____2841 =
+                      let uu____2842 = e_term_aq aq  in
+                      embed uu____2842 rng t1  in
+                    FStar_Syntax_Syntax.as_arg uu____2841  in
+                  let uu____2845 =
+                    let uu____2856 =
+                      let uu____2865 =
+                        let uu____2866 = e_term_aq aq  in
+                        embed uu____2866 rng t2  in
+                      FStar_Syntax_Syntax.as_arg uu____2865  in
+                    [uu____2856]  in
+                  uu____2832 :: uu____2845  in
+                uu____2811 :: uu____2821  in
+              uu____2789 :: uu____2800  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_Let.FStar_Reflection_Data.t
-              uu____2728
+              uu____2788
              in
-          uu____2723 FStar_Pervasives_Native.None rng
+          uu____2783 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Match (t1,brs) ->
-          let uu____2855 =
-            let uu____2860 =
-              let uu____2861 =
-                let uu____2870 =
-                  let uu____2871 = e_term_aq aq  in embed uu____2871 rng t1
+          let uu____2915 =
+            let uu____2920 =
+              let uu____2921 =
+                let uu____2930 =
+                  let uu____2931 = e_term_aq aq  in embed uu____2931 rng t1
                    in
-                FStar_Syntax_Syntax.as_arg uu____2870  in
-              let uu____2874 =
-                let uu____2885 =
-                  let uu____2894 =
-                    let uu____2895 =
-                      let uu____2904 = e_branch_aq aq  in
-                      FStar_Syntax_Embeddings.e_list uu____2904  in
-                    embed uu____2895 rng brs  in
-                  FStar_Syntax_Syntax.as_arg uu____2894  in
-                [uu____2885]  in
-              uu____2861 :: uu____2874  in
+                FStar_Syntax_Syntax.as_arg uu____2930  in
+              let uu____2934 =
+                let uu____2945 =
+                  let uu____2954 =
+                    let uu____2955 =
+                      let uu____2964 = e_branch_aq aq  in
+                      FStar_Syntax_Embeddings.e_list uu____2964  in
+                    embed uu____2955 rng brs  in
+                  FStar_Syntax_Syntax.as_arg uu____2954  in
+                [uu____2945]  in
+              uu____2921 :: uu____2934  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_Match.FStar_Reflection_Data.t
-              uu____2860
+              uu____2920
              in
-          uu____2855 FStar_Pervasives_Native.None rng
+          uu____2915 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_AscribedT (e,t1,tacopt) ->
-          let uu____2952 =
-            let uu____2957 =
-              let uu____2958 =
-                let uu____2967 =
-                  let uu____2968 = e_term_aq aq  in embed uu____2968 rng e
+          let uu____3012 =
+            let uu____3017 =
+              let uu____3018 =
+                let uu____3027 =
+                  let uu____3028 = e_term_aq aq  in embed uu____3028 rng e
                    in
-                FStar_Syntax_Syntax.as_arg uu____2967  in
-              let uu____2971 =
-                let uu____2982 =
-                  let uu____2991 =
-                    let uu____2992 = e_term_aq aq  in embed uu____2992 rng t1
+                FStar_Syntax_Syntax.as_arg uu____3027  in
+              let uu____3031 =
+                let uu____3042 =
+                  let uu____3051 =
+                    let uu____3052 = e_term_aq aq  in embed uu____3052 rng t1
                      in
-                  FStar_Syntax_Syntax.as_arg uu____2991  in
-                let uu____2995 =
-                  let uu____3006 =
-                    let uu____3015 =
-                      let uu____3016 =
-                        let uu____3021 = e_term_aq aq  in
-                        FStar_Syntax_Embeddings.e_option uu____3021  in
-                      embed uu____3016 rng tacopt  in
-                    FStar_Syntax_Syntax.as_arg uu____3015  in
-                  [uu____3006]  in
-                uu____2982 :: uu____2995  in
-              uu____2958 :: uu____2971  in
+                  FStar_Syntax_Syntax.as_arg uu____3051  in
+                let uu____3055 =
+                  let uu____3066 =
+                    let uu____3075 =
+                      let uu____3076 =
+                        let uu____3081 = e_term_aq aq  in
+                        FStar_Syntax_Embeddings.e_option uu____3081  in
+                      embed uu____3076 rng tacopt  in
+                    FStar_Syntax_Syntax.as_arg uu____3075  in
+                  [uu____3066]  in
+                uu____3042 :: uu____3055  in
+              uu____3018 :: uu____3031  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.t
-              uu____2957
+              uu____3017
              in
-          uu____2952 FStar_Pervasives_Native.None rng
+          uu____3012 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_AscribedC (e,c,tacopt) ->
-          let uu____3065 =
-            let uu____3070 =
-              let uu____3071 =
-                let uu____3080 =
-                  let uu____3081 = e_term_aq aq  in embed uu____3081 rng e
+          let uu____3125 =
+            let uu____3130 =
+              let uu____3131 =
+                let uu____3140 =
+                  let uu____3141 = e_term_aq aq  in embed uu____3141 rng e
                    in
-                FStar_Syntax_Syntax.as_arg uu____3080  in
-              let uu____3084 =
-                let uu____3095 =
-                  let uu____3104 = embed e_comp rng c  in
-                  FStar_Syntax_Syntax.as_arg uu____3104  in
-                let uu____3105 =
-                  let uu____3116 =
-                    let uu____3125 =
-                      let uu____3126 =
-                        let uu____3131 = e_term_aq aq  in
-                        FStar_Syntax_Embeddings.e_option uu____3131  in
-                      embed uu____3126 rng tacopt  in
-                    FStar_Syntax_Syntax.as_arg uu____3125  in
-                  [uu____3116]  in
-                uu____3095 :: uu____3105  in
-              uu____3071 :: uu____3084  in
+                FStar_Syntax_Syntax.as_arg uu____3140  in
+              let uu____3144 =
+                let uu____3155 =
+                  let uu____3164 = embed e_comp rng c  in
+                  FStar_Syntax_Syntax.as_arg uu____3164  in
+                let uu____3165 =
+                  let uu____3176 =
+                    let uu____3185 =
+                      let uu____3186 =
+                        let uu____3191 = e_term_aq aq  in
+                        FStar_Syntax_Embeddings.e_option uu____3191  in
+                      embed uu____3186 rng tacopt  in
+                    FStar_Syntax_Syntax.as_arg uu____3185  in
+                  [uu____3176]  in
+                uu____3155 :: uu____3165  in
+              uu____3131 :: uu____3144  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_AscC.FStar_Reflection_Data.t
-              uu____3070
+              uu____3130
              in
-          uu____3065 FStar_Pervasives_Native.None rng
+          uu____3125 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Unknown  ->
-          let uu___370_3168 =
+          let uu___385_3228 =
             FStar_Reflection_Data.ref_Tv_Unknown.FStar_Reflection_Data.t  in
           {
-            FStar_Syntax_Syntax.n = (uu___370_3168.FStar_Syntax_Syntax.n);
+            FStar_Syntax_Syntax.n = (uu___385_3228.FStar_Syntax_Syntax.n);
             FStar_Syntax_Syntax.pos = rng;
             FStar_Syntax_Syntax.vars =
-              (uu___370_3168.FStar_Syntax_Syntax.vars)
+              (uu___385_3228.FStar_Syntax_Syntax.vars)
           }
        in
     let unembed_term_view w t =
-      let uu____3186 = FStar_Syntax_Util.head_and_args t  in
-      match uu____3186 with
+      let uu____3246 = FStar_Syntax_Util.head_and_args t  in
+      match uu____3246 with
       | (hd1,args) ->
-          let uu____3231 =
-            let uu____3244 =
-              let uu____3245 = FStar_Syntax_Util.un_uinst hd1  in
-              uu____3245.FStar_Syntax_Syntax.n  in
-            (uu____3244, args)  in
-          (match uu____3231 with
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(b,uu____3260)::[]) when
+          let uu____3291 =
+            let uu____3304 =
+              let uu____3305 = FStar_Syntax_Util.un_uinst hd1  in
+              uu____3305.FStar_Syntax_Syntax.n  in
+            (uu____3304, args)  in
+          (match uu____3291 with
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(b,uu____3320)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Var.FStar_Reflection_Data.lid
                ->
-               let uu____3285 = unembed' w e_bv b  in
-               FStar_Util.bind_opt uu____3285
+               let uu____3345 = unembed' w e_bv b  in
+               FStar_Util.bind_opt uu____3345
                  (fun b1  ->
                     FStar_All.pipe_left
-                      (fun _3292  -> FStar_Pervasives_Native.Some _3292)
+                      (fun _3352  -> FStar_Pervasives_Native.Some _3352)
                       (FStar_Reflection_Data.Tv_Var b1))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(b,uu____3295)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(b,uu____3355)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_BVar.FStar_Reflection_Data.lid
                ->
-               let uu____3320 = unembed' w e_bv b  in
-               FStar_Util.bind_opt uu____3320
+               let uu____3380 = unembed' w e_bv b  in
+               FStar_Util.bind_opt uu____3380
                  (fun b1  ->
                     FStar_All.pipe_left
-                      (fun _3327  -> FStar_Pervasives_Native.Some _3327)
+                      (fun _3387  -> FStar_Pervasives_Native.Some _3387)
                       (FStar_Reflection_Data.Tv_BVar b1))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(f,uu____3330)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(f,uu____3390)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_FVar.FStar_Reflection_Data.lid
                ->
-               let uu____3355 = unembed' w e_fv f  in
-               FStar_Util.bind_opt uu____3355
+               let uu____3415 = unembed' w e_fv f  in
+               FStar_Util.bind_opt uu____3415
                  (fun f1  ->
                     FStar_All.pipe_left
-                      (fun _3362  -> FStar_Pervasives_Native.Some _3362)
+                      (fun _3422  -> FStar_Pervasives_Native.Some _3422)
                       (FStar_Reflection_Data.Tv_FVar f1))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(l,uu____3365)::(r,uu____3367)::[]) when
+              fv,(l,uu____3425)::(r,uu____3427)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_App.FStar_Reflection_Data.lid
                ->
-               let uu____3402 = unembed' w e_term l  in
-               FStar_Util.bind_opt uu____3402
+               let uu____3462 = unembed' w e_term l  in
+               FStar_Util.bind_opt uu____3462
                  (fun l1  ->
-                    let uu____3408 = unembed' w e_argv r  in
-                    FStar_Util.bind_opt uu____3408
+                    let uu____3468 = unembed' w e_argv r  in
+                    FStar_Util.bind_opt uu____3468
                       (fun r1  ->
                          FStar_All.pipe_left
-                           (fun _3415  -> FStar_Pervasives_Native.Some _3415)
+                           (fun _3475  -> FStar_Pervasives_Native.Some _3475)
                            (FStar_Reflection_Data.Tv_App (l1, r1))))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(b,uu____3418)::(t1,uu____3420)::[]) when
+              fv,(b,uu____3478)::(t1,uu____3480)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Abs.FStar_Reflection_Data.lid
                ->
-               let uu____3455 = unembed' w e_binder b  in
-               FStar_Util.bind_opt uu____3455
+               let uu____3515 = unembed' w e_binder b  in
+               FStar_Util.bind_opt uu____3515
                  (fun b1  ->
-                    let uu____3461 = unembed' w e_term t1  in
-                    FStar_Util.bind_opt uu____3461
+                    let uu____3521 = unembed' w e_term t1  in
+                    FStar_Util.bind_opt uu____3521
                       (fun t2  ->
                          FStar_All.pipe_left
-                           (fun _3468  -> FStar_Pervasives_Native.Some _3468)
+                           (fun _3528  -> FStar_Pervasives_Native.Some _3528)
                            (FStar_Reflection_Data.Tv_Abs (b1, t2))))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(b,uu____3471)::(t1,uu____3473)::[]) when
+              fv,(b,uu____3531)::(t1,uu____3533)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Arrow.FStar_Reflection_Data.lid
                ->
-               let uu____3508 = unembed' w e_binder b  in
-               FStar_Util.bind_opt uu____3508
+               let uu____3568 = unembed' w e_binder b  in
+               FStar_Util.bind_opt uu____3568
                  (fun b1  ->
-                    let uu____3514 = unembed' w e_comp t1  in
-                    FStar_Util.bind_opt uu____3514
+                    let uu____3574 = unembed' w e_comp t1  in
+                    FStar_Util.bind_opt uu____3574
                       (fun c  ->
                          FStar_All.pipe_left
-                           (fun _3521  -> FStar_Pervasives_Native.Some _3521)
+                           (fun _3581  -> FStar_Pervasives_Native.Some _3581)
                            (FStar_Reflection_Data.Tv_Arrow (b1, c))))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(u,uu____3524)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(u,uu____3584)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Type.FStar_Reflection_Data.lid
                ->
-               let uu____3549 = unembed' w FStar_Syntax_Embeddings.e_unit u
+               let uu____3609 = unembed' w FStar_Syntax_Embeddings.e_unit u
                   in
-               FStar_Util.bind_opt uu____3549
+               FStar_Util.bind_opt uu____3609
                  (fun u1  ->
                     FStar_All.pipe_left
-                      (fun _3556  -> FStar_Pervasives_Native.Some _3556)
+                      (fun _3616  -> FStar_Pervasives_Native.Some _3616)
                       (FStar_Reflection_Data.Tv_Type ()))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(b,uu____3559)::(t1,uu____3561)::[]) when
+              fv,(b,uu____3619)::(t1,uu____3621)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Refine.FStar_Reflection_Data.lid
                ->
-               let uu____3596 = unembed' w e_bv b  in
-               FStar_Util.bind_opt uu____3596
+               let uu____3656 = unembed' w e_bv b  in
+               FStar_Util.bind_opt uu____3656
                  (fun b1  ->
-                    let uu____3602 = unembed' w e_term t1  in
-                    FStar_Util.bind_opt uu____3602
+                    let uu____3662 = unembed' w e_term t1  in
+                    FStar_Util.bind_opt uu____3662
                       (fun t2  ->
                          FStar_All.pipe_left
-                           (fun _3609  -> FStar_Pervasives_Native.Some _3609)
+                           (fun _3669  -> FStar_Pervasives_Native.Some _3669)
                            (FStar_Reflection_Data.Tv_Refine (b1, t2))))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(c,uu____3612)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(c,uu____3672)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Const.FStar_Reflection_Data.lid
                ->
-               let uu____3637 = unembed' w e_const c  in
-               FStar_Util.bind_opt uu____3637
+               let uu____3697 = unembed' w e_const c  in
+               FStar_Util.bind_opt uu____3697
                  (fun c1  ->
                     FStar_All.pipe_left
-                      (fun _3644  -> FStar_Pervasives_Native.Some _3644)
+                      (fun _3704  -> FStar_Pervasives_Native.Some _3704)
                       (FStar_Reflection_Data.Tv_Const c1))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(u,uu____3647)::(l,uu____3649)::[]) when
+              fv,(u,uu____3707)::(l,uu____3709)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Uvar.FStar_Reflection_Data.lid
                ->
-               let uu____3684 = unembed' w FStar_Syntax_Embeddings.e_int u
+               let uu____3744 = unembed' w FStar_Syntax_Embeddings.e_int u
                   in
-               FStar_Util.bind_opt uu____3684
+               FStar_Util.bind_opt uu____3744
                  (fun u1  ->
                     let ctx_u_s =
                       FStar_Syntax_Util.unlazy_as_t
                         FStar_Syntax_Syntax.Lazy_uvar l
                        in
                     FStar_All.pipe_left
-                      (fun _3693  -> FStar_Pervasives_Native.Some _3693)
+                      (fun _3753  -> FStar_Pervasives_Native.Some _3753)
                       (FStar_Reflection_Data.Tv_Uvar (u1, ctx_u_s)))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(r,uu____3696)::(b,uu____3698)::(t1,uu____3700)::(t2,uu____3702)::[])
+              fv,(r,uu____3756)::(b,uu____3758)::(t1,uu____3760)::(t2,uu____3762)::[])
                when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Let.FStar_Reflection_Data.lid
                ->
-               let uu____3757 = unembed' w FStar_Syntax_Embeddings.e_bool r
+               let uu____3817 = unembed' w FStar_Syntax_Embeddings.e_bool r
                   in
-               FStar_Util.bind_opt uu____3757
+               FStar_Util.bind_opt uu____3817
                  (fun r1  ->
-                    let uu____3767 = unembed' w e_bv b  in
-                    FStar_Util.bind_opt uu____3767
+                    let uu____3827 = unembed' w e_bv b  in
+                    FStar_Util.bind_opt uu____3827
                       (fun b1  ->
-                         let uu____3773 = unembed' w e_term t1  in
-                         FStar_Util.bind_opt uu____3773
+                         let uu____3833 = unembed' w e_term t1  in
+                         FStar_Util.bind_opt uu____3833
                            (fun t11  ->
-                              let uu____3779 = unembed' w e_term t2  in
-                              FStar_Util.bind_opt uu____3779
+                              let uu____3839 = unembed' w e_term t2  in
+                              FStar_Util.bind_opt uu____3839
                                 (fun t21  ->
                                    FStar_All.pipe_left
-                                     (fun _3786  ->
-                                        FStar_Pervasives_Native.Some _3786)
+                                     (fun _3846  ->
+                                        FStar_Pervasives_Native.Some _3846)
                                      (FStar_Reflection_Data.Tv_Let
                                         (r1, b1, t11, t21))))))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(t1,uu____3790)::(brs,uu____3792)::[]) when
+              fv,(t1,uu____3850)::(brs,uu____3852)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Match.FStar_Reflection_Data.lid
                ->
-               let uu____3827 = unembed' w e_term t1  in
-               FStar_Util.bind_opt uu____3827
+               let uu____3887 = unembed' w e_term t1  in
+               FStar_Util.bind_opt uu____3887
                  (fun t2  ->
-                    let uu____3833 =
-                      let uu____3838 =
+                    let uu____3893 =
+                      let uu____3898 =
                         FStar_Syntax_Embeddings.e_list e_branch  in
-                      unembed' w uu____3838 brs  in
-                    FStar_Util.bind_opt uu____3833
+                      unembed' w uu____3898 brs  in
+                    FStar_Util.bind_opt uu____3893
                       (fun brs1  ->
                          FStar_All.pipe_left
-                           (fun _3853  -> FStar_Pervasives_Native.Some _3853)
+                           (fun _3913  -> FStar_Pervasives_Native.Some _3913)
                            (FStar_Reflection_Data.Tv_Match (t2, brs1))))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(e,uu____3858)::(t1,uu____3860)::(tacopt,uu____3862)::[])
+              fv,(e,uu____3918)::(t1,uu____3920)::(tacopt,uu____3922)::[])
                when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.lid
                ->
-               let uu____3907 = unembed' w e_term e  in
-               FStar_Util.bind_opt uu____3907
+               let uu____3967 = unembed' w e_term e  in
+               FStar_Util.bind_opt uu____3967
                  (fun e1  ->
-                    let uu____3913 = unembed' w e_term t1  in
-                    FStar_Util.bind_opt uu____3913
+                    let uu____3973 = unembed' w e_term t1  in
+                    FStar_Util.bind_opt uu____3973
                       (fun t2  ->
-                         let uu____3919 =
-                           let uu____3924 =
+                         let uu____3979 =
+                           let uu____3984 =
                              FStar_Syntax_Embeddings.e_option e_term  in
-                           unembed' w uu____3924 tacopt  in
-                         FStar_Util.bind_opt uu____3919
+                           unembed' w uu____3984 tacopt  in
+                         FStar_Util.bind_opt uu____3979
                            (fun tacopt1  ->
                               FStar_All.pipe_left
-                                (fun _3939  ->
-                                   FStar_Pervasives_Native.Some _3939)
+                                (fun _3999  ->
+                                   FStar_Pervasives_Native.Some _3999)
                                 (FStar_Reflection_Data.Tv_AscribedT
                                    (e1, t2, tacopt1)))))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(e,uu____3944)::(c,uu____3946)::(tacopt,uu____3948)::[])
+              fv,(e,uu____4004)::(c,uu____4006)::(tacopt,uu____4008)::[])
                when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_AscC.FStar_Reflection_Data.lid
                ->
-               let uu____3993 = unembed' w e_term e  in
-               FStar_Util.bind_opt uu____3993
+               let uu____4053 = unembed' w e_term e  in
+               FStar_Util.bind_opt uu____4053
                  (fun e1  ->
-                    let uu____3999 = unembed' w e_comp c  in
-                    FStar_Util.bind_opt uu____3999
+                    let uu____4059 = unembed' w e_comp c  in
+                    FStar_Util.bind_opt uu____4059
                       (fun c1  ->
-                         let uu____4005 =
-                           let uu____4010 =
+                         let uu____4065 =
+                           let uu____4070 =
                              FStar_Syntax_Embeddings.e_option e_term  in
-                           unembed' w uu____4010 tacopt  in
-                         FStar_Util.bind_opt uu____4005
+                           unembed' w uu____4070 tacopt  in
+                         FStar_Util.bind_opt uu____4065
                            (fun tacopt1  ->
                               FStar_All.pipe_left
-                                (fun _4025  ->
-                                   FStar_Pervasives_Native.Some _4025)
+                                (fun _4085  ->
+                                   FStar_Pervasives_Native.Some _4085)
                                 (FStar_Reflection_Data.Tv_AscribedC
                                    (e1, c1, tacopt1)))))
            | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
@@ -1226,21 +1262,21 @@ let (e_term_view_aq :
                  FStar_Reflection_Data.ref_Tv_Unknown.FStar_Reflection_Data.lid
                ->
                FStar_All.pipe_left
-                 (fun _4045  -> FStar_Pervasives_Native.Some _4045)
+                 (fun _4105  -> FStar_Pervasives_Native.Some _4105)
                  FStar_Reflection_Data.Tv_Unknown
-           | uu____4046 ->
+           | uu____4106 ->
                (if w
                 then
-                  (let uu____4061 =
-                     let uu____4067 =
-                       let uu____4069 = FStar_Syntax_Print.term_to_string t
+                  (let uu____4121 =
+                     let uu____4127 =
+                       let uu____4129 = FStar_Syntax_Print.term_to_string t
                           in
                        FStar_Util.format1 "Not an embedded term_view: %s"
-                         uu____4069
+                         uu____4129
                         in
-                     (FStar_Errors.Warning_NotEmbedded, uu____4067)  in
+                     (FStar_Errors.Warning_NotEmbedded, uu____4127)  in
                    FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos
-                     uu____4061)
+                     uu____4121)
                 else ();
                 FStar_Pervasives_Native.None))
        in
@@ -1253,80 +1289,80 @@ let (e_term_view :
 let (e_bv_view :
   FStar_Reflection_Data.bv_view FStar_Syntax_Embeddings.embedding) =
   let embed_bv_view rng bvv =
-    let uu____4098 =
-      let uu____4103 =
-        let uu____4104 =
-          let uu____4113 =
+    let uu____4158 =
+      let uu____4163 =
+        let uu____4164 =
+          let uu____4173 =
             embed FStar_Syntax_Embeddings.e_string rng
               bvv.FStar_Reflection_Data.bv_ppname
              in
-          FStar_Syntax_Syntax.as_arg uu____4113  in
-        let uu____4115 =
-          let uu____4126 =
-            let uu____4135 =
+          FStar_Syntax_Syntax.as_arg uu____4173  in
+        let uu____4175 =
+          let uu____4186 =
+            let uu____4195 =
               embed FStar_Syntax_Embeddings.e_int rng
                 bvv.FStar_Reflection_Data.bv_index
                in
-            FStar_Syntax_Syntax.as_arg uu____4135  in
-          let uu____4136 =
-            let uu____4147 =
-              let uu____4156 =
+            FStar_Syntax_Syntax.as_arg uu____4195  in
+          let uu____4196 =
+            let uu____4207 =
+              let uu____4216 =
                 embed e_term rng bvv.FStar_Reflection_Data.bv_sort  in
-              FStar_Syntax_Syntax.as_arg uu____4156  in
-            [uu____4147]  in
-          uu____4126 :: uu____4136  in
-        uu____4104 :: uu____4115  in
+              FStar_Syntax_Syntax.as_arg uu____4216  in
+            [uu____4207]  in
+          uu____4186 :: uu____4196  in
+        uu____4164 :: uu____4175  in
       FStar_Syntax_Syntax.mk_Tm_app
-        FStar_Reflection_Data.ref_Mk_bv.FStar_Reflection_Data.t uu____4103
+        FStar_Reflection_Data.ref_Mk_bv.FStar_Reflection_Data.t uu____4163
        in
-    uu____4098 FStar_Pervasives_Native.None rng  in
+    uu____4158 FStar_Pervasives_Native.None rng  in
   let unembed_bv_view w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____4207 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____4207 with
+    let uu____4267 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____4267 with
     | (hd1,args) ->
-        let uu____4252 =
-          let uu____4265 =
-            let uu____4266 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____4266.FStar_Syntax_Syntax.n  in
-          (uu____4265, args)  in
-        (match uu____4252 with
+        let uu____4312 =
+          let uu____4325 =
+            let uu____4326 = FStar_Syntax_Util.un_uinst hd1  in
+            uu____4326.FStar_Syntax_Syntax.n  in
+          (uu____4325, args)  in
+        (match uu____4312 with
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(nm,uu____4281)::(idx,uu____4283)::(s,uu____4285)::[]) when
+            fv,(nm,uu____4341)::(idx,uu____4343)::(s,uu____4345)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Mk_bv.FStar_Reflection_Data.lid
              ->
-             let uu____4330 = unembed' w FStar_Syntax_Embeddings.e_string nm
+             let uu____4390 = unembed' w FStar_Syntax_Embeddings.e_string nm
                 in
-             FStar_Util.bind_opt uu____4330
+             FStar_Util.bind_opt uu____4390
                (fun nm1  ->
-                  let uu____4340 =
+                  let uu____4400 =
                     unembed' w FStar_Syntax_Embeddings.e_int idx  in
-                  FStar_Util.bind_opt uu____4340
+                  FStar_Util.bind_opt uu____4400
                     (fun idx1  ->
-                       let uu____4346 = unembed' w e_term s  in
-                       FStar_Util.bind_opt uu____4346
+                       let uu____4406 = unembed' w e_term s  in
+                       FStar_Util.bind_opt uu____4406
                          (fun s1  ->
                             FStar_All.pipe_left
-                              (fun _4353  ->
-                                 FStar_Pervasives_Native.Some _4353)
+                              (fun _4413  ->
+                                 FStar_Pervasives_Native.Some _4413)
                               {
                                 FStar_Reflection_Data.bv_ppname = nm1;
                                 FStar_Reflection_Data.bv_index = idx1;
                                 FStar_Reflection_Data.bv_sort = s1
                               })))
-         | uu____4354 ->
+         | uu____4414 ->
              (if w
               then
-                (let uu____4369 =
-                   let uu____4375 =
-                     let uu____4377 = FStar_Syntax_Print.term_to_string t1
+                (let uu____4429 =
+                   let uu____4435 =
+                     let uu____4437 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.format1 "Not an embedded bv_view: %s"
-                       uu____4377
+                       uu____4437
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____4375)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____4369)
+                   (FStar_Errors.Warning_NotEmbedded, uu____4435)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____4429)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -1338,113 +1374,113 @@ let (e_comp_view :
   let embed_comp_view rng cv =
     match cv with
     | FStar_Reflection_Data.C_Total (t,md) ->
-        let uu____4403 =
-          let uu____4408 =
-            let uu____4409 =
-              let uu____4418 = embed e_term rng t  in
-              FStar_Syntax_Syntax.as_arg uu____4418  in
-            let uu____4419 =
-              let uu____4430 =
-                let uu____4439 =
-                  let uu____4440 = FStar_Syntax_Embeddings.e_option e_term
+        let uu____4463 =
+          let uu____4468 =
+            let uu____4469 =
+              let uu____4478 = embed e_term rng t  in
+              FStar_Syntax_Syntax.as_arg uu____4478  in
+            let uu____4479 =
+              let uu____4490 =
+                let uu____4499 =
+                  let uu____4500 = FStar_Syntax_Embeddings.e_option e_term
                      in
-                  embed uu____4440 rng md  in
-                FStar_Syntax_Syntax.as_arg uu____4439  in
-              [uu____4430]  in
-            uu____4409 :: uu____4419  in
+                  embed uu____4500 rng md  in
+                FStar_Syntax_Syntax.as_arg uu____4499  in
+              [uu____4490]  in
+            uu____4469 :: uu____4479  in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.ref_C_Total.FStar_Reflection_Data.t
-            uu____4408
+            uu____4468
            in
-        uu____4403 FStar_Pervasives_Native.None rng
+        uu____4463 FStar_Pervasives_Native.None rng
     | FStar_Reflection_Data.C_Lemma (pre,post) ->
         let post1 = FStar_Syntax_Util.unthunk_lemma_post post  in
-        let uu____4476 =
-          let uu____4481 =
-            let uu____4482 =
-              let uu____4491 = embed e_term rng pre  in
-              FStar_Syntax_Syntax.as_arg uu____4491  in
-            let uu____4492 =
-              let uu____4503 =
-                let uu____4512 = embed e_term rng post1  in
-                FStar_Syntax_Syntax.as_arg uu____4512  in
-              [uu____4503]  in
-            uu____4482 :: uu____4492  in
+        let uu____4536 =
+          let uu____4541 =
+            let uu____4542 =
+              let uu____4551 = embed e_term rng pre  in
+              FStar_Syntax_Syntax.as_arg uu____4551  in
+            let uu____4552 =
+              let uu____4563 =
+                let uu____4572 = embed e_term rng post1  in
+                FStar_Syntax_Syntax.as_arg uu____4572  in
+              [uu____4563]  in
+            uu____4542 :: uu____4552  in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.ref_C_Lemma.FStar_Reflection_Data.t
-            uu____4481
+            uu____4541
            in
-        uu____4476 FStar_Pervasives_Native.None rng
+        uu____4536 FStar_Pervasives_Native.None rng
     | FStar_Reflection_Data.C_Unknown  ->
-        let uu___591_4537 =
+        let uu___606_4597 =
           FStar_Reflection_Data.ref_C_Unknown.FStar_Reflection_Data.t  in
         {
-          FStar_Syntax_Syntax.n = (uu___591_4537.FStar_Syntax_Syntax.n);
+          FStar_Syntax_Syntax.n = (uu___606_4597.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = rng;
-          FStar_Syntax_Syntax.vars = (uu___591_4537.FStar_Syntax_Syntax.vars)
+          FStar_Syntax_Syntax.vars = (uu___606_4597.FStar_Syntax_Syntax.vars)
         }
      in
   let unembed_comp_view w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____4556 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____4556 with
+    let uu____4616 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____4616 with
     | (hd1,args) ->
-        let uu____4601 =
-          let uu____4614 =
-            let uu____4615 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____4615.FStar_Syntax_Syntax.n  in
-          (uu____4614, args)  in
-        (match uu____4601 with
+        let uu____4661 =
+          let uu____4674 =
+            let uu____4675 = FStar_Syntax_Util.un_uinst hd1  in
+            uu____4675.FStar_Syntax_Syntax.n  in
+          (uu____4674, args)  in
+        (match uu____4661 with
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(t2,uu____4630)::(md,uu____4632)::[]) when
+            fv,(t2,uu____4690)::(md,uu____4692)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Total.FStar_Reflection_Data.lid
              ->
-             let uu____4667 = unembed' w e_term t2  in
-             FStar_Util.bind_opt uu____4667
+             let uu____4727 = unembed' w e_term t2  in
+             FStar_Util.bind_opt uu____4727
                (fun t3  ->
-                  let uu____4673 =
-                    let uu____4678 = FStar_Syntax_Embeddings.e_option e_term
+                  let uu____4733 =
+                    let uu____4738 = FStar_Syntax_Embeddings.e_option e_term
                        in
-                    unembed' w uu____4678 md  in
-                  FStar_Util.bind_opt uu____4673
+                    unembed' w uu____4738 md  in
+                  FStar_Util.bind_opt uu____4733
                     (fun md1  ->
                        FStar_All.pipe_left
-                         (fun _4693  -> FStar_Pervasives_Native.Some _4693)
+                         (fun _4753  -> FStar_Pervasives_Native.Some _4753)
                          (FStar_Reflection_Data.C_Total (t3, md1))))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(pre,uu____4698)::(post,uu____4700)::[]) when
+            fv,(pre,uu____4758)::(post,uu____4760)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Lemma.FStar_Reflection_Data.lid
              ->
-             let uu____4735 = unembed' w e_term pre  in
-             FStar_Util.bind_opt uu____4735
+             let uu____4795 = unembed' w e_term pre  in
+             FStar_Util.bind_opt uu____4795
                (fun pre1  ->
-                  let uu____4741 = unembed' w e_term post  in
-                  FStar_Util.bind_opt uu____4741
+                  let uu____4801 = unembed' w e_term post  in
+                  FStar_Util.bind_opt uu____4801
                     (fun post1  ->
                        FStar_All.pipe_left
-                         (fun _4748  -> FStar_Pervasives_Native.Some _4748)
+                         (fun _4808  -> FStar_Pervasives_Native.Some _4808)
                          (FStar_Reflection_Data.C_Lemma (pre1, post1))))
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Unknown.FStar_Reflection_Data.lid
              ->
              FStar_All.pipe_left
-               (fun _4766  -> FStar_Pervasives_Native.Some _4766)
+               (fun _4826  -> FStar_Pervasives_Native.Some _4826)
                FStar_Reflection_Data.C_Unknown
-         | uu____4767 ->
+         | uu____4827 ->
              (if w
               then
-                (let uu____4782 =
-                   let uu____4788 =
-                     let uu____4790 = FStar_Syntax_Print.term_to_string t1
+                (let uu____4842 =
+                   let uu____4848 =
+                     let uu____4850 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.format1 "Not an embedded comp_view: %s"
-                       uu____4790
+                       uu____4850
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____4788)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____4782)
+                   (FStar_Errors.Warning_NotEmbedded, uu____4848)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____4842)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -1458,23 +1494,23 @@ let (e_order : FStar_Order.order FStar_Syntax_Embeddings.embedding) =
       | FStar_Order.Lt  -> FStar_Reflection_Data.ord_Lt
       | FStar_Order.Eq  -> FStar_Reflection_Data.ord_Eq
       | FStar_Order.Gt  -> FStar_Reflection_Data.ord_Gt  in
-    let uu___638_4815 = r  in
+    let uu___653_4875 = r  in
     {
-      FStar_Syntax_Syntax.n = (uu___638_4815.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___653_4875.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___638_4815.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___653_4875.FStar_Syntax_Syntax.vars)
     }  in
   let unembed_order w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____4836 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____4836 with
+    let uu____4896 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____4896 with
     | (hd1,args) ->
-        let uu____4881 =
-          let uu____4896 =
-            let uu____4897 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____4897.FStar_Syntax_Syntax.n  in
-          (uu____4896, args)  in
-        (match uu____4881 with
+        let uu____4941 =
+          let uu____4956 =
+            let uu____4957 = FStar_Syntax_Util.un_uinst hd1  in
+            uu____4957.FStar_Syntax_Syntax.n  in
+          (uu____4956, args)  in
+        (match uu____4941 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ord_Lt_lid
@@ -1487,18 +1523,18 @@ let (e_order : FStar_Order.order FStar_Syntax_Embeddings.embedding) =
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ord_Gt_lid
              -> FStar_Pervasives_Native.Some FStar_Order.Gt
-         | uu____4969 ->
+         | uu____5029 ->
              (if w
               then
-                (let uu____4986 =
-                   let uu____4992 =
-                     let uu____4994 = FStar_Syntax_Print.term_to_string t1
+                (let uu____5046 =
+                   let uu____5052 =
+                     let uu____5054 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.format1 "Not an embedded order: %s"
-                       uu____4994
+                       uu____5054
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____4992)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____4986)
+                   (FStar_Errors.Warning_NotEmbedded, uu____5052)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____5046)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -1510,28 +1546,28 @@ let (e_sigelt : FStar_Syntax_Syntax.sigelt FStar_Syntax_Embeddings.embedding)
       FStar_Syntax_Syntax.Lazy_sigelt (FStar_Pervasives_Native.Some rng)
      in
   let unembed_sigelt w t =
-    let uu____5031 =
-      let uu____5032 = FStar_Syntax_Subst.compress t  in
-      uu____5032.FStar_Syntax_Syntax.n  in
-    match uu____5031 with
+    let uu____5091 =
+      let uu____5092 = FStar_Syntax_Subst.compress t  in
+      uu____5092.FStar_Syntax_Syntax.n  in
+    match uu____5091 with
     | FStar_Syntax_Syntax.Tm_lazy
         { FStar_Syntax_Syntax.blob = b;
           FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_sigelt ;
-          FStar_Syntax_Syntax.ltyp = uu____5038;
-          FStar_Syntax_Syntax.rng = uu____5039;_}
+          FStar_Syntax_Syntax.ltyp = uu____5098;
+          FStar_Syntax_Syntax.rng = uu____5099;_}
         ->
-        let uu____5042 = FStar_Dyn.undyn b  in
-        FStar_Pervasives_Native.Some uu____5042
-    | uu____5043 ->
+        let uu____5102 = FStar_Dyn.undyn b  in
+        FStar_Pervasives_Native.Some uu____5102
+    | uu____5103 ->
         (if w
          then
-           (let uu____5046 =
-              let uu____5052 =
-                let uu____5054 = FStar_Syntax_Print.term_to_string t  in
-                FStar_Util.format1 "Not an embedded sigelt: %s" uu____5054
+           (let uu____5106 =
+              let uu____5112 =
+                let uu____5114 = FStar_Syntax_Print.term_to_string t  in
+                FStar_Util.format1 "Not an embedded sigelt: %s" uu____5114
                  in
-              (FStar_Errors.Warning_NotEmbedded, uu____5052)  in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____5046)
+              (FStar_Errors.Warning_NotEmbedded, uu____5112)  in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____5106)
          else ();
          FStar_Pervasives_Native.None)
      in
@@ -1541,22 +1577,22 @@ let (e_ident : FStar_Ident.ident FStar_Syntax_Embeddings.embedding) =
     FStar_Syntax_Embeddings.e_tuple2 FStar_Syntax_Embeddings.e_range
       FStar_Syntax_Embeddings.e_string
      in
-  let embed_ident i rng uu____5094 uu____5095 =
-    let uu____5097 =
-      let uu____5103 = FStar_Ident.range_of_id i  in
-      let uu____5104 = FStar_Ident.text_of_id i  in (uu____5103, uu____5104)
+  let embed_ident i rng uu____5154 uu____5155 =
+    let uu____5157 =
+      let uu____5163 = FStar_Ident.range_of_id i  in
+      let uu____5164 = FStar_Ident.text_of_id i  in (uu____5163, uu____5164)
        in
-    embed repr rng uu____5097  in
-  let unembed_ident t w uu____5131 =
-    let uu____5136 = unembed' w repr t  in
-    match uu____5136 with
+    embed repr rng uu____5157  in
+  let unembed_ident t w uu____5191 =
+    let uu____5196 = unembed' w repr t  in
+    match uu____5196 with
     | FStar_Pervasives_Native.Some (rng,s) ->
-        let uu____5160 = FStar_Ident.mk_ident (s, rng)  in
-        FStar_Pervasives_Native.Some uu____5160
+        let uu____5220 = FStar_Ident.mk_ident (s, rng)  in
+        FStar_Pervasives_Native.Some uu____5220
     | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None  in
-  let uu____5167 = FStar_Syntax_Embeddings.emb_typ_of repr  in
+  let uu____5227 = FStar_Syntax_Embeddings.emb_typ_of repr  in
   FStar_Syntax_Embeddings.mk_emb_full embed_ident unembed_ident
-    FStar_Reflection_Data.fstar_refl_ident FStar_Ident.text_of_id uu____5167
+    FStar_Reflection_Data.fstar_refl_ident FStar_Ident.text_of_id uu____5227
   
 let (e_univ_name :
   FStar_Syntax_Syntax.univ_name FStar_Syntax_Embeddings.embedding) =
@@ -1571,187 +1607,187 @@ let (e_sigelt_view :
   let embed_sigelt_view rng sev =
     match sev with
     | FStar_Reflection_Data.Sg_Let (r,fv,univs1,ty,t) ->
-        let uu____5206 =
-          let uu____5211 =
-            let uu____5212 =
-              let uu____5221 = embed FStar_Syntax_Embeddings.e_bool rng r  in
-              FStar_Syntax_Syntax.as_arg uu____5221  in
-            let uu____5223 =
-              let uu____5234 =
-                let uu____5243 = embed e_fv rng fv  in
-                FStar_Syntax_Syntax.as_arg uu____5243  in
-              let uu____5244 =
-                let uu____5255 =
-                  let uu____5264 = embed e_univ_names rng univs1  in
-                  FStar_Syntax_Syntax.as_arg uu____5264  in
-                let uu____5267 =
-                  let uu____5278 =
-                    let uu____5287 = embed e_term rng ty  in
-                    FStar_Syntax_Syntax.as_arg uu____5287  in
-                  let uu____5288 =
-                    let uu____5299 =
-                      let uu____5308 = embed e_term rng t  in
-                      FStar_Syntax_Syntax.as_arg uu____5308  in
-                    [uu____5299]  in
-                  uu____5278 :: uu____5288  in
-                uu____5255 :: uu____5267  in
-              uu____5234 :: uu____5244  in
-            uu____5212 :: uu____5223  in
+        let uu____5266 =
+          let uu____5271 =
+            let uu____5272 =
+              let uu____5281 = embed FStar_Syntax_Embeddings.e_bool rng r  in
+              FStar_Syntax_Syntax.as_arg uu____5281  in
+            let uu____5283 =
+              let uu____5294 =
+                let uu____5303 = embed e_fv rng fv  in
+                FStar_Syntax_Syntax.as_arg uu____5303  in
+              let uu____5304 =
+                let uu____5315 =
+                  let uu____5324 = embed e_univ_names rng univs1  in
+                  FStar_Syntax_Syntax.as_arg uu____5324  in
+                let uu____5327 =
+                  let uu____5338 =
+                    let uu____5347 = embed e_term rng ty  in
+                    FStar_Syntax_Syntax.as_arg uu____5347  in
+                  let uu____5348 =
+                    let uu____5359 =
+                      let uu____5368 = embed e_term rng t  in
+                      FStar_Syntax_Syntax.as_arg uu____5368  in
+                    [uu____5359]  in
+                  uu____5338 :: uu____5348  in
+                uu____5315 :: uu____5327  in
+              uu____5294 :: uu____5304  in
+            uu____5272 :: uu____5283  in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.ref_Sg_Let.FStar_Reflection_Data.t
-            uu____5211
+            uu____5271
            in
-        uu____5206 FStar_Pervasives_Native.None rng
+        uu____5266 FStar_Pervasives_Native.None rng
     | FStar_Reflection_Data.Sg_Constructor (nm,ty) ->
-        let uu____5359 =
-          let uu____5364 =
-            let uu____5365 =
-              let uu____5374 =
+        let uu____5419 =
+          let uu____5424 =
+            let uu____5425 =
+              let uu____5434 =
                 embed FStar_Syntax_Embeddings.e_string_list rng nm  in
-              FStar_Syntax_Syntax.as_arg uu____5374  in
-            let uu____5378 =
-              let uu____5389 =
-                let uu____5398 = embed e_term rng ty  in
-                FStar_Syntax_Syntax.as_arg uu____5398  in
-              [uu____5389]  in
-            uu____5365 :: uu____5378  in
+              FStar_Syntax_Syntax.as_arg uu____5434  in
+            let uu____5438 =
+              let uu____5449 =
+                let uu____5458 = embed e_term rng ty  in
+                FStar_Syntax_Syntax.as_arg uu____5458  in
+              [uu____5449]  in
+            uu____5425 :: uu____5438  in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.ref_Sg_Constructor.FStar_Reflection_Data.t
-            uu____5364
+            uu____5424
            in
-        uu____5359 FStar_Pervasives_Native.None rng
+        uu____5419 FStar_Pervasives_Native.None rng
     | FStar_Reflection_Data.Sg_Inductive (nm,univs1,bs,t,dcs) ->
-        let uu____5440 =
-          let uu____5445 =
-            let uu____5446 =
-              let uu____5455 =
+        let uu____5500 =
+          let uu____5505 =
+            let uu____5506 =
+              let uu____5515 =
                 embed FStar_Syntax_Embeddings.e_string_list rng nm  in
-              FStar_Syntax_Syntax.as_arg uu____5455  in
-            let uu____5459 =
-              let uu____5470 =
-                let uu____5479 = embed e_univ_names rng univs1  in
-                FStar_Syntax_Syntax.as_arg uu____5479  in
-              let uu____5482 =
-                let uu____5493 =
-                  let uu____5502 = embed e_binders rng bs  in
-                  FStar_Syntax_Syntax.as_arg uu____5502  in
-                let uu____5503 =
-                  let uu____5514 =
-                    let uu____5523 = embed e_term rng t  in
-                    FStar_Syntax_Syntax.as_arg uu____5523  in
-                  let uu____5524 =
-                    let uu____5535 =
-                      let uu____5544 =
-                        let uu____5545 =
+              FStar_Syntax_Syntax.as_arg uu____5515  in
+            let uu____5519 =
+              let uu____5530 =
+                let uu____5539 = embed e_univ_names rng univs1  in
+                FStar_Syntax_Syntax.as_arg uu____5539  in
+              let uu____5542 =
+                let uu____5553 =
+                  let uu____5562 = embed e_binders rng bs  in
+                  FStar_Syntax_Syntax.as_arg uu____5562  in
+                let uu____5563 =
+                  let uu____5574 =
+                    let uu____5583 = embed e_term rng t  in
+                    FStar_Syntax_Syntax.as_arg uu____5583  in
+                  let uu____5584 =
+                    let uu____5595 =
+                      let uu____5604 =
+                        let uu____5605 =
                           FStar_Syntax_Embeddings.e_list
                             FStar_Syntax_Embeddings.e_string_list
                            in
-                        embed uu____5545 rng dcs  in
-                      FStar_Syntax_Syntax.as_arg uu____5544  in
-                    [uu____5535]  in
-                  uu____5514 :: uu____5524  in
-                uu____5493 :: uu____5503  in
-              uu____5470 :: uu____5482  in
-            uu____5446 :: uu____5459  in
+                        embed uu____5605 rng dcs  in
+                      FStar_Syntax_Syntax.as_arg uu____5604  in
+                    [uu____5595]  in
+                  uu____5574 :: uu____5584  in
+                uu____5553 :: uu____5563  in
+              uu____5530 :: uu____5542  in
+            uu____5506 :: uu____5519  in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.ref_Sg_Inductive.FStar_Reflection_Data.t
-            uu____5445
+            uu____5505
            in
-        uu____5440 FStar_Pervasives_Native.None rng
+        uu____5500 FStar_Pervasives_Native.None rng
     | FStar_Reflection_Data.Unk  ->
-        let uu___714_5609 =
+        let uu___729_5669 =
           FStar_Reflection_Data.ref_Unk.FStar_Reflection_Data.t  in
         {
-          FStar_Syntax_Syntax.n = (uu___714_5609.FStar_Syntax_Syntax.n);
+          FStar_Syntax_Syntax.n = (uu___729_5669.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = rng;
-          FStar_Syntax_Syntax.vars = (uu___714_5609.FStar_Syntax_Syntax.vars)
+          FStar_Syntax_Syntax.vars = (uu___729_5669.FStar_Syntax_Syntax.vars)
         }
      in
   let unembed_sigelt_view w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____5628 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____5628 with
+    let uu____5688 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____5688 with
     | (hd1,args) ->
-        let uu____5673 =
-          let uu____5686 =
-            let uu____5687 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____5687.FStar_Syntax_Syntax.n  in
-          (uu____5686, args)  in
-        (match uu____5673 with
+        let uu____5733 =
+          let uu____5746 =
+            let uu____5747 = FStar_Syntax_Util.un_uinst hd1  in
+            uu____5747.FStar_Syntax_Syntax.n  in
+          (uu____5746, args)  in
+        (match uu____5733 with
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(nm,uu____5702)::(us,uu____5704)::(bs,uu____5706)::(t2,uu____5708)::
-            (dcs,uu____5710)::[]) when
+            fv,(nm,uu____5762)::(us,uu____5764)::(bs,uu____5766)::(t2,uu____5768)::
+            (dcs,uu____5770)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Sg_Inductive.FStar_Reflection_Data.lid
              ->
-             let uu____5775 =
+             let uu____5835 =
                unembed' w FStar_Syntax_Embeddings.e_string_list nm  in
-             FStar_Util.bind_opt uu____5775
+             FStar_Util.bind_opt uu____5835
                (fun nm1  ->
-                  let uu____5793 = unembed' w e_univ_names us  in
-                  FStar_Util.bind_opt uu____5793
+                  let uu____5853 = unembed' w e_univ_names us  in
+                  FStar_Util.bind_opt uu____5853
                     (fun us1  ->
-                       let uu____5807 = unembed' w e_binders bs  in
-                       FStar_Util.bind_opt uu____5807
+                       let uu____5867 = unembed' w e_binders bs  in
+                       FStar_Util.bind_opt uu____5867
                          (fun bs1  ->
-                            let uu____5813 = unembed' w e_term t2  in
-                            FStar_Util.bind_opt uu____5813
+                            let uu____5873 = unembed' w e_term t2  in
+                            FStar_Util.bind_opt uu____5873
                               (fun t3  ->
-                                 let uu____5819 =
-                                   let uu____5827 =
+                                 let uu____5879 =
+                                   let uu____5887 =
                                      FStar_Syntax_Embeddings.e_list
                                        FStar_Syntax_Embeddings.e_string_list
                                       in
-                                   unembed' w uu____5827 dcs  in
-                                 FStar_Util.bind_opt uu____5819
+                                   unembed' w uu____5887 dcs  in
+                                 FStar_Util.bind_opt uu____5879
                                    (fun dcs1  ->
                                       FStar_All.pipe_left
-                                        (fun _5857  ->
-                                           FStar_Pervasives_Native.Some _5857)
+                                        (fun _5917  ->
+                                           FStar_Pervasives_Native.Some _5917)
                                         (FStar_Reflection_Data.Sg_Inductive
                                            (nm1, us1, bs1, t3, dcs1)))))))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(r,uu____5866)::(fvar1,uu____5868)::(univs1,uu____5870)::
-            (ty,uu____5872)::(t2,uu____5874)::[]) when
+            fv,(r,uu____5926)::(fvar1,uu____5928)::(univs1,uu____5930)::
+            (ty,uu____5932)::(t2,uu____5934)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Sg_Let.FStar_Reflection_Data.lid
              ->
-             let uu____5939 = unembed' w FStar_Syntax_Embeddings.e_bool r  in
-             FStar_Util.bind_opt uu____5939
+             let uu____5999 = unembed' w FStar_Syntax_Embeddings.e_bool r  in
+             FStar_Util.bind_opt uu____5999
                (fun r1  ->
-                  let uu____5949 = unembed' w e_fv fvar1  in
-                  FStar_Util.bind_opt uu____5949
+                  let uu____6009 = unembed' w e_fv fvar1  in
+                  FStar_Util.bind_opt uu____6009
                     (fun fvar2  ->
-                       let uu____5955 = unembed' w e_univ_names univs1  in
-                       FStar_Util.bind_opt uu____5955
+                       let uu____6015 = unembed' w e_univ_names univs1  in
+                       FStar_Util.bind_opt uu____6015
                          (fun univs2  ->
-                            let uu____5969 = unembed' w e_term ty  in
-                            FStar_Util.bind_opt uu____5969
+                            let uu____6029 = unembed' w e_term ty  in
+                            FStar_Util.bind_opt uu____6029
                               (fun ty1  ->
-                                 let uu____5975 = unembed' w e_term t2  in
-                                 FStar_Util.bind_opt uu____5975
+                                 let uu____6035 = unembed' w e_term t2  in
+                                 FStar_Util.bind_opt uu____6035
                                    (fun t3  ->
                                       FStar_All.pipe_left
-                                        (fun _5982  ->
-                                           FStar_Pervasives_Native.Some _5982)
+                                        (fun _6042  ->
+                                           FStar_Pervasives_Native.Some _6042)
                                         (FStar_Reflection_Data.Sg_Let
                                            (r1, fvar2, univs2, ty1, t3)))))))
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Unk.FStar_Reflection_Data.lid
              -> FStar_Pervasives_Native.Some FStar_Reflection_Data.Unk
-         | uu____6001 ->
+         | uu____6061 ->
              (if w
               then
-                (let uu____6016 =
-                   let uu____6022 =
-                     let uu____6024 = FStar_Syntax_Print.term_to_string t1
+                (let uu____6076 =
+                   let uu____6082 =
+                     let uu____6084 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.format1 "Not an embedded sigelt_view: %s"
-                       uu____6024
+                       uu____6084
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____6022)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____6016)
+                   (FStar_Errors.Warning_NotEmbedded, uu____6082)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____6076)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -1765,93 +1801,93 @@ let (e_exp : FStar_Reflection_Data.exp FStar_Syntax_Embeddings.embedding) =
       | FStar_Reflection_Data.Unit  ->
           FStar_Reflection_Data.ref_E_Unit.FStar_Reflection_Data.t
       | FStar_Reflection_Data.Var i ->
-          let uu____6050 =
-            let uu____6055 =
-              let uu____6056 =
-                let uu____6065 =
-                  let uu____6066 = FStar_BigInt.string_of_big_int i  in
-                  FStar_Syntax_Util.exp_int uu____6066  in
-                FStar_Syntax_Syntax.as_arg uu____6065  in
-              [uu____6056]  in
+          let uu____6110 =
+            let uu____6115 =
+              let uu____6116 =
+                let uu____6125 =
+                  let uu____6126 = FStar_BigInt.string_of_big_int i  in
+                  FStar_Syntax_Util.exp_int uu____6126  in
+                FStar_Syntax_Syntax.as_arg uu____6125  in
+              [uu____6116]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_E_Var.FStar_Reflection_Data.t
-              uu____6055
+              uu____6115
              in
-          uu____6050 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____6110 FStar_Pervasives_Native.None FStar_Range.dummyRange
       | FStar_Reflection_Data.Mult (e1,e2) ->
-          let uu____6086 =
-            let uu____6091 =
-              let uu____6092 =
-                let uu____6101 = embed_exp rng e1  in
-                FStar_Syntax_Syntax.as_arg uu____6101  in
-              let uu____6102 =
-                let uu____6113 =
-                  let uu____6122 = embed_exp rng e2  in
-                  FStar_Syntax_Syntax.as_arg uu____6122  in
-                [uu____6113]  in
-              uu____6092 :: uu____6102  in
+          let uu____6146 =
+            let uu____6151 =
+              let uu____6152 =
+                let uu____6161 = embed_exp rng e1  in
+                FStar_Syntax_Syntax.as_arg uu____6161  in
+              let uu____6162 =
+                let uu____6173 =
+                  let uu____6182 = embed_exp rng e2  in
+                  FStar_Syntax_Syntax.as_arg uu____6182  in
+                [uu____6173]  in
+              uu____6152 :: uu____6162  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_E_Mult.FStar_Reflection_Data.t
-              uu____6091
+              uu____6151
              in
-          uu____6086 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____6146 FStar_Pervasives_Native.None FStar_Range.dummyRange
        in
-    let uu___789_6147 = r  in
+    let uu___804_6207 = r  in
     {
-      FStar_Syntax_Syntax.n = (uu___789_6147.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___804_6207.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___789_6147.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___804_6207.FStar_Syntax_Syntax.vars)
     }  in
   let rec unembed_exp w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____6168 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____6168 with
+    let uu____6228 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____6228 with
     | (hd1,args) ->
-        let uu____6213 =
-          let uu____6226 =
-            let uu____6227 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____6227.FStar_Syntax_Syntax.n  in
-          (uu____6226, args)  in
-        (match uu____6213 with
+        let uu____6273 =
+          let uu____6286 =
+            let uu____6287 = FStar_Syntax_Util.un_uinst hd1  in
+            uu____6287.FStar_Syntax_Syntax.n  in
+          (uu____6286, args)  in
+        (match uu____6273 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_E_Unit.FStar_Reflection_Data.lid
              -> FStar_Pervasives_Native.Some FStar_Reflection_Data.Unit
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(i,uu____6257)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(i,uu____6317)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_E_Var.FStar_Reflection_Data.lid
              ->
-             let uu____6282 = unembed' w FStar_Syntax_Embeddings.e_int i  in
-             FStar_Util.bind_opt uu____6282
+             let uu____6342 = unembed' w FStar_Syntax_Embeddings.e_int i  in
+             FStar_Util.bind_opt uu____6342
                (fun i1  ->
                   FStar_All.pipe_left
-                    (fun _6289  -> FStar_Pervasives_Native.Some _6289)
+                    (fun _6349  -> FStar_Pervasives_Native.Some _6349)
                     (FStar_Reflection_Data.Var i1))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(e1,uu____6292)::(e2,uu____6294)::[]) when
+            fv,(e1,uu____6352)::(e2,uu____6354)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_E_Mult.FStar_Reflection_Data.lid
              ->
-             let uu____6329 = unembed_exp w e1  in
-             FStar_Util.bind_opt uu____6329
+             let uu____6389 = unembed_exp w e1  in
+             FStar_Util.bind_opt uu____6389
                (fun e11  ->
-                  let uu____6335 = unembed_exp w e2  in
-                  FStar_Util.bind_opt uu____6335
+                  let uu____6395 = unembed_exp w e2  in
+                  FStar_Util.bind_opt uu____6395
                     (fun e21  ->
                        FStar_All.pipe_left
-                         (fun _6342  -> FStar_Pervasives_Native.Some _6342)
+                         (fun _6402  -> FStar_Pervasives_Native.Some _6402)
                          (FStar_Reflection_Data.Mult (e11, e21))))
-         | uu____6343 ->
+         | uu____6403 ->
              (if w
               then
-                (let uu____6358 =
-                   let uu____6364 =
-                     let uu____6366 = FStar_Syntax_Print.term_to_string t1
+                (let uu____6418 =
+                   let uu____6424 =
+                     let uu____6426 = FStar_Syntax_Print.term_to_string t1
                         in
-                     FStar_Util.format1 "Not an embedded exp: %s" uu____6366
+                     FStar_Util.format1 "Not an embedded exp: %s" uu____6426
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____6364)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____6358)
+                   (FStar_Errors.Warning_NotEmbedded, uu____6424)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____6418)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -1866,18 +1902,18 @@ let (e_attributes :
   = FStar_Syntax_Embeddings.e_list e_attribute 
 let (e_lid : FStar_Ident.lid FStar_Syntax_Embeddings.embedding) =
   let embed1 rng lid =
-    let uu____6397 = FStar_Ident.path_of_lid lid  in
-    embed FStar_Syntax_Embeddings.e_string_list rng uu____6397  in
+    let uu____6457 = FStar_Ident.path_of_lid lid  in
+    embed FStar_Syntax_Embeddings.e_string_list rng uu____6457  in
   let unembed1 w t =
-    let uu____6425 = unembed' w FStar_Syntax_Embeddings.e_string_list t  in
-    FStar_Util.map_opt uu____6425
+    let uu____6485 = unembed' w FStar_Syntax_Embeddings.e_string_list t  in
+    FStar_Util.map_opt uu____6485
       (fun p  -> FStar_Ident.lid_of_path p t.FStar_Syntax_Syntax.pos)
      in
-  let uu____6442 = FStar_Syntax_Syntax.t_list_of FStar_Syntax_Syntax.t_string
+  let uu____6502 = FStar_Syntax_Syntax.t_list_of FStar_Syntax_Syntax.t_string
      in
   FStar_Syntax_Embeddings.mk_emb_full
-    (fun x  -> fun r  -> fun uu____6449  -> fun uu____6450  -> embed1 r x)
-    (fun x  -> fun w  -> fun uu____6457  -> unembed1 w x) uu____6442
+    (fun x  -> fun r  -> fun uu____6509  -> fun uu____6510  -> embed1 r x)
+    (fun x  -> fun w  -> fun uu____6517  -> unembed1 w x) uu____6502
     FStar_Ident.string_of_lid FStar_Syntax_Syntax.ET_abstract
   
 let (e_qualifier :
@@ -1922,120 +1958,120 @@ let (e_qualifier :
       | FStar_Syntax_Syntax.OnlyName  ->
           FStar_Reflection_Data.ref_qual_OnlyName.FStar_Reflection_Data.t
       | FStar_Syntax_Syntax.Reflectable l ->
-          let uu____6480 =
-            let uu____6485 =
-              let uu____6486 =
-                let uu____6495 = embed e_lid rng l  in
-                FStar_Syntax_Syntax.as_arg uu____6495  in
-              [uu____6486]  in
+          let uu____6540 =
+            let uu____6545 =
+              let uu____6546 =
+                let uu____6555 = embed e_lid rng l  in
+                FStar_Syntax_Syntax.as_arg uu____6555  in
+              [uu____6546]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_qual_Reflectable.FStar_Reflection_Data.t
-              uu____6485
+              uu____6545
              in
-          uu____6480 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____6540 FStar_Pervasives_Native.None FStar_Range.dummyRange
       | FStar_Syntax_Syntax.Discriminator l ->
-          let uu____6513 =
-            let uu____6518 =
-              let uu____6519 =
-                let uu____6528 = embed e_lid rng l  in
-                FStar_Syntax_Syntax.as_arg uu____6528  in
-              [uu____6519]  in
+          let uu____6573 =
+            let uu____6578 =
+              let uu____6579 =
+                let uu____6588 = embed e_lid rng l  in
+                FStar_Syntax_Syntax.as_arg uu____6588  in
+              [uu____6579]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_qual_Discriminator.FStar_Reflection_Data.t
-              uu____6518
+              uu____6578
              in
-          uu____6513 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____6573 FStar_Pervasives_Native.None FStar_Range.dummyRange
       | FStar_Syntax_Syntax.Action l ->
-          let uu____6546 =
-            let uu____6551 =
-              let uu____6552 =
-                let uu____6561 = embed e_lid rng l  in
-                FStar_Syntax_Syntax.as_arg uu____6561  in
-              [uu____6552]  in
+          let uu____6606 =
+            let uu____6611 =
+              let uu____6612 =
+                let uu____6621 = embed e_lid rng l  in
+                FStar_Syntax_Syntax.as_arg uu____6621  in
+              [uu____6612]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_qual_Action.FStar_Reflection_Data.t
-              uu____6551
+              uu____6611
              in
-          uu____6546 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____6606 FStar_Pervasives_Native.None FStar_Range.dummyRange
       | FStar_Syntax_Syntax.Projector (l,i) ->
-          let uu____6580 =
-            let uu____6585 =
-              let uu____6586 =
-                let uu____6595 = embed e_lid rng l  in
-                FStar_Syntax_Syntax.as_arg uu____6595  in
-              let uu____6596 =
-                let uu____6607 =
-                  let uu____6616 = embed e_ident rng i  in
-                  FStar_Syntax_Syntax.as_arg uu____6616  in
-                [uu____6607]  in
-              uu____6586 :: uu____6596  in
+          let uu____6640 =
+            let uu____6645 =
+              let uu____6646 =
+                let uu____6655 = embed e_lid rng l  in
+                FStar_Syntax_Syntax.as_arg uu____6655  in
+              let uu____6656 =
+                let uu____6667 =
+                  let uu____6676 = embed e_ident rng i  in
+                  FStar_Syntax_Syntax.as_arg uu____6676  in
+                [uu____6667]  in
+              uu____6646 :: uu____6656  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_qual_Projector.FStar_Reflection_Data.t
-              uu____6585
+              uu____6645
              in
-          uu____6580 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____6640 FStar_Pervasives_Native.None FStar_Range.dummyRange
       | FStar_Syntax_Syntax.RecordType (ids1,ids2) ->
-          let uu____6651 =
-            let uu____6656 =
-              let uu____6657 =
-                let uu____6666 =
-                  let uu____6667 = FStar_Syntax_Embeddings.e_list e_ident  in
-                  embed uu____6667 rng ids1  in
-                FStar_Syntax_Syntax.as_arg uu____6666  in
-              let uu____6674 =
-                let uu____6685 =
-                  let uu____6694 =
-                    let uu____6695 = FStar_Syntax_Embeddings.e_list e_ident
+          let uu____6711 =
+            let uu____6716 =
+              let uu____6717 =
+                let uu____6726 =
+                  let uu____6727 = FStar_Syntax_Embeddings.e_list e_ident  in
+                  embed uu____6727 rng ids1  in
+                FStar_Syntax_Syntax.as_arg uu____6726  in
+              let uu____6734 =
+                let uu____6745 =
+                  let uu____6754 =
+                    let uu____6755 = FStar_Syntax_Embeddings.e_list e_ident
                        in
-                    embed uu____6695 rng ids2  in
-                  FStar_Syntax_Syntax.as_arg uu____6694  in
-                [uu____6685]  in
-              uu____6657 :: uu____6674  in
+                    embed uu____6755 rng ids2  in
+                  FStar_Syntax_Syntax.as_arg uu____6754  in
+                [uu____6745]  in
+              uu____6717 :: uu____6734  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_qual_RecordType.FStar_Reflection_Data.t
-              uu____6656
+              uu____6716
              in
-          uu____6651 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____6711 FStar_Pervasives_Native.None FStar_Range.dummyRange
       | FStar_Syntax_Syntax.RecordConstructor (ids1,ids2) ->
-          let uu____6736 =
-            let uu____6741 =
-              let uu____6742 =
-                let uu____6751 =
-                  let uu____6752 = FStar_Syntax_Embeddings.e_list e_ident  in
-                  embed uu____6752 rng ids1  in
-                FStar_Syntax_Syntax.as_arg uu____6751  in
-              let uu____6759 =
-                let uu____6770 =
-                  let uu____6779 =
-                    let uu____6780 = FStar_Syntax_Embeddings.e_list e_ident
+          let uu____6796 =
+            let uu____6801 =
+              let uu____6802 =
+                let uu____6811 =
+                  let uu____6812 = FStar_Syntax_Embeddings.e_list e_ident  in
+                  embed uu____6812 rng ids1  in
+                FStar_Syntax_Syntax.as_arg uu____6811  in
+              let uu____6819 =
+                let uu____6830 =
+                  let uu____6839 =
+                    let uu____6840 = FStar_Syntax_Embeddings.e_list e_ident
                        in
-                    embed uu____6780 rng ids2  in
-                  FStar_Syntax_Syntax.as_arg uu____6779  in
-                [uu____6770]  in
-              uu____6742 :: uu____6759  in
+                    embed uu____6840 rng ids2  in
+                  FStar_Syntax_Syntax.as_arg uu____6839  in
+                [uu____6830]  in
+              uu____6802 :: uu____6819  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_qual_RecordConstructor.FStar_Reflection_Data.t
-              uu____6741
+              uu____6801
              in
-          uu____6736 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____6796 FStar_Pervasives_Native.None FStar_Range.dummyRange
        in
-    let uu___879_6811 = r  in
+    let uu___894_6871 = r  in
     {
-      FStar_Syntax_Syntax.n = (uu___879_6811.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___894_6871.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___879_6811.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___894_6871.FStar_Syntax_Syntax.vars)
     }  in
   let unembed1 w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____6832 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____6832 with
+    let uu____6892 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____6892 with
     | (hd1,args) ->
-        let uu____6877 =
-          let uu____6890 =
-            let uu____6891 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____6891.FStar_Syntax_Syntax.n  in
-          (uu____6890, args)  in
-        (match uu____6877 with
+        let uu____6937 =
+          let uu____6950 =
+            let uu____6951 = FStar_Syntax_Util.un_uinst hd1  in
+            uu____6951.FStar_Syntax_Syntax.n  in
+          (uu____6950, args)  in
+        (match uu____6937 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Assumption.FStar_Reflection_Data.lid
@@ -2116,101 +2152,101 @@ let (e_qualifier :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_OnlyName.FStar_Reflection_Data.lid
              -> FStar_Pervasives_Native.Some FStar_Syntax_Syntax.OnlyName
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____7176)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____7236)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Reflectable.FStar_Reflection_Data.lid
              ->
-             let uu____7201 = unembed' w e_lid l  in
-             FStar_Util.bind_opt uu____7201
+             let uu____7261 = unembed' w e_lid l  in
+             FStar_Util.bind_opt uu____7261
                (fun l1  ->
                   FStar_All.pipe_left
-                    (fun _7208  -> FStar_Pervasives_Native.Some _7208)
+                    (fun _7268  -> FStar_Pervasives_Native.Some _7268)
                     (FStar_Syntax_Syntax.Reflectable l1))
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____7211)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____7271)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Discriminator.FStar_Reflection_Data.lid
              ->
-             let uu____7236 = unembed' w e_lid l  in
-             FStar_Util.bind_opt uu____7236
+             let uu____7296 = unembed' w e_lid l  in
+             FStar_Util.bind_opt uu____7296
                (fun l1  ->
                   FStar_All.pipe_left
-                    (fun _7243  -> FStar_Pervasives_Native.Some _7243)
+                    (fun _7303  -> FStar_Pervasives_Native.Some _7303)
                     (FStar_Syntax_Syntax.Discriminator l1))
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____7246)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____7306)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Action.FStar_Reflection_Data.lid
              ->
-             let uu____7271 = unembed' w e_lid l  in
-             FStar_Util.bind_opt uu____7271
+             let uu____7331 = unembed' w e_lid l  in
+             FStar_Util.bind_opt uu____7331
                (fun l1  ->
                   FStar_All.pipe_left
-                    (fun _7278  -> FStar_Pervasives_Native.Some _7278)
+                    (fun _7338  -> FStar_Pervasives_Native.Some _7338)
                     (FStar_Syntax_Syntax.Action l1))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(l,uu____7281)::(i,uu____7283)::[]) when
+            fv,(l,uu____7341)::(i,uu____7343)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Projector.FStar_Reflection_Data.lid
              ->
-             let uu____7318 = unembed' w e_lid l  in
-             FStar_Util.bind_opt uu____7318
+             let uu____7378 = unembed' w e_lid l  in
+             FStar_Util.bind_opt uu____7378
                (fun l1  ->
-                  let uu____7324 = unembed' w e_ident i  in
-                  FStar_Util.bind_opt uu____7324
+                  let uu____7384 = unembed' w e_ident i  in
+                  FStar_Util.bind_opt uu____7384
                     (fun i1  ->
                        FStar_All.pipe_left
-                         (fun _7331  -> FStar_Pervasives_Native.Some _7331)
+                         (fun _7391  -> FStar_Pervasives_Native.Some _7391)
                          (FStar_Syntax_Syntax.Projector (l1, i1))))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(ids1,uu____7334)::(ids2,uu____7336)::[]) when
+            fv,(ids1,uu____7394)::(ids2,uu____7396)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_RecordType.FStar_Reflection_Data.lid
              ->
-             let uu____7371 =
-               let uu____7376 = FStar_Syntax_Embeddings.e_list e_ident  in
-               unembed' w uu____7376 ids1  in
-             FStar_Util.bind_opt uu____7371
+             let uu____7431 =
+               let uu____7436 = FStar_Syntax_Embeddings.e_list e_ident  in
+               unembed' w uu____7436 ids1  in
+             FStar_Util.bind_opt uu____7431
                (fun ids11  ->
-                  let uu____7390 =
-                    let uu____7395 = FStar_Syntax_Embeddings.e_list e_ident
+                  let uu____7450 =
+                    let uu____7455 = FStar_Syntax_Embeddings.e_list e_ident
                        in
-                    unembed' w uu____7395 ids2  in
-                  FStar_Util.bind_opt uu____7390
+                    unembed' w uu____7455 ids2  in
+                  FStar_Util.bind_opt uu____7450
                     (fun ids21  ->
                        FStar_All.pipe_left
-                         (fun _7410  -> FStar_Pervasives_Native.Some _7410)
+                         (fun _7470  -> FStar_Pervasives_Native.Some _7470)
                          (FStar_Syntax_Syntax.RecordType (ids11, ids21))))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(ids1,uu____7417)::(ids2,uu____7419)::[]) when
+            fv,(ids1,uu____7477)::(ids2,uu____7479)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_RecordConstructor.FStar_Reflection_Data.lid
              ->
-             let uu____7454 =
-               let uu____7459 = FStar_Syntax_Embeddings.e_list e_ident  in
-               unembed' w uu____7459 ids1  in
-             FStar_Util.bind_opt uu____7454
+             let uu____7514 =
+               let uu____7519 = FStar_Syntax_Embeddings.e_list e_ident  in
+               unembed' w uu____7519 ids1  in
+             FStar_Util.bind_opt uu____7514
                (fun ids11  ->
-                  let uu____7473 =
-                    let uu____7478 = FStar_Syntax_Embeddings.e_list e_ident
+                  let uu____7533 =
+                    let uu____7538 = FStar_Syntax_Embeddings.e_list e_ident
                        in
-                    unembed' w uu____7478 ids2  in
-                  FStar_Util.bind_opt uu____7473
+                    unembed' w uu____7538 ids2  in
+                  FStar_Util.bind_opt uu____7533
                     (fun ids21  ->
                        FStar_All.pipe_left
-                         (fun _7493  -> FStar_Pervasives_Native.Some _7493)
+                         (fun _7553  -> FStar_Pervasives_Native.Some _7553)
                          (FStar_Syntax_Syntax.RecordConstructor
                             (ids11, ids21))))
-         | uu____7498 ->
+         | uu____7558 ->
              (if w
               then
-                (let uu____7513 =
-                   let uu____7519 =
-                     let uu____7521 = FStar_Syntax_Print.term_to_string t1
+                (let uu____7573 =
+                   let uu____7579 =
+                     let uu____7581 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.format1 "Not an embedded qualifier: %s"
-                       uu____7521
+                       uu____7581
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____7519)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____7513)
+                   (FStar_Errors.Warning_NotEmbedded, uu____7579)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____7573)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -2222,102 +2258,105 @@ let (unfold_lazy_bv :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i  ->
     let bv = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob  in
-    let uu____7539 =
-      let uu____7544 =
-        let uu____7545 =
-          let uu____7554 =
-            let uu____7555 = FStar_Reflection_Basic.inspect_bv bv  in
-            embed e_bv_view i.FStar_Syntax_Syntax.rng uu____7555  in
-          FStar_Syntax_Syntax.as_arg uu____7554  in
-        [uu____7545]  in
+    let uu____7599 =
+      let uu____7604 =
+        let uu____7605 =
+          let uu____7614 =
+            let uu____7615 = FStar_Reflection_Basic.inspect_bv bv  in
+            embed e_bv_view i.FStar_Syntax_Syntax.rng uu____7615  in
+          FStar_Syntax_Syntax.as_arg uu____7614  in
+        [uu____7605]  in
       FStar_Syntax_Syntax.mk_Tm_app
         FStar_Reflection_Data.fstar_refl_pack_bv.FStar_Reflection_Data.t
-        uu____7544
+        uu____7604
        in
-    uu____7539 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
+    uu____7599 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
   
 let (unfold_lazy_binder :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i  ->
     let binder = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob  in
-    let uu____7579 = FStar_Reflection_Basic.inspect_binder binder  in
-    match uu____7579 with
+    let uu____7639 = FStar_Reflection_Basic.inspect_binder binder  in
+    match uu____7639 with
     | (bv,aq) ->
-        let uu____7586 =
-          let uu____7591 =
-            let uu____7592 =
-              let uu____7601 = embed e_bv i.FStar_Syntax_Syntax.rng bv  in
-              FStar_Syntax_Syntax.as_arg uu____7601  in
-            let uu____7602 =
-              let uu____7613 =
-                let uu____7622 = embed e_aqualv i.FStar_Syntax_Syntax.rng aq
+        let uu____7646 =
+          let uu____7651 =
+            let uu____7652 =
+              let uu____7661 = embed e_bv i.FStar_Syntax_Syntax.rng bv  in
+              FStar_Syntax_Syntax.as_arg uu____7661  in
+            let uu____7662 =
+              let uu____7673 =
+                let uu____7682 = embed e_aqualv i.FStar_Syntax_Syntax.rng aq
                    in
-                FStar_Syntax_Syntax.as_arg uu____7622  in
-              [uu____7613]  in
-            uu____7592 :: uu____7602  in
+                FStar_Syntax_Syntax.as_arg uu____7682  in
+              [uu____7673]  in
+            uu____7652 :: uu____7662  in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.fstar_refl_pack_binder.FStar_Reflection_Data.t
-            uu____7591
+            uu____7651
            in
-        uu____7586 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
+        uu____7646 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
   
 let (unfold_lazy_fvar :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i  ->
     let fv = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob  in
-    let uu____7654 =
-      let uu____7659 =
-        let uu____7660 =
-          let uu____7669 =
-            let uu____7670 =
+    let uu____7714 =
+      let uu____7719 =
+        let uu____7720 =
+          let uu____7729 =
+            let uu____7730 =
               FStar_Syntax_Embeddings.e_list FStar_Syntax_Embeddings.e_string
                in
-            let uu____7677 = FStar_Reflection_Basic.inspect_fv fv  in
-            embed uu____7670 i.FStar_Syntax_Syntax.rng uu____7677  in
-          FStar_Syntax_Syntax.as_arg uu____7669  in
-        [uu____7660]  in
+            let uu____7737 = FStar_Reflection_Basic.inspect_fv fv  in
+            embed uu____7730 i.FStar_Syntax_Syntax.rng uu____7737  in
+          FStar_Syntax_Syntax.as_arg uu____7729  in
+        [uu____7720]  in
       FStar_Syntax_Syntax.mk_Tm_app
         FStar_Reflection_Data.fstar_refl_pack_fv.FStar_Reflection_Data.t
-        uu____7659
+        uu____7719
        in
-    uu____7654 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
+    uu____7714 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
   
 let (unfold_lazy_comp :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i  ->
     let comp = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob  in
-    let uu____7707 =
-      let uu____7712 =
-        let uu____7713 =
-          let uu____7722 =
-            let uu____7723 = FStar_Reflection_Basic.inspect_comp comp  in
-            embed e_comp_view i.FStar_Syntax_Syntax.rng uu____7723  in
-          FStar_Syntax_Syntax.as_arg uu____7722  in
-        [uu____7713]  in
+    let uu____7767 =
+      let uu____7772 =
+        let uu____7773 =
+          let uu____7782 =
+            let uu____7783 = FStar_Reflection_Basic.inspect_comp comp  in
+            embed e_comp_view i.FStar_Syntax_Syntax.rng uu____7783  in
+          FStar_Syntax_Syntax.as_arg uu____7782  in
+        [uu____7773]  in
       FStar_Syntax_Syntax.mk_Tm_app
         FStar_Reflection_Data.fstar_refl_pack_comp.FStar_Reflection_Data.t
-        uu____7712
+        uu____7772
        in
-    uu____7707 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
+    uu____7767 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
   
 let (unfold_lazy_env :
+  FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
+  fun i  -> FStar_Syntax_Util.exp_unit 
+let (unfold_lazy_optionstate :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i  -> FStar_Syntax_Util.exp_unit 
 let (unfold_lazy_sigelt :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i  ->
     let sigelt = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob  in
-    let uu____7753 =
-      let uu____7758 =
-        let uu____7759 =
-          let uu____7768 =
-            let uu____7769 = FStar_Reflection_Basic.inspect_sigelt sigelt  in
-            embed e_sigelt_view i.FStar_Syntax_Syntax.rng uu____7769  in
-          FStar_Syntax_Syntax.as_arg uu____7768  in
-        [uu____7759]  in
+    let uu____7819 =
+      let uu____7824 =
+        let uu____7825 =
+          let uu____7834 =
+            let uu____7835 = FStar_Reflection_Basic.inspect_sigelt sigelt  in
+            embed e_sigelt_view i.FStar_Syntax_Syntax.rng uu____7835  in
+          FStar_Syntax_Syntax.as_arg uu____7834  in
+        [uu____7825]  in
       FStar_Syntax_Syntax.mk_Tm_app
         FStar_Reflection_Data.fstar_refl_pack_sigelt.FStar_Reflection_Data.t
-        uu____7758
+        uu____7824
        in
-    uu____7753 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
+    uu____7819 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
   

--- a/src/ocaml-output/FStar_Reflection_Embeddings.ml
+++ b/src/ocaml-output/FStar_Reflection_Embeddings.ml
@@ -523,154 +523,162 @@ let rec (e_pattern' :
              in
           uu____1491 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Pat_Cons (fv,ps) ->
-          let uu____1529 =
-            let uu____1534 =
-              let uu____1535 =
-                let uu____1544 = embed e_fv rng fv  in
-                FStar_Syntax_Syntax.as_arg uu____1544  in
+          let uu____1539 =
+            let uu____1544 =
               let uu____1545 =
-                let uu____1556 =
-                  let uu____1565 =
-                    let uu____1566 =
-                      let uu____1571 = e_pattern' ()  in
-                      FStar_Syntax_Embeddings.e_list uu____1571  in
-                    embed uu____1566 rng ps  in
-                  FStar_Syntax_Syntax.as_arg uu____1565  in
-                [uu____1556]  in
-              uu____1535 :: uu____1545  in
+                let uu____1554 = embed e_fv rng fv  in
+                FStar_Syntax_Syntax.as_arg uu____1554  in
+              let uu____1555 =
+                let uu____1566 =
+                  let uu____1575 =
+                    let uu____1576 =
+                      let uu____1586 =
+                        let uu____1594 = e_pattern' ()  in
+                        FStar_Syntax_Embeddings.e_tuple2 uu____1594
+                          FStar_Syntax_Embeddings.e_bool
+                         in
+                      FStar_Syntax_Embeddings.e_list uu____1586  in
+                    embed uu____1576 rng ps  in
+                  FStar_Syntax_Syntax.as_arg uu____1575  in
+                [uu____1566]  in
+              uu____1545 :: uu____1555  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Pat_Cons.FStar_Reflection_Data.t
-              uu____1534
+              uu____1544
              in
-          uu____1529 FStar_Pervasives_Native.None rng
+          uu____1539 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Pat_Var bv ->
-          let uu____1601 =
-            let uu____1606 =
-              let uu____1607 =
-                let uu____1616 = embed e_bv rng bv  in
-                FStar_Syntax_Syntax.as_arg uu____1616  in
-              [uu____1607]  in
+          let uu____1635 =
+            let uu____1640 =
+              let uu____1641 =
+                let uu____1650 = embed e_bv rng bv  in
+                FStar_Syntax_Syntax.as_arg uu____1650  in
+              [uu____1641]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Pat_Var.FStar_Reflection_Data.t
-              uu____1606
+              uu____1640
              in
-          uu____1601 FStar_Pervasives_Native.None rng
+          uu____1635 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Pat_Wild bv ->
-          let uu____1634 =
-            let uu____1639 =
-              let uu____1640 =
-                let uu____1649 = embed e_bv rng bv  in
-                FStar_Syntax_Syntax.as_arg uu____1649  in
-              [uu____1640]  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Pat_Wild.FStar_Reflection_Data.t
-              uu____1639
-             in
-          uu____1634 FStar_Pervasives_Native.None rng
-      | FStar_Reflection_Data.Pat_Dot_Term (bv,t) ->
           let uu____1668 =
             let uu____1673 =
               let uu____1674 =
                 let uu____1683 = embed e_bv rng bv  in
                 FStar_Syntax_Syntax.as_arg uu____1683  in
-              let uu____1684 =
-                let uu____1695 =
-                  let uu____1704 = embed e_term rng t  in
-                  FStar_Syntax_Syntax.as_arg uu____1704  in
-                [uu____1695]  in
-              uu____1674 :: uu____1684  in
+              [uu____1674]  in
             FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Pat_Dot_Term.FStar_Reflection_Data.t
+              FStar_Reflection_Data.ref_Pat_Wild.FStar_Reflection_Data.t
               uu____1673
              in
           uu____1668 FStar_Pervasives_Native.None rng
+      | FStar_Reflection_Data.Pat_Dot_Term (bv,t) ->
+          let uu____1702 =
+            let uu____1707 =
+              let uu____1708 =
+                let uu____1717 = embed e_bv rng bv  in
+                FStar_Syntax_Syntax.as_arg uu____1717  in
+              let uu____1718 =
+                let uu____1729 =
+                  let uu____1738 = embed e_term rng t  in
+                  FStar_Syntax_Syntax.as_arg uu____1738  in
+                [uu____1729]  in
+              uu____1708 :: uu____1718  in
+            FStar_Syntax_Syntax.mk_Tm_app
+              FStar_Reflection_Data.ref_Pat_Dot_Term.FStar_Reflection_Data.t
+              uu____1707
+             in
+          uu____1702 FStar_Pervasives_Native.None rng
        in
     let rec unembed_pattern w t =
       let t1 = FStar_Syntax_Util.unascribe t  in
-      let uu____1747 = FStar_Syntax_Util.head_and_args t1  in
-      match uu____1747 with
+      let uu____1781 = FStar_Syntax_Util.head_and_args t1  in
+      match uu____1781 with
       | (hd1,args) ->
-          let uu____1792 =
-            let uu____1805 =
-              let uu____1806 = FStar_Syntax_Util.un_uinst hd1  in
-              uu____1806.FStar_Syntax_Syntax.n  in
-            (uu____1805, args)  in
-          (match uu____1792 with
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(c,uu____1821)::[]) when
+          let uu____1826 =
+            let uu____1839 =
+              let uu____1840 = FStar_Syntax_Util.un_uinst hd1  in
+              uu____1840.FStar_Syntax_Syntax.n  in
+            (uu____1839, args)  in
+          (match uu____1826 with
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(c,uu____1855)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Constant.FStar_Reflection_Data.lid
                ->
-               let uu____1846 = unembed' w e_const c  in
-               FStar_Util.bind_opt uu____1846
+               let uu____1880 = unembed' w e_const c  in
+               FStar_Util.bind_opt uu____1880
                  (fun c1  ->
                     FStar_All.pipe_left
-                      (fun _1853  -> FStar_Pervasives_Native.Some _1853)
+                      (fun _1887  -> FStar_Pervasives_Native.Some _1887)
                       (FStar_Reflection_Data.Pat_Constant c1))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(f,uu____1856)::(ps,uu____1858)::[]) when
+              fv,(f,uu____1890)::(ps,uu____1892)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Cons.FStar_Reflection_Data.lid
                ->
-               let uu____1893 = unembed' w e_fv f  in
-               FStar_Util.bind_opt uu____1893
+               let uu____1927 = unembed' w e_fv f  in
+               FStar_Util.bind_opt uu____1927
                  (fun f1  ->
-                    let uu____1899 =
-                      let uu____1904 =
-                        let uu____1909 = e_pattern' ()  in
-                        FStar_Syntax_Embeddings.e_list uu____1909  in
-                      unembed' w uu____1904 ps  in
-                    FStar_Util.bind_opt uu____1899
+                    let uu____1933 =
+                      let uu____1943 =
+                        let uu____1953 =
+                          let uu____1961 = e_pattern' ()  in
+                          FStar_Syntax_Embeddings.e_tuple2 uu____1961
+                            FStar_Syntax_Embeddings.e_bool
+                           in
+                        FStar_Syntax_Embeddings.e_list uu____1953  in
+                      unembed' w uu____1943 ps  in
+                    FStar_Util.bind_opt uu____1933
                       (fun ps1  ->
                          FStar_All.pipe_left
-                           (fun _1922  -> FStar_Pervasives_Native.Some _1922)
+                           (fun _1995  -> FStar_Pervasives_Native.Some _1995)
                            (FStar_Reflection_Data.Pat_Cons (f1, ps1))))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(bv,uu____1927)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(bv,uu____2005)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Var.FStar_Reflection_Data.lid
                ->
-               let uu____1952 = unembed' w e_bv bv  in
-               FStar_Util.bind_opt uu____1952
+               let uu____2030 = unembed' w e_bv bv  in
+               FStar_Util.bind_opt uu____2030
                  (fun bv1  ->
                     FStar_All.pipe_left
-                      (fun _1959  -> FStar_Pervasives_Native.Some _1959)
+                      (fun _2037  -> FStar_Pervasives_Native.Some _2037)
                       (FStar_Reflection_Data.Pat_Var bv1))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(bv,uu____1962)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(bv,uu____2040)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Wild.FStar_Reflection_Data.lid
                ->
-               let uu____1987 = unembed' w e_bv bv  in
-               FStar_Util.bind_opt uu____1987
+               let uu____2065 = unembed' w e_bv bv  in
+               FStar_Util.bind_opt uu____2065
                  (fun bv1  ->
                     FStar_All.pipe_left
-                      (fun _1994  -> FStar_Pervasives_Native.Some _1994)
+                      (fun _2072  -> FStar_Pervasives_Native.Some _2072)
                       (FStar_Reflection_Data.Pat_Wild bv1))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(bv,uu____1997)::(t2,uu____1999)::[]) when
+              fv,(bv,uu____2075)::(t2,uu____2077)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Dot_Term.FStar_Reflection_Data.lid
                ->
-               let uu____2034 = unembed' w e_bv bv  in
-               FStar_Util.bind_opt uu____2034
+               let uu____2112 = unembed' w e_bv bv  in
+               FStar_Util.bind_opt uu____2112
                  (fun bv1  ->
-                    let uu____2040 = unembed' w e_term t2  in
-                    FStar_Util.bind_opt uu____2040
+                    let uu____2118 = unembed' w e_term t2  in
+                    FStar_Util.bind_opt uu____2118
                       (fun t3  ->
                          FStar_All.pipe_left
-                           (fun _2047  -> FStar_Pervasives_Native.Some _2047)
+                           (fun _2125  -> FStar_Pervasives_Native.Some _2125)
                            (FStar_Reflection_Data.Pat_Dot_Term (bv1, t3))))
-           | uu____2048 ->
+           | uu____2126 ->
                (if w
                 then
-                  (let uu____2063 =
-                     let uu____2069 =
-                       let uu____2071 = FStar_Syntax_Print.term_to_string t1
+                  (let uu____2141 =
+                     let uu____2147 =
+                       let uu____2149 = FStar_Syntax_Print.term_to_string t1
                           in
                        FStar_Util.format1 "Not an embedded pattern: %s"
-                         uu____2071
+                         uu____2149
                         in
-                     (FStar_Errors.Warning_NotEmbedded, uu____2069)  in
+                     (FStar_Errors.Warning_NotEmbedded, uu____2147)  in
                    FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos
-                     uu____2063)
+                     uu____2141)
                 else ();
                 FStar_Pervasives_Native.None))
        in
@@ -691,8 +699,8 @@ let (e_branch_aq :
       FStar_Syntax_Embeddings.embedding)
   =
   fun aq  ->
-    let uu____2098 = e_term_aq aq  in
-    FStar_Syntax_Embeddings.e_tuple2 e_pattern uu____2098
+    let uu____2176 = e_term_aq aq  in
+    FStar_Syntax_Embeddings.e_tuple2 e_pattern uu____2176
   
 let (e_argv_aq :
   FStar_Syntax_Syntax.antiquotations ->
@@ -700,8 +708,8 @@ let (e_argv_aq :
       FStar_Syntax_Embeddings.embedding)
   =
   fun aq  ->
-    let uu____2113 = e_term_aq aq  in
-    FStar_Syntax_Embeddings.e_tuple2 uu____2113 e_aqualv
+    let uu____2191 = e_term_aq aq  in
+    FStar_Syntax_Embeddings.e_tuple2 uu____2191 e_aqualv
   
 let (e_term_view_aq :
   FStar_Syntax_Syntax.antiquotations ->
@@ -711,506 +719,506 @@ let (e_term_view_aq :
     let embed_term_view rng t =
       match t with
       | FStar_Reflection_Data.Tv_FVar fv ->
-          let uu____2136 =
-            let uu____2141 =
-              let uu____2142 =
-                let uu____2151 = embed e_fv rng fv  in
-                FStar_Syntax_Syntax.as_arg uu____2151  in
-              [uu____2142]  in
+          let uu____2214 =
+            let uu____2219 =
+              let uu____2220 =
+                let uu____2229 = embed e_fv rng fv  in
+                FStar_Syntax_Syntax.as_arg uu____2229  in
+              [uu____2220]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_FVar.FStar_Reflection_Data.t
-              uu____2141
+              uu____2219
              in
-          uu____2136 FStar_Pervasives_Native.None rng
+          uu____2214 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_BVar fv ->
-          let uu____2169 =
-            let uu____2174 =
-              let uu____2175 =
-                let uu____2184 = embed e_bv rng fv  in
-                FStar_Syntax_Syntax.as_arg uu____2184  in
-              [uu____2175]  in
+          let uu____2247 =
+            let uu____2252 =
+              let uu____2253 =
+                let uu____2262 = embed e_bv rng fv  in
+                FStar_Syntax_Syntax.as_arg uu____2262  in
+              [uu____2253]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_BVar.FStar_Reflection_Data.t
-              uu____2174
+              uu____2252
              in
-          uu____2169 FStar_Pervasives_Native.None rng
+          uu____2247 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Var bv ->
-          let uu____2202 =
-            let uu____2207 =
-              let uu____2208 =
-                let uu____2217 = embed e_bv rng bv  in
-                FStar_Syntax_Syntax.as_arg uu____2217  in
-              [uu____2208]  in
+          let uu____2280 =
+            let uu____2285 =
+              let uu____2286 =
+                let uu____2295 = embed e_bv rng bv  in
+                FStar_Syntax_Syntax.as_arg uu____2295  in
+              [uu____2286]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_Var.FStar_Reflection_Data.t
-              uu____2207
+              uu____2285
              in
-          uu____2202 FStar_Pervasives_Native.None rng
+          uu____2280 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_App (hd1,a) ->
-          let uu____2236 =
-            let uu____2241 =
-              let uu____2242 =
-                let uu____2251 =
-                  let uu____2252 = e_term_aq aq  in embed uu____2252 rng hd1
+          let uu____2314 =
+            let uu____2319 =
+              let uu____2320 =
+                let uu____2329 =
+                  let uu____2330 = e_term_aq aq  in embed uu____2330 rng hd1
                    in
-                FStar_Syntax_Syntax.as_arg uu____2251  in
-              let uu____2255 =
-                let uu____2266 =
-                  let uu____2275 =
-                    let uu____2276 = e_argv_aq aq  in embed uu____2276 rng a
+                FStar_Syntax_Syntax.as_arg uu____2329  in
+              let uu____2333 =
+                let uu____2344 =
+                  let uu____2353 =
+                    let uu____2354 = e_argv_aq aq  in embed uu____2354 rng a
                      in
-                  FStar_Syntax_Syntax.as_arg uu____2275  in
-                [uu____2266]  in
-              uu____2242 :: uu____2255  in
+                  FStar_Syntax_Syntax.as_arg uu____2353  in
+                [uu____2344]  in
+              uu____2320 :: uu____2333  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_App.FStar_Reflection_Data.t
-              uu____2241
+              uu____2319
              in
-          uu____2236 FStar_Pervasives_Native.None rng
+          uu____2314 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Abs (b,t1) ->
-          let uu____2313 =
-            let uu____2318 =
-              let uu____2319 =
-                let uu____2328 = embed e_binder rng b  in
-                FStar_Syntax_Syntax.as_arg uu____2328  in
-              let uu____2329 =
-                let uu____2340 =
-                  let uu____2349 =
-                    let uu____2350 = e_term_aq aq  in embed uu____2350 rng t1
+          let uu____2391 =
+            let uu____2396 =
+              let uu____2397 =
+                let uu____2406 = embed e_binder rng b  in
+                FStar_Syntax_Syntax.as_arg uu____2406  in
+              let uu____2407 =
+                let uu____2418 =
+                  let uu____2427 =
+                    let uu____2428 = e_term_aq aq  in embed uu____2428 rng t1
                      in
-                  FStar_Syntax_Syntax.as_arg uu____2349  in
-                [uu____2340]  in
-              uu____2319 :: uu____2329  in
+                  FStar_Syntax_Syntax.as_arg uu____2427  in
+                [uu____2418]  in
+              uu____2397 :: uu____2407  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_Abs.FStar_Reflection_Data.t
-              uu____2318
+              uu____2396
              in
-          uu____2313 FStar_Pervasives_Native.None rng
+          uu____2391 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Arrow (b,c) ->
-          let uu____2379 =
-            let uu____2384 =
-              let uu____2385 =
-                let uu____2394 = embed e_binder rng b  in
-                FStar_Syntax_Syntax.as_arg uu____2394  in
-              let uu____2395 =
-                let uu____2406 =
-                  let uu____2415 = embed e_comp rng c  in
-                  FStar_Syntax_Syntax.as_arg uu____2415  in
-                [uu____2406]  in
-              uu____2385 :: uu____2395  in
+          let uu____2457 =
+            let uu____2462 =
+              let uu____2463 =
+                let uu____2472 = embed e_binder rng b  in
+                FStar_Syntax_Syntax.as_arg uu____2472  in
+              let uu____2473 =
+                let uu____2484 =
+                  let uu____2493 = embed e_comp rng c  in
+                  FStar_Syntax_Syntax.as_arg uu____2493  in
+                [uu____2484]  in
+              uu____2463 :: uu____2473  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_Arrow.FStar_Reflection_Data.t
-              uu____2384
+              uu____2462
              in
-          uu____2379 FStar_Pervasives_Native.None rng
+          uu____2457 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Type u ->
-          let uu____2441 =
-            let uu____2446 =
-              let uu____2447 =
-                let uu____2456 = embed FStar_Syntax_Embeddings.e_unit rng ()
+          let uu____2519 =
+            let uu____2524 =
+              let uu____2525 =
+                let uu____2534 = embed FStar_Syntax_Embeddings.e_unit rng ()
                    in
-                FStar_Syntax_Syntax.as_arg uu____2456  in
-              [uu____2447]  in
+                FStar_Syntax_Syntax.as_arg uu____2534  in
+              [uu____2525]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_Type.FStar_Reflection_Data.t
-              uu____2446
+              uu____2524
              in
-          uu____2441 FStar_Pervasives_Native.None rng
+          uu____2519 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Refine (bv,t1) ->
-          let uu____2475 =
-            let uu____2480 =
-              let uu____2481 =
-                let uu____2490 = embed e_bv rng bv  in
-                FStar_Syntax_Syntax.as_arg uu____2490  in
-              let uu____2491 =
-                let uu____2502 =
-                  let uu____2511 =
-                    let uu____2512 = e_term_aq aq  in embed uu____2512 rng t1
+          let uu____2553 =
+            let uu____2558 =
+              let uu____2559 =
+                let uu____2568 = embed e_bv rng bv  in
+                FStar_Syntax_Syntax.as_arg uu____2568  in
+              let uu____2569 =
+                let uu____2580 =
+                  let uu____2589 =
+                    let uu____2590 = e_term_aq aq  in embed uu____2590 rng t1
                      in
-                  FStar_Syntax_Syntax.as_arg uu____2511  in
-                [uu____2502]  in
-              uu____2481 :: uu____2491  in
+                  FStar_Syntax_Syntax.as_arg uu____2589  in
+                [uu____2580]  in
+              uu____2559 :: uu____2569  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_Refine.FStar_Reflection_Data.t
-              uu____2480
+              uu____2558
              in
-          uu____2475 FStar_Pervasives_Native.None rng
+          uu____2553 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Const c ->
-          let uu____2540 =
-            let uu____2545 =
-              let uu____2546 =
-                let uu____2555 = embed e_const rng c  in
-                FStar_Syntax_Syntax.as_arg uu____2555  in
-              [uu____2546]  in
+          let uu____2618 =
+            let uu____2623 =
+              let uu____2624 =
+                let uu____2633 = embed e_const rng c  in
+                FStar_Syntax_Syntax.as_arg uu____2633  in
+              [uu____2624]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_Const.FStar_Reflection_Data.t
-              uu____2545
+              uu____2623
              in
-          uu____2540 FStar_Pervasives_Native.None rng
+          uu____2618 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Uvar (u,d) ->
-          let uu____2574 =
-            let uu____2579 =
-              let uu____2580 =
-                let uu____2589 = embed FStar_Syntax_Embeddings.e_int rng u
+          let uu____2652 =
+            let uu____2657 =
+              let uu____2658 =
+                let uu____2667 = embed FStar_Syntax_Embeddings.e_int rng u
                    in
-                FStar_Syntax_Syntax.as_arg uu____2589  in
-              let uu____2590 =
-                let uu____2601 =
-                  let uu____2610 =
+                FStar_Syntax_Syntax.as_arg uu____2667  in
+              let uu____2668 =
+                let uu____2679 =
+                  let uu____2688 =
                     FStar_Syntax_Util.mk_lazy (u, d)
                       FStar_Syntax_Util.t_ctx_uvar_and_sust
                       FStar_Syntax_Syntax.Lazy_uvar
                       FStar_Pervasives_Native.None
                      in
-                  FStar_Syntax_Syntax.as_arg uu____2610  in
-                [uu____2601]  in
-              uu____2580 :: uu____2590  in
+                  FStar_Syntax_Syntax.as_arg uu____2688  in
+                [uu____2679]  in
+              uu____2658 :: uu____2668  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_Uvar.FStar_Reflection_Data.t
-              uu____2579
+              uu____2657
              in
-          uu____2574 FStar_Pervasives_Native.None rng
+          uu____2652 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Let (r,b,t1,t2) ->
-          let uu____2645 =
-            let uu____2650 =
-              let uu____2651 =
-                let uu____2660 = embed FStar_Syntax_Embeddings.e_bool rng r
+          let uu____2723 =
+            let uu____2728 =
+              let uu____2729 =
+                let uu____2738 = embed FStar_Syntax_Embeddings.e_bool rng r
                    in
-                FStar_Syntax_Syntax.as_arg uu____2660  in
-              let uu____2662 =
-                let uu____2673 =
-                  let uu____2682 = embed e_bv rng b  in
-                  FStar_Syntax_Syntax.as_arg uu____2682  in
-                let uu____2683 =
-                  let uu____2694 =
-                    let uu____2703 =
-                      let uu____2704 = e_term_aq aq  in
-                      embed uu____2704 rng t1  in
-                    FStar_Syntax_Syntax.as_arg uu____2703  in
-                  let uu____2707 =
-                    let uu____2718 =
-                      let uu____2727 =
-                        let uu____2728 = e_term_aq aq  in
-                        embed uu____2728 rng t2  in
-                      FStar_Syntax_Syntax.as_arg uu____2727  in
-                    [uu____2718]  in
-                  uu____2694 :: uu____2707  in
-                uu____2673 :: uu____2683  in
-              uu____2651 :: uu____2662  in
+                FStar_Syntax_Syntax.as_arg uu____2738  in
+              let uu____2740 =
+                let uu____2751 =
+                  let uu____2760 = embed e_bv rng b  in
+                  FStar_Syntax_Syntax.as_arg uu____2760  in
+                let uu____2761 =
+                  let uu____2772 =
+                    let uu____2781 =
+                      let uu____2782 = e_term_aq aq  in
+                      embed uu____2782 rng t1  in
+                    FStar_Syntax_Syntax.as_arg uu____2781  in
+                  let uu____2785 =
+                    let uu____2796 =
+                      let uu____2805 =
+                        let uu____2806 = e_term_aq aq  in
+                        embed uu____2806 rng t2  in
+                      FStar_Syntax_Syntax.as_arg uu____2805  in
+                    [uu____2796]  in
+                  uu____2772 :: uu____2785  in
+                uu____2751 :: uu____2761  in
+              uu____2729 :: uu____2740  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_Let.FStar_Reflection_Data.t
-              uu____2650
+              uu____2728
              in
-          uu____2645 FStar_Pervasives_Native.None rng
+          uu____2723 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Match (t1,brs) ->
-          let uu____2777 =
-            let uu____2782 =
-              let uu____2783 =
-                let uu____2792 =
-                  let uu____2793 = e_term_aq aq  in embed uu____2793 rng t1
+          let uu____2855 =
+            let uu____2860 =
+              let uu____2861 =
+                let uu____2870 =
+                  let uu____2871 = e_term_aq aq  in embed uu____2871 rng t1
                    in
-                FStar_Syntax_Syntax.as_arg uu____2792  in
-              let uu____2796 =
-                let uu____2807 =
-                  let uu____2816 =
-                    let uu____2817 =
-                      let uu____2826 = e_branch_aq aq  in
-                      FStar_Syntax_Embeddings.e_list uu____2826  in
-                    embed uu____2817 rng brs  in
-                  FStar_Syntax_Syntax.as_arg uu____2816  in
-                [uu____2807]  in
-              uu____2783 :: uu____2796  in
+                FStar_Syntax_Syntax.as_arg uu____2870  in
+              let uu____2874 =
+                let uu____2885 =
+                  let uu____2894 =
+                    let uu____2895 =
+                      let uu____2904 = e_branch_aq aq  in
+                      FStar_Syntax_Embeddings.e_list uu____2904  in
+                    embed uu____2895 rng brs  in
+                  FStar_Syntax_Syntax.as_arg uu____2894  in
+                [uu____2885]  in
+              uu____2861 :: uu____2874  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_Match.FStar_Reflection_Data.t
-              uu____2782
+              uu____2860
              in
-          uu____2777 FStar_Pervasives_Native.None rng
+          uu____2855 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_AscribedT (e,t1,tacopt) ->
-          let uu____2874 =
-            let uu____2879 =
-              let uu____2880 =
-                let uu____2889 =
-                  let uu____2890 = e_term_aq aq  in embed uu____2890 rng e
+          let uu____2952 =
+            let uu____2957 =
+              let uu____2958 =
+                let uu____2967 =
+                  let uu____2968 = e_term_aq aq  in embed uu____2968 rng e
                    in
-                FStar_Syntax_Syntax.as_arg uu____2889  in
-              let uu____2893 =
-                let uu____2904 =
-                  let uu____2913 =
-                    let uu____2914 = e_term_aq aq  in embed uu____2914 rng t1
+                FStar_Syntax_Syntax.as_arg uu____2967  in
+              let uu____2971 =
+                let uu____2982 =
+                  let uu____2991 =
+                    let uu____2992 = e_term_aq aq  in embed uu____2992 rng t1
                      in
-                  FStar_Syntax_Syntax.as_arg uu____2913  in
-                let uu____2917 =
-                  let uu____2928 =
-                    let uu____2937 =
-                      let uu____2938 =
-                        let uu____2943 = e_term_aq aq  in
-                        FStar_Syntax_Embeddings.e_option uu____2943  in
-                      embed uu____2938 rng tacopt  in
-                    FStar_Syntax_Syntax.as_arg uu____2937  in
-                  [uu____2928]  in
-                uu____2904 :: uu____2917  in
-              uu____2880 :: uu____2893  in
+                  FStar_Syntax_Syntax.as_arg uu____2991  in
+                let uu____2995 =
+                  let uu____3006 =
+                    let uu____3015 =
+                      let uu____3016 =
+                        let uu____3021 = e_term_aq aq  in
+                        FStar_Syntax_Embeddings.e_option uu____3021  in
+                      embed uu____3016 rng tacopt  in
+                    FStar_Syntax_Syntax.as_arg uu____3015  in
+                  [uu____3006]  in
+                uu____2982 :: uu____2995  in
+              uu____2958 :: uu____2971  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.t
-              uu____2879
+              uu____2957
              in
-          uu____2874 FStar_Pervasives_Native.None rng
+          uu____2952 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_AscribedC (e,c,tacopt) ->
-          let uu____2987 =
-            let uu____2992 =
-              let uu____2993 =
-                let uu____3002 =
-                  let uu____3003 = e_term_aq aq  in embed uu____3003 rng e
+          let uu____3065 =
+            let uu____3070 =
+              let uu____3071 =
+                let uu____3080 =
+                  let uu____3081 = e_term_aq aq  in embed uu____3081 rng e
                    in
-                FStar_Syntax_Syntax.as_arg uu____3002  in
-              let uu____3006 =
-                let uu____3017 =
-                  let uu____3026 = embed e_comp rng c  in
-                  FStar_Syntax_Syntax.as_arg uu____3026  in
-                let uu____3027 =
-                  let uu____3038 =
-                    let uu____3047 =
-                      let uu____3048 =
-                        let uu____3053 = e_term_aq aq  in
-                        FStar_Syntax_Embeddings.e_option uu____3053  in
-                      embed uu____3048 rng tacopt  in
-                    FStar_Syntax_Syntax.as_arg uu____3047  in
-                  [uu____3038]  in
-                uu____3017 :: uu____3027  in
-              uu____2993 :: uu____3006  in
+                FStar_Syntax_Syntax.as_arg uu____3080  in
+              let uu____3084 =
+                let uu____3095 =
+                  let uu____3104 = embed e_comp rng c  in
+                  FStar_Syntax_Syntax.as_arg uu____3104  in
+                let uu____3105 =
+                  let uu____3116 =
+                    let uu____3125 =
+                      let uu____3126 =
+                        let uu____3131 = e_term_aq aq  in
+                        FStar_Syntax_Embeddings.e_option uu____3131  in
+                      embed uu____3126 rng tacopt  in
+                    FStar_Syntax_Syntax.as_arg uu____3125  in
+                  [uu____3116]  in
+                uu____3095 :: uu____3105  in
+              uu____3071 :: uu____3084  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_Tv_AscC.FStar_Reflection_Data.t
-              uu____2992
+              uu____3070
              in
-          uu____2987 FStar_Pervasives_Native.None rng
+          uu____3065 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Unknown  ->
-          let uu___370_3090 =
+          let uu___370_3168 =
             FStar_Reflection_Data.ref_Tv_Unknown.FStar_Reflection_Data.t  in
           {
-            FStar_Syntax_Syntax.n = (uu___370_3090.FStar_Syntax_Syntax.n);
+            FStar_Syntax_Syntax.n = (uu___370_3168.FStar_Syntax_Syntax.n);
             FStar_Syntax_Syntax.pos = rng;
             FStar_Syntax_Syntax.vars =
-              (uu___370_3090.FStar_Syntax_Syntax.vars)
+              (uu___370_3168.FStar_Syntax_Syntax.vars)
           }
        in
     let unembed_term_view w t =
-      let uu____3108 = FStar_Syntax_Util.head_and_args t  in
-      match uu____3108 with
+      let uu____3186 = FStar_Syntax_Util.head_and_args t  in
+      match uu____3186 with
       | (hd1,args) ->
-          let uu____3153 =
-            let uu____3166 =
-              let uu____3167 = FStar_Syntax_Util.un_uinst hd1  in
-              uu____3167.FStar_Syntax_Syntax.n  in
-            (uu____3166, args)  in
-          (match uu____3153 with
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(b,uu____3182)::[]) when
+          let uu____3231 =
+            let uu____3244 =
+              let uu____3245 = FStar_Syntax_Util.un_uinst hd1  in
+              uu____3245.FStar_Syntax_Syntax.n  in
+            (uu____3244, args)  in
+          (match uu____3231 with
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(b,uu____3260)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Var.FStar_Reflection_Data.lid
                ->
-               let uu____3207 = unembed' w e_bv b  in
-               FStar_Util.bind_opt uu____3207
+               let uu____3285 = unembed' w e_bv b  in
+               FStar_Util.bind_opt uu____3285
                  (fun b1  ->
                     FStar_All.pipe_left
-                      (fun _3214  -> FStar_Pervasives_Native.Some _3214)
+                      (fun _3292  -> FStar_Pervasives_Native.Some _3292)
                       (FStar_Reflection_Data.Tv_Var b1))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(b,uu____3217)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(b,uu____3295)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_BVar.FStar_Reflection_Data.lid
                ->
-               let uu____3242 = unembed' w e_bv b  in
-               FStar_Util.bind_opt uu____3242
+               let uu____3320 = unembed' w e_bv b  in
+               FStar_Util.bind_opt uu____3320
                  (fun b1  ->
                     FStar_All.pipe_left
-                      (fun _3249  -> FStar_Pervasives_Native.Some _3249)
+                      (fun _3327  -> FStar_Pervasives_Native.Some _3327)
                       (FStar_Reflection_Data.Tv_BVar b1))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(f,uu____3252)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(f,uu____3330)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_FVar.FStar_Reflection_Data.lid
                ->
-               let uu____3277 = unembed' w e_fv f  in
-               FStar_Util.bind_opt uu____3277
+               let uu____3355 = unembed' w e_fv f  in
+               FStar_Util.bind_opt uu____3355
                  (fun f1  ->
                     FStar_All.pipe_left
-                      (fun _3284  -> FStar_Pervasives_Native.Some _3284)
+                      (fun _3362  -> FStar_Pervasives_Native.Some _3362)
                       (FStar_Reflection_Data.Tv_FVar f1))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(l,uu____3287)::(r,uu____3289)::[]) when
+              fv,(l,uu____3365)::(r,uu____3367)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_App.FStar_Reflection_Data.lid
                ->
-               let uu____3324 = unembed' w e_term l  in
-               FStar_Util.bind_opt uu____3324
+               let uu____3402 = unembed' w e_term l  in
+               FStar_Util.bind_opt uu____3402
                  (fun l1  ->
-                    let uu____3330 = unembed' w e_argv r  in
-                    FStar_Util.bind_opt uu____3330
+                    let uu____3408 = unembed' w e_argv r  in
+                    FStar_Util.bind_opt uu____3408
                       (fun r1  ->
                          FStar_All.pipe_left
-                           (fun _3337  -> FStar_Pervasives_Native.Some _3337)
+                           (fun _3415  -> FStar_Pervasives_Native.Some _3415)
                            (FStar_Reflection_Data.Tv_App (l1, r1))))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(b,uu____3340)::(t1,uu____3342)::[]) when
+              fv,(b,uu____3418)::(t1,uu____3420)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Abs.FStar_Reflection_Data.lid
                ->
-               let uu____3377 = unembed' w e_binder b  in
-               FStar_Util.bind_opt uu____3377
+               let uu____3455 = unembed' w e_binder b  in
+               FStar_Util.bind_opt uu____3455
                  (fun b1  ->
-                    let uu____3383 = unembed' w e_term t1  in
-                    FStar_Util.bind_opt uu____3383
+                    let uu____3461 = unembed' w e_term t1  in
+                    FStar_Util.bind_opt uu____3461
                       (fun t2  ->
                          FStar_All.pipe_left
-                           (fun _3390  -> FStar_Pervasives_Native.Some _3390)
+                           (fun _3468  -> FStar_Pervasives_Native.Some _3468)
                            (FStar_Reflection_Data.Tv_Abs (b1, t2))))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(b,uu____3393)::(t1,uu____3395)::[]) when
+              fv,(b,uu____3471)::(t1,uu____3473)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Arrow.FStar_Reflection_Data.lid
                ->
-               let uu____3430 = unembed' w e_binder b  in
-               FStar_Util.bind_opt uu____3430
+               let uu____3508 = unembed' w e_binder b  in
+               FStar_Util.bind_opt uu____3508
                  (fun b1  ->
-                    let uu____3436 = unembed' w e_comp t1  in
-                    FStar_Util.bind_opt uu____3436
+                    let uu____3514 = unembed' w e_comp t1  in
+                    FStar_Util.bind_opt uu____3514
                       (fun c  ->
                          FStar_All.pipe_left
-                           (fun _3443  -> FStar_Pervasives_Native.Some _3443)
+                           (fun _3521  -> FStar_Pervasives_Native.Some _3521)
                            (FStar_Reflection_Data.Tv_Arrow (b1, c))))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(u,uu____3446)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(u,uu____3524)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Type.FStar_Reflection_Data.lid
                ->
-               let uu____3471 = unembed' w FStar_Syntax_Embeddings.e_unit u
+               let uu____3549 = unembed' w FStar_Syntax_Embeddings.e_unit u
                   in
-               FStar_Util.bind_opt uu____3471
+               FStar_Util.bind_opt uu____3549
                  (fun u1  ->
                     FStar_All.pipe_left
-                      (fun _3478  -> FStar_Pervasives_Native.Some _3478)
+                      (fun _3556  -> FStar_Pervasives_Native.Some _3556)
                       (FStar_Reflection_Data.Tv_Type ()))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(b,uu____3481)::(t1,uu____3483)::[]) when
+              fv,(b,uu____3559)::(t1,uu____3561)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Refine.FStar_Reflection_Data.lid
                ->
-               let uu____3518 = unembed' w e_bv b  in
-               FStar_Util.bind_opt uu____3518
+               let uu____3596 = unembed' w e_bv b  in
+               FStar_Util.bind_opt uu____3596
                  (fun b1  ->
-                    let uu____3524 = unembed' w e_term t1  in
-                    FStar_Util.bind_opt uu____3524
+                    let uu____3602 = unembed' w e_term t1  in
+                    FStar_Util.bind_opt uu____3602
                       (fun t2  ->
                          FStar_All.pipe_left
-                           (fun _3531  -> FStar_Pervasives_Native.Some _3531)
+                           (fun _3609  -> FStar_Pervasives_Native.Some _3609)
                            (FStar_Reflection_Data.Tv_Refine (b1, t2))))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(c,uu____3534)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(c,uu____3612)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Const.FStar_Reflection_Data.lid
                ->
-               let uu____3559 = unembed' w e_const c  in
-               FStar_Util.bind_opt uu____3559
+               let uu____3637 = unembed' w e_const c  in
+               FStar_Util.bind_opt uu____3637
                  (fun c1  ->
                     FStar_All.pipe_left
-                      (fun _3566  -> FStar_Pervasives_Native.Some _3566)
+                      (fun _3644  -> FStar_Pervasives_Native.Some _3644)
                       (FStar_Reflection_Data.Tv_Const c1))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(u,uu____3569)::(l,uu____3571)::[]) when
+              fv,(u,uu____3647)::(l,uu____3649)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Uvar.FStar_Reflection_Data.lid
                ->
-               let uu____3606 = unembed' w FStar_Syntax_Embeddings.e_int u
+               let uu____3684 = unembed' w FStar_Syntax_Embeddings.e_int u
                   in
-               FStar_Util.bind_opt uu____3606
+               FStar_Util.bind_opt uu____3684
                  (fun u1  ->
                     let ctx_u_s =
                       FStar_Syntax_Util.unlazy_as_t
                         FStar_Syntax_Syntax.Lazy_uvar l
                        in
                     FStar_All.pipe_left
-                      (fun _3615  -> FStar_Pervasives_Native.Some _3615)
+                      (fun _3693  -> FStar_Pervasives_Native.Some _3693)
                       (FStar_Reflection_Data.Tv_Uvar (u1, ctx_u_s)))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(r,uu____3618)::(b,uu____3620)::(t1,uu____3622)::(t2,uu____3624)::[])
+              fv,(r,uu____3696)::(b,uu____3698)::(t1,uu____3700)::(t2,uu____3702)::[])
                when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Let.FStar_Reflection_Data.lid
                ->
-               let uu____3679 = unembed' w FStar_Syntax_Embeddings.e_bool r
+               let uu____3757 = unembed' w FStar_Syntax_Embeddings.e_bool r
                   in
-               FStar_Util.bind_opt uu____3679
+               FStar_Util.bind_opt uu____3757
                  (fun r1  ->
-                    let uu____3689 = unembed' w e_bv b  in
-                    FStar_Util.bind_opt uu____3689
+                    let uu____3767 = unembed' w e_bv b  in
+                    FStar_Util.bind_opt uu____3767
                       (fun b1  ->
-                         let uu____3695 = unembed' w e_term t1  in
-                         FStar_Util.bind_opt uu____3695
+                         let uu____3773 = unembed' w e_term t1  in
+                         FStar_Util.bind_opt uu____3773
                            (fun t11  ->
-                              let uu____3701 = unembed' w e_term t2  in
-                              FStar_Util.bind_opt uu____3701
+                              let uu____3779 = unembed' w e_term t2  in
+                              FStar_Util.bind_opt uu____3779
                                 (fun t21  ->
                                    FStar_All.pipe_left
-                                     (fun _3708  ->
-                                        FStar_Pervasives_Native.Some _3708)
+                                     (fun _3786  ->
+                                        FStar_Pervasives_Native.Some _3786)
                                      (FStar_Reflection_Data.Tv_Let
                                         (r1, b1, t11, t21))))))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(t1,uu____3712)::(brs,uu____3714)::[]) when
+              fv,(t1,uu____3790)::(brs,uu____3792)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Match.FStar_Reflection_Data.lid
                ->
-               let uu____3749 = unembed' w e_term t1  in
-               FStar_Util.bind_opt uu____3749
+               let uu____3827 = unembed' w e_term t1  in
+               FStar_Util.bind_opt uu____3827
                  (fun t2  ->
-                    let uu____3755 =
-                      let uu____3760 =
+                    let uu____3833 =
+                      let uu____3838 =
                         FStar_Syntax_Embeddings.e_list e_branch  in
-                      unembed' w uu____3760 brs  in
-                    FStar_Util.bind_opt uu____3755
+                      unembed' w uu____3838 brs  in
+                    FStar_Util.bind_opt uu____3833
                       (fun brs1  ->
                          FStar_All.pipe_left
-                           (fun _3775  -> FStar_Pervasives_Native.Some _3775)
+                           (fun _3853  -> FStar_Pervasives_Native.Some _3853)
                            (FStar_Reflection_Data.Tv_Match (t2, brs1))))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(e,uu____3780)::(t1,uu____3782)::(tacopt,uu____3784)::[])
+              fv,(e,uu____3858)::(t1,uu____3860)::(tacopt,uu____3862)::[])
                when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.lid
                ->
-               let uu____3829 = unembed' w e_term e  in
-               FStar_Util.bind_opt uu____3829
+               let uu____3907 = unembed' w e_term e  in
+               FStar_Util.bind_opt uu____3907
                  (fun e1  ->
-                    let uu____3835 = unembed' w e_term t1  in
-                    FStar_Util.bind_opt uu____3835
+                    let uu____3913 = unembed' w e_term t1  in
+                    FStar_Util.bind_opt uu____3913
                       (fun t2  ->
-                         let uu____3841 =
-                           let uu____3846 =
+                         let uu____3919 =
+                           let uu____3924 =
                              FStar_Syntax_Embeddings.e_option e_term  in
-                           unembed' w uu____3846 tacopt  in
-                         FStar_Util.bind_opt uu____3841
+                           unembed' w uu____3924 tacopt  in
+                         FStar_Util.bind_opt uu____3919
                            (fun tacopt1  ->
                               FStar_All.pipe_left
-                                (fun _3861  ->
-                                   FStar_Pervasives_Native.Some _3861)
+                                (fun _3939  ->
+                                   FStar_Pervasives_Native.Some _3939)
                                 (FStar_Reflection_Data.Tv_AscribedT
                                    (e1, t2, tacopt1)))))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(e,uu____3866)::(c,uu____3868)::(tacopt,uu____3870)::[])
+              fv,(e,uu____3944)::(c,uu____3946)::(tacopt,uu____3948)::[])
                when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_AscC.FStar_Reflection_Data.lid
                ->
-               let uu____3915 = unembed' w e_term e  in
-               FStar_Util.bind_opt uu____3915
+               let uu____3993 = unembed' w e_term e  in
+               FStar_Util.bind_opt uu____3993
                  (fun e1  ->
-                    let uu____3921 = unembed' w e_comp c  in
-                    FStar_Util.bind_opt uu____3921
+                    let uu____3999 = unembed' w e_comp c  in
+                    FStar_Util.bind_opt uu____3999
                       (fun c1  ->
-                         let uu____3927 =
-                           let uu____3932 =
+                         let uu____4005 =
+                           let uu____4010 =
                              FStar_Syntax_Embeddings.e_option e_term  in
-                           unembed' w uu____3932 tacopt  in
-                         FStar_Util.bind_opt uu____3927
+                           unembed' w uu____4010 tacopt  in
+                         FStar_Util.bind_opt uu____4005
                            (fun tacopt1  ->
                               FStar_All.pipe_left
-                                (fun _3947  ->
-                                   FStar_Pervasives_Native.Some _3947)
+                                (fun _4025  ->
+                                   FStar_Pervasives_Native.Some _4025)
                                 (FStar_Reflection_Data.Tv_AscribedC
                                    (e1, c1, tacopt1)))))
            | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
@@ -1218,21 +1226,21 @@ let (e_term_view_aq :
                  FStar_Reflection_Data.ref_Tv_Unknown.FStar_Reflection_Data.lid
                ->
                FStar_All.pipe_left
-                 (fun _3967  -> FStar_Pervasives_Native.Some _3967)
+                 (fun _4045  -> FStar_Pervasives_Native.Some _4045)
                  FStar_Reflection_Data.Tv_Unknown
-           | uu____3968 ->
+           | uu____4046 ->
                (if w
                 then
-                  (let uu____3983 =
-                     let uu____3989 =
-                       let uu____3991 = FStar_Syntax_Print.term_to_string t
+                  (let uu____4061 =
+                     let uu____4067 =
+                       let uu____4069 = FStar_Syntax_Print.term_to_string t
                           in
                        FStar_Util.format1 "Not an embedded term_view: %s"
-                         uu____3991
+                         uu____4069
                         in
-                     (FStar_Errors.Warning_NotEmbedded, uu____3989)  in
+                     (FStar_Errors.Warning_NotEmbedded, uu____4067)  in
                    FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos
-                     uu____3983)
+                     uu____4061)
                 else ();
                 FStar_Pervasives_Native.None))
        in
@@ -1245,80 +1253,80 @@ let (e_term_view :
 let (e_bv_view :
   FStar_Reflection_Data.bv_view FStar_Syntax_Embeddings.embedding) =
   let embed_bv_view rng bvv =
-    let uu____4020 =
-      let uu____4025 =
-        let uu____4026 =
-          let uu____4035 =
+    let uu____4098 =
+      let uu____4103 =
+        let uu____4104 =
+          let uu____4113 =
             embed FStar_Syntax_Embeddings.e_string rng
               bvv.FStar_Reflection_Data.bv_ppname
              in
-          FStar_Syntax_Syntax.as_arg uu____4035  in
-        let uu____4037 =
-          let uu____4048 =
-            let uu____4057 =
+          FStar_Syntax_Syntax.as_arg uu____4113  in
+        let uu____4115 =
+          let uu____4126 =
+            let uu____4135 =
               embed FStar_Syntax_Embeddings.e_int rng
                 bvv.FStar_Reflection_Data.bv_index
                in
-            FStar_Syntax_Syntax.as_arg uu____4057  in
-          let uu____4058 =
-            let uu____4069 =
-              let uu____4078 =
+            FStar_Syntax_Syntax.as_arg uu____4135  in
+          let uu____4136 =
+            let uu____4147 =
+              let uu____4156 =
                 embed e_term rng bvv.FStar_Reflection_Data.bv_sort  in
-              FStar_Syntax_Syntax.as_arg uu____4078  in
-            [uu____4069]  in
-          uu____4048 :: uu____4058  in
-        uu____4026 :: uu____4037  in
+              FStar_Syntax_Syntax.as_arg uu____4156  in
+            [uu____4147]  in
+          uu____4126 :: uu____4136  in
+        uu____4104 :: uu____4115  in
       FStar_Syntax_Syntax.mk_Tm_app
-        FStar_Reflection_Data.ref_Mk_bv.FStar_Reflection_Data.t uu____4025
+        FStar_Reflection_Data.ref_Mk_bv.FStar_Reflection_Data.t uu____4103
        in
-    uu____4020 FStar_Pervasives_Native.None rng  in
+    uu____4098 FStar_Pervasives_Native.None rng  in
   let unembed_bv_view w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____4129 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____4129 with
+    let uu____4207 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____4207 with
     | (hd1,args) ->
-        let uu____4174 =
-          let uu____4187 =
-            let uu____4188 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____4188.FStar_Syntax_Syntax.n  in
-          (uu____4187, args)  in
-        (match uu____4174 with
+        let uu____4252 =
+          let uu____4265 =
+            let uu____4266 = FStar_Syntax_Util.un_uinst hd1  in
+            uu____4266.FStar_Syntax_Syntax.n  in
+          (uu____4265, args)  in
+        (match uu____4252 with
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(nm,uu____4203)::(idx,uu____4205)::(s,uu____4207)::[]) when
+            fv,(nm,uu____4281)::(idx,uu____4283)::(s,uu____4285)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Mk_bv.FStar_Reflection_Data.lid
              ->
-             let uu____4252 = unembed' w FStar_Syntax_Embeddings.e_string nm
+             let uu____4330 = unembed' w FStar_Syntax_Embeddings.e_string nm
                 in
-             FStar_Util.bind_opt uu____4252
+             FStar_Util.bind_opt uu____4330
                (fun nm1  ->
-                  let uu____4262 =
+                  let uu____4340 =
                     unembed' w FStar_Syntax_Embeddings.e_int idx  in
-                  FStar_Util.bind_opt uu____4262
+                  FStar_Util.bind_opt uu____4340
                     (fun idx1  ->
-                       let uu____4268 = unembed' w e_term s  in
-                       FStar_Util.bind_opt uu____4268
+                       let uu____4346 = unembed' w e_term s  in
+                       FStar_Util.bind_opt uu____4346
                          (fun s1  ->
                             FStar_All.pipe_left
-                              (fun _4275  ->
-                                 FStar_Pervasives_Native.Some _4275)
+                              (fun _4353  ->
+                                 FStar_Pervasives_Native.Some _4353)
                               {
                                 FStar_Reflection_Data.bv_ppname = nm1;
                                 FStar_Reflection_Data.bv_index = idx1;
                                 FStar_Reflection_Data.bv_sort = s1
                               })))
-         | uu____4276 ->
+         | uu____4354 ->
              (if w
               then
-                (let uu____4291 =
-                   let uu____4297 =
-                     let uu____4299 = FStar_Syntax_Print.term_to_string t1
+                (let uu____4369 =
+                   let uu____4375 =
+                     let uu____4377 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.format1 "Not an embedded bv_view: %s"
-                       uu____4299
+                       uu____4377
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____4297)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____4291)
+                   (FStar_Errors.Warning_NotEmbedded, uu____4375)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____4369)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -1330,113 +1338,113 @@ let (e_comp_view :
   let embed_comp_view rng cv =
     match cv with
     | FStar_Reflection_Data.C_Total (t,md) ->
-        let uu____4325 =
-          let uu____4330 =
-            let uu____4331 =
-              let uu____4340 = embed e_term rng t  in
-              FStar_Syntax_Syntax.as_arg uu____4340  in
-            let uu____4341 =
-              let uu____4352 =
-                let uu____4361 =
-                  let uu____4362 = FStar_Syntax_Embeddings.e_option e_term
+        let uu____4403 =
+          let uu____4408 =
+            let uu____4409 =
+              let uu____4418 = embed e_term rng t  in
+              FStar_Syntax_Syntax.as_arg uu____4418  in
+            let uu____4419 =
+              let uu____4430 =
+                let uu____4439 =
+                  let uu____4440 = FStar_Syntax_Embeddings.e_option e_term
                      in
-                  embed uu____4362 rng md  in
-                FStar_Syntax_Syntax.as_arg uu____4361  in
-              [uu____4352]  in
-            uu____4331 :: uu____4341  in
+                  embed uu____4440 rng md  in
+                FStar_Syntax_Syntax.as_arg uu____4439  in
+              [uu____4430]  in
+            uu____4409 :: uu____4419  in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.ref_C_Total.FStar_Reflection_Data.t
-            uu____4330
+            uu____4408
            in
-        uu____4325 FStar_Pervasives_Native.None rng
+        uu____4403 FStar_Pervasives_Native.None rng
     | FStar_Reflection_Data.C_Lemma (pre,post) ->
         let post1 = FStar_Syntax_Util.unthunk_lemma_post post  in
-        let uu____4398 =
-          let uu____4403 =
-            let uu____4404 =
-              let uu____4413 = embed e_term rng pre  in
-              FStar_Syntax_Syntax.as_arg uu____4413  in
-            let uu____4414 =
-              let uu____4425 =
-                let uu____4434 = embed e_term rng post1  in
-                FStar_Syntax_Syntax.as_arg uu____4434  in
-              [uu____4425]  in
-            uu____4404 :: uu____4414  in
+        let uu____4476 =
+          let uu____4481 =
+            let uu____4482 =
+              let uu____4491 = embed e_term rng pre  in
+              FStar_Syntax_Syntax.as_arg uu____4491  in
+            let uu____4492 =
+              let uu____4503 =
+                let uu____4512 = embed e_term rng post1  in
+                FStar_Syntax_Syntax.as_arg uu____4512  in
+              [uu____4503]  in
+            uu____4482 :: uu____4492  in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.ref_C_Lemma.FStar_Reflection_Data.t
-            uu____4403
+            uu____4481
            in
-        uu____4398 FStar_Pervasives_Native.None rng
+        uu____4476 FStar_Pervasives_Native.None rng
     | FStar_Reflection_Data.C_Unknown  ->
-        let uu___591_4459 =
+        let uu___591_4537 =
           FStar_Reflection_Data.ref_C_Unknown.FStar_Reflection_Data.t  in
         {
-          FStar_Syntax_Syntax.n = (uu___591_4459.FStar_Syntax_Syntax.n);
+          FStar_Syntax_Syntax.n = (uu___591_4537.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = rng;
-          FStar_Syntax_Syntax.vars = (uu___591_4459.FStar_Syntax_Syntax.vars)
+          FStar_Syntax_Syntax.vars = (uu___591_4537.FStar_Syntax_Syntax.vars)
         }
      in
   let unembed_comp_view w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____4478 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____4478 with
+    let uu____4556 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____4556 with
     | (hd1,args) ->
-        let uu____4523 =
-          let uu____4536 =
-            let uu____4537 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____4537.FStar_Syntax_Syntax.n  in
-          (uu____4536, args)  in
-        (match uu____4523 with
+        let uu____4601 =
+          let uu____4614 =
+            let uu____4615 = FStar_Syntax_Util.un_uinst hd1  in
+            uu____4615.FStar_Syntax_Syntax.n  in
+          (uu____4614, args)  in
+        (match uu____4601 with
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(t2,uu____4552)::(md,uu____4554)::[]) when
+            fv,(t2,uu____4630)::(md,uu____4632)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Total.FStar_Reflection_Data.lid
              ->
-             let uu____4589 = unembed' w e_term t2  in
-             FStar_Util.bind_opt uu____4589
+             let uu____4667 = unembed' w e_term t2  in
+             FStar_Util.bind_opt uu____4667
                (fun t3  ->
-                  let uu____4595 =
-                    let uu____4600 = FStar_Syntax_Embeddings.e_option e_term
+                  let uu____4673 =
+                    let uu____4678 = FStar_Syntax_Embeddings.e_option e_term
                        in
-                    unembed' w uu____4600 md  in
-                  FStar_Util.bind_opt uu____4595
+                    unembed' w uu____4678 md  in
+                  FStar_Util.bind_opt uu____4673
                     (fun md1  ->
                        FStar_All.pipe_left
-                         (fun _4615  -> FStar_Pervasives_Native.Some _4615)
+                         (fun _4693  -> FStar_Pervasives_Native.Some _4693)
                          (FStar_Reflection_Data.C_Total (t3, md1))))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(pre,uu____4620)::(post,uu____4622)::[]) when
+            fv,(pre,uu____4698)::(post,uu____4700)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Lemma.FStar_Reflection_Data.lid
              ->
-             let uu____4657 = unembed' w e_term pre  in
-             FStar_Util.bind_opt uu____4657
+             let uu____4735 = unembed' w e_term pre  in
+             FStar_Util.bind_opt uu____4735
                (fun pre1  ->
-                  let uu____4663 = unembed' w e_term post  in
-                  FStar_Util.bind_opt uu____4663
+                  let uu____4741 = unembed' w e_term post  in
+                  FStar_Util.bind_opt uu____4741
                     (fun post1  ->
                        FStar_All.pipe_left
-                         (fun _4670  -> FStar_Pervasives_Native.Some _4670)
+                         (fun _4748  -> FStar_Pervasives_Native.Some _4748)
                          (FStar_Reflection_Data.C_Lemma (pre1, post1))))
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Unknown.FStar_Reflection_Data.lid
              ->
              FStar_All.pipe_left
-               (fun _4688  -> FStar_Pervasives_Native.Some _4688)
+               (fun _4766  -> FStar_Pervasives_Native.Some _4766)
                FStar_Reflection_Data.C_Unknown
-         | uu____4689 ->
+         | uu____4767 ->
              (if w
               then
-                (let uu____4704 =
-                   let uu____4710 =
-                     let uu____4712 = FStar_Syntax_Print.term_to_string t1
+                (let uu____4782 =
+                   let uu____4788 =
+                     let uu____4790 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.format1 "Not an embedded comp_view: %s"
-                       uu____4712
+                       uu____4790
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____4710)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____4704)
+                   (FStar_Errors.Warning_NotEmbedded, uu____4788)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____4782)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -1450,23 +1458,23 @@ let (e_order : FStar_Order.order FStar_Syntax_Embeddings.embedding) =
       | FStar_Order.Lt  -> FStar_Reflection_Data.ord_Lt
       | FStar_Order.Eq  -> FStar_Reflection_Data.ord_Eq
       | FStar_Order.Gt  -> FStar_Reflection_Data.ord_Gt  in
-    let uu___638_4737 = r  in
+    let uu___638_4815 = r  in
     {
-      FStar_Syntax_Syntax.n = (uu___638_4737.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___638_4815.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___638_4737.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___638_4815.FStar_Syntax_Syntax.vars)
     }  in
   let unembed_order w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____4758 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____4758 with
+    let uu____4836 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____4836 with
     | (hd1,args) ->
-        let uu____4803 =
-          let uu____4818 =
-            let uu____4819 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____4819.FStar_Syntax_Syntax.n  in
-          (uu____4818, args)  in
-        (match uu____4803 with
+        let uu____4881 =
+          let uu____4896 =
+            let uu____4897 = FStar_Syntax_Util.un_uinst hd1  in
+            uu____4897.FStar_Syntax_Syntax.n  in
+          (uu____4896, args)  in
+        (match uu____4881 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ord_Lt_lid
@@ -1479,18 +1487,18 @@ let (e_order : FStar_Order.order FStar_Syntax_Embeddings.embedding) =
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ord_Gt_lid
              -> FStar_Pervasives_Native.Some FStar_Order.Gt
-         | uu____4891 ->
+         | uu____4969 ->
              (if w
               then
-                (let uu____4908 =
-                   let uu____4914 =
-                     let uu____4916 = FStar_Syntax_Print.term_to_string t1
+                (let uu____4986 =
+                   let uu____4992 =
+                     let uu____4994 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.format1 "Not an embedded order: %s"
-                       uu____4916
+                       uu____4994
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____4914)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____4908)
+                   (FStar_Errors.Warning_NotEmbedded, uu____4992)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____4986)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -1502,28 +1510,28 @@ let (e_sigelt : FStar_Syntax_Syntax.sigelt FStar_Syntax_Embeddings.embedding)
       FStar_Syntax_Syntax.Lazy_sigelt (FStar_Pervasives_Native.Some rng)
      in
   let unembed_sigelt w t =
-    let uu____4953 =
-      let uu____4954 = FStar_Syntax_Subst.compress t  in
-      uu____4954.FStar_Syntax_Syntax.n  in
-    match uu____4953 with
+    let uu____5031 =
+      let uu____5032 = FStar_Syntax_Subst.compress t  in
+      uu____5032.FStar_Syntax_Syntax.n  in
+    match uu____5031 with
     | FStar_Syntax_Syntax.Tm_lazy
         { FStar_Syntax_Syntax.blob = b;
           FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_sigelt ;
-          FStar_Syntax_Syntax.ltyp = uu____4960;
-          FStar_Syntax_Syntax.rng = uu____4961;_}
+          FStar_Syntax_Syntax.ltyp = uu____5038;
+          FStar_Syntax_Syntax.rng = uu____5039;_}
         ->
-        let uu____4964 = FStar_Dyn.undyn b  in
-        FStar_Pervasives_Native.Some uu____4964
-    | uu____4965 ->
+        let uu____5042 = FStar_Dyn.undyn b  in
+        FStar_Pervasives_Native.Some uu____5042
+    | uu____5043 ->
         (if w
          then
-           (let uu____4968 =
-              let uu____4974 =
-                let uu____4976 = FStar_Syntax_Print.term_to_string t  in
-                FStar_Util.format1 "Not an embedded sigelt: %s" uu____4976
+           (let uu____5046 =
+              let uu____5052 =
+                let uu____5054 = FStar_Syntax_Print.term_to_string t  in
+                FStar_Util.format1 "Not an embedded sigelt: %s" uu____5054
                  in
-              (FStar_Errors.Warning_NotEmbedded, uu____4974)  in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____4968)
+              (FStar_Errors.Warning_NotEmbedded, uu____5052)  in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____5046)
          else ();
          FStar_Pervasives_Native.None)
      in
@@ -1533,22 +1541,22 @@ let (e_ident : FStar_Ident.ident FStar_Syntax_Embeddings.embedding) =
     FStar_Syntax_Embeddings.e_tuple2 FStar_Syntax_Embeddings.e_range
       FStar_Syntax_Embeddings.e_string
      in
-  let embed_ident i rng uu____5016 uu____5017 =
-    let uu____5019 =
-      let uu____5025 = FStar_Ident.range_of_id i  in
-      let uu____5026 = FStar_Ident.text_of_id i  in (uu____5025, uu____5026)
+  let embed_ident i rng uu____5094 uu____5095 =
+    let uu____5097 =
+      let uu____5103 = FStar_Ident.range_of_id i  in
+      let uu____5104 = FStar_Ident.text_of_id i  in (uu____5103, uu____5104)
        in
-    embed repr rng uu____5019  in
-  let unembed_ident t w uu____5053 =
-    let uu____5058 = unembed' w repr t  in
-    match uu____5058 with
+    embed repr rng uu____5097  in
+  let unembed_ident t w uu____5131 =
+    let uu____5136 = unembed' w repr t  in
+    match uu____5136 with
     | FStar_Pervasives_Native.Some (rng,s) ->
-        let uu____5082 = FStar_Ident.mk_ident (s, rng)  in
-        FStar_Pervasives_Native.Some uu____5082
+        let uu____5160 = FStar_Ident.mk_ident (s, rng)  in
+        FStar_Pervasives_Native.Some uu____5160
     | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None  in
-  let uu____5089 = FStar_Syntax_Embeddings.emb_typ_of repr  in
+  let uu____5167 = FStar_Syntax_Embeddings.emb_typ_of repr  in
   FStar_Syntax_Embeddings.mk_emb_full embed_ident unembed_ident
-    FStar_Reflection_Data.fstar_refl_ident FStar_Ident.text_of_id uu____5089
+    FStar_Reflection_Data.fstar_refl_ident FStar_Ident.text_of_id uu____5167
   
 let (e_univ_name :
   FStar_Syntax_Syntax.univ_name FStar_Syntax_Embeddings.embedding) =
@@ -1563,187 +1571,187 @@ let (e_sigelt_view :
   let embed_sigelt_view rng sev =
     match sev with
     | FStar_Reflection_Data.Sg_Let (r,fv,univs1,ty,t) ->
-        let uu____5128 =
-          let uu____5133 =
-            let uu____5134 =
-              let uu____5143 = embed FStar_Syntax_Embeddings.e_bool rng r  in
-              FStar_Syntax_Syntax.as_arg uu____5143  in
-            let uu____5145 =
-              let uu____5156 =
-                let uu____5165 = embed e_fv rng fv  in
-                FStar_Syntax_Syntax.as_arg uu____5165  in
-              let uu____5166 =
-                let uu____5177 =
-                  let uu____5186 = embed e_univ_names rng univs1  in
-                  FStar_Syntax_Syntax.as_arg uu____5186  in
-                let uu____5189 =
-                  let uu____5200 =
-                    let uu____5209 = embed e_term rng ty  in
-                    FStar_Syntax_Syntax.as_arg uu____5209  in
-                  let uu____5210 =
-                    let uu____5221 =
-                      let uu____5230 = embed e_term rng t  in
-                      FStar_Syntax_Syntax.as_arg uu____5230  in
-                    [uu____5221]  in
-                  uu____5200 :: uu____5210  in
-                uu____5177 :: uu____5189  in
-              uu____5156 :: uu____5166  in
-            uu____5134 :: uu____5145  in
+        let uu____5206 =
+          let uu____5211 =
+            let uu____5212 =
+              let uu____5221 = embed FStar_Syntax_Embeddings.e_bool rng r  in
+              FStar_Syntax_Syntax.as_arg uu____5221  in
+            let uu____5223 =
+              let uu____5234 =
+                let uu____5243 = embed e_fv rng fv  in
+                FStar_Syntax_Syntax.as_arg uu____5243  in
+              let uu____5244 =
+                let uu____5255 =
+                  let uu____5264 = embed e_univ_names rng univs1  in
+                  FStar_Syntax_Syntax.as_arg uu____5264  in
+                let uu____5267 =
+                  let uu____5278 =
+                    let uu____5287 = embed e_term rng ty  in
+                    FStar_Syntax_Syntax.as_arg uu____5287  in
+                  let uu____5288 =
+                    let uu____5299 =
+                      let uu____5308 = embed e_term rng t  in
+                      FStar_Syntax_Syntax.as_arg uu____5308  in
+                    [uu____5299]  in
+                  uu____5278 :: uu____5288  in
+                uu____5255 :: uu____5267  in
+              uu____5234 :: uu____5244  in
+            uu____5212 :: uu____5223  in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.ref_Sg_Let.FStar_Reflection_Data.t
-            uu____5133
+            uu____5211
            in
-        uu____5128 FStar_Pervasives_Native.None rng
+        uu____5206 FStar_Pervasives_Native.None rng
     | FStar_Reflection_Data.Sg_Constructor (nm,ty) ->
-        let uu____5281 =
-          let uu____5286 =
-            let uu____5287 =
-              let uu____5296 =
+        let uu____5359 =
+          let uu____5364 =
+            let uu____5365 =
+              let uu____5374 =
                 embed FStar_Syntax_Embeddings.e_string_list rng nm  in
-              FStar_Syntax_Syntax.as_arg uu____5296  in
-            let uu____5300 =
-              let uu____5311 =
-                let uu____5320 = embed e_term rng ty  in
-                FStar_Syntax_Syntax.as_arg uu____5320  in
-              [uu____5311]  in
-            uu____5287 :: uu____5300  in
+              FStar_Syntax_Syntax.as_arg uu____5374  in
+            let uu____5378 =
+              let uu____5389 =
+                let uu____5398 = embed e_term rng ty  in
+                FStar_Syntax_Syntax.as_arg uu____5398  in
+              [uu____5389]  in
+            uu____5365 :: uu____5378  in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.ref_Sg_Constructor.FStar_Reflection_Data.t
-            uu____5286
+            uu____5364
            in
-        uu____5281 FStar_Pervasives_Native.None rng
+        uu____5359 FStar_Pervasives_Native.None rng
     | FStar_Reflection_Data.Sg_Inductive (nm,univs1,bs,t,dcs) ->
-        let uu____5362 =
-          let uu____5367 =
-            let uu____5368 =
-              let uu____5377 =
+        let uu____5440 =
+          let uu____5445 =
+            let uu____5446 =
+              let uu____5455 =
                 embed FStar_Syntax_Embeddings.e_string_list rng nm  in
-              FStar_Syntax_Syntax.as_arg uu____5377  in
-            let uu____5381 =
-              let uu____5392 =
-                let uu____5401 = embed e_univ_names rng univs1  in
-                FStar_Syntax_Syntax.as_arg uu____5401  in
-              let uu____5404 =
-                let uu____5415 =
-                  let uu____5424 = embed e_binders rng bs  in
-                  FStar_Syntax_Syntax.as_arg uu____5424  in
-                let uu____5425 =
-                  let uu____5436 =
-                    let uu____5445 = embed e_term rng t  in
-                    FStar_Syntax_Syntax.as_arg uu____5445  in
-                  let uu____5446 =
-                    let uu____5457 =
-                      let uu____5466 =
-                        let uu____5467 =
+              FStar_Syntax_Syntax.as_arg uu____5455  in
+            let uu____5459 =
+              let uu____5470 =
+                let uu____5479 = embed e_univ_names rng univs1  in
+                FStar_Syntax_Syntax.as_arg uu____5479  in
+              let uu____5482 =
+                let uu____5493 =
+                  let uu____5502 = embed e_binders rng bs  in
+                  FStar_Syntax_Syntax.as_arg uu____5502  in
+                let uu____5503 =
+                  let uu____5514 =
+                    let uu____5523 = embed e_term rng t  in
+                    FStar_Syntax_Syntax.as_arg uu____5523  in
+                  let uu____5524 =
+                    let uu____5535 =
+                      let uu____5544 =
+                        let uu____5545 =
                           FStar_Syntax_Embeddings.e_list
                             FStar_Syntax_Embeddings.e_string_list
                            in
-                        embed uu____5467 rng dcs  in
-                      FStar_Syntax_Syntax.as_arg uu____5466  in
-                    [uu____5457]  in
-                  uu____5436 :: uu____5446  in
-                uu____5415 :: uu____5425  in
-              uu____5392 :: uu____5404  in
-            uu____5368 :: uu____5381  in
+                        embed uu____5545 rng dcs  in
+                      FStar_Syntax_Syntax.as_arg uu____5544  in
+                    [uu____5535]  in
+                  uu____5514 :: uu____5524  in
+                uu____5493 :: uu____5503  in
+              uu____5470 :: uu____5482  in
+            uu____5446 :: uu____5459  in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.ref_Sg_Inductive.FStar_Reflection_Data.t
-            uu____5367
+            uu____5445
            in
-        uu____5362 FStar_Pervasives_Native.None rng
+        uu____5440 FStar_Pervasives_Native.None rng
     | FStar_Reflection_Data.Unk  ->
-        let uu___714_5531 =
+        let uu___714_5609 =
           FStar_Reflection_Data.ref_Unk.FStar_Reflection_Data.t  in
         {
-          FStar_Syntax_Syntax.n = (uu___714_5531.FStar_Syntax_Syntax.n);
+          FStar_Syntax_Syntax.n = (uu___714_5609.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = rng;
-          FStar_Syntax_Syntax.vars = (uu___714_5531.FStar_Syntax_Syntax.vars)
+          FStar_Syntax_Syntax.vars = (uu___714_5609.FStar_Syntax_Syntax.vars)
         }
      in
   let unembed_sigelt_view w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____5550 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____5550 with
+    let uu____5628 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____5628 with
     | (hd1,args) ->
-        let uu____5595 =
-          let uu____5608 =
-            let uu____5609 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____5609.FStar_Syntax_Syntax.n  in
-          (uu____5608, args)  in
-        (match uu____5595 with
+        let uu____5673 =
+          let uu____5686 =
+            let uu____5687 = FStar_Syntax_Util.un_uinst hd1  in
+            uu____5687.FStar_Syntax_Syntax.n  in
+          (uu____5686, args)  in
+        (match uu____5673 with
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(nm,uu____5624)::(us,uu____5626)::(bs,uu____5628)::(t2,uu____5630)::
-            (dcs,uu____5632)::[]) when
+            fv,(nm,uu____5702)::(us,uu____5704)::(bs,uu____5706)::(t2,uu____5708)::
+            (dcs,uu____5710)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Sg_Inductive.FStar_Reflection_Data.lid
              ->
-             let uu____5697 =
+             let uu____5775 =
                unembed' w FStar_Syntax_Embeddings.e_string_list nm  in
-             FStar_Util.bind_opt uu____5697
+             FStar_Util.bind_opt uu____5775
                (fun nm1  ->
-                  let uu____5715 = unembed' w e_univ_names us  in
-                  FStar_Util.bind_opt uu____5715
+                  let uu____5793 = unembed' w e_univ_names us  in
+                  FStar_Util.bind_opt uu____5793
                     (fun us1  ->
-                       let uu____5729 = unembed' w e_binders bs  in
-                       FStar_Util.bind_opt uu____5729
+                       let uu____5807 = unembed' w e_binders bs  in
+                       FStar_Util.bind_opt uu____5807
                          (fun bs1  ->
-                            let uu____5735 = unembed' w e_term t2  in
-                            FStar_Util.bind_opt uu____5735
+                            let uu____5813 = unembed' w e_term t2  in
+                            FStar_Util.bind_opt uu____5813
                               (fun t3  ->
-                                 let uu____5741 =
-                                   let uu____5749 =
+                                 let uu____5819 =
+                                   let uu____5827 =
                                      FStar_Syntax_Embeddings.e_list
                                        FStar_Syntax_Embeddings.e_string_list
                                       in
-                                   unembed' w uu____5749 dcs  in
-                                 FStar_Util.bind_opt uu____5741
+                                   unembed' w uu____5827 dcs  in
+                                 FStar_Util.bind_opt uu____5819
                                    (fun dcs1  ->
                                       FStar_All.pipe_left
-                                        (fun _5779  ->
-                                           FStar_Pervasives_Native.Some _5779)
+                                        (fun _5857  ->
+                                           FStar_Pervasives_Native.Some _5857)
                                         (FStar_Reflection_Data.Sg_Inductive
                                            (nm1, us1, bs1, t3, dcs1)))))))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(r,uu____5788)::(fvar1,uu____5790)::(univs1,uu____5792)::
-            (ty,uu____5794)::(t2,uu____5796)::[]) when
+            fv,(r,uu____5866)::(fvar1,uu____5868)::(univs1,uu____5870)::
+            (ty,uu____5872)::(t2,uu____5874)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Sg_Let.FStar_Reflection_Data.lid
              ->
-             let uu____5861 = unembed' w FStar_Syntax_Embeddings.e_bool r  in
-             FStar_Util.bind_opt uu____5861
+             let uu____5939 = unembed' w FStar_Syntax_Embeddings.e_bool r  in
+             FStar_Util.bind_opt uu____5939
                (fun r1  ->
-                  let uu____5871 = unembed' w e_fv fvar1  in
-                  FStar_Util.bind_opt uu____5871
+                  let uu____5949 = unembed' w e_fv fvar1  in
+                  FStar_Util.bind_opt uu____5949
                     (fun fvar2  ->
-                       let uu____5877 = unembed' w e_univ_names univs1  in
-                       FStar_Util.bind_opt uu____5877
+                       let uu____5955 = unembed' w e_univ_names univs1  in
+                       FStar_Util.bind_opt uu____5955
                          (fun univs2  ->
-                            let uu____5891 = unembed' w e_term ty  in
-                            FStar_Util.bind_opt uu____5891
+                            let uu____5969 = unembed' w e_term ty  in
+                            FStar_Util.bind_opt uu____5969
                               (fun ty1  ->
-                                 let uu____5897 = unembed' w e_term t2  in
-                                 FStar_Util.bind_opt uu____5897
+                                 let uu____5975 = unembed' w e_term t2  in
+                                 FStar_Util.bind_opt uu____5975
                                    (fun t3  ->
                                       FStar_All.pipe_left
-                                        (fun _5904  ->
-                                           FStar_Pervasives_Native.Some _5904)
+                                        (fun _5982  ->
+                                           FStar_Pervasives_Native.Some _5982)
                                         (FStar_Reflection_Data.Sg_Let
                                            (r1, fvar2, univs2, ty1, t3)))))))
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Unk.FStar_Reflection_Data.lid
              -> FStar_Pervasives_Native.Some FStar_Reflection_Data.Unk
-         | uu____5923 ->
+         | uu____6001 ->
              (if w
               then
-                (let uu____5938 =
-                   let uu____5944 =
-                     let uu____5946 = FStar_Syntax_Print.term_to_string t1
+                (let uu____6016 =
+                   let uu____6022 =
+                     let uu____6024 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.format1 "Not an embedded sigelt_view: %s"
-                       uu____5946
+                       uu____6024
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____5944)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____5938)
+                   (FStar_Errors.Warning_NotEmbedded, uu____6022)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____6016)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -1757,93 +1765,93 @@ let (e_exp : FStar_Reflection_Data.exp FStar_Syntax_Embeddings.embedding) =
       | FStar_Reflection_Data.Unit  ->
           FStar_Reflection_Data.ref_E_Unit.FStar_Reflection_Data.t
       | FStar_Reflection_Data.Var i ->
-          let uu____5972 =
-            let uu____5977 =
-              let uu____5978 =
-                let uu____5987 =
-                  let uu____5988 = FStar_BigInt.string_of_big_int i  in
-                  FStar_Syntax_Util.exp_int uu____5988  in
-                FStar_Syntax_Syntax.as_arg uu____5987  in
-              [uu____5978]  in
+          let uu____6050 =
+            let uu____6055 =
+              let uu____6056 =
+                let uu____6065 =
+                  let uu____6066 = FStar_BigInt.string_of_big_int i  in
+                  FStar_Syntax_Util.exp_int uu____6066  in
+                FStar_Syntax_Syntax.as_arg uu____6065  in
+              [uu____6056]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_E_Var.FStar_Reflection_Data.t
-              uu____5977
+              uu____6055
              in
-          uu____5972 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____6050 FStar_Pervasives_Native.None FStar_Range.dummyRange
       | FStar_Reflection_Data.Mult (e1,e2) ->
-          let uu____6008 =
-            let uu____6013 =
-              let uu____6014 =
-                let uu____6023 = embed_exp rng e1  in
-                FStar_Syntax_Syntax.as_arg uu____6023  in
-              let uu____6024 =
-                let uu____6035 =
-                  let uu____6044 = embed_exp rng e2  in
-                  FStar_Syntax_Syntax.as_arg uu____6044  in
-                [uu____6035]  in
-              uu____6014 :: uu____6024  in
+          let uu____6086 =
+            let uu____6091 =
+              let uu____6092 =
+                let uu____6101 = embed_exp rng e1  in
+                FStar_Syntax_Syntax.as_arg uu____6101  in
+              let uu____6102 =
+                let uu____6113 =
+                  let uu____6122 = embed_exp rng e2  in
+                  FStar_Syntax_Syntax.as_arg uu____6122  in
+                [uu____6113]  in
+              uu____6092 :: uu____6102  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_E_Mult.FStar_Reflection_Data.t
-              uu____6013
+              uu____6091
              in
-          uu____6008 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____6086 FStar_Pervasives_Native.None FStar_Range.dummyRange
        in
-    let uu___789_6069 = r  in
+    let uu___789_6147 = r  in
     {
-      FStar_Syntax_Syntax.n = (uu___789_6069.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___789_6147.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___789_6069.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___789_6147.FStar_Syntax_Syntax.vars)
     }  in
   let rec unembed_exp w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____6090 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____6090 with
+    let uu____6168 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____6168 with
     | (hd1,args) ->
-        let uu____6135 =
-          let uu____6148 =
-            let uu____6149 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____6149.FStar_Syntax_Syntax.n  in
-          (uu____6148, args)  in
-        (match uu____6135 with
+        let uu____6213 =
+          let uu____6226 =
+            let uu____6227 = FStar_Syntax_Util.un_uinst hd1  in
+            uu____6227.FStar_Syntax_Syntax.n  in
+          (uu____6226, args)  in
+        (match uu____6213 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_E_Unit.FStar_Reflection_Data.lid
              -> FStar_Pervasives_Native.Some FStar_Reflection_Data.Unit
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(i,uu____6179)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(i,uu____6257)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_E_Var.FStar_Reflection_Data.lid
              ->
-             let uu____6204 = unembed' w FStar_Syntax_Embeddings.e_int i  in
-             FStar_Util.bind_opt uu____6204
+             let uu____6282 = unembed' w FStar_Syntax_Embeddings.e_int i  in
+             FStar_Util.bind_opt uu____6282
                (fun i1  ->
                   FStar_All.pipe_left
-                    (fun _6211  -> FStar_Pervasives_Native.Some _6211)
+                    (fun _6289  -> FStar_Pervasives_Native.Some _6289)
                     (FStar_Reflection_Data.Var i1))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(e1,uu____6214)::(e2,uu____6216)::[]) when
+            fv,(e1,uu____6292)::(e2,uu____6294)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_E_Mult.FStar_Reflection_Data.lid
              ->
-             let uu____6251 = unembed_exp w e1  in
-             FStar_Util.bind_opt uu____6251
+             let uu____6329 = unembed_exp w e1  in
+             FStar_Util.bind_opt uu____6329
                (fun e11  ->
-                  let uu____6257 = unembed_exp w e2  in
-                  FStar_Util.bind_opt uu____6257
+                  let uu____6335 = unembed_exp w e2  in
+                  FStar_Util.bind_opt uu____6335
                     (fun e21  ->
                        FStar_All.pipe_left
-                         (fun _6264  -> FStar_Pervasives_Native.Some _6264)
+                         (fun _6342  -> FStar_Pervasives_Native.Some _6342)
                          (FStar_Reflection_Data.Mult (e11, e21))))
-         | uu____6265 ->
+         | uu____6343 ->
              (if w
               then
-                (let uu____6280 =
-                   let uu____6286 =
-                     let uu____6288 = FStar_Syntax_Print.term_to_string t1
+                (let uu____6358 =
+                   let uu____6364 =
+                     let uu____6366 = FStar_Syntax_Print.term_to_string t1
                         in
-                     FStar_Util.format1 "Not an embedded exp: %s" uu____6288
+                     FStar_Util.format1 "Not an embedded exp: %s" uu____6366
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____6286)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____6280)
+                   (FStar_Errors.Warning_NotEmbedded, uu____6364)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____6358)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -1858,18 +1866,18 @@ let (e_attributes :
   = FStar_Syntax_Embeddings.e_list e_attribute 
 let (e_lid : FStar_Ident.lid FStar_Syntax_Embeddings.embedding) =
   let embed1 rng lid =
-    let uu____6319 = FStar_Ident.path_of_lid lid  in
-    embed FStar_Syntax_Embeddings.e_string_list rng uu____6319  in
+    let uu____6397 = FStar_Ident.path_of_lid lid  in
+    embed FStar_Syntax_Embeddings.e_string_list rng uu____6397  in
   let unembed1 w t =
-    let uu____6347 = unembed' w FStar_Syntax_Embeddings.e_string_list t  in
-    FStar_Util.map_opt uu____6347
+    let uu____6425 = unembed' w FStar_Syntax_Embeddings.e_string_list t  in
+    FStar_Util.map_opt uu____6425
       (fun p  -> FStar_Ident.lid_of_path p t.FStar_Syntax_Syntax.pos)
      in
-  let uu____6364 = FStar_Syntax_Syntax.t_list_of FStar_Syntax_Syntax.t_string
+  let uu____6442 = FStar_Syntax_Syntax.t_list_of FStar_Syntax_Syntax.t_string
      in
   FStar_Syntax_Embeddings.mk_emb_full
-    (fun x  -> fun r  -> fun uu____6371  -> fun uu____6372  -> embed1 r x)
-    (fun x  -> fun w  -> fun uu____6379  -> unembed1 w x) uu____6364
+    (fun x  -> fun r  -> fun uu____6449  -> fun uu____6450  -> embed1 r x)
+    (fun x  -> fun w  -> fun uu____6457  -> unembed1 w x) uu____6442
     FStar_Ident.string_of_lid FStar_Syntax_Syntax.ET_abstract
   
 let (e_qualifier :
@@ -1914,120 +1922,120 @@ let (e_qualifier :
       | FStar_Syntax_Syntax.OnlyName  ->
           FStar_Reflection_Data.ref_qual_OnlyName.FStar_Reflection_Data.t
       | FStar_Syntax_Syntax.Reflectable l ->
-          let uu____6402 =
-            let uu____6407 =
-              let uu____6408 =
-                let uu____6417 = embed e_lid rng l  in
-                FStar_Syntax_Syntax.as_arg uu____6417  in
-              [uu____6408]  in
+          let uu____6480 =
+            let uu____6485 =
+              let uu____6486 =
+                let uu____6495 = embed e_lid rng l  in
+                FStar_Syntax_Syntax.as_arg uu____6495  in
+              [uu____6486]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_qual_Reflectable.FStar_Reflection_Data.t
-              uu____6407
+              uu____6485
              in
-          uu____6402 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____6480 FStar_Pervasives_Native.None FStar_Range.dummyRange
       | FStar_Syntax_Syntax.Discriminator l ->
-          let uu____6435 =
-            let uu____6440 =
-              let uu____6441 =
-                let uu____6450 = embed e_lid rng l  in
-                FStar_Syntax_Syntax.as_arg uu____6450  in
-              [uu____6441]  in
+          let uu____6513 =
+            let uu____6518 =
+              let uu____6519 =
+                let uu____6528 = embed e_lid rng l  in
+                FStar_Syntax_Syntax.as_arg uu____6528  in
+              [uu____6519]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_qual_Discriminator.FStar_Reflection_Data.t
-              uu____6440
+              uu____6518
              in
-          uu____6435 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____6513 FStar_Pervasives_Native.None FStar_Range.dummyRange
       | FStar_Syntax_Syntax.Action l ->
-          let uu____6468 =
-            let uu____6473 =
-              let uu____6474 =
-                let uu____6483 = embed e_lid rng l  in
-                FStar_Syntax_Syntax.as_arg uu____6483  in
-              [uu____6474]  in
+          let uu____6546 =
+            let uu____6551 =
+              let uu____6552 =
+                let uu____6561 = embed e_lid rng l  in
+                FStar_Syntax_Syntax.as_arg uu____6561  in
+              [uu____6552]  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_qual_Action.FStar_Reflection_Data.t
-              uu____6473
+              uu____6551
              in
-          uu____6468 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____6546 FStar_Pervasives_Native.None FStar_Range.dummyRange
       | FStar_Syntax_Syntax.Projector (l,i) ->
-          let uu____6502 =
-            let uu____6507 =
-              let uu____6508 =
-                let uu____6517 = embed e_lid rng l  in
-                FStar_Syntax_Syntax.as_arg uu____6517  in
-              let uu____6518 =
-                let uu____6529 =
-                  let uu____6538 = embed e_ident rng i  in
-                  FStar_Syntax_Syntax.as_arg uu____6538  in
-                [uu____6529]  in
-              uu____6508 :: uu____6518  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_qual_Projector.FStar_Reflection_Data.t
-              uu____6507
-             in
-          uu____6502 FStar_Pervasives_Native.None FStar_Range.dummyRange
-      | FStar_Syntax_Syntax.RecordType (ids1,ids2) ->
-          let uu____6573 =
-            let uu____6578 =
-              let uu____6579 =
-                let uu____6588 =
-                  let uu____6589 = FStar_Syntax_Embeddings.e_list e_ident  in
-                  embed uu____6589 rng ids1  in
-                FStar_Syntax_Syntax.as_arg uu____6588  in
+          let uu____6580 =
+            let uu____6585 =
+              let uu____6586 =
+                let uu____6595 = embed e_lid rng l  in
+                FStar_Syntax_Syntax.as_arg uu____6595  in
               let uu____6596 =
                 let uu____6607 =
-                  let uu____6616 =
-                    let uu____6617 = FStar_Syntax_Embeddings.e_list e_ident
-                       in
-                    embed uu____6617 rng ids2  in
+                  let uu____6616 = embed e_ident rng i  in
                   FStar_Syntax_Syntax.as_arg uu____6616  in
                 [uu____6607]  in
-              uu____6579 :: uu____6596  in
+              uu____6586 :: uu____6596  in
+            FStar_Syntax_Syntax.mk_Tm_app
+              FStar_Reflection_Data.ref_qual_Projector.FStar_Reflection_Data.t
+              uu____6585
+             in
+          uu____6580 FStar_Pervasives_Native.None FStar_Range.dummyRange
+      | FStar_Syntax_Syntax.RecordType (ids1,ids2) ->
+          let uu____6651 =
+            let uu____6656 =
+              let uu____6657 =
+                let uu____6666 =
+                  let uu____6667 = FStar_Syntax_Embeddings.e_list e_ident  in
+                  embed uu____6667 rng ids1  in
+                FStar_Syntax_Syntax.as_arg uu____6666  in
+              let uu____6674 =
+                let uu____6685 =
+                  let uu____6694 =
+                    let uu____6695 = FStar_Syntax_Embeddings.e_list e_ident
+                       in
+                    embed uu____6695 rng ids2  in
+                  FStar_Syntax_Syntax.as_arg uu____6694  in
+                [uu____6685]  in
+              uu____6657 :: uu____6674  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_qual_RecordType.FStar_Reflection_Data.t
-              uu____6578
+              uu____6656
              in
-          uu____6573 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____6651 FStar_Pervasives_Native.None FStar_Range.dummyRange
       | FStar_Syntax_Syntax.RecordConstructor (ids1,ids2) ->
-          let uu____6658 =
-            let uu____6663 =
-              let uu____6664 =
-                let uu____6673 =
-                  let uu____6674 = FStar_Syntax_Embeddings.e_list e_ident  in
-                  embed uu____6674 rng ids1  in
-                FStar_Syntax_Syntax.as_arg uu____6673  in
-              let uu____6681 =
-                let uu____6692 =
-                  let uu____6701 =
-                    let uu____6702 = FStar_Syntax_Embeddings.e_list e_ident
+          let uu____6736 =
+            let uu____6741 =
+              let uu____6742 =
+                let uu____6751 =
+                  let uu____6752 = FStar_Syntax_Embeddings.e_list e_ident  in
+                  embed uu____6752 rng ids1  in
+                FStar_Syntax_Syntax.as_arg uu____6751  in
+              let uu____6759 =
+                let uu____6770 =
+                  let uu____6779 =
+                    let uu____6780 = FStar_Syntax_Embeddings.e_list e_ident
                        in
-                    embed uu____6702 rng ids2  in
-                  FStar_Syntax_Syntax.as_arg uu____6701  in
-                [uu____6692]  in
-              uu____6664 :: uu____6681  in
+                    embed uu____6780 rng ids2  in
+                  FStar_Syntax_Syntax.as_arg uu____6779  in
+                [uu____6770]  in
+              uu____6742 :: uu____6759  in
             FStar_Syntax_Syntax.mk_Tm_app
               FStar_Reflection_Data.ref_qual_RecordConstructor.FStar_Reflection_Data.t
-              uu____6663
+              uu____6741
              in
-          uu____6658 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          uu____6736 FStar_Pervasives_Native.None FStar_Range.dummyRange
        in
-    let uu___879_6733 = r  in
+    let uu___879_6811 = r  in
     {
-      FStar_Syntax_Syntax.n = (uu___879_6733.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___879_6811.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___879_6733.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___879_6811.FStar_Syntax_Syntax.vars)
     }  in
   let unembed1 w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____6754 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____6754 with
+    let uu____6832 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____6832 with
     | (hd1,args) ->
-        let uu____6799 =
-          let uu____6812 =
-            let uu____6813 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____6813.FStar_Syntax_Syntax.n  in
-          (uu____6812, args)  in
-        (match uu____6799 with
+        let uu____6877 =
+          let uu____6890 =
+            let uu____6891 = FStar_Syntax_Util.un_uinst hd1  in
+            uu____6891.FStar_Syntax_Syntax.n  in
+          (uu____6890, args)  in
+        (match uu____6877 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Assumption.FStar_Reflection_Data.lid
@@ -2108,101 +2116,101 @@ let (e_qualifier :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_OnlyName.FStar_Reflection_Data.lid
              -> FStar_Pervasives_Native.Some FStar_Syntax_Syntax.OnlyName
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____7098)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____7176)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Reflectable.FStar_Reflection_Data.lid
              ->
-             let uu____7123 = unembed' w e_lid l  in
-             FStar_Util.bind_opt uu____7123
+             let uu____7201 = unembed' w e_lid l  in
+             FStar_Util.bind_opt uu____7201
                (fun l1  ->
                   FStar_All.pipe_left
-                    (fun _7130  -> FStar_Pervasives_Native.Some _7130)
+                    (fun _7208  -> FStar_Pervasives_Native.Some _7208)
                     (FStar_Syntax_Syntax.Reflectable l1))
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____7133)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____7211)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Discriminator.FStar_Reflection_Data.lid
              ->
-             let uu____7158 = unembed' w e_lid l  in
-             FStar_Util.bind_opt uu____7158
+             let uu____7236 = unembed' w e_lid l  in
+             FStar_Util.bind_opt uu____7236
                (fun l1  ->
                   FStar_All.pipe_left
-                    (fun _7165  -> FStar_Pervasives_Native.Some _7165)
+                    (fun _7243  -> FStar_Pervasives_Native.Some _7243)
                     (FStar_Syntax_Syntax.Discriminator l1))
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____7168)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____7246)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Action.FStar_Reflection_Data.lid
              ->
-             let uu____7193 = unembed' w e_lid l  in
-             FStar_Util.bind_opt uu____7193
+             let uu____7271 = unembed' w e_lid l  in
+             FStar_Util.bind_opt uu____7271
                (fun l1  ->
                   FStar_All.pipe_left
-                    (fun _7200  -> FStar_Pervasives_Native.Some _7200)
+                    (fun _7278  -> FStar_Pervasives_Native.Some _7278)
                     (FStar_Syntax_Syntax.Action l1))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(l,uu____7203)::(i,uu____7205)::[]) when
+            fv,(l,uu____7281)::(i,uu____7283)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Projector.FStar_Reflection_Data.lid
              ->
-             let uu____7240 = unembed' w e_lid l  in
-             FStar_Util.bind_opt uu____7240
+             let uu____7318 = unembed' w e_lid l  in
+             FStar_Util.bind_opt uu____7318
                (fun l1  ->
-                  let uu____7246 = unembed' w e_ident i  in
-                  FStar_Util.bind_opt uu____7246
+                  let uu____7324 = unembed' w e_ident i  in
+                  FStar_Util.bind_opt uu____7324
                     (fun i1  ->
                        FStar_All.pipe_left
-                         (fun _7253  -> FStar_Pervasives_Native.Some _7253)
+                         (fun _7331  -> FStar_Pervasives_Native.Some _7331)
                          (FStar_Syntax_Syntax.Projector (l1, i1))))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(ids1,uu____7256)::(ids2,uu____7258)::[]) when
+            fv,(ids1,uu____7334)::(ids2,uu____7336)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_RecordType.FStar_Reflection_Data.lid
              ->
-             let uu____7293 =
-               let uu____7298 = FStar_Syntax_Embeddings.e_list e_ident  in
-               unembed' w uu____7298 ids1  in
-             FStar_Util.bind_opt uu____7293
+             let uu____7371 =
+               let uu____7376 = FStar_Syntax_Embeddings.e_list e_ident  in
+               unembed' w uu____7376 ids1  in
+             FStar_Util.bind_opt uu____7371
                (fun ids11  ->
-                  let uu____7312 =
-                    let uu____7317 = FStar_Syntax_Embeddings.e_list e_ident
+                  let uu____7390 =
+                    let uu____7395 = FStar_Syntax_Embeddings.e_list e_ident
                        in
-                    unembed' w uu____7317 ids2  in
-                  FStar_Util.bind_opt uu____7312
+                    unembed' w uu____7395 ids2  in
+                  FStar_Util.bind_opt uu____7390
                     (fun ids21  ->
                        FStar_All.pipe_left
-                         (fun _7332  -> FStar_Pervasives_Native.Some _7332)
+                         (fun _7410  -> FStar_Pervasives_Native.Some _7410)
                          (FStar_Syntax_Syntax.RecordType (ids11, ids21))))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(ids1,uu____7339)::(ids2,uu____7341)::[]) when
+            fv,(ids1,uu____7417)::(ids2,uu____7419)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_RecordConstructor.FStar_Reflection_Data.lid
              ->
-             let uu____7376 =
-               let uu____7381 = FStar_Syntax_Embeddings.e_list e_ident  in
-               unembed' w uu____7381 ids1  in
-             FStar_Util.bind_opt uu____7376
+             let uu____7454 =
+               let uu____7459 = FStar_Syntax_Embeddings.e_list e_ident  in
+               unembed' w uu____7459 ids1  in
+             FStar_Util.bind_opt uu____7454
                (fun ids11  ->
-                  let uu____7395 =
-                    let uu____7400 = FStar_Syntax_Embeddings.e_list e_ident
+                  let uu____7473 =
+                    let uu____7478 = FStar_Syntax_Embeddings.e_list e_ident
                        in
-                    unembed' w uu____7400 ids2  in
-                  FStar_Util.bind_opt uu____7395
+                    unembed' w uu____7478 ids2  in
+                  FStar_Util.bind_opt uu____7473
                     (fun ids21  ->
                        FStar_All.pipe_left
-                         (fun _7415  -> FStar_Pervasives_Native.Some _7415)
+                         (fun _7493  -> FStar_Pervasives_Native.Some _7493)
                          (FStar_Syntax_Syntax.RecordConstructor
                             (ids11, ids21))))
-         | uu____7420 ->
+         | uu____7498 ->
              (if w
               then
-                (let uu____7435 =
-                   let uu____7441 =
-                     let uu____7443 = FStar_Syntax_Print.term_to_string t1
+                (let uu____7513 =
+                   let uu____7519 =
+                     let uu____7521 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.format1 "Not an embedded qualifier: %s"
-                       uu____7443
+                       uu____7521
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____7441)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____7435)
+                   (FStar_Errors.Warning_NotEmbedded, uu____7519)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____7513)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -2214,83 +2222,83 @@ let (unfold_lazy_bv :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i  ->
     let bv = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob  in
-    let uu____7461 =
-      let uu____7466 =
-        let uu____7467 =
-          let uu____7476 =
-            let uu____7477 = FStar_Reflection_Basic.inspect_bv bv  in
-            embed e_bv_view i.FStar_Syntax_Syntax.rng uu____7477  in
-          FStar_Syntax_Syntax.as_arg uu____7476  in
-        [uu____7467]  in
+    let uu____7539 =
+      let uu____7544 =
+        let uu____7545 =
+          let uu____7554 =
+            let uu____7555 = FStar_Reflection_Basic.inspect_bv bv  in
+            embed e_bv_view i.FStar_Syntax_Syntax.rng uu____7555  in
+          FStar_Syntax_Syntax.as_arg uu____7554  in
+        [uu____7545]  in
       FStar_Syntax_Syntax.mk_Tm_app
         FStar_Reflection_Data.fstar_refl_pack_bv.FStar_Reflection_Data.t
-        uu____7466
+        uu____7544
        in
-    uu____7461 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
+    uu____7539 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
   
 let (unfold_lazy_binder :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i  ->
     let binder = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob  in
-    let uu____7501 = FStar_Reflection_Basic.inspect_binder binder  in
-    match uu____7501 with
+    let uu____7579 = FStar_Reflection_Basic.inspect_binder binder  in
+    match uu____7579 with
     | (bv,aq) ->
-        let uu____7508 =
-          let uu____7513 =
-            let uu____7514 =
-              let uu____7523 = embed e_bv i.FStar_Syntax_Syntax.rng bv  in
-              FStar_Syntax_Syntax.as_arg uu____7523  in
-            let uu____7524 =
-              let uu____7535 =
-                let uu____7544 = embed e_aqualv i.FStar_Syntax_Syntax.rng aq
+        let uu____7586 =
+          let uu____7591 =
+            let uu____7592 =
+              let uu____7601 = embed e_bv i.FStar_Syntax_Syntax.rng bv  in
+              FStar_Syntax_Syntax.as_arg uu____7601  in
+            let uu____7602 =
+              let uu____7613 =
+                let uu____7622 = embed e_aqualv i.FStar_Syntax_Syntax.rng aq
                    in
-                FStar_Syntax_Syntax.as_arg uu____7544  in
-              [uu____7535]  in
-            uu____7514 :: uu____7524  in
+                FStar_Syntax_Syntax.as_arg uu____7622  in
+              [uu____7613]  in
+            uu____7592 :: uu____7602  in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.fstar_refl_pack_binder.FStar_Reflection_Data.t
-            uu____7513
+            uu____7591
            in
-        uu____7508 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
+        uu____7586 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
   
 let (unfold_lazy_fvar :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i  ->
     let fv = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob  in
-    let uu____7576 =
-      let uu____7581 =
-        let uu____7582 =
-          let uu____7591 =
-            let uu____7592 =
+    let uu____7654 =
+      let uu____7659 =
+        let uu____7660 =
+          let uu____7669 =
+            let uu____7670 =
               FStar_Syntax_Embeddings.e_list FStar_Syntax_Embeddings.e_string
                in
-            let uu____7599 = FStar_Reflection_Basic.inspect_fv fv  in
-            embed uu____7592 i.FStar_Syntax_Syntax.rng uu____7599  in
-          FStar_Syntax_Syntax.as_arg uu____7591  in
-        [uu____7582]  in
+            let uu____7677 = FStar_Reflection_Basic.inspect_fv fv  in
+            embed uu____7670 i.FStar_Syntax_Syntax.rng uu____7677  in
+          FStar_Syntax_Syntax.as_arg uu____7669  in
+        [uu____7660]  in
       FStar_Syntax_Syntax.mk_Tm_app
         FStar_Reflection_Data.fstar_refl_pack_fv.FStar_Reflection_Data.t
-        uu____7581
+        uu____7659
        in
-    uu____7576 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
+    uu____7654 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
   
 let (unfold_lazy_comp :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i  ->
     let comp = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob  in
-    let uu____7629 =
-      let uu____7634 =
-        let uu____7635 =
-          let uu____7644 =
-            let uu____7645 = FStar_Reflection_Basic.inspect_comp comp  in
-            embed e_comp_view i.FStar_Syntax_Syntax.rng uu____7645  in
-          FStar_Syntax_Syntax.as_arg uu____7644  in
-        [uu____7635]  in
+    let uu____7707 =
+      let uu____7712 =
+        let uu____7713 =
+          let uu____7722 =
+            let uu____7723 = FStar_Reflection_Basic.inspect_comp comp  in
+            embed e_comp_view i.FStar_Syntax_Syntax.rng uu____7723  in
+          FStar_Syntax_Syntax.as_arg uu____7722  in
+        [uu____7713]  in
       FStar_Syntax_Syntax.mk_Tm_app
         FStar_Reflection_Data.fstar_refl_pack_comp.FStar_Reflection_Data.t
-        uu____7634
+        uu____7712
        in
-    uu____7629 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
+    uu____7707 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
   
 let (unfold_lazy_env :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
@@ -2299,17 +2307,17 @@ let (unfold_lazy_sigelt :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i  ->
     let sigelt = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob  in
-    let uu____7675 =
-      let uu____7680 =
-        let uu____7681 =
-          let uu____7690 =
-            let uu____7691 = FStar_Reflection_Basic.inspect_sigelt sigelt  in
-            embed e_sigelt_view i.FStar_Syntax_Syntax.rng uu____7691  in
-          FStar_Syntax_Syntax.as_arg uu____7690  in
-        [uu____7681]  in
+    let uu____7753 =
+      let uu____7758 =
+        let uu____7759 =
+          let uu____7768 =
+            let uu____7769 = FStar_Reflection_Basic.inspect_sigelt sigelt  in
+            embed e_sigelt_view i.FStar_Syntax_Syntax.rng uu____7769  in
+          FStar_Syntax_Syntax.as_arg uu____7768  in
+        [uu____7759]  in
       FStar_Syntax_Syntax.mk_Tm_app
         FStar_Reflection_Data.fstar_refl_pack_sigelt.FStar_Reflection_Data.t
-        uu____7680
+        uu____7758
        in
-    uu____7675 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
+    uu____7753 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
   

--- a/src/ocaml-output/FStar_Reflection_Interpreter.ml
+++ b/src/ocaml-output/FStar_Reflection_Interpreter.ml
@@ -336,113 +336,108 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                        in
                     let uu____940 =
                       let uu____943 =
-                        mk1 "sigelt_attrs"
-                          FStar_Reflection_Basic.sigelt_attrs
-                          FStar_Reflection_Embeddings.e_sigelt
-                          FStar_Reflection_Embeddings.e_attributes
-                          FStar_Reflection_Basic.sigelt_attrs
-                          FStar_Reflection_NBEEmbeddings.e_sigelt
-                          FStar_Reflection_NBEEmbeddings.e_attributes
-                         in
-                      let uu____949 =
-                        let uu____952 =
-                          mk2 "set_sigelt_attrs"
-                            FStar_Reflection_Basic.set_sigelt_attrs
-                            FStar_Reflection_Embeddings.e_attributes
-                            FStar_Reflection_Embeddings.e_sigelt
-                            FStar_Reflection_Embeddings.e_sigelt
-                            FStar_Reflection_Basic.set_sigelt_attrs
-                            FStar_Reflection_NBEEmbeddings.e_attributes
-                            FStar_Reflection_NBEEmbeddings.e_sigelt
-                            FStar_Reflection_NBEEmbeddings.e_sigelt
+                        let uu____944 =
+                          FStar_Syntax_Embeddings.e_option
+                            FStar_Reflection_Embeddings.e_optionstate
                            in
-                        let uu____958 =
-                          let uu____961 =
-                            mk1 "sigelt_quals"
-                              FStar_Reflection_Basic.sigelt_quals
+                        let uu____949 =
+                          FStar_TypeChecker_NBETerm.e_option
+                            FStar_Reflection_NBEEmbeddings.e_optionstate
+                           in
+                        mk1 "sigelt_opts" FStar_Reflection_Basic.sigelt_opts
+                          FStar_Reflection_Embeddings.e_sigelt uu____944
+                          FStar_Reflection_Basic.sigelt_opts
+                          FStar_Reflection_NBEEmbeddings.e_sigelt uu____949
+                         in
+                      let uu____959 =
+                        let uu____962 =
+                          mk1 "sigelt_attrs"
+                            FStar_Reflection_Basic.sigelt_attrs
+                            FStar_Reflection_Embeddings.e_sigelt
+                            FStar_Reflection_Embeddings.e_attributes
+                            FStar_Reflection_Basic.sigelt_attrs
+                            FStar_Reflection_NBEEmbeddings.e_sigelt
+                            FStar_Reflection_NBEEmbeddings.e_attributes
+                           in
+                        let uu____968 =
+                          let uu____971 =
+                            mk2 "set_sigelt_attrs"
+                              FStar_Reflection_Basic.set_sigelt_attrs
+                              FStar_Reflection_Embeddings.e_attributes
                               FStar_Reflection_Embeddings.e_sigelt
-                              FStar_Reflection_Embeddings.e_qualifiers
-                              FStar_Reflection_Basic.sigelt_quals
+                              FStar_Reflection_Embeddings.e_sigelt
+                              FStar_Reflection_Basic.set_sigelt_attrs
+                              FStar_Reflection_NBEEmbeddings.e_attributes
                               FStar_Reflection_NBEEmbeddings.e_sigelt
-                              FStar_Reflection_NBEEmbeddings.e_qualifiers
+                              FStar_Reflection_NBEEmbeddings.e_sigelt
                              in
-                          let uu____967 =
-                            let uu____970 =
-                              mk2 "set_sigelt_quals"
-                                FStar_Reflection_Basic.set_sigelt_quals
+                          let uu____977 =
+                            let uu____980 =
+                              mk1 "sigelt_quals"
+                                FStar_Reflection_Basic.sigelt_quals
+                                FStar_Reflection_Embeddings.e_sigelt
                                 FStar_Reflection_Embeddings.e_qualifiers
-                                FStar_Reflection_Embeddings.e_sigelt
-                                FStar_Reflection_Embeddings.e_sigelt
-                                FStar_Reflection_Basic.set_sigelt_quals
+                                FStar_Reflection_Basic.sigelt_quals
+                                FStar_Reflection_NBEEmbeddings.e_sigelt
                                 FStar_Reflection_NBEEmbeddings.e_qualifiers
-                                FStar_Reflection_NBEEmbeddings.e_sigelt
-                                FStar_Reflection_NBEEmbeddings.e_sigelt
                                in
-                            let uu____976 =
-                              let uu____979 =
-                                mk1 "inspect_binder"
-                                  FStar_Reflection_Basic.inspect_binder
-                                  FStar_Reflection_Embeddings.e_binder
-                                  FStar_Reflection_Embeddings.e_binder_view
-                                  FStar_Reflection_Basic.inspect_binder
-                                  FStar_Reflection_NBEEmbeddings.e_binder
-                                  FStar_Reflection_NBEEmbeddings.e_binder_view
+                            let uu____986 =
+                              let uu____989 =
+                                mk2 "set_sigelt_quals"
+                                  FStar_Reflection_Basic.set_sigelt_quals
+                                  FStar_Reflection_Embeddings.e_qualifiers
+                                  FStar_Reflection_Embeddings.e_sigelt
+                                  FStar_Reflection_Embeddings.e_sigelt
+                                  FStar_Reflection_Basic.set_sigelt_quals
+                                  FStar_Reflection_NBEEmbeddings.e_qualifiers
+                                  FStar_Reflection_NBEEmbeddings.e_sigelt
+                                  FStar_Reflection_NBEEmbeddings.e_sigelt
                                  in
-                              let uu____981 =
-                                let uu____984 =
-                                  mk2 "pack_binder"
-                                    FStar_Reflection_Basic.pack_binder
-                                    FStar_Reflection_Embeddings.e_bv
-                                    FStar_Reflection_Embeddings.e_aqualv
+                              let uu____995 =
+                                let uu____998 =
+                                  mk1 "inspect_binder"
+                                    FStar_Reflection_Basic.inspect_binder
                                     FStar_Reflection_Embeddings.e_binder
-                                    FStar_Reflection_Basic.pack_binder
-                                    FStar_Reflection_NBEEmbeddings.e_bv
-                                    FStar_Reflection_NBEEmbeddings.e_aqualv
+                                    FStar_Reflection_Embeddings.e_binder_view
+                                    FStar_Reflection_Basic.inspect_binder
                                     FStar_Reflection_NBEEmbeddings.e_binder
+                                    FStar_Reflection_NBEEmbeddings.e_binder_view
                                    in
-                                let uu____986 =
-                                  let uu____989 =
-                                    mk2 "compare_bv"
-                                      FStar_Reflection_Basic.compare_bv
+                                let uu____1000 =
+                                  let uu____1003 =
+                                    mk2 "pack_binder"
+                                      FStar_Reflection_Basic.pack_binder
                                       FStar_Reflection_Embeddings.e_bv
-                                      FStar_Reflection_Embeddings.e_bv
-                                      FStar_Reflection_Embeddings.e_order
-                                      FStar_Reflection_Basic.compare_bv
+                                      FStar_Reflection_Embeddings.e_aqualv
+                                      FStar_Reflection_Embeddings.e_binder
+                                      FStar_Reflection_Basic.pack_binder
                                       FStar_Reflection_NBEEmbeddings.e_bv
-                                      FStar_Reflection_NBEEmbeddings.e_bv
-                                      FStar_Reflection_NBEEmbeddings.e_order
+                                      FStar_Reflection_NBEEmbeddings.e_aqualv
+                                      FStar_Reflection_NBEEmbeddings.e_binder
                                      in
-                                  let uu____991 =
-                                    let uu____994 =
-                                      mk2 "is_free"
-                                        FStar_Reflection_Basic.is_free
+                                  let uu____1005 =
+                                    let uu____1008 =
+                                      mk2 "compare_bv"
+                                        FStar_Reflection_Basic.compare_bv
                                         FStar_Reflection_Embeddings.e_bv
-                                        FStar_Reflection_Embeddings.e_term
-                                        FStar_Syntax_Embeddings.e_bool
-                                        FStar_Reflection_Basic.is_free
+                                        FStar_Reflection_Embeddings.e_bv
+                                        FStar_Reflection_Embeddings.e_order
+                                        FStar_Reflection_Basic.compare_bv
                                         FStar_Reflection_NBEEmbeddings.e_bv
-                                        FStar_Reflection_NBEEmbeddings.e_term
-                                        FStar_TypeChecker_NBETerm.e_bool
+                                        FStar_Reflection_NBEEmbeddings.e_bv
+                                        FStar_Reflection_NBEEmbeddings.e_order
                                        in
-                                    let uu____998 =
-                                      let uu____1001 =
-                                        let uu____1002 =
-                                          FStar_Syntax_Embeddings.e_list
-                                            FStar_Reflection_Embeddings.e_fv
-                                           in
-                                        let uu____1007 =
-                                          FStar_TypeChecker_NBETerm.e_list
-                                            FStar_Reflection_NBEEmbeddings.e_fv
-                                           in
-                                        mk2 "lookup_attr"
-                                          FStar_Reflection_Basic.lookup_attr
+                                    let uu____1010 =
+                                      let uu____1013 =
+                                        mk2 "is_free"
+                                          FStar_Reflection_Basic.is_free
+                                          FStar_Reflection_Embeddings.e_bv
                                           FStar_Reflection_Embeddings.e_term
-                                          FStar_Reflection_Embeddings.e_env
-                                          uu____1002
-                                          FStar_Reflection_Basic.lookup_attr
+                                          FStar_Syntax_Embeddings.e_bool
+                                          FStar_Reflection_Basic.is_free
+                                          FStar_Reflection_NBEEmbeddings.e_bv
                                           FStar_Reflection_NBEEmbeddings.e_term
-                                          FStar_Reflection_NBEEmbeddings.e_env
-                                          uu____1007
+                                          FStar_TypeChecker_NBETerm.e_bool
                                          in
                                       let uu____1017 =
                                         let uu____1020 =
@@ -454,11 +449,13 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                                             FStar_TypeChecker_NBETerm.e_list
                                               FStar_Reflection_NBEEmbeddings.e_fv
                                              in
-                                          mk1 "all_defs_in_env"
-                                            FStar_Reflection_Basic.all_defs_in_env
+                                          mk2 "lookup_attr"
+                                            FStar_Reflection_Basic.lookup_attr
+                                            FStar_Reflection_Embeddings.e_term
                                             FStar_Reflection_Embeddings.e_env
                                             uu____1021
-                                            FStar_Reflection_Basic.all_defs_in_env
+                                            FStar_Reflection_Basic.lookup_attr
+                                            FStar_Reflection_NBEEmbeddings.e_term
                                             FStar_Reflection_NBEEmbeddings.e_env
                                             uu____1026
                                            in
@@ -472,129 +469,150 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                                               FStar_TypeChecker_NBETerm.e_list
                                                 FStar_Reflection_NBEEmbeddings.e_fv
                                                in
-                                            mk2 "defs_in_module"
-                                              FStar_Reflection_Basic.defs_in_module
+                                            mk1 "all_defs_in_env"
+                                              FStar_Reflection_Basic.all_defs_in_env
                                               FStar_Reflection_Embeddings.e_env
-                                              FStar_Syntax_Embeddings.e_string_list
                                               uu____1040
-                                              FStar_Reflection_Basic.defs_in_module
+                                              FStar_Reflection_Basic.all_defs_in_env
                                               FStar_Reflection_NBEEmbeddings.e_env
-                                              FStar_TypeChecker_NBETerm.e_string_list
                                               uu____1045
                                              in
-                                          let uu____1061 =
-                                            let uu____1064 =
-                                              mk2 "term_eq"
-                                                FStar_Reflection_Basic.term_eq
-                                                FStar_Reflection_Embeddings.e_term
-                                                FStar_Reflection_Embeddings.e_term
-                                                FStar_Syntax_Embeddings.e_bool
-                                                FStar_Reflection_Basic.term_eq
-                                                FStar_Reflection_NBEEmbeddings.e_term
-                                                FStar_Reflection_NBEEmbeddings.e_term
-                                                FStar_TypeChecker_NBETerm.e_bool
-                                               in
-                                            let uu____1068 =
-                                              let uu____1071 =
-                                                mk1 "moduleof"
-                                                  FStar_Reflection_Basic.moduleof
-                                                  FStar_Reflection_Embeddings.e_env
-                                                  FStar_Syntax_Embeddings.e_string_list
-                                                  FStar_Reflection_Basic.moduleof
-                                                  FStar_Reflection_NBEEmbeddings.e_env
-                                                  FStar_TypeChecker_NBETerm.e_string_list
+                                          let uu____1055 =
+                                            let uu____1058 =
+                                              let uu____1059 =
+                                                FStar_Syntax_Embeddings.e_list
+                                                  FStar_Reflection_Embeddings.e_fv
                                                  in
-                                              let uu____1079 =
-                                                let uu____1082 =
-                                                  mk1 "term_to_string"
-                                                    FStar_Reflection_Basic.term_to_string
-                                                    FStar_Reflection_Embeddings.e_term
-                                                    FStar_Syntax_Embeddings.e_string
-                                                    FStar_Reflection_Basic.term_to_string
-                                                    FStar_Reflection_NBEEmbeddings.e_term
-                                                    FStar_TypeChecker_NBETerm.e_string
+                                              let uu____1064 =
+                                                FStar_TypeChecker_NBETerm.e_list
+                                                  FStar_Reflection_NBEEmbeddings.e_fv
+                                                 in
+                                              mk2 "defs_in_module"
+                                                FStar_Reflection_Basic.defs_in_module
+                                                FStar_Reflection_Embeddings.e_env
+                                                FStar_Syntax_Embeddings.e_string_list
+                                                uu____1059
+                                                FStar_Reflection_Basic.defs_in_module
+                                                FStar_Reflection_NBEEmbeddings.e_env
+                                                FStar_TypeChecker_NBETerm.e_string_list
+                                                uu____1064
+                                               in
+                                            let uu____1080 =
+                                              let uu____1083 =
+                                                mk2 "term_eq"
+                                                  FStar_Reflection_Basic.term_eq
+                                                  FStar_Reflection_Embeddings.e_term
+                                                  FStar_Reflection_Embeddings.e_term
+                                                  FStar_Syntax_Embeddings.e_bool
+                                                  FStar_Reflection_Basic.term_eq
+                                                  FStar_Reflection_NBEEmbeddings.e_term
+                                                  FStar_Reflection_NBEEmbeddings.e_term
+                                                  FStar_TypeChecker_NBETerm.e_bool
+                                                 in
+                                              let uu____1087 =
+                                                let uu____1090 =
+                                                  mk1 "moduleof"
+                                                    FStar_Reflection_Basic.moduleof
+                                                    FStar_Reflection_Embeddings.e_env
+                                                    FStar_Syntax_Embeddings.e_string_list
+                                                    FStar_Reflection_Basic.moduleof
+                                                    FStar_Reflection_NBEEmbeddings.e_env
+                                                    FStar_TypeChecker_NBETerm.e_string_list
                                                    in
-                                                let uu____1086 =
-                                                  let uu____1089 =
-                                                    mk1 "comp_to_string"
-                                                      FStar_Reflection_Basic.comp_to_string
-                                                      FStar_Reflection_Embeddings.e_comp
+                                                let uu____1098 =
+                                                  let uu____1101 =
+                                                    mk1 "term_to_string"
+                                                      FStar_Reflection_Basic.term_to_string
+                                                      FStar_Reflection_Embeddings.e_term
                                                       FStar_Syntax_Embeddings.e_string
-                                                      FStar_Reflection_Basic.comp_to_string
-                                                      FStar_Reflection_NBEEmbeddings.e_comp
+                                                      FStar_Reflection_Basic.term_to_string
+                                                      FStar_Reflection_NBEEmbeddings.e_term
                                                       FStar_TypeChecker_NBETerm.e_string
                                                      in
-                                                  let uu____1093 =
-                                                    let uu____1096 =
-                                                      mk1 "binders_of_env"
-                                                        FStar_Reflection_Basic.binders_of_env
-                                                        FStar_Reflection_Embeddings.e_env
-                                                        FStar_Reflection_Embeddings.e_binders
-                                                        FStar_Reflection_Basic.binders_of_env
-                                                        FStar_Reflection_NBEEmbeddings.e_env
-                                                        FStar_Reflection_NBEEmbeddings.e_binders
+                                                  let uu____1105 =
+                                                    let uu____1108 =
+                                                      mk1 "comp_to_string"
+                                                        FStar_Reflection_Basic.comp_to_string
+                                                        FStar_Reflection_Embeddings.e_comp
+                                                        FStar_Syntax_Embeddings.e_string
+                                                        FStar_Reflection_Basic.comp_to_string
+                                                        FStar_Reflection_NBEEmbeddings.e_comp
+                                                        FStar_TypeChecker_NBETerm.e_string
                                                        in
-                                                    let uu____1098 =
-                                                      let uu____1101 =
-                                                        let uu____1102 =
-                                                          FStar_Syntax_Embeddings.e_option
-                                                            FStar_Reflection_Embeddings.e_sigelt
-                                                           in
-                                                        let uu____1107 =
-                                                          FStar_TypeChecker_NBETerm.e_option
-                                                            FStar_Reflection_NBEEmbeddings.e_sigelt
-                                                           in
-                                                        mk2 "lookup_typ"
-                                                          FStar_Reflection_Basic.lookup_typ
+                                                    let uu____1112 =
+                                                      let uu____1115 =
+                                                        mk1 "binders_of_env"
+                                                          FStar_Reflection_Basic.binders_of_env
                                                           FStar_Reflection_Embeddings.e_env
-                                                          FStar_Syntax_Embeddings.e_string_list
-                                                          uu____1102
-                                                          FStar_Reflection_Basic.lookup_typ
+                                                          FStar_Reflection_Embeddings.e_binders
+                                                          FStar_Reflection_Basic.binders_of_env
                                                           FStar_Reflection_NBEEmbeddings.e_env
-                                                          FStar_TypeChecker_NBETerm.e_string_list
-                                                          uu____1107
+                                                          FStar_Reflection_NBEEmbeddings.e_binders
                                                          in
-                                                      let uu____1123 =
-                                                        let uu____1126 =
-                                                          let uu____1127 =
-                                                            FStar_Syntax_Embeddings.e_list
-                                                              FStar_Syntax_Embeddings.e_string_list
+                                                      let uu____1117 =
+                                                        let uu____1120 =
+                                                          let uu____1121 =
+                                                            FStar_Syntax_Embeddings.e_option
+                                                              FStar_Reflection_Embeddings.e_sigelt
                                                              in
-                                                          let uu____1138 =
-                                                            FStar_TypeChecker_NBETerm.e_list
-                                                              FStar_TypeChecker_NBETerm.e_string_list
+                                                          let uu____1126 =
+                                                            FStar_TypeChecker_NBETerm.e_option
+                                                              FStar_Reflection_NBEEmbeddings.e_sigelt
                                                              in
-                                                          mk1
-                                                            "env_open_modules"
-                                                            FStar_Reflection_Basic.env_open_modules
+                                                          mk2 "lookup_typ"
+                                                            FStar_Reflection_Basic.lookup_typ
                                                             FStar_Reflection_Embeddings.e_env
-                                                            uu____1127
-                                                            FStar_Reflection_Basic.env_open_modules
+                                                            FStar_Syntax_Embeddings.e_string_list
+                                                            uu____1121
+                                                            FStar_Reflection_Basic.lookup_typ
                                                             FStar_Reflection_NBEEmbeddings.e_env
-                                                            uu____1138
+                                                            FStar_TypeChecker_NBETerm.e_string_list
+                                                            uu____1126
                                                            in
-                                                        [uu____1126]  in
-                                                      uu____1101 ::
-                                                        uu____1123
+                                                        let uu____1142 =
+                                                          let uu____1145 =
+                                                            let uu____1146 =
+                                                              FStar_Syntax_Embeddings.e_list
+                                                                FStar_Syntax_Embeddings.e_string_list
+                                                               in
+                                                            let uu____1157 =
+                                                              FStar_TypeChecker_NBETerm.e_list
+                                                                FStar_TypeChecker_NBETerm.e_string_list
+                                                               in
+                                                            mk1
+                                                              "env_open_modules"
+                                                              FStar_Reflection_Basic.env_open_modules
+                                                              FStar_Reflection_Embeddings.e_env
+                                                              uu____1146
+                                                              FStar_Reflection_Basic.env_open_modules
+                                                              FStar_Reflection_NBEEmbeddings.e_env
+                                                              uu____1157
+                                                             in
+                                                          [uu____1145]  in
+                                                        uu____1120 ::
+                                                          uu____1142
+                                                         in
+                                                      uu____1115 ::
+                                                        uu____1117
                                                        in
-                                                    uu____1096 :: uu____1098
+                                                    uu____1108 :: uu____1112
                                                      in
-                                                  uu____1089 :: uu____1093
+                                                  uu____1101 :: uu____1105
                                                    in
-                                                uu____1082 :: uu____1086  in
-                                              uu____1071 :: uu____1079  in
-                                            uu____1064 :: uu____1068  in
-                                          uu____1039 :: uu____1061  in
+                                                uu____1090 :: uu____1098  in
+                                              uu____1083 :: uu____1087  in
+                                            uu____1058 :: uu____1080  in
+                                          uu____1039 :: uu____1055  in
                                         uu____1020 :: uu____1036  in
-                                      uu____1001 :: uu____1017  in
-                                    uu____994 :: uu____998  in
-                                  uu____989 :: uu____991  in
-                                uu____984 :: uu____986  in
-                              uu____979 :: uu____981  in
-                            uu____970 :: uu____976  in
-                          uu____961 :: uu____967  in
-                        uu____952 :: uu____958  in
-                      uu____943 :: uu____949  in
+                                      uu____1013 :: uu____1017  in
+                                    uu____1008 :: uu____1010  in
+                                  uu____1003 :: uu____1005  in
+                                uu____998 :: uu____1000  in
+                              uu____989 :: uu____995  in
+                            uu____980 :: uu____986  in
+                          uu____971 :: uu____977  in
+                        uu____962 :: uu____968  in
+                      uu____943 :: uu____959  in
                     uu____938 :: uu____940  in
                   uu____933 :: uu____935  in
                 uu____928 :: uu____930  in

--- a/src/ocaml-output/FStar_Reflection_NBEEmbeddings.ml
+++ b/src/ocaml-output/FStar_Reflection_NBEEmbeddings.ml
@@ -478,130 +478,138 @@ let rec (e_pattern' :
             FStar_Reflection_Data.ref_Pat_Constant.FStar_Reflection_Data.fv
             [] uu____1158
       | FStar_Reflection_Data.Pat_Cons (fv,ps) ->
-          let uu____1185 =
-            let uu____1192 =
-              let uu____1197 = FStar_TypeChecker_NBETerm.embed e_fv cb fv  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1197  in
-            let uu____1198 =
-              let uu____1205 =
-                let uu____1210 =
-                  let uu____1211 =
-                    let uu____1216 = e_pattern' ()  in
-                    FStar_TypeChecker_NBETerm.e_list uu____1216  in
-                  FStar_TypeChecker_NBETerm.embed uu____1211 cb ps  in
-                FStar_TypeChecker_NBETerm.as_arg uu____1210  in
-              [uu____1205]  in
-            uu____1192 :: uu____1198  in
+          let uu____1195 =
+            let uu____1202 =
+              let uu____1207 = FStar_TypeChecker_NBETerm.embed e_fv cb fv  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1207  in
+            let uu____1208 =
+              let uu____1215 =
+                let uu____1220 =
+                  let uu____1221 =
+                    let uu____1231 =
+                      let uu____1239 = e_pattern' ()  in
+                      FStar_TypeChecker_NBETerm.e_tuple2 uu____1239
+                        FStar_TypeChecker_NBETerm.e_bool
+                       in
+                    FStar_TypeChecker_NBETerm.e_list uu____1231  in
+                  FStar_TypeChecker_NBETerm.embed uu____1221 cb ps  in
+                FStar_TypeChecker_NBETerm.as_arg uu____1220  in
+              [uu____1215]  in
+            uu____1202 :: uu____1208  in
           mkConstruct
             FStar_Reflection_Data.ref_Pat_Cons.FStar_Reflection_Data.fv []
-            uu____1185
+            uu____1195
       | FStar_Reflection_Data.Pat_Var bv ->
-          let uu____1234 =
-            let uu____1241 =
-              let uu____1246 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1246  in
-            [uu____1241]  in
+          let uu____1268 =
+            let uu____1275 =
+              let uu____1280 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1280  in
+            [uu____1275]  in
           mkConstruct
             FStar_Reflection_Data.ref_Pat_Var.FStar_Reflection_Data.fv []
-            uu____1234
+            uu____1268
       | FStar_Reflection_Data.Pat_Wild bv ->
-          let uu____1256 =
-            let uu____1263 =
-              let uu____1268 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1268  in
-            [uu____1263]  in
+          let uu____1290 =
+            let uu____1297 =
+              let uu____1302 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1302  in
+            [uu____1297]  in
           mkConstruct
             FStar_Reflection_Data.ref_Pat_Wild.FStar_Reflection_Data.fv []
-            uu____1256
+            uu____1290
       | FStar_Reflection_Data.Pat_Dot_Term (bv,t) ->
-          let uu____1279 =
-            let uu____1286 =
-              let uu____1291 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1291  in
-            let uu____1292 =
-              let uu____1299 =
-                let uu____1304 = FStar_TypeChecker_NBETerm.embed e_term cb t
+          let uu____1313 =
+            let uu____1320 =
+              let uu____1325 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1325  in
+            let uu____1326 =
+              let uu____1333 =
+                let uu____1338 = FStar_TypeChecker_NBETerm.embed e_term cb t
                    in
-                FStar_TypeChecker_NBETerm.as_arg uu____1304  in
-              [uu____1299]  in
-            uu____1286 :: uu____1292  in
+                FStar_TypeChecker_NBETerm.as_arg uu____1338  in
+              [uu____1333]  in
+            uu____1320 :: uu____1326  in
           mkConstruct
             FStar_Reflection_Data.ref_Pat_Dot_Term.FStar_Reflection_Data.fv
-            [] uu____1279
+            [] uu____1313
        in
     let unembed_pattern cb t =
       match t with
-      | FStar_TypeChecker_NBETerm.Construct (fv,[],(c,uu____1334)::[]) when
+      | FStar_TypeChecker_NBETerm.Construct (fv,[],(c,uu____1368)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Pat_Constant.FStar_Reflection_Data.lid
           ->
-          let uu____1351 = FStar_TypeChecker_NBETerm.unembed e_const cb c  in
-          FStar_Util.bind_opt uu____1351
+          let uu____1385 = FStar_TypeChecker_NBETerm.unembed e_const cb c  in
+          FStar_Util.bind_opt uu____1385
             (fun c1  ->
                FStar_All.pipe_left
-                 (fun _1358  -> FStar_Pervasives_Native.Some _1358)
+                 (fun _1392  -> FStar_Pervasives_Native.Some _1392)
                  (FStar_Reflection_Data.Pat_Constant c1))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,[],(ps,uu____1361)::(f,uu____1363)::[]) when
+          (fv,[],(ps,uu____1395)::(f,uu____1397)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Pat_Cons.FStar_Reflection_Data.lid
           ->
-          let uu____1384 = FStar_TypeChecker_NBETerm.unembed e_fv cb f  in
-          FStar_Util.bind_opt uu____1384
+          let uu____1418 = FStar_TypeChecker_NBETerm.unembed e_fv cb f  in
+          FStar_Util.bind_opt uu____1418
             (fun f1  ->
-               let uu____1390 =
-                 let uu____1395 =
-                   let uu____1400 = e_pattern' ()  in
-                   FStar_TypeChecker_NBETerm.e_list uu____1400  in
-                 FStar_TypeChecker_NBETerm.unembed uu____1395 cb ps  in
-               FStar_Util.bind_opt uu____1390
+               let uu____1424 =
+                 let uu____1434 =
+                   let uu____1444 =
+                     let uu____1452 = e_pattern' ()  in
+                     FStar_TypeChecker_NBETerm.e_tuple2 uu____1452
+                       FStar_TypeChecker_NBETerm.e_bool
+                      in
+                   FStar_TypeChecker_NBETerm.e_list uu____1444  in
+                 FStar_TypeChecker_NBETerm.unembed uu____1434 cb ps  in
+               FStar_Util.bind_opt uu____1424
                  (fun ps1  ->
                     FStar_All.pipe_left
-                      (fun _1413  -> FStar_Pervasives_Native.Some _1413)
+                      (fun _1486  -> FStar_Pervasives_Native.Some _1486)
                       (FStar_Reflection_Data.Pat_Cons (f1, ps1))))
-      | FStar_TypeChecker_NBETerm.Construct (fv,[],(bv,uu____1418)::[]) when
+      | FStar_TypeChecker_NBETerm.Construct (fv,[],(bv,uu____1496)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Pat_Var.FStar_Reflection_Data.lid
           ->
-          let uu____1435 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv  in
-          FStar_Util.bind_opt uu____1435
+          let uu____1513 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv  in
+          FStar_Util.bind_opt uu____1513
             (fun bv1  ->
                FStar_All.pipe_left
-                 (fun _1442  -> FStar_Pervasives_Native.Some _1442)
+                 (fun _1520  -> FStar_Pervasives_Native.Some _1520)
                  (FStar_Reflection_Data.Pat_Var bv1))
-      | FStar_TypeChecker_NBETerm.Construct (fv,[],(bv,uu____1445)::[]) when
+      | FStar_TypeChecker_NBETerm.Construct (fv,[],(bv,uu____1523)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Pat_Wild.FStar_Reflection_Data.lid
           ->
-          let uu____1462 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv  in
-          FStar_Util.bind_opt uu____1462
+          let uu____1540 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv  in
+          FStar_Util.bind_opt uu____1540
             (fun bv1  ->
                FStar_All.pipe_left
-                 (fun _1469  -> FStar_Pervasives_Native.Some _1469)
+                 (fun _1547  -> FStar_Pervasives_Native.Some _1547)
                  (FStar_Reflection_Data.Pat_Wild bv1))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,[],(t1,uu____1472)::(bv,uu____1474)::[]) when
+          (fv,[],(t1,uu____1550)::(bv,uu____1552)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Pat_Dot_Term.FStar_Reflection_Data.lid
           ->
-          let uu____1495 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv  in
-          FStar_Util.bind_opt uu____1495
+          let uu____1573 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv  in
+          FStar_Util.bind_opt uu____1573
             (fun bv1  ->
-               let uu____1501 =
+               let uu____1579 =
                  FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
-               FStar_Util.bind_opt uu____1501
+               FStar_Util.bind_opt uu____1579
                  (fun t2  ->
                     FStar_All.pipe_left
-                      (fun _1508  -> FStar_Pervasives_Native.Some _1508)
+                      (fun _1586  -> FStar_Pervasives_Native.Some _1586)
                       (FStar_Reflection_Data.Pat_Dot_Term (bv1, t2))))
-      | uu____1509 ->
-          ((let uu____1511 =
-              let uu____1517 =
-                let uu____1519 = FStar_TypeChecker_NBETerm.t_to_string t  in
-                FStar_Util.format1 "Not an embedded pattern: %s" uu____1519
+      | uu____1587 ->
+          ((let uu____1589 =
+              let uu____1595 =
+                let uu____1597 = FStar_TypeChecker_NBETerm.t_to_string t  in
+                FStar_Util.format1 "Not an embedded pattern: %s" uu____1597
                  in
-              (FStar_Errors.Warning_NotEmbedded, uu____1517)  in
-            FStar_Errors.log_issue FStar_Range.dummyRange uu____1511);
+              (FStar_Errors.Warning_NotEmbedded, uu____1595)  in
+            FStar_Errors.log_issue FStar_Range.dummyRange uu____1589);
            FStar_Pervasives_Native.None)
        in
     mk_emb' embed_pattern unembed_pattern
@@ -622,8 +630,8 @@ let (e_branch_aq :
       FStar_TypeChecker_NBETerm.embedding)
   =
   fun aq  ->
-    let uu____1560 = e_term_aq aq  in
-    FStar_TypeChecker_NBETerm.e_tuple2 e_pattern uu____1560
+    let uu____1638 = e_term_aq aq  in
+    FStar_TypeChecker_NBETerm.e_tuple2 e_pattern uu____1638
   
 let (e_argv_aq :
   (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term'
@@ -632,13 +640,13 @@ let (e_argv_aq :
       FStar_TypeChecker_NBETerm.embedding)
   =
   fun aq  ->
-    let uu____1591 = e_term_aq aq  in
-    FStar_TypeChecker_NBETerm.e_tuple2 uu____1591 e_aqualv
+    let uu____1669 = e_term_aq aq  in
+    FStar_TypeChecker_NBETerm.e_tuple2 uu____1669 e_aqualv
   
 let rec unlazy_as_t :
-  'Auu____1601 .
+  'Auu____1679 .
     FStar_Syntax_Syntax.lazy_kind ->
-      FStar_TypeChecker_NBETerm.t -> 'Auu____1601
+      FStar_TypeChecker_NBETerm.t -> 'Auu____1679
   =
   fun k  ->
     fun t  ->
@@ -646,10 +654,10 @@ let rec unlazy_as_t :
       | FStar_TypeChecker_NBETerm.Lazy
           (FStar_Util.Inl
            { FStar_Syntax_Syntax.blob = v1; FStar_Syntax_Syntax.lkind = k';
-             FStar_Syntax_Syntax.ltyp = uu____1614;
-             FStar_Syntax_Syntax.rng = uu____1615;_},uu____1616)
+             FStar_Syntax_Syntax.ltyp = uu____1692;
+             FStar_Syntax_Syntax.rng = uu____1693;_},uu____1694)
           when FStar_Syntax_Util.eq_lazy_kind k k' -> FStar_Dyn.undyn v1
-      | uu____1635 -> failwith "Not a Lazy of the expected kind (NBE)"
+      | uu____1713 -> failwith "Not a Lazy of the expected kind (NBE)"
   
 let (e_term_view_aq :
   (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term'
@@ -660,221 +668,194 @@ let (e_term_view_aq :
     let embed_term_view cb tv =
       match tv with
       | FStar_Reflection_Data.Tv_FVar fv ->
-          let uu____1673 =
-            let uu____1680 =
-              let uu____1685 = FStar_TypeChecker_NBETerm.embed e_fv cb fv  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1685  in
-            [uu____1680]  in
+          let uu____1751 =
+            let uu____1758 =
+              let uu____1763 = FStar_TypeChecker_NBETerm.embed e_fv cb fv  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1763  in
+            [uu____1758]  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_FVar.FStar_Reflection_Data.fv []
-            uu____1673
+            uu____1751
       | FStar_Reflection_Data.Tv_BVar bv ->
-          let uu____1695 =
-            let uu____1702 =
-              let uu____1707 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1707  in
-            [uu____1702]  in
+          let uu____1773 =
+            let uu____1780 =
+              let uu____1785 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1785  in
+            [uu____1780]  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_BVar.FStar_Reflection_Data.fv []
-            uu____1695
+            uu____1773
       | FStar_Reflection_Data.Tv_Var bv ->
-          let uu____1717 =
-            let uu____1724 =
-              let uu____1729 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1729  in
-            [uu____1724]  in
+          let uu____1795 =
+            let uu____1802 =
+              let uu____1807 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1807  in
+            [uu____1802]  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Var.FStar_Reflection_Data.fv []
-            uu____1717
+            uu____1795
       | FStar_Reflection_Data.Tv_App (hd1,a) ->
-          let uu____1740 =
-            let uu____1747 =
-              let uu____1752 =
-                let uu____1753 = e_term_aq aq  in
-                FStar_TypeChecker_NBETerm.embed uu____1753 cb hd1  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1752  in
-            let uu____1756 =
-              let uu____1763 =
-                let uu____1768 =
-                  let uu____1769 = e_argv_aq aq  in
-                  FStar_TypeChecker_NBETerm.embed uu____1769 cb a  in
-                FStar_TypeChecker_NBETerm.as_arg uu____1768  in
-              [uu____1763]  in
-            uu____1747 :: uu____1756  in
+          let uu____1818 =
+            let uu____1825 =
+              let uu____1830 =
+                let uu____1831 = e_term_aq aq  in
+                FStar_TypeChecker_NBETerm.embed uu____1831 cb hd1  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1830  in
+            let uu____1834 =
+              let uu____1841 =
+                let uu____1846 =
+                  let uu____1847 = e_argv_aq aq  in
+                  FStar_TypeChecker_NBETerm.embed uu____1847 cb a  in
+                FStar_TypeChecker_NBETerm.as_arg uu____1846  in
+              [uu____1841]  in
+            uu____1825 :: uu____1834  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_App.FStar_Reflection_Data.fv []
-            uu____1740
+            uu____1818
       | FStar_Reflection_Data.Tv_Abs (b,t) ->
-          let uu____1794 =
-            let uu____1801 =
-              let uu____1806 = FStar_TypeChecker_NBETerm.embed e_binder cb b
+          let uu____1872 =
+            let uu____1879 =
+              let uu____1884 = FStar_TypeChecker_NBETerm.embed e_binder cb b
                  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1806  in
-            let uu____1807 =
-              let uu____1814 =
-                let uu____1819 =
-                  let uu____1820 = e_term_aq aq  in
-                  FStar_TypeChecker_NBETerm.embed uu____1820 cb t  in
-                FStar_TypeChecker_NBETerm.as_arg uu____1819  in
-              [uu____1814]  in
-            uu____1801 :: uu____1807  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1884  in
+            let uu____1885 =
+              let uu____1892 =
+                let uu____1897 =
+                  let uu____1898 = e_term_aq aq  in
+                  FStar_TypeChecker_NBETerm.embed uu____1898 cb t  in
+                FStar_TypeChecker_NBETerm.as_arg uu____1897  in
+              [uu____1892]  in
+            uu____1879 :: uu____1885  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Abs.FStar_Reflection_Data.fv []
-            uu____1794
+            uu____1872
       | FStar_Reflection_Data.Tv_Arrow (b,c) ->
-          let uu____1837 =
-            let uu____1844 =
-              let uu____1849 = FStar_TypeChecker_NBETerm.embed e_binder cb b
+          let uu____1915 =
+            let uu____1922 =
+              let uu____1927 = FStar_TypeChecker_NBETerm.embed e_binder cb b
                  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1849  in
-            let uu____1850 =
-              let uu____1857 =
-                let uu____1862 = FStar_TypeChecker_NBETerm.embed e_comp cb c
+              FStar_TypeChecker_NBETerm.as_arg uu____1927  in
+            let uu____1928 =
+              let uu____1935 =
+                let uu____1940 = FStar_TypeChecker_NBETerm.embed e_comp cb c
                    in
-                FStar_TypeChecker_NBETerm.as_arg uu____1862  in
-              [uu____1857]  in
-            uu____1844 :: uu____1850  in
+                FStar_TypeChecker_NBETerm.as_arg uu____1940  in
+              [uu____1935]  in
+            uu____1922 :: uu____1928  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Arrow.FStar_Reflection_Data.fv []
-            uu____1837
+            uu____1915
       | FStar_Reflection_Data.Tv_Type u ->
-          let uu____1876 =
-            let uu____1883 =
-              let uu____1888 =
+          let uu____1954 =
+            let uu____1961 =
+              let uu____1966 =
                 FStar_TypeChecker_NBETerm.embed
                   FStar_TypeChecker_NBETerm.e_unit cb ()
                  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1888  in
-            [uu____1883]  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1966  in
+            [uu____1961]  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Type.FStar_Reflection_Data.fv []
-            uu____1876
+            uu____1954
       | FStar_Reflection_Data.Tv_Refine (bv,t) ->
-          let uu____1899 =
-            let uu____1906 =
-              let uu____1911 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1911  in
-            let uu____1912 =
-              let uu____1919 =
-                let uu____1924 =
-                  let uu____1925 = e_term_aq aq  in
-                  FStar_TypeChecker_NBETerm.embed uu____1925 cb t  in
-                FStar_TypeChecker_NBETerm.as_arg uu____1924  in
-              [uu____1919]  in
-            uu____1906 :: uu____1912  in
+          let uu____1977 =
+            let uu____1984 =
+              let uu____1989 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1989  in
+            let uu____1990 =
+              let uu____1997 =
+                let uu____2002 =
+                  let uu____2003 = e_term_aq aq  in
+                  FStar_TypeChecker_NBETerm.embed uu____2003 cb t  in
+                FStar_TypeChecker_NBETerm.as_arg uu____2002  in
+              [uu____1997]  in
+            uu____1984 :: uu____1990  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Refine.FStar_Reflection_Data.fv []
-            uu____1899
+            uu____1977
       | FStar_Reflection_Data.Tv_Const c ->
-          let uu____1941 =
-            let uu____1948 =
-              let uu____1953 = FStar_TypeChecker_NBETerm.embed e_const cb c
+          let uu____2019 =
+            let uu____2026 =
+              let uu____2031 = FStar_TypeChecker_NBETerm.embed e_const cb c
                  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1953  in
-            [uu____1948]  in
+              FStar_TypeChecker_NBETerm.as_arg uu____2031  in
+            [uu____2026]  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Const.FStar_Reflection_Data.fv []
-            uu____1941
+            uu____2019
       | FStar_Reflection_Data.Tv_Uvar (u,d) ->
-          let uu____1964 =
-            let uu____1971 =
-              let uu____1976 =
+          let uu____2042 =
+            let uu____2049 =
+              let uu____2054 =
                 FStar_TypeChecker_NBETerm.embed
                   FStar_TypeChecker_NBETerm.e_int cb u
                  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1976  in
-            let uu____1977 =
-              let uu____1984 =
-                let uu____1989 =
+              FStar_TypeChecker_NBETerm.as_arg uu____2054  in
+            let uu____2055 =
+              let uu____2062 =
+                let uu____2067 =
                   mk_lazy cb (u, d) FStar_Syntax_Util.t_ctx_uvar_and_sust
                     FStar_Syntax_Syntax.Lazy_uvar
                    in
-                FStar_TypeChecker_NBETerm.as_arg uu____1989  in
-              [uu____1984]  in
-            uu____1971 :: uu____1977  in
+                FStar_TypeChecker_NBETerm.as_arg uu____2067  in
+              [uu____2062]  in
+            uu____2049 :: uu____2055  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Uvar.FStar_Reflection_Data.fv []
-            uu____1964
+            uu____2042
       | FStar_Reflection_Data.Tv_Let (r,b,t1,t2) ->
-          let uu____2012 =
-            let uu____2019 =
-              let uu____2024 =
+          let uu____2090 =
+            let uu____2097 =
+              let uu____2102 =
                 FStar_TypeChecker_NBETerm.embed
                   FStar_TypeChecker_NBETerm.e_bool cb r
                  in
-              FStar_TypeChecker_NBETerm.as_arg uu____2024  in
-            let uu____2026 =
-              let uu____2033 =
-                let uu____2038 = FStar_TypeChecker_NBETerm.embed e_bv cb b
+              FStar_TypeChecker_NBETerm.as_arg uu____2102  in
+            let uu____2104 =
+              let uu____2111 =
+                let uu____2116 = FStar_TypeChecker_NBETerm.embed e_bv cb b
                    in
-                FStar_TypeChecker_NBETerm.as_arg uu____2038  in
-              let uu____2039 =
-                let uu____2046 =
-                  let uu____2051 =
-                    let uu____2052 = e_term_aq aq  in
-                    FStar_TypeChecker_NBETerm.embed uu____2052 cb t1  in
-                  FStar_TypeChecker_NBETerm.as_arg uu____2051  in
-                let uu____2055 =
-                  let uu____2062 =
-                    let uu____2067 =
-                      let uu____2068 = e_term_aq aq  in
-                      FStar_TypeChecker_NBETerm.embed uu____2068 cb t2  in
-                    FStar_TypeChecker_NBETerm.as_arg uu____2067  in
-                  [uu____2062]  in
-                uu____2046 :: uu____2055  in
-              uu____2033 :: uu____2039  in
-            uu____2019 :: uu____2026  in
+                FStar_TypeChecker_NBETerm.as_arg uu____2116  in
+              let uu____2117 =
+                let uu____2124 =
+                  let uu____2129 =
+                    let uu____2130 = e_term_aq aq  in
+                    FStar_TypeChecker_NBETerm.embed uu____2130 cb t1  in
+                  FStar_TypeChecker_NBETerm.as_arg uu____2129  in
+                let uu____2133 =
+                  let uu____2140 =
+                    let uu____2145 =
+                      let uu____2146 = e_term_aq aq  in
+                      FStar_TypeChecker_NBETerm.embed uu____2146 cb t2  in
+                    FStar_TypeChecker_NBETerm.as_arg uu____2145  in
+                  [uu____2140]  in
+                uu____2124 :: uu____2133  in
+              uu____2111 :: uu____2117  in
+            uu____2097 :: uu____2104  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Let.FStar_Reflection_Data.fv []
-            uu____2012
+            uu____2090
       | FStar_Reflection_Data.Tv_Match (t,brs) ->
-          let uu____2097 =
-            let uu____2104 =
-              let uu____2109 =
-                let uu____2110 = e_term_aq aq  in
-                FStar_TypeChecker_NBETerm.embed uu____2110 cb t  in
-              FStar_TypeChecker_NBETerm.as_arg uu____2109  in
-            let uu____2113 =
-              let uu____2120 =
-                let uu____2125 =
-                  let uu____2126 =
-                    let uu____2135 = e_branch_aq aq  in
-                    FStar_TypeChecker_NBETerm.e_list uu____2135  in
-                  FStar_TypeChecker_NBETerm.embed uu____2126 cb brs  in
-                FStar_TypeChecker_NBETerm.as_arg uu____2125  in
-              [uu____2120]  in
-            uu____2104 :: uu____2113  in
+          let uu____2175 =
+            let uu____2182 =
+              let uu____2187 =
+                let uu____2188 = e_term_aq aq  in
+                FStar_TypeChecker_NBETerm.embed uu____2188 cb t  in
+              FStar_TypeChecker_NBETerm.as_arg uu____2187  in
+            let uu____2191 =
+              let uu____2198 =
+                let uu____2203 =
+                  let uu____2204 =
+                    let uu____2213 = e_branch_aq aq  in
+                    FStar_TypeChecker_NBETerm.e_list uu____2213  in
+                  FStar_TypeChecker_NBETerm.embed uu____2204 cb brs  in
+                FStar_TypeChecker_NBETerm.as_arg uu____2203  in
+              [uu____2198]  in
+            uu____2182 :: uu____2191  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Match.FStar_Reflection_Data.fv []
-            uu____2097
+            uu____2175
       | FStar_Reflection_Data.Tv_AscribedT (e,t,tacopt) ->
-          let uu____2171 =
-            let uu____2178 =
-              let uu____2183 =
-                let uu____2184 = e_term_aq aq  in
-                FStar_TypeChecker_NBETerm.embed uu____2184 cb e  in
-              FStar_TypeChecker_NBETerm.as_arg uu____2183  in
-            let uu____2187 =
-              let uu____2194 =
-                let uu____2199 =
-                  let uu____2200 = e_term_aq aq  in
-                  FStar_TypeChecker_NBETerm.embed uu____2200 cb t  in
-                FStar_TypeChecker_NBETerm.as_arg uu____2199  in
-              let uu____2203 =
-                let uu____2210 =
-                  let uu____2215 =
-                    let uu____2216 =
-                      let uu____2221 = e_term_aq aq  in
-                      FStar_TypeChecker_NBETerm.e_option uu____2221  in
-                    FStar_TypeChecker_NBETerm.embed uu____2216 cb tacopt  in
-                  FStar_TypeChecker_NBETerm.as_arg uu____2215  in
-                [uu____2210]  in
-              uu____2194 :: uu____2203  in
-            uu____2178 :: uu____2187  in
-          mkConstruct
-            FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.fv []
-            uu____2171
-      | FStar_Reflection_Data.Tv_AscribedC (e,c,tacopt) ->
           let uu____2249 =
             let uu____2256 =
               let uu____2261 =
@@ -883,23 +864,50 @@ let (e_term_view_aq :
               FStar_TypeChecker_NBETerm.as_arg uu____2261  in
             let uu____2265 =
               let uu____2272 =
-                let uu____2277 = FStar_TypeChecker_NBETerm.embed e_comp cb c
-                   in
+                let uu____2277 =
+                  let uu____2278 = e_term_aq aq  in
+                  FStar_TypeChecker_NBETerm.embed uu____2278 cb t  in
                 FStar_TypeChecker_NBETerm.as_arg uu____2277  in
-              let uu____2278 =
-                let uu____2285 =
-                  let uu____2290 =
-                    let uu____2291 =
-                      let uu____2296 = e_term_aq aq  in
-                      FStar_TypeChecker_NBETerm.e_option uu____2296  in
-                    FStar_TypeChecker_NBETerm.embed uu____2291 cb tacopt  in
-                  FStar_TypeChecker_NBETerm.as_arg uu____2290  in
-                [uu____2285]  in
-              uu____2272 :: uu____2278  in
+              let uu____2281 =
+                let uu____2288 =
+                  let uu____2293 =
+                    let uu____2294 =
+                      let uu____2299 = e_term_aq aq  in
+                      FStar_TypeChecker_NBETerm.e_option uu____2299  in
+                    FStar_TypeChecker_NBETerm.embed uu____2294 cb tacopt  in
+                  FStar_TypeChecker_NBETerm.as_arg uu____2293  in
+                [uu____2288]  in
+              uu____2272 :: uu____2281  in
             uu____2256 :: uu____2265  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.fv []
             uu____2249
+      | FStar_Reflection_Data.Tv_AscribedC (e,c,tacopt) ->
+          let uu____2327 =
+            let uu____2334 =
+              let uu____2339 =
+                let uu____2340 = e_term_aq aq  in
+                FStar_TypeChecker_NBETerm.embed uu____2340 cb e  in
+              FStar_TypeChecker_NBETerm.as_arg uu____2339  in
+            let uu____2343 =
+              let uu____2350 =
+                let uu____2355 = FStar_TypeChecker_NBETerm.embed e_comp cb c
+                   in
+                FStar_TypeChecker_NBETerm.as_arg uu____2355  in
+              let uu____2356 =
+                let uu____2363 =
+                  let uu____2368 =
+                    let uu____2369 =
+                      let uu____2374 = e_term_aq aq  in
+                      FStar_TypeChecker_NBETerm.e_option uu____2374  in
+                    FStar_TypeChecker_NBETerm.embed uu____2369 cb tacopt  in
+                  FStar_TypeChecker_NBETerm.as_arg uu____2368  in
+                [uu____2363]  in
+              uu____2350 :: uu____2356  in
+            uu____2334 :: uu____2343  in
+          mkConstruct
+            FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.fv []
+            uu____2327
       | FStar_Reflection_Data.Tv_Unknown  ->
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Unknown.FStar_Reflection_Data.fv []
@@ -908,250 +916,250 @@ let (e_term_view_aq :
     let unembed_term_view cb t =
       match t with
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2337,(b,uu____2339)::[]) when
+          (fv,uu____2415,(b,uu____2417)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Var.FStar_Reflection_Data.lid
           ->
-          let uu____2358 = FStar_TypeChecker_NBETerm.unembed e_bv cb b  in
-          FStar_Util.bind_opt uu____2358
+          let uu____2436 = FStar_TypeChecker_NBETerm.unembed e_bv cb b  in
+          FStar_Util.bind_opt uu____2436
             (fun b1  ->
                FStar_All.pipe_left
-                 (fun _2365  -> FStar_Pervasives_Native.Some _2365)
+                 (fun _2443  -> FStar_Pervasives_Native.Some _2443)
                  (FStar_Reflection_Data.Tv_Var b1))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2367,(b,uu____2369)::[]) when
+          (fv,uu____2445,(b,uu____2447)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_BVar.FStar_Reflection_Data.lid
           ->
-          let uu____2388 = FStar_TypeChecker_NBETerm.unembed e_bv cb b  in
-          FStar_Util.bind_opt uu____2388
+          let uu____2466 = FStar_TypeChecker_NBETerm.unembed e_bv cb b  in
+          FStar_Util.bind_opt uu____2466
             (fun b1  ->
                FStar_All.pipe_left
-                 (fun _2395  -> FStar_Pervasives_Native.Some _2395)
+                 (fun _2473  -> FStar_Pervasives_Native.Some _2473)
                  (FStar_Reflection_Data.Tv_BVar b1))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2397,(f,uu____2399)::[]) when
+          (fv,uu____2475,(f,uu____2477)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_FVar.FStar_Reflection_Data.lid
           ->
-          let uu____2418 = FStar_TypeChecker_NBETerm.unembed e_fv cb f  in
-          FStar_Util.bind_opt uu____2418
+          let uu____2496 = FStar_TypeChecker_NBETerm.unembed e_fv cb f  in
+          FStar_Util.bind_opt uu____2496
             (fun f1  ->
                FStar_All.pipe_left
-                 (fun _2425  -> FStar_Pervasives_Native.Some _2425)
+                 (fun _2503  -> FStar_Pervasives_Native.Some _2503)
                  (FStar_Reflection_Data.Tv_FVar f1))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2427,(r,uu____2429)::(l,uu____2431)::[]) when
+          (fv,uu____2505,(r,uu____2507)::(l,uu____2509)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_App.FStar_Reflection_Data.lid
           ->
-          let uu____2454 = FStar_TypeChecker_NBETerm.unembed e_term cb l  in
-          FStar_Util.bind_opt uu____2454
+          let uu____2532 = FStar_TypeChecker_NBETerm.unembed e_term cb l  in
+          FStar_Util.bind_opt uu____2532
             (fun l1  ->
-               let uu____2460 = FStar_TypeChecker_NBETerm.unembed e_argv cb r
+               let uu____2538 = FStar_TypeChecker_NBETerm.unembed e_argv cb r
                   in
-               FStar_Util.bind_opt uu____2460
+               FStar_Util.bind_opt uu____2538
                  (fun r1  ->
                     FStar_All.pipe_left
-                      (fun _2467  -> FStar_Pervasives_Native.Some _2467)
+                      (fun _2545  -> FStar_Pervasives_Native.Some _2545)
                       (FStar_Reflection_Data.Tv_App (l1, r1))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2469,(t1,uu____2471)::(b,uu____2473)::[]) when
+          (fv,uu____2547,(t1,uu____2549)::(b,uu____2551)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Abs.FStar_Reflection_Data.lid
           ->
-          let uu____2496 = FStar_TypeChecker_NBETerm.unembed e_binder cb b
+          let uu____2574 = FStar_TypeChecker_NBETerm.unembed e_binder cb b
              in
-          FStar_Util.bind_opt uu____2496
+          FStar_Util.bind_opt uu____2574
             (fun b1  ->
-               let uu____2502 =
+               let uu____2580 =
                  FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
-               FStar_Util.bind_opt uu____2502
+               FStar_Util.bind_opt uu____2580
                  (fun t2  ->
                     FStar_All.pipe_left
-                      (fun _2509  -> FStar_Pervasives_Native.Some _2509)
+                      (fun _2587  -> FStar_Pervasives_Native.Some _2587)
                       (FStar_Reflection_Data.Tv_Abs (b1, t2))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2511,(t1,uu____2513)::(b,uu____2515)::[]) when
+          (fv,uu____2589,(t1,uu____2591)::(b,uu____2593)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Arrow.FStar_Reflection_Data.lid
           ->
-          let uu____2538 = FStar_TypeChecker_NBETerm.unembed e_binder cb b
+          let uu____2616 = FStar_TypeChecker_NBETerm.unembed e_binder cb b
              in
-          FStar_Util.bind_opt uu____2538
+          FStar_Util.bind_opt uu____2616
             (fun b1  ->
-               let uu____2544 =
+               let uu____2622 =
                  FStar_TypeChecker_NBETerm.unembed e_comp cb t1  in
-               FStar_Util.bind_opt uu____2544
+               FStar_Util.bind_opt uu____2622
                  (fun c  ->
                     FStar_All.pipe_left
-                      (fun _2551  -> FStar_Pervasives_Native.Some _2551)
+                      (fun _2629  -> FStar_Pervasives_Native.Some _2629)
                       (FStar_Reflection_Data.Tv_Arrow (b1, c))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2553,(u,uu____2555)::[]) when
+          (fv,uu____2631,(u,uu____2633)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Type.FStar_Reflection_Data.lid
           ->
-          let uu____2574 =
+          let uu____2652 =
             FStar_TypeChecker_NBETerm.unembed
               FStar_TypeChecker_NBETerm.e_unit cb u
              in
-          FStar_Util.bind_opt uu____2574
+          FStar_Util.bind_opt uu____2652
             (fun u1  ->
                FStar_All.pipe_left
-                 (fun _2581  -> FStar_Pervasives_Native.Some _2581)
+                 (fun _2659  -> FStar_Pervasives_Native.Some _2659)
                  (FStar_Reflection_Data.Tv_Type ()))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2583,(t1,uu____2585)::(b,uu____2587)::[]) when
+          (fv,uu____2661,(t1,uu____2663)::(b,uu____2665)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Refine.FStar_Reflection_Data.lid
           ->
-          let uu____2610 = FStar_TypeChecker_NBETerm.unembed e_bv cb b  in
-          FStar_Util.bind_opt uu____2610
+          let uu____2688 = FStar_TypeChecker_NBETerm.unembed e_bv cb b  in
+          FStar_Util.bind_opt uu____2688
             (fun b1  ->
-               let uu____2616 =
+               let uu____2694 =
                  FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
-               FStar_Util.bind_opt uu____2616
+               FStar_Util.bind_opt uu____2694
                  (fun t2  ->
                     FStar_All.pipe_left
-                      (fun _2623  -> FStar_Pervasives_Native.Some _2623)
+                      (fun _2701  -> FStar_Pervasives_Native.Some _2701)
                       (FStar_Reflection_Data.Tv_Refine (b1, t2))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2625,(c,uu____2627)::[]) when
+          (fv,uu____2703,(c,uu____2705)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Const.FStar_Reflection_Data.lid
           ->
-          let uu____2646 = FStar_TypeChecker_NBETerm.unembed e_const cb c  in
-          FStar_Util.bind_opt uu____2646
+          let uu____2724 = FStar_TypeChecker_NBETerm.unembed e_const cb c  in
+          FStar_Util.bind_opt uu____2724
             (fun c1  ->
                FStar_All.pipe_left
-                 (fun _2653  -> FStar_Pervasives_Native.Some _2653)
+                 (fun _2731  -> FStar_Pervasives_Native.Some _2731)
                  (FStar_Reflection_Data.Tv_Const c1))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2655,(l,uu____2657)::(u,uu____2659)::[]) when
+          (fv,uu____2733,(l,uu____2735)::(u,uu____2737)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Uvar.FStar_Reflection_Data.lid
           ->
-          let uu____2682 =
+          let uu____2760 =
             FStar_TypeChecker_NBETerm.unembed FStar_TypeChecker_NBETerm.e_int
               cb u
              in
-          FStar_Util.bind_opt uu____2682
+          FStar_Util.bind_opt uu____2760
             (fun u1  ->
                let ctx_u_s = unlazy_as_t FStar_Syntax_Syntax.Lazy_uvar l  in
                FStar_All.pipe_left
-                 (fun _2691  -> FStar_Pervasives_Native.Some _2691)
+                 (fun _2769  -> FStar_Pervasives_Native.Some _2769)
                  (FStar_Reflection_Data.Tv_Uvar (u1, ctx_u_s)))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2693,(t2,uu____2695)::(t1,uu____2697)::(b,uu____2699)::
-           (r,uu____2701)::[])
+          (fv,uu____2771,(t2,uu____2773)::(t1,uu____2775)::(b,uu____2777)::
+           (r,uu____2779)::[])
           when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Let.FStar_Reflection_Data.lid
           ->
-          let uu____2732 =
+          let uu____2810 =
             FStar_TypeChecker_NBETerm.unembed
               FStar_TypeChecker_NBETerm.e_bool cb r
              in
-          FStar_Util.bind_opt uu____2732
+          FStar_Util.bind_opt uu____2810
             (fun r1  ->
-               let uu____2742 = FStar_TypeChecker_NBETerm.unembed e_bv cb b
+               let uu____2820 = FStar_TypeChecker_NBETerm.unembed e_bv cb b
                   in
-               FStar_Util.bind_opt uu____2742
+               FStar_Util.bind_opt uu____2820
                  (fun b1  ->
-                    let uu____2748 =
+                    let uu____2826 =
                       FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
-                    FStar_Util.bind_opt uu____2748
+                    FStar_Util.bind_opt uu____2826
                       (fun t11  ->
-                         let uu____2754 =
+                         let uu____2832 =
                            FStar_TypeChecker_NBETerm.unembed e_term cb t2  in
-                         FStar_Util.bind_opt uu____2754
+                         FStar_Util.bind_opt uu____2832
                            (fun t21  ->
                               FStar_All.pipe_left
-                                (fun _2761  ->
-                                   FStar_Pervasives_Native.Some _2761)
+                                (fun _2839  ->
+                                   FStar_Pervasives_Native.Some _2839)
                                 (FStar_Reflection_Data.Tv_Let
                                    (r1, b1, t11, t21))))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2764,(brs,uu____2766)::(t1,uu____2768)::[]) when
+          (fv,uu____2842,(brs,uu____2844)::(t1,uu____2846)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Match.FStar_Reflection_Data.lid
           ->
-          let uu____2791 = FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
-          FStar_Util.bind_opt uu____2791
+          let uu____2869 = FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
+          FStar_Util.bind_opt uu____2869
             (fun t2  ->
-               let uu____2797 =
-                 let uu____2802 = FStar_TypeChecker_NBETerm.e_list e_branch
+               let uu____2875 =
+                 let uu____2880 = FStar_TypeChecker_NBETerm.e_list e_branch
                     in
-                 FStar_TypeChecker_NBETerm.unembed uu____2802 cb brs  in
-               FStar_Util.bind_opt uu____2797
+                 FStar_TypeChecker_NBETerm.unembed uu____2880 cb brs  in
+               FStar_Util.bind_opt uu____2875
                  (fun brs1  ->
                     FStar_All.pipe_left
-                      (fun _2817  -> FStar_Pervasives_Native.Some _2817)
+                      (fun _2895  -> FStar_Pervasives_Native.Some _2895)
                       (FStar_Reflection_Data.Tv_Match (t2, brs1))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2821,(tacopt,uu____2823)::(t1,uu____2825)::(e,uu____2827)::[])
+          (fv,uu____2899,(tacopt,uu____2901)::(t1,uu____2903)::(e,uu____2905)::[])
           when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.lid
           ->
-          let uu____2854 = FStar_TypeChecker_NBETerm.unembed e_term cb e  in
-          FStar_Util.bind_opt uu____2854
+          let uu____2932 = FStar_TypeChecker_NBETerm.unembed e_term cb e  in
+          FStar_Util.bind_opt uu____2932
             (fun e1  ->
-               let uu____2860 =
+               let uu____2938 =
                  FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
-               FStar_Util.bind_opt uu____2860
+               FStar_Util.bind_opt uu____2938
                  (fun t2  ->
-                    let uu____2866 =
-                      let uu____2871 =
+                    let uu____2944 =
+                      let uu____2949 =
                         FStar_TypeChecker_NBETerm.e_option e_term  in
-                      FStar_TypeChecker_NBETerm.unembed uu____2871 cb tacopt
+                      FStar_TypeChecker_NBETerm.unembed uu____2949 cb tacopt
                        in
-                    FStar_Util.bind_opt uu____2866
+                    FStar_Util.bind_opt uu____2944
                       (fun tacopt1  ->
                          FStar_All.pipe_left
-                           (fun _2886  -> FStar_Pervasives_Native.Some _2886)
+                           (fun _2964  -> FStar_Pervasives_Native.Some _2964)
                            (FStar_Reflection_Data.Tv_AscribedT
                               (e1, t2, tacopt1)))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2890,(tacopt,uu____2892)::(c,uu____2894)::(e,uu____2896)::[])
+          (fv,uu____2968,(tacopt,uu____2970)::(c,uu____2972)::(e,uu____2974)::[])
           when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_AscC.FStar_Reflection_Data.lid
           ->
-          let uu____2923 = FStar_TypeChecker_NBETerm.unembed e_term cb e  in
-          FStar_Util.bind_opt uu____2923
+          let uu____3001 = FStar_TypeChecker_NBETerm.unembed e_term cb e  in
+          FStar_Util.bind_opt uu____3001
             (fun e1  ->
-               let uu____2929 = FStar_TypeChecker_NBETerm.unembed e_comp cb c
+               let uu____3007 = FStar_TypeChecker_NBETerm.unembed e_comp cb c
                   in
-               FStar_Util.bind_opt uu____2929
+               FStar_Util.bind_opt uu____3007
                  (fun c1  ->
-                    let uu____2935 =
-                      let uu____2940 =
+                    let uu____3013 =
+                      let uu____3018 =
                         FStar_TypeChecker_NBETerm.e_option e_term  in
-                      FStar_TypeChecker_NBETerm.unembed uu____2940 cb tacopt
+                      FStar_TypeChecker_NBETerm.unembed uu____3018 cb tacopt
                        in
-                    FStar_Util.bind_opt uu____2935
+                    FStar_Util.bind_opt uu____3013
                       (fun tacopt1  ->
                          FStar_All.pipe_left
-                           (fun _2955  -> FStar_Pervasives_Native.Some _2955)
+                           (fun _3033  -> FStar_Pervasives_Native.Some _3033)
                            (FStar_Reflection_Data.Tv_AscribedC
                               (e1, c1, tacopt1)))))
-      | FStar_TypeChecker_NBETerm.Construct (fv,uu____2959,[]) when
+      | FStar_TypeChecker_NBETerm.Construct (fv,uu____3037,[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Unknown.FStar_Reflection_Data.lid
           ->
           FStar_All.pipe_left
-            (fun _2976  -> FStar_Pervasives_Native.Some _2976)
+            (fun _3054  -> FStar_Pervasives_Native.Some _3054)
             FStar_Reflection_Data.Tv_Unknown
-      | uu____2977 ->
-          ((let uu____2979 =
-              let uu____2985 =
-                let uu____2987 = FStar_TypeChecker_NBETerm.t_to_string t  in
-                FStar_Util.format1 "Not an embedded term_view: %s" uu____2987
+      | uu____3055 ->
+          ((let uu____3057 =
+              let uu____3063 =
+                let uu____3065 = FStar_TypeChecker_NBETerm.t_to_string t  in
+                FStar_Util.format1 "Not an embedded term_view: %s" uu____3065
                  in
-              (FStar_Errors.Warning_NotEmbedded, uu____2985)  in
-            FStar_Errors.log_issue FStar_Range.dummyRange uu____2979);
+              (FStar_Errors.Warning_NotEmbedded, uu____3063)  in
+            FStar_Errors.log_issue FStar_Range.dummyRange uu____3057);
            FStar_Pervasives_Native.None)
        in
     mk_emb' embed_term_view unembed_term_view
@@ -1163,71 +1171,71 @@ let (e_term_view :
 let (e_bv_view :
   FStar_Reflection_Data.bv_view FStar_TypeChecker_NBETerm.embedding) =
   let embed_bv_view cb bvv =
-    let uu____3014 =
-      let uu____3021 =
-        let uu____3026 =
+    let uu____3092 =
+      let uu____3099 =
+        let uu____3104 =
           FStar_TypeChecker_NBETerm.embed FStar_TypeChecker_NBETerm.e_string
             cb bvv.FStar_Reflection_Data.bv_ppname
            in
-        FStar_TypeChecker_NBETerm.as_arg uu____3026  in
-      let uu____3028 =
-        let uu____3035 =
-          let uu____3040 =
+        FStar_TypeChecker_NBETerm.as_arg uu____3104  in
+      let uu____3106 =
+        let uu____3113 =
+          let uu____3118 =
             FStar_TypeChecker_NBETerm.embed FStar_TypeChecker_NBETerm.e_int
               cb bvv.FStar_Reflection_Data.bv_index
              in
-          FStar_TypeChecker_NBETerm.as_arg uu____3040  in
-        let uu____3041 =
-          let uu____3048 =
-            let uu____3053 =
+          FStar_TypeChecker_NBETerm.as_arg uu____3118  in
+        let uu____3119 =
+          let uu____3126 =
+            let uu____3131 =
               FStar_TypeChecker_NBETerm.embed e_term cb
                 bvv.FStar_Reflection_Data.bv_sort
                in
-            FStar_TypeChecker_NBETerm.as_arg uu____3053  in
-          [uu____3048]  in
-        uu____3035 :: uu____3041  in
-      uu____3021 :: uu____3028  in
+            FStar_TypeChecker_NBETerm.as_arg uu____3131  in
+          [uu____3126]  in
+        uu____3113 :: uu____3119  in
+      uu____3099 :: uu____3106  in
     mkConstruct FStar_Reflection_Data.ref_Mk_bv.FStar_Reflection_Data.fv []
-      uu____3014
+      uu____3092
      in
   let unembed_bv_view cb t =
     match t with
     | FStar_TypeChecker_NBETerm.Construct
-        (fv,uu____3086,(s,uu____3088)::(idx,uu____3090)::(nm,uu____3092)::[])
+        (fv,uu____3164,(s,uu____3166)::(idx,uu____3168)::(nm,uu____3170)::[])
         when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_Mk_bv.FStar_Reflection_Data.lid
         ->
-        let uu____3119 =
+        let uu____3197 =
           FStar_TypeChecker_NBETerm.unembed
             FStar_TypeChecker_NBETerm.e_string cb nm
            in
-        FStar_Util.bind_opt uu____3119
+        FStar_Util.bind_opt uu____3197
           (fun nm1  ->
-             let uu____3129 =
+             let uu____3207 =
                FStar_TypeChecker_NBETerm.unembed
                  FStar_TypeChecker_NBETerm.e_int cb idx
                 in
-             FStar_Util.bind_opt uu____3129
+             FStar_Util.bind_opt uu____3207
                (fun idx1  ->
-                  let uu____3135 =
+                  let uu____3213 =
                     FStar_TypeChecker_NBETerm.unembed e_term cb s  in
-                  FStar_Util.bind_opt uu____3135
+                  FStar_Util.bind_opt uu____3213
                     (fun s1  ->
                        FStar_All.pipe_left
-                         (fun _3142  -> FStar_Pervasives_Native.Some _3142)
+                         (fun _3220  -> FStar_Pervasives_Native.Some _3220)
                          {
                            FStar_Reflection_Data.bv_ppname = nm1;
                            FStar_Reflection_Data.bv_index = idx1;
                            FStar_Reflection_Data.bv_sort = s1
                          })))
-    | uu____3143 ->
-        ((let uu____3145 =
-            let uu____3151 =
-              let uu____3153 = FStar_TypeChecker_NBETerm.t_to_string t  in
-              FStar_Util.format1 "Not an embedded bv_view: %s" uu____3153  in
-            (FStar_Errors.Warning_NotEmbedded, uu____3151)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____3145);
+    | uu____3221 ->
+        ((let uu____3223 =
+            let uu____3229 =
+              let uu____3231 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded bv_view: %s" uu____3231  in
+            (FStar_Errors.Warning_NotEmbedded, uu____3229)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____3223);
          FStar_Pervasives_Native.None)
      in
   mk_emb' embed_bv_view unembed_bv_view
@@ -1238,39 +1246,39 @@ let (e_comp_view :
   let embed_comp_view cb cv =
     match cv with
     | FStar_Reflection_Data.C_Total (t,md) ->
-        let uu____3177 =
-          let uu____3184 =
-            let uu____3189 = FStar_TypeChecker_NBETerm.embed e_term cb t  in
-            FStar_TypeChecker_NBETerm.as_arg uu____3189  in
-          let uu____3190 =
-            let uu____3197 =
-              let uu____3202 =
-                let uu____3203 = FStar_TypeChecker_NBETerm.e_option e_term
+        let uu____3255 =
+          let uu____3262 =
+            let uu____3267 = FStar_TypeChecker_NBETerm.embed e_term cb t  in
+            FStar_TypeChecker_NBETerm.as_arg uu____3267  in
+          let uu____3268 =
+            let uu____3275 =
+              let uu____3280 =
+                let uu____3281 = FStar_TypeChecker_NBETerm.e_option e_term
                    in
-                FStar_TypeChecker_NBETerm.embed uu____3203 cb md  in
-              FStar_TypeChecker_NBETerm.as_arg uu____3202  in
-            [uu____3197]  in
-          uu____3184 :: uu____3190  in
+                FStar_TypeChecker_NBETerm.embed uu____3281 cb md  in
+              FStar_TypeChecker_NBETerm.as_arg uu____3280  in
+            [uu____3275]  in
+          uu____3262 :: uu____3268  in
         mkConstruct
           FStar_Reflection_Data.ref_C_Total.FStar_Reflection_Data.fv []
-          uu____3177
+          uu____3255
     | FStar_Reflection_Data.C_Lemma (pre,post) ->
         let post1 = FStar_Syntax_Util.unthunk_lemma_post post  in
-        let uu____3227 =
-          let uu____3234 =
-            let uu____3239 = FStar_TypeChecker_NBETerm.embed e_term cb pre
+        let uu____3305 =
+          let uu____3312 =
+            let uu____3317 = FStar_TypeChecker_NBETerm.embed e_term cb pre
                in
-            FStar_TypeChecker_NBETerm.as_arg uu____3239  in
-          let uu____3240 =
-            let uu____3247 =
-              let uu____3252 =
+            FStar_TypeChecker_NBETerm.as_arg uu____3317  in
+          let uu____3318 =
+            let uu____3325 =
+              let uu____3330 =
                 FStar_TypeChecker_NBETerm.embed e_term cb post1  in
-              FStar_TypeChecker_NBETerm.as_arg uu____3252  in
-            [uu____3247]  in
-          uu____3234 :: uu____3240  in
+              FStar_TypeChecker_NBETerm.as_arg uu____3330  in
+            [uu____3325]  in
+          uu____3312 :: uu____3318  in
         mkConstruct
           FStar_Reflection_Data.ref_C_Lemma.FStar_Reflection_Data.fv []
-          uu____3227
+          uu____3305
     | FStar_Reflection_Data.C_Unknown  ->
         mkConstruct
           FStar_Reflection_Data.ref_C_Unknown.FStar_Reflection_Data.fv [] []
@@ -1278,51 +1286,51 @@ let (e_comp_view :
   let unembed_comp_view cb t =
     match t with
     | FStar_TypeChecker_NBETerm.Construct
-        (fv,uu____3285,(md,uu____3287)::(t1,uu____3289)::[]) when
+        (fv,uu____3363,(md,uu____3365)::(t1,uu____3367)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_Total.FStar_Reflection_Data.lid
         ->
-        let uu____3312 = FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
-        FStar_Util.bind_opt uu____3312
+        let uu____3390 = FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
+        FStar_Util.bind_opt uu____3390
           (fun t2  ->
-             let uu____3318 =
-               let uu____3323 = FStar_TypeChecker_NBETerm.e_option e_term  in
-               FStar_TypeChecker_NBETerm.unembed uu____3323 cb md  in
-             FStar_Util.bind_opt uu____3318
+             let uu____3396 =
+               let uu____3401 = FStar_TypeChecker_NBETerm.e_option e_term  in
+               FStar_TypeChecker_NBETerm.unembed uu____3401 cb md  in
+             FStar_Util.bind_opt uu____3396
                (fun md1  ->
                   FStar_All.pipe_left
-                    (fun _3338  -> FStar_Pervasives_Native.Some _3338)
+                    (fun _3416  -> FStar_Pervasives_Native.Some _3416)
                     (FStar_Reflection_Data.C_Total (t2, md1))))
     | FStar_TypeChecker_NBETerm.Construct
-        (fv,uu____3342,(post,uu____3344)::(pre,uu____3346)::[]) when
+        (fv,uu____3420,(post,uu____3422)::(pre,uu____3424)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_Lemma.FStar_Reflection_Data.lid
         ->
-        let uu____3369 = FStar_TypeChecker_NBETerm.unembed e_term cb pre  in
-        FStar_Util.bind_opt uu____3369
+        let uu____3447 = FStar_TypeChecker_NBETerm.unembed e_term cb pre  in
+        FStar_Util.bind_opt uu____3447
           (fun pre1  ->
-             let uu____3375 =
+             let uu____3453 =
                FStar_TypeChecker_NBETerm.unembed e_term cb post  in
-             FStar_Util.bind_opt uu____3375
+             FStar_Util.bind_opt uu____3453
                (fun post1  ->
                   FStar_All.pipe_left
-                    (fun _3382  -> FStar_Pervasives_Native.Some _3382)
+                    (fun _3460  -> FStar_Pervasives_Native.Some _3460)
                     (FStar_Reflection_Data.C_Lemma (pre1, post1))))
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____3384,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____3462,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_Unknown.FStar_Reflection_Data.lid
         ->
         FStar_All.pipe_left
-          (fun _3401  -> FStar_Pervasives_Native.Some _3401)
+          (fun _3479  -> FStar_Pervasives_Native.Some _3479)
           FStar_Reflection_Data.C_Unknown
-    | uu____3402 ->
-        ((let uu____3404 =
-            let uu____3410 =
-              let uu____3412 = FStar_TypeChecker_NBETerm.t_to_string t  in
-              FStar_Util.format1 "Not an embedded comp_view: %s" uu____3412
+    | uu____3480 ->
+        ((let uu____3482 =
+            let uu____3488 =
+              let uu____3490 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded comp_view: %s" uu____3490
                in
-            (FStar_Errors.Warning_NotEmbedded, uu____3410)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____3404);
+            (FStar_Errors.Warning_NotEmbedded, uu____3488)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____3482);
          FStar_Pervasives_Native.None)
      in
   mk_emb' embed_comp_view unembed_comp_view
@@ -1337,29 +1345,29 @@ let (e_order : FStar_Order.order FStar_TypeChecker_NBETerm.embedding) =
      in
   let unembed_order cb t =
     match t with
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____3458,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____3536,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Reflection_Data.ord_Lt_lid ->
         FStar_Pervasives_Native.Some FStar_Order.Lt
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____3474,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____3552,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Reflection_Data.ord_Eq_lid ->
         FStar_Pervasives_Native.Some FStar_Order.Eq
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____3490,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____3568,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Reflection_Data.ord_Gt_lid ->
         FStar_Pervasives_Native.Some FStar_Order.Gt
-    | uu____3505 ->
-        ((let uu____3507 =
-            let uu____3513 =
-              let uu____3515 = FStar_TypeChecker_NBETerm.t_to_string t  in
-              FStar_Util.format1 "Not an embedded order: %s" uu____3515  in
-            (FStar_Errors.Warning_NotEmbedded, uu____3513)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____3507);
+    | uu____3583 ->
+        ((let uu____3585 =
+            let uu____3591 =
+              let uu____3593 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded order: %s" uu____3593  in
+            (FStar_Errors.Warning_NotEmbedded, uu____3591)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____3585);
          FStar_Pervasives_Native.None)
      in
-  let uu____3519 =
+  let uu____3597 =
     FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.order_lid
       FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
      in
-  mk_emb' embed_order unembed_order uu____3519 
+  mk_emb' embed_order unembed_order uu____3597 
 let (e_sigelt :
   FStar_Syntax_Syntax.sigelt FStar_TypeChecker_NBETerm.embedding) =
   let embed_sigelt cb se =
@@ -1372,18 +1380,18 @@ let (e_sigelt :
         (FStar_Util.Inl
          { FStar_Syntax_Syntax.blob = b;
            FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_sigelt ;
-           FStar_Syntax_Syntax.ltyp = uu____3550;
-           FStar_Syntax_Syntax.rng = uu____3551;_},uu____3552)
+           FStar_Syntax_Syntax.ltyp = uu____3628;
+           FStar_Syntax_Syntax.rng = uu____3629;_},uu____3630)
         ->
-        let uu____3571 = FStar_Dyn.undyn b  in
-        FStar_Pervasives_Native.Some uu____3571
-    | uu____3572 ->
-        ((let uu____3574 =
-            let uu____3580 =
-              let uu____3582 = FStar_TypeChecker_NBETerm.t_to_string t  in
-              FStar_Util.format1 "Not an embedded sigelt: %s" uu____3582  in
-            (FStar_Errors.Warning_NotEmbedded, uu____3580)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____3574);
+        let uu____3649 = FStar_Dyn.undyn b  in
+        FStar_Pervasives_Native.Some uu____3649
+    | uu____3650 ->
+        ((let uu____3652 =
+            let uu____3658 =
+              let uu____3660 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded sigelt: %s" uu____3660  in
+            (FStar_Errors.Warning_NotEmbedded, uu____3658)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____3652);
          FStar_Pervasives_Native.None)
      in
   mk_emb' embed_sigelt unembed_sigelt
@@ -1395,17 +1403,17 @@ let (e_ident : FStar_Ident.ident FStar_TypeChecker_NBETerm.embedding) =
       FStar_TypeChecker_NBETerm.e_string
      in
   let embed_ident cb i =
-    let uu____3611 =
-      let uu____3617 = FStar_Ident.range_of_id i  in
-      let uu____3618 = FStar_Ident.text_of_id i  in (uu____3617, uu____3618)
+    let uu____3689 =
+      let uu____3695 = FStar_Ident.range_of_id i  in
+      let uu____3696 = FStar_Ident.text_of_id i  in (uu____3695, uu____3696)
        in
-    FStar_TypeChecker_NBETerm.embed repr cb uu____3611  in
+    FStar_TypeChecker_NBETerm.embed repr cb uu____3689  in
   let unembed_ident cb t =
-    let uu____3641 = FStar_TypeChecker_NBETerm.unembed repr cb t  in
-    match uu____3641 with
+    let uu____3719 = FStar_TypeChecker_NBETerm.unembed repr cb t  in
+    match uu____3719 with
     | FStar_Pervasives_Native.Some (rng,s) ->
-        let uu____3665 = FStar_Ident.mk_ident (s, rng)  in
-        FStar_Pervasives_Native.Some uu____3665
+        let uu____3743 = FStar_Ident.mk_ident (s, rng)  in
+        FStar_Pervasives_Native.Some uu____3743
     | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None  in
   let range_fv =
     FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.range_lid
@@ -1416,35 +1424,35 @@ let (e_ident : FStar_Ident.ident FStar_TypeChecker_NBETerm.embedding) =
       FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
      in
   let et =
-    let uu____3675 =
-      let uu____3683 =
+    let uu____3753 =
+      let uu____3761 =
         FStar_Ident.string_of_lid FStar_Parser_Const.lid_tuple2  in
-      let uu____3685 =
-        let uu____3688 = fv_as_emb_typ range_fv  in
-        let uu____3689 =
-          let uu____3692 = fv_as_emb_typ string_fv  in [uu____3692]  in
-        uu____3688 :: uu____3689  in
-      (uu____3683, uu____3685)  in
-    FStar_Syntax_Syntax.ET_app uu____3675  in
-  let uu____3696 =
-    let uu____3697 =
+      let uu____3763 =
+        let uu____3766 = fv_as_emb_typ range_fv  in
+        let uu____3767 =
+          let uu____3770 = fv_as_emb_typ string_fv  in [uu____3770]  in
+        uu____3766 :: uu____3767  in
+      (uu____3761, uu____3763)  in
+    FStar_Syntax_Syntax.ET_app uu____3753  in
+  let uu____3774 =
+    let uu____3775 =
       FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.lid_tuple2
         FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
        in
-    let uu____3698 =
-      let uu____3705 =
-        let uu____3710 = mkFV range_fv [] []  in
-        FStar_TypeChecker_NBETerm.as_arg uu____3710  in
-      let uu____3715 =
-        let uu____3722 =
-          let uu____3727 = mkFV string_fv [] []  in
-          FStar_TypeChecker_NBETerm.as_arg uu____3727  in
-        [uu____3722]  in
-      uu____3705 :: uu____3715  in
-    mkFV uu____3697 [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]
-      uu____3698
+    let uu____3776 =
+      let uu____3783 =
+        let uu____3788 = mkFV range_fv [] []  in
+        FStar_TypeChecker_NBETerm.as_arg uu____3788  in
+      let uu____3793 =
+        let uu____3800 =
+          let uu____3805 = mkFV string_fv [] []  in
+          FStar_TypeChecker_NBETerm.as_arg uu____3805  in
+        [uu____3800]  in
+      uu____3783 :: uu____3793  in
+    mkFV uu____3775 [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]
+      uu____3776
      in
-  FStar_TypeChecker_NBETerm.mk_emb embed_ident unembed_ident uu____3696 et 
+  FStar_TypeChecker_NBETerm.mk_emb embed_ident unembed_ident uu____3774 et 
 let (e_univ_name :
   FStar_Syntax_Syntax.univ_name FStar_TypeChecker_NBETerm.embedding) =
   e_ident 
@@ -1460,91 +1468,91 @@ let (e_sigelt_view :
   let embed_sigelt_view cb sev =
     match sev with
     | FStar_Reflection_Data.Sg_Let (r,fv,univs1,ty,t) ->
-        let uu____3784 =
-          let uu____3791 =
-            let uu____3796 =
+        let uu____3862 =
+          let uu____3869 =
+            let uu____3874 =
               FStar_TypeChecker_NBETerm.embed
                 FStar_TypeChecker_NBETerm.e_bool cb r
                in
-            FStar_TypeChecker_NBETerm.as_arg uu____3796  in
-          let uu____3798 =
-            let uu____3805 =
-              let uu____3810 = FStar_TypeChecker_NBETerm.embed e_fv cb fv  in
-              FStar_TypeChecker_NBETerm.as_arg uu____3810  in
-            let uu____3811 =
-              let uu____3818 =
-                let uu____3823 =
+            FStar_TypeChecker_NBETerm.as_arg uu____3874  in
+          let uu____3876 =
+            let uu____3883 =
+              let uu____3888 = FStar_TypeChecker_NBETerm.embed e_fv cb fv  in
+              FStar_TypeChecker_NBETerm.as_arg uu____3888  in
+            let uu____3889 =
+              let uu____3896 =
+                let uu____3901 =
                   FStar_TypeChecker_NBETerm.embed e_univ_names cb univs1  in
-                FStar_TypeChecker_NBETerm.as_arg uu____3823  in
-              let uu____3826 =
-                let uu____3833 =
-                  let uu____3838 =
+                FStar_TypeChecker_NBETerm.as_arg uu____3901  in
+              let uu____3904 =
+                let uu____3911 =
+                  let uu____3916 =
                     FStar_TypeChecker_NBETerm.embed e_term cb ty  in
-                  FStar_TypeChecker_NBETerm.as_arg uu____3838  in
-                let uu____3839 =
-                  let uu____3846 =
-                    let uu____3851 =
+                  FStar_TypeChecker_NBETerm.as_arg uu____3916  in
+                let uu____3917 =
+                  let uu____3924 =
+                    let uu____3929 =
                       FStar_TypeChecker_NBETerm.embed e_term cb t  in
-                    FStar_TypeChecker_NBETerm.as_arg uu____3851  in
-                  [uu____3846]  in
-                uu____3833 :: uu____3839  in
-              uu____3818 :: uu____3826  in
-            uu____3805 :: uu____3811  in
-          uu____3791 :: uu____3798  in
+                    FStar_TypeChecker_NBETerm.as_arg uu____3929  in
+                  [uu____3924]  in
+                uu____3911 :: uu____3917  in
+              uu____3896 :: uu____3904  in
+            uu____3883 :: uu____3889  in
+          uu____3869 :: uu____3876  in
         mkConstruct FStar_Reflection_Data.ref_Sg_Let.FStar_Reflection_Data.fv
-          [] uu____3784
+          [] uu____3862
     | FStar_Reflection_Data.Sg_Constructor (nm,ty) ->
-        let uu____3878 =
-          let uu____3885 =
-            let uu____3890 =
+        let uu____3956 =
+          let uu____3963 =
+            let uu____3968 =
               FStar_TypeChecker_NBETerm.embed e_string_list cb nm  in
-            FStar_TypeChecker_NBETerm.as_arg uu____3890  in
-          let uu____3894 =
-            let uu____3901 =
-              let uu____3906 = FStar_TypeChecker_NBETerm.embed e_term cb ty
+            FStar_TypeChecker_NBETerm.as_arg uu____3968  in
+          let uu____3972 =
+            let uu____3979 =
+              let uu____3984 = FStar_TypeChecker_NBETerm.embed e_term cb ty
                  in
-              FStar_TypeChecker_NBETerm.as_arg uu____3906  in
-            [uu____3901]  in
-          uu____3885 :: uu____3894  in
+              FStar_TypeChecker_NBETerm.as_arg uu____3984  in
+            [uu____3979]  in
+          uu____3963 :: uu____3972  in
         mkConstruct
           FStar_Reflection_Data.ref_Sg_Constructor.FStar_Reflection_Data.fv
-          [] uu____3878
+          [] uu____3956
     | FStar_Reflection_Data.Sg_Inductive (nm,univs1,bs,t,dcs) ->
-        let uu____3936 =
-          let uu____3943 =
-            let uu____3948 =
+        let uu____4014 =
+          let uu____4021 =
+            let uu____4026 =
               FStar_TypeChecker_NBETerm.embed e_string_list cb nm  in
-            FStar_TypeChecker_NBETerm.as_arg uu____3948  in
-          let uu____3952 =
-            let uu____3959 =
-              let uu____3964 =
+            FStar_TypeChecker_NBETerm.as_arg uu____4026  in
+          let uu____4030 =
+            let uu____4037 =
+              let uu____4042 =
                 FStar_TypeChecker_NBETerm.embed e_univ_names cb univs1  in
-              FStar_TypeChecker_NBETerm.as_arg uu____3964  in
-            let uu____3967 =
-              let uu____3974 =
-                let uu____3979 =
+              FStar_TypeChecker_NBETerm.as_arg uu____4042  in
+            let uu____4045 =
+              let uu____4052 =
+                let uu____4057 =
                   FStar_TypeChecker_NBETerm.embed e_binders cb bs  in
-                FStar_TypeChecker_NBETerm.as_arg uu____3979  in
-              let uu____3980 =
-                let uu____3987 =
-                  let uu____3992 =
+                FStar_TypeChecker_NBETerm.as_arg uu____4057  in
+              let uu____4058 =
+                let uu____4065 =
+                  let uu____4070 =
                     FStar_TypeChecker_NBETerm.embed e_term cb t  in
-                  FStar_TypeChecker_NBETerm.as_arg uu____3992  in
-                let uu____3993 =
-                  let uu____4000 =
-                    let uu____4005 =
-                      let uu____4006 =
+                  FStar_TypeChecker_NBETerm.as_arg uu____4070  in
+                let uu____4071 =
+                  let uu____4078 =
+                    let uu____4083 =
+                      let uu____4084 =
                         FStar_TypeChecker_NBETerm.e_list e_string_list  in
-                      FStar_TypeChecker_NBETerm.embed uu____4006 cb dcs  in
-                    FStar_TypeChecker_NBETerm.as_arg uu____4005  in
-                  [uu____4000]  in
-                uu____3987 :: uu____3993  in
-              uu____3974 :: uu____3980  in
-            uu____3959 :: uu____3967  in
-          uu____3943 :: uu____3952  in
+                      FStar_TypeChecker_NBETerm.embed uu____4084 cb dcs  in
+                    FStar_TypeChecker_NBETerm.as_arg uu____4083  in
+                  [uu____4078]  in
+                uu____4065 :: uu____4071  in
+              uu____4052 :: uu____4058  in
+            uu____4037 :: uu____4045  in
+          uu____4021 :: uu____4030  in
         mkConstruct
           FStar_Reflection_Data.ref_Sg_Inductive.FStar_Reflection_Data.fv []
-          uu____3936
+          uu____4014
     | FStar_Reflection_Data.Unk  ->
         mkConstruct FStar_Reflection_Data.ref_Unk.FStar_Reflection_Data.fv []
           []
@@ -1552,91 +1560,91 @@ let (e_sigelt_view :
   let unembed_sigelt_view cb t =
     match t with
     | FStar_TypeChecker_NBETerm.Construct
-        (fv,uu____4066,(dcs,uu____4068)::(t1,uu____4070)::(bs,uu____4072)::
-         (us,uu____4074)::(nm,uu____4076)::[])
+        (fv,uu____4144,(dcs,uu____4146)::(t1,uu____4148)::(bs,uu____4150)::
+         (us,uu____4152)::(nm,uu____4154)::[])
         when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_Sg_Inductive.FStar_Reflection_Data.lid
         ->
-        let uu____4111 =
+        let uu____4189 =
           FStar_TypeChecker_NBETerm.unembed e_string_list cb nm  in
-        FStar_Util.bind_opt uu____4111
+        FStar_Util.bind_opt uu____4189
           (fun nm1  ->
-             let uu____4129 =
+             let uu____4207 =
                FStar_TypeChecker_NBETerm.unembed e_univ_names cb us  in
-             FStar_Util.bind_opt uu____4129
+             FStar_Util.bind_opt uu____4207
                (fun us1  ->
-                  let uu____4143 =
+                  let uu____4221 =
                     FStar_TypeChecker_NBETerm.unembed e_binders cb bs  in
-                  FStar_Util.bind_opt uu____4143
+                  FStar_Util.bind_opt uu____4221
                     (fun bs1  ->
-                       let uu____4149 =
+                       let uu____4227 =
                          FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
-                       FStar_Util.bind_opt uu____4149
+                       FStar_Util.bind_opt uu____4227
                          (fun t2  ->
-                            let uu____4155 =
-                              let uu____4163 =
+                            let uu____4233 =
+                              let uu____4241 =
                                 FStar_TypeChecker_NBETerm.e_list
                                   e_string_list
                                  in
-                              FStar_TypeChecker_NBETerm.unembed uu____4163 cb
+                              FStar_TypeChecker_NBETerm.unembed uu____4241 cb
                                 dcs
                                in
-                            FStar_Util.bind_opt uu____4155
+                            FStar_Util.bind_opt uu____4233
                               (fun dcs1  ->
                                  FStar_All.pipe_left
-                                   (fun _4193  ->
-                                      FStar_Pervasives_Native.Some _4193)
+                                   (fun _4271  ->
+                                      FStar_Pervasives_Native.Some _4271)
                                    (FStar_Reflection_Data.Sg_Inductive
                                       (nm1, us1, bs1, t2, dcs1)))))))
     | FStar_TypeChecker_NBETerm.Construct
-        (fv,uu____4201,(t1,uu____4203)::(ty,uu____4205)::(univs1,uu____4207)::
-         (fvar1,uu____4209)::(r,uu____4211)::[])
+        (fv,uu____4279,(t1,uu____4281)::(ty,uu____4283)::(univs1,uu____4285)::
+         (fvar1,uu____4287)::(r,uu____4289)::[])
         when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_Sg_Let.FStar_Reflection_Data.lid
         ->
-        let uu____4246 =
+        let uu____4324 =
           FStar_TypeChecker_NBETerm.unembed FStar_TypeChecker_NBETerm.e_bool
             cb r
            in
-        FStar_Util.bind_opt uu____4246
+        FStar_Util.bind_opt uu____4324
           (fun r1  ->
-             let uu____4256 = FStar_TypeChecker_NBETerm.unembed e_fv cb fvar1
+             let uu____4334 = FStar_TypeChecker_NBETerm.unembed e_fv cb fvar1
                 in
-             FStar_Util.bind_opt uu____4256
+             FStar_Util.bind_opt uu____4334
                (fun fvar2  ->
-                  let uu____4262 =
+                  let uu____4340 =
                     FStar_TypeChecker_NBETerm.unembed e_univ_names cb univs1
                      in
-                  FStar_Util.bind_opt uu____4262
+                  FStar_Util.bind_opt uu____4340
                     (fun univs2  ->
-                       let uu____4276 =
+                       let uu____4354 =
                          FStar_TypeChecker_NBETerm.unembed e_term cb ty  in
-                       FStar_Util.bind_opt uu____4276
+                       FStar_Util.bind_opt uu____4354
                          (fun ty1  ->
-                            let uu____4282 =
+                            let uu____4360 =
                               FStar_TypeChecker_NBETerm.unembed e_term cb t1
                                in
-                            FStar_Util.bind_opt uu____4282
+                            FStar_Util.bind_opt uu____4360
                               (fun t2  ->
                                  FStar_All.pipe_left
-                                   (fun _4289  ->
-                                      FStar_Pervasives_Native.Some _4289)
+                                   (fun _4367  ->
+                                      FStar_Pervasives_Native.Some _4367)
                                    (FStar_Reflection_Data.Sg_Let
                                       (r1, fvar2, univs2, ty1, t2)))))))
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____4294,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____4372,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_Unk.FStar_Reflection_Data.lid
         -> FStar_Pervasives_Native.Some FStar_Reflection_Data.Unk
-    | uu____4309 ->
-        ((let uu____4311 =
-            let uu____4317 =
-              let uu____4319 = FStar_TypeChecker_NBETerm.t_to_string t  in
-              FStar_Util.format1 "Not an embedded sigelt_view: %s" uu____4319
+    | uu____4387 ->
+        ((let uu____4389 =
+            let uu____4395 =
+              let uu____4397 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded sigelt_view: %s" uu____4397
                in
-            (FStar_Errors.Warning_NotEmbedded, uu____4317)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____4311);
+            (FStar_Errors.Warning_NotEmbedded, uu____4395)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____4389);
          FStar_Pervasives_Native.None)
      in
   mk_emb' embed_sigelt_view unembed_sigelt_view
@@ -1649,70 +1657,70 @@ let (e_exp : FStar_Reflection_Data.exp FStar_TypeChecker_NBETerm.embedding) =
         mkConstruct FStar_Reflection_Data.ref_E_Unit.FStar_Reflection_Data.fv
           [] []
     | FStar_Reflection_Data.Var i ->
-        let uu____4342 =
-          let uu____4349 =
+        let uu____4420 =
+          let uu____4427 =
             FStar_TypeChecker_NBETerm.as_arg
               (FStar_TypeChecker_NBETerm.Constant
                  (FStar_TypeChecker_NBETerm.Int i))
              in
-          [uu____4349]  in
+          [uu____4427]  in
         mkConstruct FStar_Reflection_Data.ref_E_Var.FStar_Reflection_Data.fv
-          [] uu____4342
+          [] uu____4420
     | FStar_Reflection_Data.Mult (e1,e2) ->
-        let uu____4364 =
-          let uu____4371 =
-            let uu____4376 = embed_exp cb e1  in
-            FStar_TypeChecker_NBETerm.as_arg uu____4376  in
-          let uu____4377 =
-            let uu____4384 =
-              let uu____4389 = embed_exp cb e2  in
-              FStar_TypeChecker_NBETerm.as_arg uu____4389  in
-            [uu____4384]  in
-          uu____4371 :: uu____4377  in
+        let uu____4442 =
+          let uu____4449 =
+            let uu____4454 = embed_exp cb e1  in
+            FStar_TypeChecker_NBETerm.as_arg uu____4454  in
+          let uu____4455 =
+            let uu____4462 =
+              let uu____4467 = embed_exp cb e2  in
+              FStar_TypeChecker_NBETerm.as_arg uu____4467  in
+            [uu____4462]  in
+          uu____4449 :: uu____4455  in
         mkConstruct FStar_Reflection_Data.ref_E_Mult.FStar_Reflection_Data.fv
-          [] uu____4364
+          [] uu____4442
      in
   let rec unembed_exp cb t =
     match t with
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____4418,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____4496,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_E_Unit.FStar_Reflection_Data.lid
         -> FStar_Pervasives_Native.Some FStar_Reflection_Data.Unit
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____4434,(i,uu____4436)::[])
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____4512,(i,uu____4514)::[])
         when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_E_Var.FStar_Reflection_Data.lid
         ->
-        let uu____4455 =
+        let uu____4533 =
           FStar_TypeChecker_NBETerm.unembed FStar_TypeChecker_NBETerm.e_int
             cb i
            in
-        FStar_Util.bind_opt uu____4455
+        FStar_Util.bind_opt uu____4533
           (fun i1  ->
              FStar_All.pipe_left
-               (fun _4462  -> FStar_Pervasives_Native.Some _4462)
+               (fun _4540  -> FStar_Pervasives_Native.Some _4540)
                (FStar_Reflection_Data.Var i1))
     | FStar_TypeChecker_NBETerm.Construct
-        (fv,uu____4464,(e2,uu____4466)::(e1,uu____4468)::[]) when
+        (fv,uu____4542,(e2,uu____4544)::(e1,uu____4546)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_E_Mult.FStar_Reflection_Data.lid
         ->
-        let uu____4491 = unembed_exp cb e1  in
-        FStar_Util.bind_opt uu____4491
+        let uu____4569 = unembed_exp cb e1  in
+        FStar_Util.bind_opt uu____4569
           (fun e11  ->
-             let uu____4497 = unembed_exp cb e2  in
-             FStar_Util.bind_opt uu____4497
+             let uu____4575 = unembed_exp cb e2  in
+             FStar_Util.bind_opt uu____4575
                (fun e21  ->
                   FStar_All.pipe_left
-                    (fun _4504  -> FStar_Pervasives_Native.Some _4504)
+                    (fun _4582  -> FStar_Pervasives_Native.Some _4582)
                     (FStar_Reflection_Data.Mult (e11, e21))))
-    | uu____4505 ->
-        ((let uu____4507 =
-            let uu____4513 =
-              let uu____4515 = FStar_TypeChecker_NBETerm.t_to_string t  in
-              FStar_Util.format1 "Not an embedded exp: %s" uu____4515  in
-            (FStar_Errors.Warning_NotEmbedded, uu____4513)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____4507);
+    | uu____4583 ->
+        ((let uu____4585 =
+            let uu____4591 =
+              let uu____4593 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded exp: %s" uu____4593  in
+            (FStar_Errors.Warning_NotEmbedded, uu____4591)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____4585);
          FStar_Pervasives_Native.None)
      in
   mk_emb' embed_exp unembed_exp FStar_Reflection_Data.fstar_refl_exp_fv 
@@ -1727,18 +1735,18 @@ let (e_attributes :
   = FStar_TypeChecker_NBETerm.e_list e_attribute 
 let (e_lid : FStar_Ident.lid FStar_TypeChecker_NBETerm.embedding) =
   let embed1 rng lid =
-    let uu____4544 = FStar_Ident.path_of_lid lid  in
-    FStar_TypeChecker_NBETerm.embed e_string_list rng uu____4544  in
+    let uu____4622 = FStar_Ident.path_of_lid lid  in
+    FStar_TypeChecker_NBETerm.embed e_string_list rng uu____4622  in
   let unembed1 cb t =
-    let uu____4566 = FStar_TypeChecker_NBETerm.unembed e_string_list cb t  in
-    FStar_Util.map_opt uu____4566
+    let uu____4644 = FStar_TypeChecker_NBETerm.unembed e_string_list cb t  in
+    FStar_Util.map_opt uu____4644
       (fun p  -> FStar_Ident.lid_of_path p FStar_Range.dummyRange)
      in
-  let uu____4583 =
+  let uu____4661 =
     mkConstruct FStar_Reflection_Data.fstar_refl_aqualv_fv [] []  in
-  let uu____4588 = fv_as_emb_typ FStar_Reflection_Data.fstar_refl_aqualv_fv
+  let uu____4666 = fv_as_emb_typ FStar_Reflection_Data.fstar_refl_aqualv_fv
      in
-  FStar_TypeChecker_NBETerm.mk_emb embed1 unembed1 uu____4583 uu____4588 
+  FStar_TypeChecker_NBETerm.mk_emb embed1 unembed1 uu____4661 uu____4666 
 let (e_qualifier :
   FStar_Syntax_Syntax.qualifier FStar_TypeChecker_NBETerm.embedding) =
   let embed1 cb q =
@@ -1813,83 +1821,83 @@ let (e_qualifier :
           FStar_Reflection_Data.ref_qual_OnlyName.FStar_Reflection_Data.fv []
           []
     | FStar_Syntax_Syntax.Reflectable l ->
-        let uu____4676 =
-          let uu____4683 =
-            let uu____4688 = FStar_TypeChecker_NBETerm.embed e_lid cb l  in
-            FStar_TypeChecker_NBETerm.as_arg uu____4688  in
-          [uu____4683]  in
+        let uu____4754 =
+          let uu____4761 =
+            let uu____4766 = FStar_TypeChecker_NBETerm.embed e_lid cb l  in
+            FStar_TypeChecker_NBETerm.as_arg uu____4766  in
+          [uu____4761]  in
         mkConstruct
           FStar_Reflection_Data.ref_qual_Reflectable.FStar_Reflection_Data.fv
-          [] uu____4676
+          [] uu____4754
     | FStar_Syntax_Syntax.Discriminator l ->
-        let uu____4698 =
-          let uu____4705 =
-            let uu____4710 = FStar_TypeChecker_NBETerm.embed e_lid cb l  in
-            FStar_TypeChecker_NBETerm.as_arg uu____4710  in
-          [uu____4705]  in
+        let uu____4776 =
+          let uu____4783 =
+            let uu____4788 = FStar_TypeChecker_NBETerm.embed e_lid cb l  in
+            FStar_TypeChecker_NBETerm.as_arg uu____4788  in
+          [uu____4783]  in
         mkConstruct
           FStar_Reflection_Data.ref_qual_Discriminator.FStar_Reflection_Data.fv
-          [] uu____4698
+          [] uu____4776
     | FStar_Syntax_Syntax.Action l ->
-        let uu____4720 =
-          let uu____4727 =
-            let uu____4732 = FStar_TypeChecker_NBETerm.embed e_lid cb l  in
-            FStar_TypeChecker_NBETerm.as_arg uu____4732  in
-          [uu____4727]  in
+        let uu____4798 =
+          let uu____4805 =
+            let uu____4810 = FStar_TypeChecker_NBETerm.embed e_lid cb l  in
+            FStar_TypeChecker_NBETerm.as_arg uu____4810  in
+          [uu____4805]  in
         mkConstruct
           FStar_Reflection_Data.ref_qual_Action.FStar_Reflection_Data.fv []
-          uu____4720
+          uu____4798
     | FStar_Syntax_Syntax.Projector (l,i) ->
-        let uu____4743 =
-          let uu____4750 =
-            let uu____4755 = FStar_TypeChecker_NBETerm.embed e_lid cb l  in
-            FStar_TypeChecker_NBETerm.as_arg uu____4755  in
-          let uu____4756 =
-            let uu____4763 =
-              let uu____4768 = FStar_TypeChecker_NBETerm.embed e_ident cb i
+        let uu____4821 =
+          let uu____4828 =
+            let uu____4833 = FStar_TypeChecker_NBETerm.embed e_lid cb l  in
+            FStar_TypeChecker_NBETerm.as_arg uu____4833  in
+          let uu____4834 =
+            let uu____4841 =
+              let uu____4846 = FStar_TypeChecker_NBETerm.embed e_ident cb i
                  in
-              FStar_TypeChecker_NBETerm.as_arg uu____4768  in
-            [uu____4763]  in
-          uu____4750 :: uu____4756  in
+              FStar_TypeChecker_NBETerm.as_arg uu____4846  in
+            [uu____4841]  in
+          uu____4828 :: uu____4834  in
         mkConstruct
           FStar_Reflection_Data.ref_qual_Projector.FStar_Reflection_Data.fv
-          [] uu____4743
+          [] uu____4821
     | FStar_Syntax_Syntax.RecordType (ids1,ids2) ->
-        let uu____4791 =
-          let uu____4798 =
-            let uu____4803 =
-              let uu____4804 = FStar_TypeChecker_NBETerm.e_list e_ident  in
-              FStar_TypeChecker_NBETerm.embed uu____4804 cb ids1  in
-            FStar_TypeChecker_NBETerm.as_arg uu____4803  in
-          let uu____4811 =
-            let uu____4818 =
-              let uu____4823 =
-                let uu____4824 = FStar_TypeChecker_NBETerm.e_list e_ident  in
-                FStar_TypeChecker_NBETerm.embed uu____4824 cb ids2  in
-              FStar_TypeChecker_NBETerm.as_arg uu____4823  in
-            [uu____4818]  in
-          uu____4798 :: uu____4811  in
+        let uu____4869 =
+          let uu____4876 =
+            let uu____4881 =
+              let uu____4882 = FStar_TypeChecker_NBETerm.e_list e_ident  in
+              FStar_TypeChecker_NBETerm.embed uu____4882 cb ids1  in
+            FStar_TypeChecker_NBETerm.as_arg uu____4881  in
+          let uu____4889 =
+            let uu____4896 =
+              let uu____4901 =
+                let uu____4902 = FStar_TypeChecker_NBETerm.e_list e_ident  in
+                FStar_TypeChecker_NBETerm.embed uu____4902 cb ids2  in
+              FStar_TypeChecker_NBETerm.as_arg uu____4901  in
+            [uu____4896]  in
+          uu____4876 :: uu____4889  in
         mkConstruct
           FStar_Reflection_Data.ref_qual_RecordType.FStar_Reflection_Data.fv
-          [] uu____4791
+          [] uu____4869
     | FStar_Syntax_Syntax.RecordConstructor (ids1,ids2) ->
-        let uu____4853 =
-          let uu____4860 =
-            let uu____4865 =
-              let uu____4866 = FStar_TypeChecker_NBETerm.e_list e_ident  in
-              FStar_TypeChecker_NBETerm.embed uu____4866 cb ids1  in
-            FStar_TypeChecker_NBETerm.as_arg uu____4865  in
-          let uu____4873 =
-            let uu____4880 =
-              let uu____4885 =
-                let uu____4886 = FStar_TypeChecker_NBETerm.e_list e_ident  in
-                FStar_TypeChecker_NBETerm.embed uu____4886 cb ids2  in
-              FStar_TypeChecker_NBETerm.as_arg uu____4885  in
-            [uu____4880]  in
-          uu____4860 :: uu____4873  in
+        let uu____4931 =
+          let uu____4938 =
+            let uu____4943 =
+              let uu____4944 = FStar_TypeChecker_NBETerm.e_list e_ident  in
+              FStar_TypeChecker_NBETerm.embed uu____4944 cb ids1  in
+            FStar_TypeChecker_NBETerm.as_arg uu____4943  in
+          let uu____4951 =
+            let uu____4958 =
+              let uu____4963 =
+                let uu____4964 = FStar_TypeChecker_NBETerm.e_list e_ident  in
+                FStar_TypeChecker_NBETerm.embed uu____4964 cb ids2  in
+              FStar_TypeChecker_NBETerm.as_arg uu____4963  in
+            [uu____4958]  in
+          uu____4938 :: uu____4951  in
         mkConstruct
           FStar_Reflection_Data.ref_qual_RecordConstructor.FStar_Reflection_Data.fv
-          [] uu____4853
+          [] uu____4931
      in
   let unembed1 cb t =
     match t with
@@ -1970,95 +1978,95 @@ let (e_qualifier :
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_qual_OnlyName.FStar_Reflection_Data.lid
         -> FStar_Pervasives_Native.Some FStar_Syntax_Syntax.OnlyName
-    | FStar_TypeChecker_NBETerm.Construct (fv,[],(l,uu____5156)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,[],(l,uu____5234)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_qual_Reflectable.FStar_Reflection_Data.lid
         ->
-        let uu____5173 = FStar_TypeChecker_NBETerm.unembed e_lid cb l  in
-        FStar_Util.bind_opt uu____5173
+        let uu____5251 = FStar_TypeChecker_NBETerm.unembed e_lid cb l  in
+        FStar_Util.bind_opt uu____5251
           (fun l1  ->
              FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Reflectable l1))
-    | FStar_TypeChecker_NBETerm.Construct (fv,[],(l,uu____5180)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,[],(l,uu____5258)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_qual_Discriminator.FStar_Reflection_Data.lid
         ->
-        let uu____5197 = FStar_TypeChecker_NBETerm.unembed e_lid cb l  in
-        FStar_Util.bind_opt uu____5197
+        let uu____5275 = FStar_TypeChecker_NBETerm.unembed e_lid cb l  in
+        FStar_Util.bind_opt uu____5275
           (fun l1  ->
              FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Discriminator l1))
-    | FStar_TypeChecker_NBETerm.Construct (fv,[],(l,uu____5204)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,[],(l,uu____5282)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_qual_Action.FStar_Reflection_Data.lid
         ->
-        let uu____5221 = FStar_TypeChecker_NBETerm.unembed e_lid cb l  in
-        FStar_Util.bind_opt uu____5221
+        let uu____5299 = FStar_TypeChecker_NBETerm.unembed e_lid cb l  in
+        FStar_Util.bind_opt uu____5299
           (fun l1  ->
              FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Action l1))
     | FStar_TypeChecker_NBETerm.Construct
-        (fv,[],(i,uu____5228)::(l,uu____5230)::[]) when
+        (fv,[],(i,uu____5306)::(l,uu____5308)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_qual_Projector.FStar_Reflection_Data.lid
         ->
-        let uu____5251 = FStar_TypeChecker_NBETerm.unembed e_ident cb i  in
-        FStar_Util.bind_opt uu____5251
+        let uu____5329 = FStar_TypeChecker_NBETerm.unembed e_ident cb i  in
+        FStar_Util.bind_opt uu____5329
           (fun i1  ->
-             let uu____5257 = FStar_TypeChecker_NBETerm.unembed e_lid cb l
+             let uu____5335 = FStar_TypeChecker_NBETerm.unembed e_lid cb l
                 in
-             FStar_Util.bind_opt uu____5257
+             FStar_Util.bind_opt uu____5335
                (fun l1  ->
                   FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.Projector (l1, i1))))
     | FStar_TypeChecker_NBETerm.Construct
-        (fv,[],(ids2,uu____5264)::(ids1,uu____5266)::[]) when
+        (fv,[],(ids2,uu____5342)::(ids1,uu____5344)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_qual_RecordType.FStar_Reflection_Data.lid
         ->
-        let uu____5287 =
-          let uu____5292 = FStar_TypeChecker_NBETerm.e_list e_ident  in
-          FStar_TypeChecker_NBETerm.unembed uu____5292 cb ids1  in
-        FStar_Util.bind_opt uu____5287
+        let uu____5365 =
+          let uu____5370 = FStar_TypeChecker_NBETerm.e_list e_ident  in
+          FStar_TypeChecker_NBETerm.unembed uu____5370 cb ids1  in
+        FStar_Util.bind_opt uu____5365
           (fun ids11  ->
-             let uu____5306 =
-               let uu____5311 = FStar_TypeChecker_NBETerm.e_list e_ident  in
-               FStar_TypeChecker_NBETerm.unembed uu____5311 cb ids2  in
-             FStar_Util.bind_opt uu____5306
+             let uu____5384 =
+               let uu____5389 = FStar_TypeChecker_NBETerm.e_list e_ident  in
+               FStar_TypeChecker_NBETerm.unembed uu____5389 cb ids2  in
+             FStar_Util.bind_opt uu____5384
                (fun ids21  ->
                   FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.RecordType (ids11, ids21))))
     | FStar_TypeChecker_NBETerm.Construct
-        (fv,[],(ids2,uu____5330)::(ids1,uu____5332)::[]) when
+        (fv,[],(ids2,uu____5408)::(ids1,uu____5410)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_qual_RecordConstructor.FStar_Reflection_Data.lid
         ->
-        let uu____5353 =
-          let uu____5358 = FStar_TypeChecker_NBETerm.e_list e_ident  in
-          FStar_TypeChecker_NBETerm.unembed uu____5358 cb ids1  in
-        FStar_Util.bind_opt uu____5353
+        let uu____5431 =
+          let uu____5436 = FStar_TypeChecker_NBETerm.e_list e_ident  in
+          FStar_TypeChecker_NBETerm.unembed uu____5436 cb ids1  in
+        FStar_Util.bind_opt uu____5431
           (fun ids11  ->
-             let uu____5372 =
-               let uu____5377 = FStar_TypeChecker_NBETerm.e_list e_ident  in
-               FStar_TypeChecker_NBETerm.unembed uu____5377 cb ids2  in
-             FStar_Util.bind_opt uu____5372
+             let uu____5450 =
+               let uu____5455 = FStar_TypeChecker_NBETerm.e_list e_ident  in
+               FStar_TypeChecker_NBETerm.unembed uu____5455 cb ids2  in
+             FStar_Util.bind_opt uu____5450
                (fun ids21  ->
                   FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.RecordConstructor (ids11, ids21))))
-    | uu____5394 ->
-        ((let uu____5396 =
-            let uu____5402 =
-              let uu____5404 = FStar_TypeChecker_NBETerm.t_to_string t  in
-              FStar_Util.format1 "Not an embedded qualifier: %s" uu____5404
+    | uu____5472 ->
+        ((let uu____5474 =
+            let uu____5480 =
+              let uu____5482 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded qualifier: %s" uu____5482
                in
-            (FStar_Errors.Warning_NotEmbedded, uu____5402)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____5396);
+            (FStar_Errors.Warning_NotEmbedded, uu____5480)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____5474);
          FStar_Pervasives_Native.None)
      in
-  let uu____5408 =
+  let uu____5486 =
     mkConstruct FStar_Reflection_Data.fstar_refl_qualifier_fv [] []  in
-  let uu____5413 =
+  let uu____5491 =
     fv_as_emb_typ FStar_Reflection_Data.fstar_refl_qualifier_fv  in
-  FStar_TypeChecker_NBETerm.mk_emb embed1 unembed1 uu____5408 uu____5413 
+  FStar_TypeChecker_NBETerm.mk_emb embed1 unembed1 uu____5486 uu____5491 
 let (e_qualifiers :
   FStar_Syntax_Syntax.qualifier Prims.list
     FStar_TypeChecker_NBETerm.embedding)

--- a/src/ocaml-output/FStar_Reflection_NBEEmbeddings.ml
+++ b/src/ocaml-output/FStar_Reflection_NBEEmbeddings.ml
@@ -135,6 +135,36 @@ let (e_binder :
   mk_emb' embed_binder unembed_binder
     FStar_Reflection_Data.fstar_refl_binder_fv
   
+let (e_optionstate :
+  FStar_Options.optionstate FStar_TypeChecker_NBETerm.embedding) =
+  let embed_optionstate cb b =
+    mk_lazy cb b FStar_Reflection_Data.fstar_refl_optionstate
+      FStar_Syntax_Syntax.Lazy_optionstate
+     in
+  let unembed_optionstate cb t =
+    match t with
+    | FStar_TypeChecker_NBETerm.Lazy
+        (FStar_Util.Inl
+         { FStar_Syntax_Syntax.blob = b;
+           FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_optionstate ;
+           FStar_Syntax_Syntax.ltyp = uu____371;
+           FStar_Syntax_Syntax.rng = uu____372;_},uu____373)
+        ->
+        let uu____392 = FStar_Dyn.undyn b  in
+        FStar_Pervasives_Native.Some uu____392
+    | uu____393 ->
+        ((let uu____395 =
+            let uu____401 =
+              let uu____403 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded optionstate: %s" uu____403
+               in
+            (FStar_Errors.Warning_NotEmbedded, uu____401)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____395);
+         FStar_Pervasives_Native.None)
+     in
+  mk_emb' embed_optionstate unembed_optionstate
+    FStar_Reflection_Data.fstar_refl_optionstate_fv
+  
 let rec mapM_opt :
   'a 'b .
     ('a -> 'b FStar_Pervasives_Native.option) ->
@@ -145,11 +175,11 @@ let rec mapM_opt :
       match l with
       | [] -> FStar_Pervasives_Native.Some []
       | x::xs ->
-          let uu____387 = f x  in
-          FStar_Util.bind_opt uu____387
+          let uu____453 = f x  in
+          FStar_Util.bind_opt uu____453
             (fun x1  ->
-               let uu____395 = mapM_opt f xs  in
-               FStar_Util.bind_opt uu____395
+               let uu____461 = mapM_opt f xs  in
+               FStar_Util.bind_opt uu____461
                  (fun xs1  -> FStar_Pervasives_Native.Some (x1 :: xs1)))
   
 let (e_term_aq :
@@ -169,15 +199,15 @@ let (e_term_aq :
       match t with
       | FStar_TypeChecker_NBETerm.Quote (tm,qi) ->
           FStar_Pervasives_Native.Some tm
-      | uu____465 -> FStar_Pervasives_Native.None  in
-    let uu____466 = mkFV FStar_Reflection_Data.fstar_refl_term_fv [] []  in
-    let uu____471 = fv_as_emb_typ FStar_Reflection_Data.fstar_refl_term_fv
+      | uu____531 -> FStar_Pervasives_Native.None  in
+    let uu____532 = mkFV FStar_Reflection_Data.fstar_refl_term_fv [] []  in
+    let uu____537 = fv_as_emb_typ FStar_Reflection_Data.fstar_refl_term_fv
        in
     {
       FStar_TypeChecker_NBETerm.em = embed_term;
       FStar_TypeChecker_NBETerm.un = unembed_term;
-      FStar_TypeChecker_NBETerm.typ = uu____466;
-      FStar_TypeChecker_NBETerm.emb_typ = uu____471
+      FStar_TypeChecker_NBETerm.typ = uu____532;
+      FStar_TypeChecker_NBETerm.emb_typ = uu____537
     }
   
 let (e_term : FStar_Syntax_Syntax.term FStar_TypeChecker_NBETerm.embedding) =
@@ -193,13 +223,13 @@ let (e_aqualv :
         mkConstruct
           FStar_Reflection_Data.ref_Q_Implicit.FStar_Reflection_Data.fv [] []
     | FStar_Reflection_Data.Q_Meta t ->
-        let uu____504 =
-          let uu____511 =
-            let uu____516 = FStar_TypeChecker_NBETerm.embed e_term cb t  in
-            FStar_TypeChecker_NBETerm.as_arg uu____516  in
-          [uu____511]  in
+        let uu____570 =
+          let uu____577 =
+            let uu____582 = FStar_TypeChecker_NBETerm.embed e_term cb t  in
+            FStar_TypeChecker_NBETerm.as_arg uu____582  in
+          [uu____577]  in
         mkConstruct FStar_Reflection_Data.ref_Q_Meta.FStar_Reflection_Data.fv
-          [] uu____504
+          [] uu____570
      in
   let unembed_aqualv cb t =
     match t with
@@ -211,29 +241,29 @@ let (e_aqualv :
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_Q_Implicit.FStar_Reflection_Data.lid
         -> FStar_Pervasives_Native.Some FStar_Reflection_Data.Q_Implicit
-    | FStar_TypeChecker_NBETerm.Construct (fv,[],(t1,uu____568)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,[],(t1,uu____634)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_Q_Meta.FStar_Reflection_Data.lid
         ->
-        let uu____585 = FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
-        FStar_Util.bind_opt uu____585
+        let uu____651 = FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
+        FStar_Util.bind_opt uu____651
           (fun t2  ->
              FStar_Pervasives_Native.Some (FStar_Reflection_Data.Q_Meta t2))
-    | uu____590 ->
-        ((let uu____592 =
-            let uu____598 =
-              let uu____600 = FStar_TypeChecker_NBETerm.t_to_string t  in
-              FStar_Util.format1 "Not an embedded aqualv: %s" uu____600  in
-            (FStar_Errors.Warning_NotEmbedded, uu____598)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____592);
+    | uu____656 ->
+        ((let uu____658 =
+            let uu____664 =
+              let uu____666 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded aqualv: %s" uu____666  in
+            (FStar_Errors.Warning_NotEmbedded, uu____664)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____658);
          FStar_Pervasives_Native.None)
      in
-  let uu____604 =
+  let uu____670 =
     mkConstruct FStar_Reflection_Data.fstar_refl_aqualv_fv [] []  in
-  let uu____609 = fv_as_emb_typ FStar_Reflection_Data.fstar_refl_aqualv_fv
+  let uu____675 = fv_as_emb_typ FStar_Reflection_Data.fstar_refl_aqualv_fv
      in
-  FStar_TypeChecker_NBETerm.mk_emb embed_aqualv unembed_aqualv uu____604
-    uu____609
+  FStar_TypeChecker_NBETerm.mk_emb embed_aqualv unembed_aqualv uu____670
+    uu____675
   
 let (e_binders :
   FStar_Syntax_Syntax.binders FStar_TypeChecker_NBETerm.embedding) =
@@ -249,18 +279,18 @@ let (e_fv : FStar_Syntax_Syntax.fv FStar_TypeChecker_NBETerm.embedding) =
         (FStar_Util.Inl
          { FStar_Syntax_Syntax.blob = b;
            FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_fvar ;
-           FStar_Syntax_Syntax.ltyp = uu____643;
-           FStar_Syntax_Syntax.rng = uu____644;_},uu____645)
+           FStar_Syntax_Syntax.ltyp = uu____709;
+           FStar_Syntax_Syntax.rng = uu____710;_},uu____711)
         ->
-        let uu____664 = FStar_Dyn.undyn b  in
-        FStar_Pervasives_Native.Some uu____664
-    | uu____665 ->
-        ((let uu____667 =
-            let uu____673 =
-              let uu____675 = FStar_TypeChecker_NBETerm.t_to_string t  in
-              FStar_Util.format1 "Not an embedded fvar: %s" uu____675  in
-            (FStar_Errors.Warning_NotEmbedded, uu____673)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____667);
+        let uu____730 = FStar_Dyn.undyn b  in
+        FStar_Pervasives_Native.Some uu____730
+    | uu____731 ->
+        ((let uu____733 =
+            let uu____739 =
+              let uu____741 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded fvar: %s" uu____741  in
+            (FStar_Errors.Warning_NotEmbedded, uu____739)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____733);
          FStar_Pervasives_Native.None)
      in
   mk_emb' embed_fv unembed_fv FStar_Reflection_Data.fstar_refl_fv_fv 
@@ -275,18 +305,18 @@ let (e_comp : FStar_Syntax_Syntax.comp FStar_TypeChecker_NBETerm.embedding) =
         (FStar_Util.Inl
          { FStar_Syntax_Syntax.blob = b;
            FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_comp ;
-           FStar_Syntax_Syntax.ltyp = uu____709;
-           FStar_Syntax_Syntax.rng = uu____710;_},uu____711)
+           FStar_Syntax_Syntax.ltyp = uu____775;
+           FStar_Syntax_Syntax.rng = uu____776;_},uu____777)
         ->
-        let uu____730 = FStar_Dyn.undyn b  in
-        FStar_Pervasives_Native.Some uu____730
-    | uu____731 ->
-        ((let uu____733 =
-            let uu____739 =
-              let uu____741 = FStar_TypeChecker_NBETerm.t_to_string t  in
-              FStar_Util.format1 "Not an embedded comp: %s" uu____741  in
-            (FStar_Errors.Warning_NotEmbedded, uu____739)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____733);
+        let uu____796 = FStar_Dyn.undyn b  in
+        FStar_Pervasives_Native.Some uu____796
+    | uu____797 ->
+        ((let uu____799 =
+            let uu____805 =
+              let uu____807 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded comp: %s" uu____807  in
+            (FStar_Errors.Warning_NotEmbedded, uu____805)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____799);
          FStar_Pervasives_Native.None)
      in
   mk_emb' embed_comp unembed_comp FStar_Reflection_Data.fstar_refl_comp_fv 
@@ -301,18 +331,18 @@ let (e_env : FStar_TypeChecker_Env.env FStar_TypeChecker_NBETerm.embedding) =
         (FStar_Util.Inl
          { FStar_Syntax_Syntax.blob = b;
            FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_env ;
-           FStar_Syntax_Syntax.ltyp = uu____775;
-           FStar_Syntax_Syntax.rng = uu____776;_},uu____777)
+           FStar_Syntax_Syntax.ltyp = uu____841;
+           FStar_Syntax_Syntax.rng = uu____842;_},uu____843)
         ->
-        let uu____796 = FStar_Dyn.undyn b  in
-        FStar_Pervasives_Native.Some uu____796
-    | uu____797 ->
-        ((let uu____799 =
-            let uu____805 =
-              let uu____807 = FStar_TypeChecker_NBETerm.t_to_string t  in
-              FStar_Util.format1 "Not an embedded env: %s" uu____807  in
-            (FStar_Errors.Warning_NotEmbedded, uu____805)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____799);
+        let uu____862 = FStar_Dyn.undyn b  in
+        FStar_Pervasives_Native.Some uu____862
+    | uu____863 ->
+        ((let uu____865 =
+            let uu____871 =
+              let uu____873 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded env: %s" uu____873  in
+            (FStar_Errors.Warning_NotEmbedded, uu____871)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____865);
          FStar_Pervasives_Native.None)
      in
   mk_emb' embed_env unembed_env FStar_Reflection_Data.fstar_refl_env_fv 
@@ -330,54 +360,54 @@ let (e_const :
         mkConstruct
           FStar_Reflection_Data.ref_C_False.FStar_Reflection_Data.fv [] []
     | FStar_Reflection_Data.C_Int i ->
-        let uu____838 =
-          let uu____845 =
+        let uu____904 =
+          let uu____911 =
             FStar_TypeChecker_NBETerm.as_arg
               (FStar_TypeChecker_NBETerm.Constant
                  (FStar_TypeChecker_NBETerm.Int i))
              in
-          [uu____845]  in
+          [uu____911]  in
         mkConstruct FStar_Reflection_Data.ref_C_Int.FStar_Reflection_Data.fv
-          [] uu____838
+          [] uu____904
     | FStar_Reflection_Data.C_String s ->
-        let uu____860 =
-          let uu____867 =
-            let uu____872 =
+        let uu____926 =
+          let uu____933 =
+            let uu____938 =
               FStar_TypeChecker_NBETerm.embed
                 FStar_TypeChecker_NBETerm.e_string cb s
                in
-            FStar_TypeChecker_NBETerm.as_arg uu____872  in
-          [uu____867]  in
+            FStar_TypeChecker_NBETerm.as_arg uu____938  in
+          [uu____933]  in
         mkConstruct
           FStar_Reflection_Data.ref_C_String.FStar_Reflection_Data.fv []
-          uu____860
+          uu____926
     | FStar_Reflection_Data.C_Range r ->
-        let uu____883 =
-          let uu____890 =
-            let uu____895 =
+        let uu____949 =
+          let uu____956 =
+            let uu____961 =
               FStar_TypeChecker_NBETerm.embed
                 FStar_TypeChecker_NBETerm.e_range cb r
                in
-            FStar_TypeChecker_NBETerm.as_arg uu____895  in
-          [uu____890]  in
+            FStar_TypeChecker_NBETerm.as_arg uu____961  in
+          [uu____956]  in
         mkConstruct
           FStar_Reflection_Data.ref_C_Range.FStar_Reflection_Data.fv []
-          uu____883
+          uu____949
     | FStar_Reflection_Data.C_Reify  ->
         mkConstruct
           FStar_Reflection_Data.ref_C_Reify.FStar_Reflection_Data.fv [] []
     | FStar_Reflection_Data.C_Reflect ns ->
-        let uu____909 =
-          let uu____916 =
-            let uu____921 =
+        let uu____975 =
+          let uu____982 =
+            let uu____987 =
               FStar_TypeChecker_NBETerm.embed
                 FStar_TypeChecker_NBETerm.e_string_list cb ns
                in
-            FStar_TypeChecker_NBETerm.as_arg uu____921  in
-          [uu____916]  in
+            FStar_TypeChecker_NBETerm.as_arg uu____987  in
+          [uu____982]  in
         mkConstruct
           FStar_Reflection_Data.ref_C_Reflect.FStar_Reflection_Data.fv []
-          uu____909
+          uu____975
      in
   let unembed_const cb t =
     match t with
@@ -393,69 +423,69 @@ let (e_const :
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_False.FStar_Reflection_Data.lid
         -> FStar_Pervasives_Native.Some FStar_Reflection_Data.C_False
-    | FStar_TypeChecker_NBETerm.Construct (fv,[],(i,uu____989)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,[],(i,uu____1055)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_Int.FStar_Reflection_Data.lid
         ->
-        let uu____1006 =
+        let uu____1072 =
           FStar_TypeChecker_NBETerm.unembed FStar_TypeChecker_NBETerm.e_int
             cb i
            in
-        FStar_Util.bind_opt uu____1006
+        FStar_Util.bind_opt uu____1072
           (fun i1  ->
              FStar_All.pipe_left
-               (fun _1013  -> FStar_Pervasives_Native.Some _1013)
+               (fun _1079  -> FStar_Pervasives_Native.Some _1079)
                (FStar_Reflection_Data.C_Int i1))
-    | FStar_TypeChecker_NBETerm.Construct (fv,[],(s,uu____1016)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,[],(s,uu____1082)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_String.FStar_Reflection_Data.lid
         ->
-        let uu____1033 =
+        let uu____1099 =
           FStar_TypeChecker_NBETerm.unembed
             FStar_TypeChecker_NBETerm.e_string cb s
            in
-        FStar_Util.bind_opt uu____1033
+        FStar_Util.bind_opt uu____1099
           (fun s1  ->
              FStar_All.pipe_left
-               (fun _1044  -> FStar_Pervasives_Native.Some _1044)
+               (fun _1110  -> FStar_Pervasives_Native.Some _1110)
                (FStar_Reflection_Data.C_String s1))
-    | FStar_TypeChecker_NBETerm.Construct (fv,[],(r,uu____1047)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,[],(r,uu____1113)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_Range.FStar_Reflection_Data.lid
         ->
-        let uu____1064 =
+        let uu____1130 =
           FStar_TypeChecker_NBETerm.unembed FStar_TypeChecker_NBETerm.e_range
             cb r
            in
-        FStar_Util.bind_opt uu____1064
+        FStar_Util.bind_opt uu____1130
           (fun r1  ->
              FStar_All.pipe_left
-               (fun _1071  -> FStar_Pervasives_Native.Some _1071)
+               (fun _1137  -> FStar_Pervasives_Native.Some _1137)
                (FStar_Reflection_Data.C_Range r1))
     | FStar_TypeChecker_NBETerm.Construct (fv,[],[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_Reify.FStar_Reflection_Data.lid
         -> FStar_Pervasives_Native.Some FStar_Reflection_Data.C_Reify
-    | FStar_TypeChecker_NBETerm.Construct (fv,[],(ns,uu____1087)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,[],(ns,uu____1153)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_Reflect.FStar_Reflection_Data.lid
         ->
-        let uu____1104 =
+        let uu____1170 =
           FStar_TypeChecker_NBETerm.unembed
             FStar_TypeChecker_NBETerm.e_string_list cb ns
            in
-        FStar_Util.bind_opt uu____1104
+        FStar_Util.bind_opt uu____1170
           (fun ns1  ->
              FStar_All.pipe_left
-               (fun _1123  -> FStar_Pervasives_Native.Some _1123)
+               (fun _1189  -> FStar_Pervasives_Native.Some _1189)
                (FStar_Reflection_Data.C_Reflect ns1))
-    | uu____1124 ->
-        ((let uu____1126 =
-            let uu____1132 =
-              let uu____1134 = FStar_TypeChecker_NBETerm.t_to_string t  in
-              FStar_Util.format1 "Not an embedded vconst: %s" uu____1134  in
-            (FStar_Errors.Warning_NotEmbedded, uu____1132)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____1126);
+    | uu____1190 ->
+        ((let uu____1192 =
+            let uu____1198 =
+              let uu____1200 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded vconst: %s" uu____1200  in
+            (FStar_Errors.Warning_NotEmbedded, uu____1198)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____1192);
          FStar_Pervasives_Native.None)
      in
   mk_emb' embed_const unembed_const
@@ -464,152 +494,152 @@ let (e_const :
 let rec (e_pattern' :
   unit -> FStar_Reflection_Data.pattern FStar_TypeChecker_NBETerm.embedding)
   =
-  fun uu____1145  ->
+  fun uu____1211  ->
     let embed_pattern cb p =
       match p with
       | FStar_Reflection_Data.Pat_Constant c ->
-          let uu____1158 =
-            let uu____1165 =
-              let uu____1170 = FStar_TypeChecker_NBETerm.embed e_const cb c
+          let uu____1224 =
+            let uu____1231 =
+              let uu____1236 = FStar_TypeChecker_NBETerm.embed e_const cb c
                  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1170  in
-            [uu____1165]  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1236  in
+            [uu____1231]  in
           mkConstruct
             FStar_Reflection_Data.ref_Pat_Constant.FStar_Reflection_Data.fv
-            [] uu____1158
+            [] uu____1224
       | FStar_Reflection_Data.Pat_Cons (fv,ps) ->
-          let uu____1195 =
-            let uu____1202 =
-              let uu____1207 = FStar_TypeChecker_NBETerm.embed e_fv cb fv  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1207  in
-            let uu____1208 =
-              let uu____1215 =
-                let uu____1220 =
-                  let uu____1221 =
-                    let uu____1231 =
-                      let uu____1239 = e_pattern' ()  in
-                      FStar_TypeChecker_NBETerm.e_tuple2 uu____1239
+          let uu____1261 =
+            let uu____1268 =
+              let uu____1273 = FStar_TypeChecker_NBETerm.embed e_fv cb fv  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1273  in
+            let uu____1274 =
+              let uu____1281 =
+                let uu____1286 =
+                  let uu____1287 =
+                    let uu____1297 =
+                      let uu____1305 = e_pattern' ()  in
+                      FStar_TypeChecker_NBETerm.e_tuple2 uu____1305
                         FStar_TypeChecker_NBETerm.e_bool
                        in
-                    FStar_TypeChecker_NBETerm.e_list uu____1231  in
-                  FStar_TypeChecker_NBETerm.embed uu____1221 cb ps  in
-                FStar_TypeChecker_NBETerm.as_arg uu____1220  in
-              [uu____1215]  in
-            uu____1202 :: uu____1208  in
+                    FStar_TypeChecker_NBETerm.e_list uu____1297  in
+                  FStar_TypeChecker_NBETerm.embed uu____1287 cb ps  in
+                FStar_TypeChecker_NBETerm.as_arg uu____1286  in
+              [uu____1281]  in
+            uu____1268 :: uu____1274  in
           mkConstruct
             FStar_Reflection_Data.ref_Pat_Cons.FStar_Reflection_Data.fv []
-            uu____1195
+            uu____1261
       | FStar_Reflection_Data.Pat_Var bv ->
-          let uu____1268 =
-            let uu____1275 =
-              let uu____1280 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1280  in
-            [uu____1275]  in
+          let uu____1334 =
+            let uu____1341 =
+              let uu____1346 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1346  in
+            [uu____1341]  in
           mkConstruct
             FStar_Reflection_Data.ref_Pat_Var.FStar_Reflection_Data.fv []
-            uu____1268
+            uu____1334
       | FStar_Reflection_Data.Pat_Wild bv ->
-          let uu____1290 =
-            let uu____1297 =
-              let uu____1302 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1302  in
-            [uu____1297]  in
+          let uu____1356 =
+            let uu____1363 =
+              let uu____1368 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1368  in
+            [uu____1363]  in
           mkConstruct
             FStar_Reflection_Data.ref_Pat_Wild.FStar_Reflection_Data.fv []
-            uu____1290
+            uu____1356
       | FStar_Reflection_Data.Pat_Dot_Term (bv,t) ->
-          let uu____1313 =
-            let uu____1320 =
-              let uu____1325 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1325  in
-            let uu____1326 =
-              let uu____1333 =
-                let uu____1338 = FStar_TypeChecker_NBETerm.embed e_term cb t
+          let uu____1379 =
+            let uu____1386 =
+              let uu____1391 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1391  in
+            let uu____1392 =
+              let uu____1399 =
+                let uu____1404 = FStar_TypeChecker_NBETerm.embed e_term cb t
                    in
-                FStar_TypeChecker_NBETerm.as_arg uu____1338  in
-              [uu____1333]  in
-            uu____1320 :: uu____1326  in
+                FStar_TypeChecker_NBETerm.as_arg uu____1404  in
+              [uu____1399]  in
+            uu____1386 :: uu____1392  in
           mkConstruct
             FStar_Reflection_Data.ref_Pat_Dot_Term.FStar_Reflection_Data.fv
-            [] uu____1313
+            [] uu____1379
        in
     let unembed_pattern cb t =
       match t with
-      | FStar_TypeChecker_NBETerm.Construct (fv,[],(c,uu____1368)::[]) when
+      | FStar_TypeChecker_NBETerm.Construct (fv,[],(c,uu____1434)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Pat_Constant.FStar_Reflection_Data.lid
           ->
-          let uu____1385 = FStar_TypeChecker_NBETerm.unembed e_const cb c  in
-          FStar_Util.bind_opt uu____1385
+          let uu____1451 = FStar_TypeChecker_NBETerm.unembed e_const cb c  in
+          FStar_Util.bind_opt uu____1451
             (fun c1  ->
                FStar_All.pipe_left
-                 (fun _1392  -> FStar_Pervasives_Native.Some _1392)
+                 (fun _1458  -> FStar_Pervasives_Native.Some _1458)
                  (FStar_Reflection_Data.Pat_Constant c1))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,[],(ps,uu____1395)::(f,uu____1397)::[]) when
+          (fv,[],(ps,uu____1461)::(f,uu____1463)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Pat_Cons.FStar_Reflection_Data.lid
           ->
-          let uu____1418 = FStar_TypeChecker_NBETerm.unembed e_fv cb f  in
-          FStar_Util.bind_opt uu____1418
+          let uu____1484 = FStar_TypeChecker_NBETerm.unembed e_fv cb f  in
+          FStar_Util.bind_opt uu____1484
             (fun f1  ->
-               let uu____1424 =
-                 let uu____1434 =
-                   let uu____1444 =
-                     let uu____1452 = e_pattern' ()  in
-                     FStar_TypeChecker_NBETerm.e_tuple2 uu____1452
+               let uu____1490 =
+                 let uu____1500 =
+                   let uu____1510 =
+                     let uu____1518 = e_pattern' ()  in
+                     FStar_TypeChecker_NBETerm.e_tuple2 uu____1518
                        FStar_TypeChecker_NBETerm.e_bool
                       in
-                   FStar_TypeChecker_NBETerm.e_list uu____1444  in
-                 FStar_TypeChecker_NBETerm.unembed uu____1434 cb ps  in
-               FStar_Util.bind_opt uu____1424
+                   FStar_TypeChecker_NBETerm.e_list uu____1510  in
+                 FStar_TypeChecker_NBETerm.unembed uu____1500 cb ps  in
+               FStar_Util.bind_opt uu____1490
                  (fun ps1  ->
                     FStar_All.pipe_left
-                      (fun _1486  -> FStar_Pervasives_Native.Some _1486)
+                      (fun _1552  -> FStar_Pervasives_Native.Some _1552)
                       (FStar_Reflection_Data.Pat_Cons (f1, ps1))))
-      | FStar_TypeChecker_NBETerm.Construct (fv,[],(bv,uu____1496)::[]) when
+      | FStar_TypeChecker_NBETerm.Construct (fv,[],(bv,uu____1562)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Pat_Var.FStar_Reflection_Data.lid
           ->
-          let uu____1513 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv  in
-          FStar_Util.bind_opt uu____1513
+          let uu____1579 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv  in
+          FStar_Util.bind_opt uu____1579
             (fun bv1  ->
                FStar_All.pipe_left
-                 (fun _1520  -> FStar_Pervasives_Native.Some _1520)
+                 (fun _1586  -> FStar_Pervasives_Native.Some _1586)
                  (FStar_Reflection_Data.Pat_Var bv1))
-      | FStar_TypeChecker_NBETerm.Construct (fv,[],(bv,uu____1523)::[]) when
+      | FStar_TypeChecker_NBETerm.Construct (fv,[],(bv,uu____1589)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Pat_Wild.FStar_Reflection_Data.lid
           ->
-          let uu____1540 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv  in
-          FStar_Util.bind_opt uu____1540
+          let uu____1606 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv  in
+          FStar_Util.bind_opt uu____1606
             (fun bv1  ->
                FStar_All.pipe_left
-                 (fun _1547  -> FStar_Pervasives_Native.Some _1547)
+                 (fun _1613  -> FStar_Pervasives_Native.Some _1613)
                  (FStar_Reflection_Data.Pat_Wild bv1))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,[],(t1,uu____1550)::(bv,uu____1552)::[]) when
+          (fv,[],(t1,uu____1616)::(bv,uu____1618)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Pat_Dot_Term.FStar_Reflection_Data.lid
           ->
-          let uu____1573 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv  in
-          FStar_Util.bind_opt uu____1573
+          let uu____1639 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv  in
+          FStar_Util.bind_opt uu____1639
             (fun bv1  ->
-               let uu____1579 =
+               let uu____1645 =
                  FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
-               FStar_Util.bind_opt uu____1579
+               FStar_Util.bind_opt uu____1645
                  (fun t2  ->
                     FStar_All.pipe_left
-                      (fun _1586  -> FStar_Pervasives_Native.Some _1586)
+                      (fun _1652  -> FStar_Pervasives_Native.Some _1652)
                       (FStar_Reflection_Data.Pat_Dot_Term (bv1, t2))))
-      | uu____1587 ->
-          ((let uu____1589 =
-              let uu____1595 =
-                let uu____1597 = FStar_TypeChecker_NBETerm.t_to_string t  in
-                FStar_Util.format1 "Not an embedded pattern: %s" uu____1597
+      | uu____1653 ->
+          ((let uu____1655 =
+              let uu____1661 =
+                let uu____1663 = FStar_TypeChecker_NBETerm.t_to_string t  in
+                FStar_Util.format1 "Not an embedded pattern: %s" uu____1663
                  in
-              (FStar_Errors.Warning_NotEmbedded, uu____1595)  in
-            FStar_Errors.log_issue FStar_Range.dummyRange uu____1589);
+              (FStar_Errors.Warning_NotEmbedded, uu____1661)  in
+            FStar_Errors.log_issue FStar_Range.dummyRange uu____1655);
            FStar_Pervasives_Native.None)
        in
     mk_emb' embed_pattern unembed_pattern
@@ -630,8 +660,8 @@ let (e_branch_aq :
       FStar_TypeChecker_NBETerm.embedding)
   =
   fun aq  ->
-    let uu____1638 = e_term_aq aq  in
-    FStar_TypeChecker_NBETerm.e_tuple2 e_pattern uu____1638
+    let uu____1704 = e_term_aq aq  in
+    FStar_TypeChecker_NBETerm.e_tuple2 e_pattern uu____1704
   
 let (e_argv_aq :
   (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term'
@@ -640,13 +670,13 @@ let (e_argv_aq :
       FStar_TypeChecker_NBETerm.embedding)
   =
   fun aq  ->
-    let uu____1669 = e_term_aq aq  in
-    FStar_TypeChecker_NBETerm.e_tuple2 uu____1669 e_aqualv
+    let uu____1735 = e_term_aq aq  in
+    FStar_TypeChecker_NBETerm.e_tuple2 uu____1735 e_aqualv
   
 let rec unlazy_as_t :
-  'Auu____1679 .
+  'Auu____1745 .
     FStar_Syntax_Syntax.lazy_kind ->
-      FStar_TypeChecker_NBETerm.t -> 'Auu____1679
+      FStar_TypeChecker_NBETerm.t -> 'Auu____1745
   =
   fun k  ->
     fun t  ->
@@ -654,10 +684,10 @@ let rec unlazy_as_t :
       | FStar_TypeChecker_NBETerm.Lazy
           (FStar_Util.Inl
            { FStar_Syntax_Syntax.blob = v1; FStar_Syntax_Syntax.lkind = k';
-             FStar_Syntax_Syntax.ltyp = uu____1692;
-             FStar_Syntax_Syntax.rng = uu____1693;_},uu____1694)
+             FStar_Syntax_Syntax.ltyp = uu____1758;
+             FStar_Syntax_Syntax.rng = uu____1759;_},uu____1760)
           when FStar_Syntax_Util.eq_lazy_kind k k' -> FStar_Dyn.undyn v1
-      | uu____1713 -> failwith "Not a Lazy of the expected kind (NBE)"
+      | uu____1779 -> failwith "Not a Lazy of the expected kind (NBE)"
   
 let (e_term_view_aq :
   (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term'
@@ -668,246 +698,246 @@ let (e_term_view_aq :
     let embed_term_view cb tv =
       match tv with
       | FStar_Reflection_Data.Tv_FVar fv ->
-          let uu____1751 =
-            let uu____1758 =
-              let uu____1763 = FStar_TypeChecker_NBETerm.embed e_fv cb fv  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1763  in
-            [uu____1758]  in
+          let uu____1817 =
+            let uu____1824 =
+              let uu____1829 = FStar_TypeChecker_NBETerm.embed e_fv cb fv  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1829  in
+            [uu____1824]  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_FVar.FStar_Reflection_Data.fv []
-            uu____1751
+            uu____1817
       | FStar_Reflection_Data.Tv_BVar bv ->
-          let uu____1773 =
-            let uu____1780 =
-              let uu____1785 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1785  in
-            [uu____1780]  in
+          let uu____1839 =
+            let uu____1846 =
+              let uu____1851 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1851  in
+            [uu____1846]  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_BVar.FStar_Reflection_Data.fv []
-            uu____1773
+            uu____1839
       | FStar_Reflection_Data.Tv_Var bv ->
-          let uu____1795 =
-            let uu____1802 =
-              let uu____1807 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1807  in
-            [uu____1802]  in
+          let uu____1861 =
+            let uu____1868 =
+              let uu____1873 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1873  in
+            [uu____1868]  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Var.FStar_Reflection_Data.fv []
-            uu____1795
+            uu____1861
       | FStar_Reflection_Data.Tv_App (hd1,a) ->
-          let uu____1818 =
-            let uu____1825 =
-              let uu____1830 =
-                let uu____1831 = e_term_aq aq  in
-                FStar_TypeChecker_NBETerm.embed uu____1831 cb hd1  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1830  in
-            let uu____1834 =
-              let uu____1841 =
-                let uu____1846 =
-                  let uu____1847 = e_argv_aq aq  in
-                  FStar_TypeChecker_NBETerm.embed uu____1847 cb a  in
-                FStar_TypeChecker_NBETerm.as_arg uu____1846  in
-              [uu____1841]  in
-            uu____1825 :: uu____1834  in
+          let uu____1884 =
+            let uu____1891 =
+              let uu____1896 =
+                let uu____1897 = e_term_aq aq  in
+                FStar_TypeChecker_NBETerm.embed uu____1897 cb hd1  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1896  in
+            let uu____1900 =
+              let uu____1907 =
+                let uu____1912 =
+                  let uu____1913 = e_argv_aq aq  in
+                  FStar_TypeChecker_NBETerm.embed uu____1913 cb a  in
+                FStar_TypeChecker_NBETerm.as_arg uu____1912  in
+              [uu____1907]  in
+            uu____1891 :: uu____1900  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_App.FStar_Reflection_Data.fv []
-            uu____1818
+            uu____1884
       | FStar_Reflection_Data.Tv_Abs (b,t) ->
-          let uu____1872 =
-            let uu____1879 =
-              let uu____1884 = FStar_TypeChecker_NBETerm.embed e_binder cb b
+          let uu____1938 =
+            let uu____1945 =
+              let uu____1950 = FStar_TypeChecker_NBETerm.embed e_binder cb b
                  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1884  in
-            let uu____1885 =
-              let uu____1892 =
-                let uu____1897 =
-                  let uu____1898 = e_term_aq aq  in
-                  FStar_TypeChecker_NBETerm.embed uu____1898 cb t  in
-                FStar_TypeChecker_NBETerm.as_arg uu____1897  in
-              [uu____1892]  in
-            uu____1879 :: uu____1885  in
+              FStar_TypeChecker_NBETerm.as_arg uu____1950  in
+            let uu____1951 =
+              let uu____1958 =
+                let uu____1963 =
+                  let uu____1964 = e_term_aq aq  in
+                  FStar_TypeChecker_NBETerm.embed uu____1964 cb t  in
+                FStar_TypeChecker_NBETerm.as_arg uu____1963  in
+              [uu____1958]  in
+            uu____1945 :: uu____1951  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Abs.FStar_Reflection_Data.fv []
-            uu____1872
+            uu____1938
       | FStar_Reflection_Data.Tv_Arrow (b,c) ->
-          let uu____1915 =
-            let uu____1922 =
-              let uu____1927 = FStar_TypeChecker_NBETerm.embed e_binder cb b
+          let uu____1981 =
+            let uu____1988 =
+              let uu____1993 = FStar_TypeChecker_NBETerm.embed e_binder cb b
                  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1927  in
-            let uu____1928 =
-              let uu____1935 =
-                let uu____1940 = FStar_TypeChecker_NBETerm.embed e_comp cb c
+              FStar_TypeChecker_NBETerm.as_arg uu____1993  in
+            let uu____1994 =
+              let uu____2001 =
+                let uu____2006 = FStar_TypeChecker_NBETerm.embed e_comp cb c
                    in
-                FStar_TypeChecker_NBETerm.as_arg uu____1940  in
-              [uu____1935]  in
-            uu____1922 :: uu____1928  in
+                FStar_TypeChecker_NBETerm.as_arg uu____2006  in
+              [uu____2001]  in
+            uu____1988 :: uu____1994  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Arrow.FStar_Reflection_Data.fv []
-            uu____1915
+            uu____1981
       | FStar_Reflection_Data.Tv_Type u ->
-          let uu____1954 =
-            let uu____1961 =
-              let uu____1966 =
+          let uu____2020 =
+            let uu____2027 =
+              let uu____2032 =
                 FStar_TypeChecker_NBETerm.embed
                   FStar_TypeChecker_NBETerm.e_unit cb ()
                  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1966  in
-            [uu____1961]  in
+              FStar_TypeChecker_NBETerm.as_arg uu____2032  in
+            [uu____2027]  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Type.FStar_Reflection_Data.fv []
-            uu____1954
+            uu____2020
       | FStar_Reflection_Data.Tv_Refine (bv,t) ->
-          let uu____1977 =
-            let uu____1984 =
-              let uu____1989 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
-              FStar_TypeChecker_NBETerm.as_arg uu____1989  in
-            let uu____1990 =
-              let uu____1997 =
-                let uu____2002 =
-                  let uu____2003 = e_term_aq aq  in
-                  FStar_TypeChecker_NBETerm.embed uu____2003 cb t  in
-                FStar_TypeChecker_NBETerm.as_arg uu____2002  in
-              [uu____1997]  in
-            uu____1984 :: uu____1990  in
+          let uu____2043 =
+            let uu____2050 =
+              let uu____2055 = FStar_TypeChecker_NBETerm.embed e_bv cb bv  in
+              FStar_TypeChecker_NBETerm.as_arg uu____2055  in
+            let uu____2056 =
+              let uu____2063 =
+                let uu____2068 =
+                  let uu____2069 = e_term_aq aq  in
+                  FStar_TypeChecker_NBETerm.embed uu____2069 cb t  in
+                FStar_TypeChecker_NBETerm.as_arg uu____2068  in
+              [uu____2063]  in
+            uu____2050 :: uu____2056  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Refine.FStar_Reflection_Data.fv []
-            uu____1977
+            uu____2043
       | FStar_Reflection_Data.Tv_Const c ->
-          let uu____2019 =
-            let uu____2026 =
-              let uu____2031 = FStar_TypeChecker_NBETerm.embed e_const cb c
+          let uu____2085 =
+            let uu____2092 =
+              let uu____2097 = FStar_TypeChecker_NBETerm.embed e_const cb c
                  in
-              FStar_TypeChecker_NBETerm.as_arg uu____2031  in
-            [uu____2026]  in
+              FStar_TypeChecker_NBETerm.as_arg uu____2097  in
+            [uu____2092]  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Const.FStar_Reflection_Data.fv []
-            uu____2019
+            uu____2085
       | FStar_Reflection_Data.Tv_Uvar (u,d) ->
-          let uu____2042 =
-            let uu____2049 =
-              let uu____2054 =
+          let uu____2108 =
+            let uu____2115 =
+              let uu____2120 =
                 FStar_TypeChecker_NBETerm.embed
                   FStar_TypeChecker_NBETerm.e_int cb u
                  in
-              FStar_TypeChecker_NBETerm.as_arg uu____2054  in
-            let uu____2055 =
-              let uu____2062 =
-                let uu____2067 =
+              FStar_TypeChecker_NBETerm.as_arg uu____2120  in
+            let uu____2121 =
+              let uu____2128 =
+                let uu____2133 =
                   mk_lazy cb (u, d) FStar_Syntax_Util.t_ctx_uvar_and_sust
                     FStar_Syntax_Syntax.Lazy_uvar
                    in
-                FStar_TypeChecker_NBETerm.as_arg uu____2067  in
-              [uu____2062]  in
-            uu____2049 :: uu____2055  in
+                FStar_TypeChecker_NBETerm.as_arg uu____2133  in
+              [uu____2128]  in
+            uu____2115 :: uu____2121  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Uvar.FStar_Reflection_Data.fv []
-            uu____2042
+            uu____2108
       | FStar_Reflection_Data.Tv_Let (r,b,t1,t2) ->
-          let uu____2090 =
-            let uu____2097 =
-              let uu____2102 =
+          let uu____2156 =
+            let uu____2163 =
+              let uu____2168 =
                 FStar_TypeChecker_NBETerm.embed
                   FStar_TypeChecker_NBETerm.e_bool cb r
                  in
-              FStar_TypeChecker_NBETerm.as_arg uu____2102  in
-            let uu____2104 =
-              let uu____2111 =
-                let uu____2116 = FStar_TypeChecker_NBETerm.embed e_bv cb b
+              FStar_TypeChecker_NBETerm.as_arg uu____2168  in
+            let uu____2170 =
+              let uu____2177 =
+                let uu____2182 = FStar_TypeChecker_NBETerm.embed e_bv cb b
                    in
-                FStar_TypeChecker_NBETerm.as_arg uu____2116  in
-              let uu____2117 =
-                let uu____2124 =
-                  let uu____2129 =
-                    let uu____2130 = e_term_aq aq  in
-                    FStar_TypeChecker_NBETerm.embed uu____2130 cb t1  in
-                  FStar_TypeChecker_NBETerm.as_arg uu____2129  in
-                let uu____2133 =
-                  let uu____2140 =
-                    let uu____2145 =
-                      let uu____2146 = e_term_aq aq  in
-                      FStar_TypeChecker_NBETerm.embed uu____2146 cb t2  in
-                    FStar_TypeChecker_NBETerm.as_arg uu____2145  in
-                  [uu____2140]  in
-                uu____2124 :: uu____2133  in
-              uu____2111 :: uu____2117  in
-            uu____2097 :: uu____2104  in
+                FStar_TypeChecker_NBETerm.as_arg uu____2182  in
+              let uu____2183 =
+                let uu____2190 =
+                  let uu____2195 =
+                    let uu____2196 = e_term_aq aq  in
+                    FStar_TypeChecker_NBETerm.embed uu____2196 cb t1  in
+                  FStar_TypeChecker_NBETerm.as_arg uu____2195  in
+                let uu____2199 =
+                  let uu____2206 =
+                    let uu____2211 =
+                      let uu____2212 = e_term_aq aq  in
+                      FStar_TypeChecker_NBETerm.embed uu____2212 cb t2  in
+                    FStar_TypeChecker_NBETerm.as_arg uu____2211  in
+                  [uu____2206]  in
+                uu____2190 :: uu____2199  in
+              uu____2177 :: uu____2183  in
+            uu____2163 :: uu____2170  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Let.FStar_Reflection_Data.fv []
-            uu____2090
+            uu____2156
       | FStar_Reflection_Data.Tv_Match (t,brs) ->
-          let uu____2175 =
-            let uu____2182 =
-              let uu____2187 =
-                let uu____2188 = e_term_aq aq  in
-                FStar_TypeChecker_NBETerm.embed uu____2188 cb t  in
-              FStar_TypeChecker_NBETerm.as_arg uu____2187  in
-            let uu____2191 =
-              let uu____2198 =
-                let uu____2203 =
-                  let uu____2204 =
-                    let uu____2213 = e_branch_aq aq  in
-                    FStar_TypeChecker_NBETerm.e_list uu____2213  in
-                  FStar_TypeChecker_NBETerm.embed uu____2204 cb brs  in
-                FStar_TypeChecker_NBETerm.as_arg uu____2203  in
-              [uu____2198]  in
-            uu____2182 :: uu____2191  in
+          let uu____2241 =
+            let uu____2248 =
+              let uu____2253 =
+                let uu____2254 = e_term_aq aq  in
+                FStar_TypeChecker_NBETerm.embed uu____2254 cb t  in
+              FStar_TypeChecker_NBETerm.as_arg uu____2253  in
+            let uu____2257 =
+              let uu____2264 =
+                let uu____2269 =
+                  let uu____2270 =
+                    let uu____2279 = e_branch_aq aq  in
+                    FStar_TypeChecker_NBETerm.e_list uu____2279  in
+                  FStar_TypeChecker_NBETerm.embed uu____2270 cb brs  in
+                FStar_TypeChecker_NBETerm.as_arg uu____2269  in
+              [uu____2264]  in
+            uu____2248 :: uu____2257  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Match.FStar_Reflection_Data.fv []
-            uu____2175
+            uu____2241
       | FStar_Reflection_Data.Tv_AscribedT (e,t,tacopt) ->
-          let uu____2249 =
-            let uu____2256 =
-              let uu____2261 =
-                let uu____2262 = e_term_aq aq  in
-                FStar_TypeChecker_NBETerm.embed uu____2262 cb e  in
-              FStar_TypeChecker_NBETerm.as_arg uu____2261  in
-            let uu____2265 =
-              let uu____2272 =
-                let uu____2277 =
-                  let uu____2278 = e_term_aq aq  in
-                  FStar_TypeChecker_NBETerm.embed uu____2278 cb t  in
-                FStar_TypeChecker_NBETerm.as_arg uu____2277  in
-              let uu____2281 =
-                let uu____2288 =
-                  let uu____2293 =
-                    let uu____2294 =
-                      let uu____2299 = e_term_aq aq  in
-                      FStar_TypeChecker_NBETerm.e_option uu____2299  in
-                    FStar_TypeChecker_NBETerm.embed uu____2294 cb tacopt  in
-                  FStar_TypeChecker_NBETerm.as_arg uu____2293  in
-                [uu____2288]  in
-              uu____2272 :: uu____2281  in
-            uu____2256 :: uu____2265  in
+          let uu____2315 =
+            let uu____2322 =
+              let uu____2327 =
+                let uu____2328 = e_term_aq aq  in
+                FStar_TypeChecker_NBETerm.embed uu____2328 cb e  in
+              FStar_TypeChecker_NBETerm.as_arg uu____2327  in
+            let uu____2331 =
+              let uu____2338 =
+                let uu____2343 =
+                  let uu____2344 = e_term_aq aq  in
+                  FStar_TypeChecker_NBETerm.embed uu____2344 cb t  in
+                FStar_TypeChecker_NBETerm.as_arg uu____2343  in
+              let uu____2347 =
+                let uu____2354 =
+                  let uu____2359 =
+                    let uu____2360 =
+                      let uu____2365 = e_term_aq aq  in
+                      FStar_TypeChecker_NBETerm.e_option uu____2365  in
+                    FStar_TypeChecker_NBETerm.embed uu____2360 cb tacopt  in
+                  FStar_TypeChecker_NBETerm.as_arg uu____2359  in
+                [uu____2354]  in
+              uu____2338 :: uu____2347  in
+            uu____2322 :: uu____2331  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.fv []
-            uu____2249
+            uu____2315
       | FStar_Reflection_Data.Tv_AscribedC (e,c,tacopt) ->
-          let uu____2327 =
-            let uu____2334 =
-              let uu____2339 =
-                let uu____2340 = e_term_aq aq  in
-                FStar_TypeChecker_NBETerm.embed uu____2340 cb e  in
-              FStar_TypeChecker_NBETerm.as_arg uu____2339  in
-            let uu____2343 =
-              let uu____2350 =
-                let uu____2355 = FStar_TypeChecker_NBETerm.embed e_comp cb c
+          let uu____2393 =
+            let uu____2400 =
+              let uu____2405 =
+                let uu____2406 = e_term_aq aq  in
+                FStar_TypeChecker_NBETerm.embed uu____2406 cb e  in
+              FStar_TypeChecker_NBETerm.as_arg uu____2405  in
+            let uu____2409 =
+              let uu____2416 =
+                let uu____2421 = FStar_TypeChecker_NBETerm.embed e_comp cb c
                    in
-                FStar_TypeChecker_NBETerm.as_arg uu____2355  in
-              let uu____2356 =
-                let uu____2363 =
-                  let uu____2368 =
-                    let uu____2369 =
-                      let uu____2374 = e_term_aq aq  in
-                      FStar_TypeChecker_NBETerm.e_option uu____2374  in
-                    FStar_TypeChecker_NBETerm.embed uu____2369 cb tacopt  in
-                  FStar_TypeChecker_NBETerm.as_arg uu____2368  in
-                [uu____2363]  in
-              uu____2350 :: uu____2356  in
-            uu____2334 :: uu____2343  in
+                FStar_TypeChecker_NBETerm.as_arg uu____2421  in
+              let uu____2422 =
+                let uu____2429 =
+                  let uu____2434 =
+                    let uu____2435 =
+                      let uu____2440 = e_term_aq aq  in
+                      FStar_TypeChecker_NBETerm.e_option uu____2440  in
+                    FStar_TypeChecker_NBETerm.embed uu____2435 cb tacopt  in
+                  FStar_TypeChecker_NBETerm.as_arg uu____2434  in
+                [uu____2429]  in
+              uu____2416 :: uu____2422  in
+            uu____2400 :: uu____2409  in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.fv []
-            uu____2327
+            uu____2393
       | FStar_Reflection_Data.Tv_Unknown  ->
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Unknown.FStar_Reflection_Data.fv []
@@ -916,250 +946,250 @@ let (e_term_view_aq :
     let unembed_term_view cb t =
       match t with
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2415,(b,uu____2417)::[]) when
+          (fv,uu____2481,(b,uu____2483)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Var.FStar_Reflection_Data.lid
           ->
-          let uu____2436 = FStar_TypeChecker_NBETerm.unembed e_bv cb b  in
-          FStar_Util.bind_opt uu____2436
+          let uu____2502 = FStar_TypeChecker_NBETerm.unembed e_bv cb b  in
+          FStar_Util.bind_opt uu____2502
             (fun b1  ->
                FStar_All.pipe_left
-                 (fun _2443  -> FStar_Pervasives_Native.Some _2443)
+                 (fun _2509  -> FStar_Pervasives_Native.Some _2509)
                  (FStar_Reflection_Data.Tv_Var b1))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2445,(b,uu____2447)::[]) when
+          (fv,uu____2511,(b,uu____2513)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_BVar.FStar_Reflection_Data.lid
           ->
-          let uu____2466 = FStar_TypeChecker_NBETerm.unembed e_bv cb b  in
-          FStar_Util.bind_opt uu____2466
+          let uu____2532 = FStar_TypeChecker_NBETerm.unembed e_bv cb b  in
+          FStar_Util.bind_opt uu____2532
             (fun b1  ->
                FStar_All.pipe_left
-                 (fun _2473  -> FStar_Pervasives_Native.Some _2473)
+                 (fun _2539  -> FStar_Pervasives_Native.Some _2539)
                  (FStar_Reflection_Data.Tv_BVar b1))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2475,(f,uu____2477)::[]) when
+          (fv,uu____2541,(f,uu____2543)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_FVar.FStar_Reflection_Data.lid
           ->
-          let uu____2496 = FStar_TypeChecker_NBETerm.unembed e_fv cb f  in
-          FStar_Util.bind_opt uu____2496
+          let uu____2562 = FStar_TypeChecker_NBETerm.unembed e_fv cb f  in
+          FStar_Util.bind_opt uu____2562
             (fun f1  ->
                FStar_All.pipe_left
-                 (fun _2503  -> FStar_Pervasives_Native.Some _2503)
+                 (fun _2569  -> FStar_Pervasives_Native.Some _2569)
                  (FStar_Reflection_Data.Tv_FVar f1))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2505,(r,uu____2507)::(l,uu____2509)::[]) when
+          (fv,uu____2571,(r,uu____2573)::(l,uu____2575)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_App.FStar_Reflection_Data.lid
           ->
-          let uu____2532 = FStar_TypeChecker_NBETerm.unembed e_term cb l  in
-          FStar_Util.bind_opt uu____2532
+          let uu____2598 = FStar_TypeChecker_NBETerm.unembed e_term cb l  in
+          FStar_Util.bind_opt uu____2598
             (fun l1  ->
-               let uu____2538 = FStar_TypeChecker_NBETerm.unembed e_argv cb r
+               let uu____2604 = FStar_TypeChecker_NBETerm.unembed e_argv cb r
                   in
-               FStar_Util.bind_opt uu____2538
+               FStar_Util.bind_opt uu____2604
                  (fun r1  ->
                     FStar_All.pipe_left
-                      (fun _2545  -> FStar_Pervasives_Native.Some _2545)
+                      (fun _2611  -> FStar_Pervasives_Native.Some _2611)
                       (FStar_Reflection_Data.Tv_App (l1, r1))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2547,(t1,uu____2549)::(b,uu____2551)::[]) when
+          (fv,uu____2613,(t1,uu____2615)::(b,uu____2617)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Abs.FStar_Reflection_Data.lid
           ->
-          let uu____2574 = FStar_TypeChecker_NBETerm.unembed e_binder cb b
+          let uu____2640 = FStar_TypeChecker_NBETerm.unembed e_binder cb b
              in
-          FStar_Util.bind_opt uu____2574
+          FStar_Util.bind_opt uu____2640
             (fun b1  ->
-               let uu____2580 =
+               let uu____2646 =
                  FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
-               FStar_Util.bind_opt uu____2580
+               FStar_Util.bind_opt uu____2646
                  (fun t2  ->
                     FStar_All.pipe_left
-                      (fun _2587  -> FStar_Pervasives_Native.Some _2587)
+                      (fun _2653  -> FStar_Pervasives_Native.Some _2653)
                       (FStar_Reflection_Data.Tv_Abs (b1, t2))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2589,(t1,uu____2591)::(b,uu____2593)::[]) when
+          (fv,uu____2655,(t1,uu____2657)::(b,uu____2659)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Arrow.FStar_Reflection_Data.lid
           ->
-          let uu____2616 = FStar_TypeChecker_NBETerm.unembed e_binder cb b
+          let uu____2682 = FStar_TypeChecker_NBETerm.unembed e_binder cb b
              in
-          FStar_Util.bind_opt uu____2616
+          FStar_Util.bind_opt uu____2682
             (fun b1  ->
-               let uu____2622 =
+               let uu____2688 =
                  FStar_TypeChecker_NBETerm.unembed e_comp cb t1  in
-               FStar_Util.bind_opt uu____2622
+               FStar_Util.bind_opt uu____2688
                  (fun c  ->
                     FStar_All.pipe_left
-                      (fun _2629  -> FStar_Pervasives_Native.Some _2629)
+                      (fun _2695  -> FStar_Pervasives_Native.Some _2695)
                       (FStar_Reflection_Data.Tv_Arrow (b1, c))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2631,(u,uu____2633)::[]) when
+          (fv,uu____2697,(u,uu____2699)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Type.FStar_Reflection_Data.lid
           ->
-          let uu____2652 =
+          let uu____2718 =
             FStar_TypeChecker_NBETerm.unembed
               FStar_TypeChecker_NBETerm.e_unit cb u
              in
-          FStar_Util.bind_opt uu____2652
+          FStar_Util.bind_opt uu____2718
             (fun u1  ->
                FStar_All.pipe_left
-                 (fun _2659  -> FStar_Pervasives_Native.Some _2659)
+                 (fun _2725  -> FStar_Pervasives_Native.Some _2725)
                  (FStar_Reflection_Data.Tv_Type ()))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2661,(t1,uu____2663)::(b,uu____2665)::[]) when
+          (fv,uu____2727,(t1,uu____2729)::(b,uu____2731)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Refine.FStar_Reflection_Data.lid
           ->
-          let uu____2688 = FStar_TypeChecker_NBETerm.unembed e_bv cb b  in
-          FStar_Util.bind_opt uu____2688
+          let uu____2754 = FStar_TypeChecker_NBETerm.unembed e_bv cb b  in
+          FStar_Util.bind_opt uu____2754
             (fun b1  ->
-               let uu____2694 =
+               let uu____2760 =
                  FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
-               FStar_Util.bind_opt uu____2694
+               FStar_Util.bind_opt uu____2760
                  (fun t2  ->
                     FStar_All.pipe_left
-                      (fun _2701  -> FStar_Pervasives_Native.Some _2701)
+                      (fun _2767  -> FStar_Pervasives_Native.Some _2767)
                       (FStar_Reflection_Data.Tv_Refine (b1, t2))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2703,(c,uu____2705)::[]) when
+          (fv,uu____2769,(c,uu____2771)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Const.FStar_Reflection_Data.lid
           ->
-          let uu____2724 = FStar_TypeChecker_NBETerm.unembed e_const cb c  in
-          FStar_Util.bind_opt uu____2724
+          let uu____2790 = FStar_TypeChecker_NBETerm.unembed e_const cb c  in
+          FStar_Util.bind_opt uu____2790
             (fun c1  ->
                FStar_All.pipe_left
-                 (fun _2731  -> FStar_Pervasives_Native.Some _2731)
+                 (fun _2797  -> FStar_Pervasives_Native.Some _2797)
                  (FStar_Reflection_Data.Tv_Const c1))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2733,(l,uu____2735)::(u,uu____2737)::[]) when
+          (fv,uu____2799,(l,uu____2801)::(u,uu____2803)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Uvar.FStar_Reflection_Data.lid
           ->
-          let uu____2760 =
+          let uu____2826 =
             FStar_TypeChecker_NBETerm.unembed FStar_TypeChecker_NBETerm.e_int
               cb u
              in
-          FStar_Util.bind_opt uu____2760
+          FStar_Util.bind_opt uu____2826
             (fun u1  ->
                let ctx_u_s = unlazy_as_t FStar_Syntax_Syntax.Lazy_uvar l  in
                FStar_All.pipe_left
-                 (fun _2769  -> FStar_Pervasives_Native.Some _2769)
+                 (fun _2835  -> FStar_Pervasives_Native.Some _2835)
                  (FStar_Reflection_Data.Tv_Uvar (u1, ctx_u_s)))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2771,(t2,uu____2773)::(t1,uu____2775)::(b,uu____2777)::
-           (r,uu____2779)::[])
+          (fv,uu____2837,(t2,uu____2839)::(t1,uu____2841)::(b,uu____2843)::
+           (r,uu____2845)::[])
           when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Let.FStar_Reflection_Data.lid
           ->
-          let uu____2810 =
+          let uu____2876 =
             FStar_TypeChecker_NBETerm.unembed
               FStar_TypeChecker_NBETerm.e_bool cb r
              in
-          FStar_Util.bind_opt uu____2810
+          FStar_Util.bind_opt uu____2876
             (fun r1  ->
-               let uu____2820 = FStar_TypeChecker_NBETerm.unembed e_bv cb b
+               let uu____2886 = FStar_TypeChecker_NBETerm.unembed e_bv cb b
                   in
-               FStar_Util.bind_opt uu____2820
+               FStar_Util.bind_opt uu____2886
                  (fun b1  ->
-                    let uu____2826 =
+                    let uu____2892 =
                       FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
-                    FStar_Util.bind_opt uu____2826
+                    FStar_Util.bind_opt uu____2892
                       (fun t11  ->
-                         let uu____2832 =
+                         let uu____2898 =
                            FStar_TypeChecker_NBETerm.unembed e_term cb t2  in
-                         FStar_Util.bind_opt uu____2832
+                         FStar_Util.bind_opt uu____2898
                            (fun t21  ->
                               FStar_All.pipe_left
-                                (fun _2839  ->
-                                   FStar_Pervasives_Native.Some _2839)
+                                (fun _2905  ->
+                                   FStar_Pervasives_Native.Some _2905)
                                 (FStar_Reflection_Data.Tv_Let
                                    (r1, b1, t11, t21))))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2842,(brs,uu____2844)::(t1,uu____2846)::[]) when
+          (fv,uu____2908,(brs,uu____2910)::(t1,uu____2912)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Match.FStar_Reflection_Data.lid
           ->
-          let uu____2869 = FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
-          FStar_Util.bind_opt uu____2869
+          let uu____2935 = FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
+          FStar_Util.bind_opt uu____2935
             (fun t2  ->
-               let uu____2875 =
-                 let uu____2880 = FStar_TypeChecker_NBETerm.e_list e_branch
+               let uu____2941 =
+                 let uu____2946 = FStar_TypeChecker_NBETerm.e_list e_branch
                     in
-                 FStar_TypeChecker_NBETerm.unembed uu____2880 cb brs  in
-               FStar_Util.bind_opt uu____2875
+                 FStar_TypeChecker_NBETerm.unembed uu____2946 cb brs  in
+               FStar_Util.bind_opt uu____2941
                  (fun brs1  ->
                     FStar_All.pipe_left
-                      (fun _2895  -> FStar_Pervasives_Native.Some _2895)
+                      (fun _2961  -> FStar_Pervasives_Native.Some _2961)
                       (FStar_Reflection_Data.Tv_Match (t2, brs1))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2899,(tacopt,uu____2901)::(t1,uu____2903)::(e,uu____2905)::[])
+          (fv,uu____2965,(tacopt,uu____2967)::(t1,uu____2969)::(e,uu____2971)::[])
           when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.lid
           ->
-          let uu____2932 = FStar_TypeChecker_NBETerm.unembed e_term cb e  in
-          FStar_Util.bind_opt uu____2932
+          let uu____2998 = FStar_TypeChecker_NBETerm.unembed e_term cb e  in
+          FStar_Util.bind_opt uu____2998
             (fun e1  ->
-               let uu____2938 =
+               let uu____3004 =
                  FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
-               FStar_Util.bind_opt uu____2938
+               FStar_Util.bind_opt uu____3004
                  (fun t2  ->
-                    let uu____2944 =
-                      let uu____2949 =
+                    let uu____3010 =
+                      let uu____3015 =
                         FStar_TypeChecker_NBETerm.e_option e_term  in
-                      FStar_TypeChecker_NBETerm.unembed uu____2949 cb tacopt
+                      FStar_TypeChecker_NBETerm.unembed uu____3015 cb tacopt
                        in
-                    FStar_Util.bind_opt uu____2944
+                    FStar_Util.bind_opt uu____3010
                       (fun tacopt1  ->
                          FStar_All.pipe_left
-                           (fun _2964  -> FStar_Pervasives_Native.Some _2964)
+                           (fun _3030  -> FStar_Pervasives_Native.Some _3030)
                            (FStar_Reflection_Data.Tv_AscribedT
                               (e1, t2, tacopt1)))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2968,(tacopt,uu____2970)::(c,uu____2972)::(e,uu____2974)::[])
+          (fv,uu____3034,(tacopt,uu____3036)::(c,uu____3038)::(e,uu____3040)::[])
           when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_AscC.FStar_Reflection_Data.lid
           ->
-          let uu____3001 = FStar_TypeChecker_NBETerm.unembed e_term cb e  in
-          FStar_Util.bind_opt uu____3001
+          let uu____3067 = FStar_TypeChecker_NBETerm.unembed e_term cb e  in
+          FStar_Util.bind_opt uu____3067
             (fun e1  ->
-               let uu____3007 = FStar_TypeChecker_NBETerm.unembed e_comp cb c
+               let uu____3073 = FStar_TypeChecker_NBETerm.unembed e_comp cb c
                   in
-               FStar_Util.bind_opt uu____3007
+               FStar_Util.bind_opt uu____3073
                  (fun c1  ->
-                    let uu____3013 =
-                      let uu____3018 =
+                    let uu____3079 =
+                      let uu____3084 =
                         FStar_TypeChecker_NBETerm.e_option e_term  in
-                      FStar_TypeChecker_NBETerm.unembed uu____3018 cb tacopt
+                      FStar_TypeChecker_NBETerm.unembed uu____3084 cb tacopt
                        in
-                    FStar_Util.bind_opt uu____3013
+                    FStar_Util.bind_opt uu____3079
                       (fun tacopt1  ->
                          FStar_All.pipe_left
-                           (fun _3033  -> FStar_Pervasives_Native.Some _3033)
+                           (fun _3099  -> FStar_Pervasives_Native.Some _3099)
                            (FStar_Reflection_Data.Tv_AscribedC
                               (e1, c1, tacopt1)))))
-      | FStar_TypeChecker_NBETerm.Construct (fv,uu____3037,[]) when
+      | FStar_TypeChecker_NBETerm.Construct (fv,uu____3103,[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Unknown.FStar_Reflection_Data.lid
           ->
           FStar_All.pipe_left
-            (fun _3054  -> FStar_Pervasives_Native.Some _3054)
+            (fun _3120  -> FStar_Pervasives_Native.Some _3120)
             FStar_Reflection_Data.Tv_Unknown
-      | uu____3055 ->
-          ((let uu____3057 =
-              let uu____3063 =
-                let uu____3065 = FStar_TypeChecker_NBETerm.t_to_string t  in
-                FStar_Util.format1 "Not an embedded term_view: %s" uu____3065
+      | uu____3121 ->
+          ((let uu____3123 =
+              let uu____3129 =
+                let uu____3131 = FStar_TypeChecker_NBETerm.t_to_string t  in
+                FStar_Util.format1 "Not an embedded term_view: %s" uu____3131
                  in
-              (FStar_Errors.Warning_NotEmbedded, uu____3063)  in
-            FStar_Errors.log_issue FStar_Range.dummyRange uu____3057);
+              (FStar_Errors.Warning_NotEmbedded, uu____3129)  in
+            FStar_Errors.log_issue FStar_Range.dummyRange uu____3123);
            FStar_Pervasives_Native.None)
        in
     mk_emb' embed_term_view unembed_term_view
@@ -1171,71 +1201,71 @@ let (e_term_view :
 let (e_bv_view :
   FStar_Reflection_Data.bv_view FStar_TypeChecker_NBETerm.embedding) =
   let embed_bv_view cb bvv =
-    let uu____3092 =
-      let uu____3099 =
-        let uu____3104 =
+    let uu____3158 =
+      let uu____3165 =
+        let uu____3170 =
           FStar_TypeChecker_NBETerm.embed FStar_TypeChecker_NBETerm.e_string
             cb bvv.FStar_Reflection_Data.bv_ppname
            in
-        FStar_TypeChecker_NBETerm.as_arg uu____3104  in
-      let uu____3106 =
-        let uu____3113 =
-          let uu____3118 =
+        FStar_TypeChecker_NBETerm.as_arg uu____3170  in
+      let uu____3172 =
+        let uu____3179 =
+          let uu____3184 =
             FStar_TypeChecker_NBETerm.embed FStar_TypeChecker_NBETerm.e_int
               cb bvv.FStar_Reflection_Data.bv_index
              in
-          FStar_TypeChecker_NBETerm.as_arg uu____3118  in
-        let uu____3119 =
-          let uu____3126 =
-            let uu____3131 =
+          FStar_TypeChecker_NBETerm.as_arg uu____3184  in
+        let uu____3185 =
+          let uu____3192 =
+            let uu____3197 =
               FStar_TypeChecker_NBETerm.embed e_term cb
                 bvv.FStar_Reflection_Data.bv_sort
                in
-            FStar_TypeChecker_NBETerm.as_arg uu____3131  in
-          [uu____3126]  in
-        uu____3113 :: uu____3119  in
-      uu____3099 :: uu____3106  in
+            FStar_TypeChecker_NBETerm.as_arg uu____3197  in
+          [uu____3192]  in
+        uu____3179 :: uu____3185  in
+      uu____3165 :: uu____3172  in
     mkConstruct FStar_Reflection_Data.ref_Mk_bv.FStar_Reflection_Data.fv []
-      uu____3092
+      uu____3158
      in
   let unembed_bv_view cb t =
     match t with
     | FStar_TypeChecker_NBETerm.Construct
-        (fv,uu____3164,(s,uu____3166)::(idx,uu____3168)::(nm,uu____3170)::[])
+        (fv,uu____3230,(s,uu____3232)::(idx,uu____3234)::(nm,uu____3236)::[])
         when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_Mk_bv.FStar_Reflection_Data.lid
         ->
-        let uu____3197 =
+        let uu____3263 =
           FStar_TypeChecker_NBETerm.unembed
             FStar_TypeChecker_NBETerm.e_string cb nm
            in
-        FStar_Util.bind_opt uu____3197
+        FStar_Util.bind_opt uu____3263
           (fun nm1  ->
-             let uu____3207 =
+             let uu____3273 =
                FStar_TypeChecker_NBETerm.unembed
                  FStar_TypeChecker_NBETerm.e_int cb idx
                 in
-             FStar_Util.bind_opt uu____3207
+             FStar_Util.bind_opt uu____3273
                (fun idx1  ->
-                  let uu____3213 =
+                  let uu____3279 =
                     FStar_TypeChecker_NBETerm.unembed e_term cb s  in
-                  FStar_Util.bind_opt uu____3213
+                  FStar_Util.bind_opt uu____3279
                     (fun s1  ->
                        FStar_All.pipe_left
-                         (fun _3220  -> FStar_Pervasives_Native.Some _3220)
+                         (fun _3286  -> FStar_Pervasives_Native.Some _3286)
                          {
                            FStar_Reflection_Data.bv_ppname = nm1;
                            FStar_Reflection_Data.bv_index = idx1;
                            FStar_Reflection_Data.bv_sort = s1
                          })))
-    | uu____3221 ->
-        ((let uu____3223 =
-            let uu____3229 =
-              let uu____3231 = FStar_TypeChecker_NBETerm.t_to_string t  in
-              FStar_Util.format1 "Not an embedded bv_view: %s" uu____3231  in
-            (FStar_Errors.Warning_NotEmbedded, uu____3229)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____3223);
+    | uu____3287 ->
+        ((let uu____3289 =
+            let uu____3295 =
+              let uu____3297 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded bv_view: %s" uu____3297  in
+            (FStar_Errors.Warning_NotEmbedded, uu____3295)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____3289);
          FStar_Pervasives_Native.None)
      in
   mk_emb' embed_bv_view unembed_bv_view
@@ -1246,39 +1276,39 @@ let (e_comp_view :
   let embed_comp_view cb cv =
     match cv with
     | FStar_Reflection_Data.C_Total (t,md) ->
-        let uu____3255 =
-          let uu____3262 =
-            let uu____3267 = FStar_TypeChecker_NBETerm.embed e_term cb t  in
-            FStar_TypeChecker_NBETerm.as_arg uu____3267  in
-          let uu____3268 =
-            let uu____3275 =
-              let uu____3280 =
-                let uu____3281 = FStar_TypeChecker_NBETerm.e_option e_term
+        let uu____3321 =
+          let uu____3328 =
+            let uu____3333 = FStar_TypeChecker_NBETerm.embed e_term cb t  in
+            FStar_TypeChecker_NBETerm.as_arg uu____3333  in
+          let uu____3334 =
+            let uu____3341 =
+              let uu____3346 =
+                let uu____3347 = FStar_TypeChecker_NBETerm.e_option e_term
                    in
-                FStar_TypeChecker_NBETerm.embed uu____3281 cb md  in
-              FStar_TypeChecker_NBETerm.as_arg uu____3280  in
-            [uu____3275]  in
-          uu____3262 :: uu____3268  in
+                FStar_TypeChecker_NBETerm.embed uu____3347 cb md  in
+              FStar_TypeChecker_NBETerm.as_arg uu____3346  in
+            [uu____3341]  in
+          uu____3328 :: uu____3334  in
         mkConstruct
           FStar_Reflection_Data.ref_C_Total.FStar_Reflection_Data.fv []
-          uu____3255
+          uu____3321
     | FStar_Reflection_Data.C_Lemma (pre,post) ->
         let post1 = FStar_Syntax_Util.unthunk_lemma_post post  in
-        let uu____3305 =
-          let uu____3312 =
-            let uu____3317 = FStar_TypeChecker_NBETerm.embed e_term cb pre
+        let uu____3371 =
+          let uu____3378 =
+            let uu____3383 = FStar_TypeChecker_NBETerm.embed e_term cb pre
                in
-            FStar_TypeChecker_NBETerm.as_arg uu____3317  in
-          let uu____3318 =
-            let uu____3325 =
-              let uu____3330 =
+            FStar_TypeChecker_NBETerm.as_arg uu____3383  in
+          let uu____3384 =
+            let uu____3391 =
+              let uu____3396 =
                 FStar_TypeChecker_NBETerm.embed e_term cb post1  in
-              FStar_TypeChecker_NBETerm.as_arg uu____3330  in
-            [uu____3325]  in
-          uu____3312 :: uu____3318  in
+              FStar_TypeChecker_NBETerm.as_arg uu____3396  in
+            [uu____3391]  in
+          uu____3378 :: uu____3384  in
         mkConstruct
           FStar_Reflection_Data.ref_C_Lemma.FStar_Reflection_Data.fv []
-          uu____3305
+          uu____3371
     | FStar_Reflection_Data.C_Unknown  ->
         mkConstruct
           FStar_Reflection_Data.ref_C_Unknown.FStar_Reflection_Data.fv [] []
@@ -1286,51 +1316,51 @@ let (e_comp_view :
   let unembed_comp_view cb t =
     match t with
     | FStar_TypeChecker_NBETerm.Construct
-        (fv,uu____3363,(md,uu____3365)::(t1,uu____3367)::[]) when
+        (fv,uu____3429,(md,uu____3431)::(t1,uu____3433)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_Total.FStar_Reflection_Data.lid
         ->
-        let uu____3390 = FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
-        FStar_Util.bind_opt uu____3390
+        let uu____3456 = FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
+        FStar_Util.bind_opt uu____3456
           (fun t2  ->
-             let uu____3396 =
-               let uu____3401 = FStar_TypeChecker_NBETerm.e_option e_term  in
-               FStar_TypeChecker_NBETerm.unembed uu____3401 cb md  in
-             FStar_Util.bind_opt uu____3396
+             let uu____3462 =
+               let uu____3467 = FStar_TypeChecker_NBETerm.e_option e_term  in
+               FStar_TypeChecker_NBETerm.unembed uu____3467 cb md  in
+             FStar_Util.bind_opt uu____3462
                (fun md1  ->
                   FStar_All.pipe_left
-                    (fun _3416  -> FStar_Pervasives_Native.Some _3416)
+                    (fun _3482  -> FStar_Pervasives_Native.Some _3482)
                     (FStar_Reflection_Data.C_Total (t2, md1))))
     | FStar_TypeChecker_NBETerm.Construct
-        (fv,uu____3420,(post,uu____3422)::(pre,uu____3424)::[]) when
+        (fv,uu____3486,(post,uu____3488)::(pre,uu____3490)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_Lemma.FStar_Reflection_Data.lid
         ->
-        let uu____3447 = FStar_TypeChecker_NBETerm.unembed e_term cb pre  in
-        FStar_Util.bind_opt uu____3447
+        let uu____3513 = FStar_TypeChecker_NBETerm.unembed e_term cb pre  in
+        FStar_Util.bind_opt uu____3513
           (fun pre1  ->
-             let uu____3453 =
+             let uu____3519 =
                FStar_TypeChecker_NBETerm.unembed e_term cb post  in
-             FStar_Util.bind_opt uu____3453
+             FStar_Util.bind_opt uu____3519
                (fun post1  ->
                   FStar_All.pipe_left
-                    (fun _3460  -> FStar_Pervasives_Native.Some _3460)
+                    (fun _3526  -> FStar_Pervasives_Native.Some _3526)
                     (FStar_Reflection_Data.C_Lemma (pre1, post1))))
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____3462,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____3528,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_Unknown.FStar_Reflection_Data.lid
         ->
         FStar_All.pipe_left
-          (fun _3479  -> FStar_Pervasives_Native.Some _3479)
+          (fun _3545  -> FStar_Pervasives_Native.Some _3545)
           FStar_Reflection_Data.C_Unknown
-    | uu____3480 ->
-        ((let uu____3482 =
-            let uu____3488 =
-              let uu____3490 = FStar_TypeChecker_NBETerm.t_to_string t  in
-              FStar_Util.format1 "Not an embedded comp_view: %s" uu____3490
+    | uu____3546 ->
+        ((let uu____3548 =
+            let uu____3554 =
+              let uu____3556 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded comp_view: %s" uu____3556
                in
-            (FStar_Errors.Warning_NotEmbedded, uu____3488)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____3482);
+            (FStar_Errors.Warning_NotEmbedded, uu____3554)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____3548);
          FStar_Pervasives_Native.None)
      in
   mk_emb' embed_comp_view unembed_comp_view
@@ -1345,29 +1375,29 @@ let (e_order : FStar_Order.order FStar_TypeChecker_NBETerm.embedding) =
      in
   let unembed_order cb t =
     match t with
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____3536,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____3602,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Reflection_Data.ord_Lt_lid ->
         FStar_Pervasives_Native.Some FStar_Order.Lt
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____3552,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____3618,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Reflection_Data.ord_Eq_lid ->
         FStar_Pervasives_Native.Some FStar_Order.Eq
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____3568,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____3634,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Reflection_Data.ord_Gt_lid ->
         FStar_Pervasives_Native.Some FStar_Order.Gt
-    | uu____3583 ->
-        ((let uu____3585 =
-            let uu____3591 =
-              let uu____3593 = FStar_TypeChecker_NBETerm.t_to_string t  in
-              FStar_Util.format1 "Not an embedded order: %s" uu____3593  in
-            (FStar_Errors.Warning_NotEmbedded, uu____3591)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____3585);
+    | uu____3649 ->
+        ((let uu____3651 =
+            let uu____3657 =
+              let uu____3659 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded order: %s" uu____3659  in
+            (FStar_Errors.Warning_NotEmbedded, uu____3657)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____3651);
          FStar_Pervasives_Native.None)
      in
-  let uu____3597 =
+  let uu____3663 =
     FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.order_lid
       FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
      in
-  mk_emb' embed_order unembed_order uu____3597 
+  mk_emb' embed_order unembed_order uu____3663 
 let (e_sigelt :
   FStar_Syntax_Syntax.sigelt FStar_TypeChecker_NBETerm.embedding) =
   let embed_sigelt cb se =
@@ -1380,18 +1410,18 @@ let (e_sigelt :
         (FStar_Util.Inl
          { FStar_Syntax_Syntax.blob = b;
            FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_sigelt ;
-           FStar_Syntax_Syntax.ltyp = uu____3628;
-           FStar_Syntax_Syntax.rng = uu____3629;_},uu____3630)
+           FStar_Syntax_Syntax.ltyp = uu____3694;
+           FStar_Syntax_Syntax.rng = uu____3695;_},uu____3696)
         ->
-        let uu____3649 = FStar_Dyn.undyn b  in
-        FStar_Pervasives_Native.Some uu____3649
-    | uu____3650 ->
-        ((let uu____3652 =
-            let uu____3658 =
-              let uu____3660 = FStar_TypeChecker_NBETerm.t_to_string t  in
-              FStar_Util.format1 "Not an embedded sigelt: %s" uu____3660  in
-            (FStar_Errors.Warning_NotEmbedded, uu____3658)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____3652);
+        let uu____3715 = FStar_Dyn.undyn b  in
+        FStar_Pervasives_Native.Some uu____3715
+    | uu____3716 ->
+        ((let uu____3718 =
+            let uu____3724 =
+              let uu____3726 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded sigelt: %s" uu____3726  in
+            (FStar_Errors.Warning_NotEmbedded, uu____3724)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____3718);
          FStar_Pervasives_Native.None)
      in
   mk_emb' embed_sigelt unembed_sigelt
@@ -1403,17 +1433,17 @@ let (e_ident : FStar_Ident.ident FStar_TypeChecker_NBETerm.embedding) =
       FStar_TypeChecker_NBETerm.e_string
      in
   let embed_ident cb i =
-    let uu____3689 =
-      let uu____3695 = FStar_Ident.range_of_id i  in
-      let uu____3696 = FStar_Ident.text_of_id i  in (uu____3695, uu____3696)
+    let uu____3755 =
+      let uu____3761 = FStar_Ident.range_of_id i  in
+      let uu____3762 = FStar_Ident.text_of_id i  in (uu____3761, uu____3762)
        in
-    FStar_TypeChecker_NBETerm.embed repr cb uu____3689  in
+    FStar_TypeChecker_NBETerm.embed repr cb uu____3755  in
   let unembed_ident cb t =
-    let uu____3719 = FStar_TypeChecker_NBETerm.unembed repr cb t  in
-    match uu____3719 with
+    let uu____3785 = FStar_TypeChecker_NBETerm.unembed repr cb t  in
+    match uu____3785 with
     | FStar_Pervasives_Native.Some (rng,s) ->
-        let uu____3743 = FStar_Ident.mk_ident (s, rng)  in
-        FStar_Pervasives_Native.Some uu____3743
+        let uu____3809 = FStar_Ident.mk_ident (s, rng)  in
+        FStar_Pervasives_Native.Some uu____3809
     | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None  in
   let range_fv =
     FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.range_lid
@@ -1424,35 +1454,35 @@ let (e_ident : FStar_Ident.ident FStar_TypeChecker_NBETerm.embedding) =
       FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
      in
   let et =
-    let uu____3753 =
-      let uu____3761 =
+    let uu____3819 =
+      let uu____3827 =
         FStar_Ident.string_of_lid FStar_Parser_Const.lid_tuple2  in
-      let uu____3763 =
-        let uu____3766 = fv_as_emb_typ range_fv  in
-        let uu____3767 =
-          let uu____3770 = fv_as_emb_typ string_fv  in [uu____3770]  in
-        uu____3766 :: uu____3767  in
-      (uu____3761, uu____3763)  in
-    FStar_Syntax_Syntax.ET_app uu____3753  in
-  let uu____3774 =
-    let uu____3775 =
+      let uu____3829 =
+        let uu____3832 = fv_as_emb_typ range_fv  in
+        let uu____3833 =
+          let uu____3836 = fv_as_emb_typ string_fv  in [uu____3836]  in
+        uu____3832 :: uu____3833  in
+      (uu____3827, uu____3829)  in
+    FStar_Syntax_Syntax.ET_app uu____3819  in
+  let uu____3840 =
+    let uu____3841 =
       FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.lid_tuple2
         FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
        in
-    let uu____3776 =
-      let uu____3783 =
-        let uu____3788 = mkFV range_fv [] []  in
-        FStar_TypeChecker_NBETerm.as_arg uu____3788  in
-      let uu____3793 =
-        let uu____3800 =
-          let uu____3805 = mkFV string_fv [] []  in
-          FStar_TypeChecker_NBETerm.as_arg uu____3805  in
-        [uu____3800]  in
-      uu____3783 :: uu____3793  in
-    mkFV uu____3775 [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]
-      uu____3776
+    let uu____3842 =
+      let uu____3849 =
+        let uu____3854 = mkFV range_fv [] []  in
+        FStar_TypeChecker_NBETerm.as_arg uu____3854  in
+      let uu____3859 =
+        let uu____3866 =
+          let uu____3871 = mkFV string_fv [] []  in
+          FStar_TypeChecker_NBETerm.as_arg uu____3871  in
+        [uu____3866]  in
+      uu____3849 :: uu____3859  in
+    mkFV uu____3841 [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]
+      uu____3842
      in
-  FStar_TypeChecker_NBETerm.mk_emb embed_ident unembed_ident uu____3774 et 
+  FStar_TypeChecker_NBETerm.mk_emb embed_ident unembed_ident uu____3840 et 
 let (e_univ_name :
   FStar_Syntax_Syntax.univ_name FStar_TypeChecker_NBETerm.embedding) =
   e_ident 
@@ -1468,91 +1498,91 @@ let (e_sigelt_view :
   let embed_sigelt_view cb sev =
     match sev with
     | FStar_Reflection_Data.Sg_Let (r,fv,univs1,ty,t) ->
-        let uu____3862 =
-          let uu____3869 =
-            let uu____3874 =
+        let uu____3928 =
+          let uu____3935 =
+            let uu____3940 =
               FStar_TypeChecker_NBETerm.embed
                 FStar_TypeChecker_NBETerm.e_bool cb r
                in
-            FStar_TypeChecker_NBETerm.as_arg uu____3874  in
-          let uu____3876 =
-            let uu____3883 =
-              let uu____3888 = FStar_TypeChecker_NBETerm.embed e_fv cb fv  in
-              FStar_TypeChecker_NBETerm.as_arg uu____3888  in
-            let uu____3889 =
-              let uu____3896 =
-                let uu____3901 =
+            FStar_TypeChecker_NBETerm.as_arg uu____3940  in
+          let uu____3942 =
+            let uu____3949 =
+              let uu____3954 = FStar_TypeChecker_NBETerm.embed e_fv cb fv  in
+              FStar_TypeChecker_NBETerm.as_arg uu____3954  in
+            let uu____3955 =
+              let uu____3962 =
+                let uu____3967 =
                   FStar_TypeChecker_NBETerm.embed e_univ_names cb univs1  in
-                FStar_TypeChecker_NBETerm.as_arg uu____3901  in
-              let uu____3904 =
-                let uu____3911 =
-                  let uu____3916 =
+                FStar_TypeChecker_NBETerm.as_arg uu____3967  in
+              let uu____3970 =
+                let uu____3977 =
+                  let uu____3982 =
                     FStar_TypeChecker_NBETerm.embed e_term cb ty  in
-                  FStar_TypeChecker_NBETerm.as_arg uu____3916  in
-                let uu____3917 =
-                  let uu____3924 =
-                    let uu____3929 =
+                  FStar_TypeChecker_NBETerm.as_arg uu____3982  in
+                let uu____3983 =
+                  let uu____3990 =
+                    let uu____3995 =
                       FStar_TypeChecker_NBETerm.embed e_term cb t  in
-                    FStar_TypeChecker_NBETerm.as_arg uu____3929  in
-                  [uu____3924]  in
-                uu____3911 :: uu____3917  in
-              uu____3896 :: uu____3904  in
-            uu____3883 :: uu____3889  in
-          uu____3869 :: uu____3876  in
+                    FStar_TypeChecker_NBETerm.as_arg uu____3995  in
+                  [uu____3990]  in
+                uu____3977 :: uu____3983  in
+              uu____3962 :: uu____3970  in
+            uu____3949 :: uu____3955  in
+          uu____3935 :: uu____3942  in
         mkConstruct FStar_Reflection_Data.ref_Sg_Let.FStar_Reflection_Data.fv
-          [] uu____3862
+          [] uu____3928
     | FStar_Reflection_Data.Sg_Constructor (nm,ty) ->
-        let uu____3956 =
-          let uu____3963 =
-            let uu____3968 =
+        let uu____4022 =
+          let uu____4029 =
+            let uu____4034 =
               FStar_TypeChecker_NBETerm.embed e_string_list cb nm  in
-            FStar_TypeChecker_NBETerm.as_arg uu____3968  in
-          let uu____3972 =
-            let uu____3979 =
-              let uu____3984 = FStar_TypeChecker_NBETerm.embed e_term cb ty
+            FStar_TypeChecker_NBETerm.as_arg uu____4034  in
+          let uu____4038 =
+            let uu____4045 =
+              let uu____4050 = FStar_TypeChecker_NBETerm.embed e_term cb ty
                  in
-              FStar_TypeChecker_NBETerm.as_arg uu____3984  in
-            [uu____3979]  in
-          uu____3963 :: uu____3972  in
+              FStar_TypeChecker_NBETerm.as_arg uu____4050  in
+            [uu____4045]  in
+          uu____4029 :: uu____4038  in
         mkConstruct
           FStar_Reflection_Data.ref_Sg_Constructor.FStar_Reflection_Data.fv
-          [] uu____3956
+          [] uu____4022
     | FStar_Reflection_Data.Sg_Inductive (nm,univs1,bs,t,dcs) ->
-        let uu____4014 =
-          let uu____4021 =
-            let uu____4026 =
+        let uu____4080 =
+          let uu____4087 =
+            let uu____4092 =
               FStar_TypeChecker_NBETerm.embed e_string_list cb nm  in
-            FStar_TypeChecker_NBETerm.as_arg uu____4026  in
-          let uu____4030 =
-            let uu____4037 =
-              let uu____4042 =
+            FStar_TypeChecker_NBETerm.as_arg uu____4092  in
+          let uu____4096 =
+            let uu____4103 =
+              let uu____4108 =
                 FStar_TypeChecker_NBETerm.embed e_univ_names cb univs1  in
-              FStar_TypeChecker_NBETerm.as_arg uu____4042  in
-            let uu____4045 =
-              let uu____4052 =
-                let uu____4057 =
+              FStar_TypeChecker_NBETerm.as_arg uu____4108  in
+            let uu____4111 =
+              let uu____4118 =
+                let uu____4123 =
                   FStar_TypeChecker_NBETerm.embed e_binders cb bs  in
-                FStar_TypeChecker_NBETerm.as_arg uu____4057  in
-              let uu____4058 =
-                let uu____4065 =
-                  let uu____4070 =
+                FStar_TypeChecker_NBETerm.as_arg uu____4123  in
+              let uu____4124 =
+                let uu____4131 =
+                  let uu____4136 =
                     FStar_TypeChecker_NBETerm.embed e_term cb t  in
-                  FStar_TypeChecker_NBETerm.as_arg uu____4070  in
-                let uu____4071 =
-                  let uu____4078 =
-                    let uu____4083 =
-                      let uu____4084 =
+                  FStar_TypeChecker_NBETerm.as_arg uu____4136  in
+                let uu____4137 =
+                  let uu____4144 =
+                    let uu____4149 =
+                      let uu____4150 =
                         FStar_TypeChecker_NBETerm.e_list e_string_list  in
-                      FStar_TypeChecker_NBETerm.embed uu____4084 cb dcs  in
-                    FStar_TypeChecker_NBETerm.as_arg uu____4083  in
-                  [uu____4078]  in
-                uu____4065 :: uu____4071  in
-              uu____4052 :: uu____4058  in
-            uu____4037 :: uu____4045  in
-          uu____4021 :: uu____4030  in
+                      FStar_TypeChecker_NBETerm.embed uu____4150 cb dcs  in
+                    FStar_TypeChecker_NBETerm.as_arg uu____4149  in
+                  [uu____4144]  in
+                uu____4131 :: uu____4137  in
+              uu____4118 :: uu____4124  in
+            uu____4103 :: uu____4111  in
+          uu____4087 :: uu____4096  in
         mkConstruct
           FStar_Reflection_Data.ref_Sg_Inductive.FStar_Reflection_Data.fv []
-          uu____4014
+          uu____4080
     | FStar_Reflection_Data.Unk  ->
         mkConstruct FStar_Reflection_Data.ref_Unk.FStar_Reflection_Data.fv []
           []
@@ -1560,91 +1590,91 @@ let (e_sigelt_view :
   let unembed_sigelt_view cb t =
     match t with
     | FStar_TypeChecker_NBETerm.Construct
-        (fv,uu____4144,(dcs,uu____4146)::(t1,uu____4148)::(bs,uu____4150)::
-         (us,uu____4152)::(nm,uu____4154)::[])
+        (fv,uu____4210,(dcs,uu____4212)::(t1,uu____4214)::(bs,uu____4216)::
+         (us,uu____4218)::(nm,uu____4220)::[])
         when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_Sg_Inductive.FStar_Reflection_Data.lid
         ->
-        let uu____4189 =
+        let uu____4255 =
           FStar_TypeChecker_NBETerm.unembed e_string_list cb nm  in
-        FStar_Util.bind_opt uu____4189
+        FStar_Util.bind_opt uu____4255
           (fun nm1  ->
-             let uu____4207 =
+             let uu____4273 =
                FStar_TypeChecker_NBETerm.unembed e_univ_names cb us  in
-             FStar_Util.bind_opt uu____4207
+             FStar_Util.bind_opt uu____4273
                (fun us1  ->
-                  let uu____4221 =
+                  let uu____4287 =
                     FStar_TypeChecker_NBETerm.unembed e_binders cb bs  in
-                  FStar_Util.bind_opt uu____4221
+                  FStar_Util.bind_opt uu____4287
                     (fun bs1  ->
-                       let uu____4227 =
+                       let uu____4293 =
                          FStar_TypeChecker_NBETerm.unembed e_term cb t1  in
-                       FStar_Util.bind_opt uu____4227
+                       FStar_Util.bind_opt uu____4293
                          (fun t2  ->
-                            let uu____4233 =
-                              let uu____4241 =
+                            let uu____4299 =
+                              let uu____4307 =
                                 FStar_TypeChecker_NBETerm.e_list
                                   e_string_list
                                  in
-                              FStar_TypeChecker_NBETerm.unembed uu____4241 cb
+                              FStar_TypeChecker_NBETerm.unembed uu____4307 cb
                                 dcs
                                in
-                            FStar_Util.bind_opt uu____4233
+                            FStar_Util.bind_opt uu____4299
                               (fun dcs1  ->
                                  FStar_All.pipe_left
-                                   (fun _4271  ->
-                                      FStar_Pervasives_Native.Some _4271)
+                                   (fun _4337  ->
+                                      FStar_Pervasives_Native.Some _4337)
                                    (FStar_Reflection_Data.Sg_Inductive
                                       (nm1, us1, bs1, t2, dcs1)))))))
     | FStar_TypeChecker_NBETerm.Construct
-        (fv,uu____4279,(t1,uu____4281)::(ty,uu____4283)::(univs1,uu____4285)::
-         (fvar1,uu____4287)::(r,uu____4289)::[])
+        (fv,uu____4345,(t1,uu____4347)::(ty,uu____4349)::(univs1,uu____4351)::
+         (fvar1,uu____4353)::(r,uu____4355)::[])
         when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_Sg_Let.FStar_Reflection_Data.lid
         ->
-        let uu____4324 =
+        let uu____4390 =
           FStar_TypeChecker_NBETerm.unembed FStar_TypeChecker_NBETerm.e_bool
             cb r
            in
-        FStar_Util.bind_opt uu____4324
+        FStar_Util.bind_opt uu____4390
           (fun r1  ->
-             let uu____4334 = FStar_TypeChecker_NBETerm.unembed e_fv cb fvar1
+             let uu____4400 = FStar_TypeChecker_NBETerm.unembed e_fv cb fvar1
                 in
-             FStar_Util.bind_opt uu____4334
+             FStar_Util.bind_opt uu____4400
                (fun fvar2  ->
-                  let uu____4340 =
+                  let uu____4406 =
                     FStar_TypeChecker_NBETerm.unembed e_univ_names cb univs1
                      in
-                  FStar_Util.bind_opt uu____4340
+                  FStar_Util.bind_opt uu____4406
                     (fun univs2  ->
-                       let uu____4354 =
+                       let uu____4420 =
                          FStar_TypeChecker_NBETerm.unembed e_term cb ty  in
-                       FStar_Util.bind_opt uu____4354
+                       FStar_Util.bind_opt uu____4420
                          (fun ty1  ->
-                            let uu____4360 =
+                            let uu____4426 =
                               FStar_TypeChecker_NBETerm.unembed e_term cb t1
                                in
-                            FStar_Util.bind_opt uu____4360
+                            FStar_Util.bind_opt uu____4426
                               (fun t2  ->
                                  FStar_All.pipe_left
-                                   (fun _4367  ->
-                                      FStar_Pervasives_Native.Some _4367)
+                                   (fun _4433  ->
+                                      FStar_Pervasives_Native.Some _4433)
                                    (FStar_Reflection_Data.Sg_Let
                                       (r1, fvar2, univs2, ty1, t2)))))))
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____4372,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____4438,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_Unk.FStar_Reflection_Data.lid
         -> FStar_Pervasives_Native.Some FStar_Reflection_Data.Unk
-    | uu____4387 ->
-        ((let uu____4389 =
-            let uu____4395 =
-              let uu____4397 = FStar_TypeChecker_NBETerm.t_to_string t  in
-              FStar_Util.format1 "Not an embedded sigelt_view: %s" uu____4397
+    | uu____4453 ->
+        ((let uu____4455 =
+            let uu____4461 =
+              let uu____4463 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded sigelt_view: %s" uu____4463
                in
-            (FStar_Errors.Warning_NotEmbedded, uu____4395)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____4389);
+            (FStar_Errors.Warning_NotEmbedded, uu____4461)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____4455);
          FStar_Pervasives_Native.None)
      in
   mk_emb' embed_sigelt_view unembed_sigelt_view
@@ -1657,70 +1687,70 @@ let (e_exp : FStar_Reflection_Data.exp FStar_TypeChecker_NBETerm.embedding) =
         mkConstruct FStar_Reflection_Data.ref_E_Unit.FStar_Reflection_Data.fv
           [] []
     | FStar_Reflection_Data.Var i ->
-        let uu____4420 =
-          let uu____4427 =
+        let uu____4486 =
+          let uu____4493 =
             FStar_TypeChecker_NBETerm.as_arg
               (FStar_TypeChecker_NBETerm.Constant
                  (FStar_TypeChecker_NBETerm.Int i))
              in
-          [uu____4427]  in
+          [uu____4493]  in
         mkConstruct FStar_Reflection_Data.ref_E_Var.FStar_Reflection_Data.fv
-          [] uu____4420
+          [] uu____4486
     | FStar_Reflection_Data.Mult (e1,e2) ->
-        let uu____4442 =
-          let uu____4449 =
-            let uu____4454 = embed_exp cb e1  in
-            FStar_TypeChecker_NBETerm.as_arg uu____4454  in
-          let uu____4455 =
-            let uu____4462 =
-              let uu____4467 = embed_exp cb e2  in
-              FStar_TypeChecker_NBETerm.as_arg uu____4467  in
-            [uu____4462]  in
-          uu____4449 :: uu____4455  in
+        let uu____4508 =
+          let uu____4515 =
+            let uu____4520 = embed_exp cb e1  in
+            FStar_TypeChecker_NBETerm.as_arg uu____4520  in
+          let uu____4521 =
+            let uu____4528 =
+              let uu____4533 = embed_exp cb e2  in
+              FStar_TypeChecker_NBETerm.as_arg uu____4533  in
+            [uu____4528]  in
+          uu____4515 :: uu____4521  in
         mkConstruct FStar_Reflection_Data.ref_E_Mult.FStar_Reflection_Data.fv
-          [] uu____4442
+          [] uu____4508
      in
   let rec unembed_exp cb t =
     match t with
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____4496,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____4562,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_E_Unit.FStar_Reflection_Data.lid
         -> FStar_Pervasives_Native.Some FStar_Reflection_Data.Unit
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____4512,(i,uu____4514)::[])
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____4578,(i,uu____4580)::[])
         when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_E_Var.FStar_Reflection_Data.lid
         ->
-        let uu____4533 =
+        let uu____4599 =
           FStar_TypeChecker_NBETerm.unembed FStar_TypeChecker_NBETerm.e_int
             cb i
            in
-        FStar_Util.bind_opt uu____4533
+        FStar_Util.bind_opt uu____4599
           (fun i1  ->
              FStar_All.pipe_left
-               (fun _4540  -> FStar_Pervasives_Native.Some _4540)
+               (fun _4606  -> FStar_Pervasives_Native.Some _4606)
                (FStar_Reflection_Data.Var i1))
     | FStar_TypeChecker_NBETerm.Construct
-        (fv,uu____4542,(e2,uu____4544)::(e1,uu____4546)::[]) when
+        (fv,uu____4608,(e2,uu____4610)::(e1,uu____4612)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_E_Mult.FStar_Reflection_Data.lid
         ->
-        let uu____4569 = unembed_exp cb e1  in
-        FStar_Util.bind_opt uu____4569
+        let uu____4635 = unembed_exp cb e1  in
+        FStar_Util.bind_opt uu____4635
           (fun e11  ->
-             let uu____4575 = unembed_exp cb e2  in
-             FStar_Util.bind_opt uu____4575
+             let uu____4641 = unembed_exp cb e2  in
+             FStar_Util.bind_opt uu____4641
                (fun e21  ->
                   FStar_All.pipe_left
-                    (fun _4582  -> FStar_Pervasives_Native.Some _4582)
+                    (fun _4648  -> FStar_Pervasives_Native.Some _4648)
                     (FStar_Reflection_Data.Mult (e11, e21))))
-    | uu____4583 ->
-        ((let uu____4585 =
-            let uu____4591 =
-              let uu____4593 = FStar_TypeChecker_NBETerm.t_to_string t  in
-              FStar_Util.format1 "Not an embedded exp: %s" uu____4593  in
-            (FStar_Errors.Warning_NotEmbedded, uu____4591)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____4585);
+    | uu____4649 ->
+        ((let uu____4651 =
+            let uu____4657 =
+              let uu____4659 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded exp: %s" uu____4659  in
+            (FStar_Errors.Warning_NotEmbedded, uu____4657)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____4651);
          FStar_Pervasives_Native.None)
      in
   mk_emb' embed_exp unembed_exp FStar_Reflection_Data.fstar_refl_exp_fv 
@@ -1735,18 +1765,18 @@ let (e_attributes :
   = FStar_TypeChecker_NBETerm.e_list e_attribute 
 let (e_lid : FStar_Ident.lid FStar_TypeChecker_NBETerm.embedding) =
   let embed1 rng lid =
-    let uu____4622 = FStar_Ident.path_of_lid lid  in
-    FStar_TypeChecker_NBETerm.embed e_string_list rng uu____4622  in
+    let uu____4688 = FStar_Ident.path_of_lid lid  in
+    FStar_TypeChecker_NBETerm.embed e_string_list rng uu____4688  in
   let unembed1 cb t =
-    let uu____4644 = FStar_TypeChecker_NBETerm.unembed e_string_list cb t  in
-    FStar_Util.map_opt uu____4644
+    let uu____4710 = FStar_TypeChecker_NBETerm.unembed e_string_list cb t  in
+    FStar_Util.map_opt uu____4710
       (fun p  -> FStar_Ident.lid_of_path p FStar_Range.dummyRange)
      in
-  let uu____4661 =
+  let uu____4727 =
     mkConstruct FStar_Reflection_Data.fstar_refl_aqualv_fv [] []  in
-  let uu____4666 = fv_as_emb_typ FStar_Reflection_Data.fstar_refl_aqualv_fv
+  let uu____4732 = fv_as_emb_typ FStar_Reflection_Data.fstar_refl_aqualv_fv
      in
-  FStar_TypeChecker_NBETerm.mk_emb embed1 unembed1 uu____4661 uu____4666 
+  FStar_TypeChecker_NBETerm.mk_emb embed1 unembed1 uu____4727 uu____4732 
 let (e_qualifier :
   FStar_Syntax_Syntax.qualifier FStar_TypeChecker_NBETerm.embedding) =
   let embed1 cb q =
@@ -1821,83 +1851,83 @@ let (e_qualifier :
           FStar_Reflection_Data.ref_qual_OnlyName.FStar_Reflection_Data.fv []
           []
     | FStar_Syntax_Syntax.Reflectable l ->
-        let uu____4754 =
-          let uu____4761 =
-            let uu____4766 = FStar_TypeChecker_NBETerm.embed e_lid cb l  in
-            FStar_TypeChecker_NBETerm.as_arg uu____4766  in
-          [uu____4761]  in
+        let uu____4820 =
+          let uu____4827 =
+            let uu____4832 = FStar_TypeChecker_NBETerm.embed e_lid cb l  in
+            FStar_TypeChecker_NBETerm.as_arg uu____4832  in
+          [uu____4827]  in
         mkConstruct
           FStar_Reflection_Data.ref_qual_Reflectable.FStar_Reflection_Data.fv
-          [] uu____4754
+          [] uu____4820
     | FStar_Syntax_Syntax.Discriminator l ->
-        let uu____4776 =
-          let uu____4783 =
-            let uu____4788 = FStar_TypeChecker_NBETerm.embed e_lid cb l  in
-            FStar_TypeChecker_NBETerm.as_arg uu____4788  in
-          [uu____4783]  in
+        let uu____4842 =
+          let uu____4849 =
+            let uu____4854 = FStar_TypeChecker_NBETerm.embed e_lid cb l  in
+            FStar_TypeChecker_NBETerm.as_arg uu____4854  in
+          [uu____4849]  in
         mkConstruct
           FStar_Reflection_Data.ref_qual_Discriminator.FStar_Reflection_Data.fv
-          [] uu____4776
+          [] uu____4842
     | FStar_Syntax_Syntax.Action l ->
-        let uu____4798 =
-          let uu____4805 =
-            let uu____4810 = FStar_TypeChecker_NBETerm.embed e_lid cb l  in
-            FStar_TypeChecker_NBETerm.as_arg uu____4810  in
-          [uu____4805]  in
+        let uu____4864 =
+          let uu____4871 =
+            let uu____4876 = FStar_TypeChecker_NBETerm.embed e_lid cb l  in
+            FStar_TypeChecker_NBETerm.as_arg uu____4876  in
+          [uu____4871]  in
         mkConstruct
           FStar_Reflection_Data.ref_qual_Action.FStar_Reflection_Data.fv []
-          uu____4798
+          uu____4864
     | FStar_Syntax_Syntax.Projector (l,i) ->
-        let uu____4821 =
-          let uu____4828 =
-            let uu____4833 = FStar_TypeChecker_NBETerm.embed e_lid cb l  in
-            FStar_TypeChecker_NBETerm.as_arg uu____4833  in
-          let uu____4834 =
-            let uu____4841 =
-              let uu____4846 = FStar_TypeChecker_NBETerm.embed e_ident cb i
+        let uu____4887 =
+          let uu____4894 =
+            let uu____4899 = FStar_TypeChecker_NBETerm.embed e_lid cb l  in
+            FStar_TypeChecker_NBETerm.as_arg uu____4899  in
+          let uu____4900 =
+            let uu____4907 =
+              let uu____4912 = FStar_TypeChecker_NBETerm.embed e_ident cb i
                  in
-              FStar_TypeChecker_NBETerm.as_arg uu____4846  in
-            [uu____4841]  in
-          uu____4828 :: uu____4834  in
+              FStar_TypeChecker_NBETerm.as_arg uu____4912  in
+            [uu____4907]  in
+          uu____4894 :: uu____4900  in
         mkConstruct
           FStar_Reflection_Data.ref_qual_Projector.FStar_Reflection_Data.fv
-          [] uu____4821
+          [] uu____4887
     | FStar_Syntax_Syntax.RecordType (ids1,ids2) ->
-        let uu____4869 =
-          let uu____4876 =
-            let uu____4881 =
-              let uu____4882 = FStar_TypeChecker_NBETerm.e_list e_ident  in
-              FStar_TypeChecker_NBETerm.embed uu____4882 cb ids1  in
-            FStar_TypeChecker_NBETerm.as_arg uu____4881  in
-          let uu____4889 =
-            let uu____4896 =
-              let uu____4901 =
-                let uu____4902 = FStar_TypeChecker_NBETerm.e_list e_ident  in
-                FStar_TypeChecker_NBETerm.embed uu____4902 cb ids2  in
-              FStar_TypeChecker_NBETerm.as_arg uu____4901  in
-            [uu____4896]  in
-          uu____4876 :: uu____4889  in
+        let uu____4935 =
+          let uu____4942 =
+            let uu____4947 =
+              let uu____4948 = FStar_TypeChecker_NBETerm.e_list e_ident  in
+              FStar_TypeChecker_NBETerm.embed uu____4948 cb ids1  in
+            FStar_TypeChecker_NBETerm.as_arg uu____4947  in
+          let uu____4955 =
+            let uu____4962 =
+              let uu____4967 =
+                let uu____4968 = FStar_TypeChecker_NBETerm.e_list e_ident  in
+                FStar_TypeChecker_NBETerm.embed uu____4968 cb ids2  in
+              FStar_TypeChecker_NBETerm.as_arg uu____4967  in
+            [uu____4962]  in
+          uu____4942 :: uu____4955  in
         mkConstruct
           FStar_Reflection_Data.ref_qual_RecordType.FStar_Reflection_Data.fv
-          [] uu____4869
+          [] uu____4935
     | FStar_Syntax_Syntax.RecordConstructor (ids1,ids2) ->
-        let uu____4931 =
-          let uu____4938 =
-            let uu____4943 =
-              let uu____4944 = FStar_TypeChecker_NBETerm.e_list e_ident  in
-              FStar_TypeChecker_NBETerm.embed uu____4944 cb ids1  in
-            FStar_TypeChecker_NBETerm.as_arg uu____4943  in
-          let uu____4951 =
-            let uu____4958 =
-              let uu____4963 =
-                let uu____4964 = FStar_TypeChecker_NBETerm.e_list e_ident  in
-                FStar_TypeChecker_NBETerm.embed uu____4964 cb ids2  in
-              FStar_TypeChecker_NBETerm.as_arg uu____4963  in
-            [uu____4958]  in
-          uu____4938 :: uu____4951  in
+        let uu____4997 =
+          let uu____5004 =
+            let uu____5009 =
+              let uu____5010 = FStar_TypeChecker_NBETerm.e_list e_ident  in
+              FStar_TypeChecker_NBETerm.embed uu____5010 cb ids1  in
+            FStar_TypeChecker_NBETerm.as_arg uu____5009  in
+          let uu____5017 =
+            let uu____5024 =
+              let uu____5029 =
+                let uu____5030 = FStar_TypeChecker_NBETerm.e_list e_ident  in
+                FStar_TypeChecker_NBETerm.embed uu____5030 cb ids2  in
+              FStar_TypeChecker_NBETerm.as_arg uu____5029  in
+            [uu____5024]  in
+          uu____5004 :: uu____5017  in
         mkConstruct
           FStar_Reflection_Data.ref_qual_RecordConstructor.FStar_Reflection_Data.fv
-          [] uu____4931
+          [] uu____4997
      in
   let unembed1 cb t =
     match t with
@@ -1978,67 +2008,50 @@ let (e_qualifier :
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_qual_OnlyName.FStar_Reflection_Data.lid
         -> FStar_Pervasives_Native.Some FStar_Syntax_Syntax.OnlyName
-    | FStar_TypeChecker_NBETerm.Construct (fv,[],(l,uu____5234)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,[],(l,uu____5300)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_qual_Reflectable.FStar_Reflection_Data.lid
         ->
-        let uu____5251 = FStar_TypeChecker_NBETerm.unembed e_lid cb l  in
-        FStar_Util.bind_opt uu____5251
+        let uu____5317 = FStar_TypeChecker_NBETerm.unembed e_lid cb l  in
+        FStar_Util.bind_opt uu____5317
           (fun l1  ->
              FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Reflectable l1))
-    | FStar_TypeChecker_NBETerm.Construct (fv,[],(l,uu____5258)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,[],(l,uu____5324)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_qual_Discriminator.FStar_Reflection_Data.lid
         ->
-        let uu____5275 = FStar_TypeChecker_NBETerm.unembed e_lid cb l  in
-        FStar_Util.bind_opt uu____5275
+        let uu____5341 = FStar_TypeChecker_NBETerm.unembed e_lid cb l  in
+        FStar_Util.bind_opt uu____5341
           (fun l1  ->
              FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Discriminator l1))
-    | FStar_TypeChecker_NBETerm.Construct (fv,[],(l,uu____5282)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,[],(l,uu____5348)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_qual_Action.FStar_Reflection_Data.lid
         ->
-        let uu____5299 = FStar_TypeChecker_NBETerm.unembed e_lid cb l  in
-        FStar_Util.bind_opt uu____5299
+        let uu____5365 = FStar_TypeChecker_NBETerm.unembed e_lid cb l  in
+        FStar_Util.bind_opt uu____5365
           (fun l1  ->
              FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Action l1))
     | FStar_TypeChecker_NBETerm.Construct
-        (fv,[],(i,uu____5306)::(l,uu____5308)::[]) when
+        (fv,[],(i,uu____5372)::(l,uu____5374)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_qual_Projector.FStar_Reflection_Data.lid
         ->
-        let uu____5329 = FStar_TypeChecker_NBETerm.unembed e_ident cb i  in
-        FStar_Util.bind_opt uu____5329
+        let uu____5395 = FStar_TypeChecker_NBETerm.unembed e_ident cb i  in
+        FStar_Util.bind_opt uu____5395
           (fun i1  ->
-             let uu____5335 = FStar_TypeChecker_NBETerm.unembed e_lid cb l
+             let uu____5401 = FStar_TypeChecker_NBETerm.unembed e_lid cb l
                 in
-             FStar_Util.bind_opt uu____5335
+             FStar_Util.bind_opt uu____5401
                (fun l1  ->
                   FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.Projector (l1, i1))))
     | FStar_TypeChecker_NBETerm.Construct
-        (fv,[],(ids2,uu____5342)::(ids1,uu____5344)::[]) when
-        FStar_Syntax_Syntax.fv_eq_lid fv
-          FStar_Reflection_Data.ref_qual_RecordType.FStar_Reflection_Data.lid
-        ->
-        let uu____5365 =
-          let uu____5370 = FStar_TypeChecker_NBETerm.e_list e_ident  in
-          FStar_TypeChecker_NBETerm.unembed uu____5370 cb ids1  in
-        FStar_Util.bind_opt uu____5365
-          (fun ids11  ->
-             let uu____5384 =
-               let uu____5389 = FStar_TypeChecker_NBETerm.e_list e_ident  in
-               FStar_TypeChecker_NBETerm.unembed uu____5389 cb ids2  in
-             FStar_Util.bind_opt uu____5384
-               (fun ids21  ->
-                  FStar_Pervasives_Native.Some
-                    (FStar_Syntax_Syntax.RecordType (ids11, ids21))))
-    | FStar_TypeChecker_NBETerm.Construct
         (fv,[],(ids2,uu____5408)::(ids1,uu____5410)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
-          FStar_Reflection_Data.ref_qual_RecordConstructor.FStar_Reflection_Data.lid
+          FStar_Reflection_Data.ref_qual_RecordType.FStar_Reflection_Data.lid
         ->
         let uu____5431 =
           let uu____5436 = FStar_TypeChecker_NBETerm.e_list e_ident  in
@@ -2051,22 +2064,39 @@ let (e_qualifier :
              FStar_Util.bind_opt uu____5450
                (fun ids21  ->
                   FStar_Pervasives_Native.Some
+                    (FStar_Syntax_Syntax.RecordType (ids11, ids21))))
+    | FStar_TypeChecker_NBETerm.Construct
+        (fv,[],(ids2,uu____5474)::(ids1,uu____5476)::[]) when
+        FStar_Syntax_Syntax.fv_eq_lid fv
+          FStar_Reflection_Data.ref_qual_RecordConstructor.FStar_Reflection_Data.lid
+        ->
+        let uu____5497 =
+          let uu____5502 = FStar_TypeChecker_NBETerm.e_list e_ident  in
+          FStar_TypeChecker_NBETerm.unembed uu____5502 cb ids1  in
+        FStar_Util.bind_opt uu____5497
+          (fun ids11  ->
+             let uu____5516 =
+               let uu____5521 = FStar_TypeChecker_NBETerm.e_list e_ident  in
+               FStar_TypeChecker_NBETerm.unembed uu____5521 cb ids2  in
+             FStar_Util.bind_opt uu____5516
+               (fun ids21  ->
+                  FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.RecordConstructor (ids11, ids21))))
-    | uu____5472 ->
-        ((let uu____5474 =
-            let uu____5480 =
-              let uu____5482 = FStar_TypeChecker_NBETerm.t_to_string t  in
-              FStar_Util.format1 "Not an embedded qualifier: %s" uu____5482
+    | uu____5538 ->
+        ((let uu____5540 =
+            let uu____5546 =
+              let uu____5548 = FStar_TypeChecker_NBETerm.t_to_string t  in
+              FStar_Util.format1 "Not an embedded qualifier: %s" uu____5548
                in
-            (FStar_Errors.Warning_NotEmbedded, uu____5480)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____5474);
+            (FStar_Errors.Warning_NotEmbedded, uu____5546)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____5540);
          FStar_Pervasives_Native.None)
      in
-  let uu____5486 =
+  let uu____5552 =
     mkConstruct FStar_Reflection_Data.fstar_refl_qualifier_fv [] []  in
-  let uu____5491 =
+  let uu____5557 =
     fv_as_emb_typ FStar_Reflection_Data.fstar_refl_qualifier_fv  in
-  FStar_TypeChecker_NBETerm.mk_emb embed1 unembed1 uu____5486 uu____5491 
+  FStar_TypeChecker_NBETerm.mk_emb embed1 unembed1 uu____5552 uu____5557 
 let (e_qualifiers :
   FStar_Syntax_Syntax.qualifier Prims.list
     FStar_TypeChecker_NBETerm.embedding)

--- a/src/ocaml-output/FStar_SMTEncoding_Encode.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Encode.ml
@@ -4869,7 +4869,9 @@ and (encode_sigelt' :
                           FStar_Syntax_Syntax.sigmeta =
                             (uu___1018_13618.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (uu___1018_13618.FStar_Syntax_Syntax.sigattrs)
+                            (uu___1018_13618.FStar_Syntax_Syntax.sigattrs);
+                          FStar_Syntax_Syntax.sigopts =
+                            (uu___1018_13618.FStar_Syntax_Syntax.sigopts)
                         }  in
                       let uu____13619 = encode_sigelt' env1 val_decl  in
                       match uu____13619 with | (decls,env2) -> (env2, decls)
@@ -4996,7 +4998,9 @@ and (encode_sigelt' :
                     FStar_Syntax_Syntax.sigmeta =
                       (uu___1083_13871.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
-                      (uu___1083_13871.FStar_Syntax_Syntax.sigattrs)
+                      (uu___1083_13871.FStar_Syntax_Syntax.sigattrs);
+                    FStar_Syntax_Syntax.sigopts =
+                      (uu___1083_13871.FStar_Syntax_Syntax.sigopts)
                   }  in
                 encode_sigelt env se1)
        | FStar_Syntax_Syntax.Sig_let ((is_rec,bindings),uu____13875) ->

--- a/src/ocaml-output/FStar_Syntax_DsEnv.ml
+++ b/src/ocaml-output/FStar_Syntax_DsEnv.ml
@@ -1572,7 +1572,8 @@ let (try_lookup_effect_name_and_attributes :
              FStar_Syntax_Syntax.sigrng = uu____5402;
              FStar_Syntax_Syntax.sigquals = uu____5403;
              FStar_Syntax_Syntax.sigmeta = uu____5404;
-             FStar_Syntax_Syntax.sigattrs = uu____5405;_},l1)
+             FStar_Syntax_Syntax.sigattrs = uu____5405;
+             FStar_Syntax_Syntax.sigopts = uu____5406;_},l1)
           ->
           FStar_Pervasives_Native.Some
             (l1, (ne.FStar_Syntax_Syntax.cattributes))
@@ -1580,10 +1581,11 @@ let (try_lookup_effect_name_and_attributes :
           ({
              FStar_Syntax_Syntax.sigel =
                FStar_Syntax_Syntax.Sig_new_effect_for_free ne;
-             FStar_Syntax_Syntax.sigrng = uu____5424;
-             FStar_Syntax_Syntax.sigquals = uu____5425;
-             FStar_Syntax_Syntax.sigmeta = uu____5426;
-             FStar_Syntax_Syntax.sigattrs = uu____5427;_},l1)
+             FStar_Syntax_Syntax.sigrng = uu____5427;
+             FStar_Syntax_Syntax.sigquals = uu____5428;
+             FStar_Syntax_Syntax.sigmeta = uu____5429;
+             FStar_Syntax_Syntax.sigattrs = uu____5430;
+             FStar_Syntax_Syntax.sigopts = uu____5431;_},l1)
           ->
           FStar_Pervasives_Native.Some
             (l1, (ne.FStar_Syntax_Syntax.cattributes))
@@ -1591,13 +1593,14 @@ let (try_lookup_effect_name_and_attributes :
           ({
              FStar_Syntax_Syntax.sigel =
                FStar_Syntax_Syntax.Sig_effect_abbrev
-               (uu____5445,uu____5446,uu____5447,uu____5448,cattributes);
-             FStar_Syntax_Syntax.sigrng = uu____5450;
-             FStar_Syntax_Syntax.sigquals = uu____5451;
-             FStar_Syntax_Syntax.sigmeta = uu____5452;
-             FStar_Syntax_Syntax.sigattrs = uu____5453;_},l1)
+               (uu____5451,uu____5452,uu____5453,uu____5454,cattributes);
+             FStar_Syntax_Syntax.sigrng = uu____5456;
+             FStar_Syntax_Syntax.sigquals = uu____5457;
+             FStar_Syntax_Syntax.sigmeta = uu____5458;
+             FStar_Syntax_Syntax.sigattrs = uu____5459;
+             FStar_Syntax_Syntax.sigopts = uu____5460;_},l1)
           -> FStar_Pervasives_Native.Some (l1, cattributes)
-      | uu____5475 -> FStar_Pervasives_Native.None
+      | uu____5484 -> FStar_Pervasives_Native.None
   
 let (try_lookup_effect_defn :
   env ->
@@ -1606,36 +1609,38 @@ let (try_lookup_effect_defn :
   =
   fun env  ->
     fun l  ->
-      let uu____5501 =
+      let uu____5510 =
         try_lookup_effect_name' (Prims.op_Negation env.iface) env l  in
-      match uu____5501 with
+      match uu____5510 with
       | FStar_Pervasives_Native.Some
           ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_new_effect
                ne;
-             FStar_Syntax_Syntax.sigrng = uu____5511;
-             FStar_Syntax_Syntax.sigquals = uu____5512;
-             FStar_Syntax_Syntax.sigmeta = uu____5513;
-             FStar_Syntax_Syntax.sigattrs = uu____5514;_},uu____5515)
+             FStar_Syntax_Syntax.sigrng = uu____5520;
+             FStar_Syntax_Syntax.sigquals = uu____5521;
+             FStar_Syntax_Syntax.sigmeta = uu____5522;
+             FStar_Syntax_Syntax.sigattrs = uu____5523;
+             FStar_Syntax_Syntax.sigopts = uu____5524;_},uu____5525)
           -> FStar_Pervasives_Native.Some ne
       | FStar_Pervasives_Native.Some
           ({
              FStar_Syntax_Syntax.sigel =
                FStar_Syntax_Syntax.Sig_new_effect_for_free ne;
-             FStar_Syntax_Syntax.sigrng = uu____5525;
-             FStar_Syntax_Syntax.sigquals = uu____5526;
-             FStar_Syntax_Syntax.sigmeta = uu____5527;
-             FStar_Syntax_Syntax.sigattrs = uu____5528;_},uu____5529)
+             FStar_Syntax_Syntax.sigrng = uu____5537;
+             FStar_Syntax_Syntax.sigquals = uu____5538;
+             FStar_Syntax_Syntax.sigmeta = uu____5539;
+             FStar_Syntax_Syntax.sigattrs = uu____5540;
+             FStar_Syntax_Syntax.sigopts = uu____5541;_},uu____5542)
           -> FStar_Pervasives_Native.Some ne
-      | uu____5538 -> FStar_Pervasives_Native.None
+      | uu____5553 -> FStar_Pervasives_Native.None
   
 let (is_effect_name : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun lid  ->
-      let uu____5557 = try_lookup_effect_name env lid  in
-      match uu____5557 with
+      let uu____5572 = try_lookup_effect_name env lid  in
+      match uu____5572 with
       | FStar_Pervasives_Native.None  -> false
-      | FStar_Pervasives_Native.Some uu____5562 -> true
+      | FStar_Pervasives_Native.Some uu____5577 -> true
   
 let (try_lookup_root_effect_name :
   env ->
@@ -1643,51 +1648,52 @@ let (try_lookup_root_effect_name :
   =
   fun env  ->
     fun l  ->
-      let uu____5577 =
+      let uu____5592 =
         try_lookup_effect_name' (Prims.op_Negation env.iface) env l  in
-      match uu____5577 with
+      match uu____5592 with
       | FStar_Pervasives_Native.Some
           ({
              FStar_Syntax_Syntax.sigel =
                FStar_Syntax_Syntax.Sig_effect_abbrev
-               (l',uu____5587,uu____5588,uu____5589,uu____5590);
-             FStar_Syntax_Syntax.sigrng = uu____5591;
-             FStar_Syntax_Syntax.sigquals = uu____5592;
-             FStar_Syntax_Syntax.sigmeta = uu____5593;
-             FStar_Syntax_Syntax.sigattrs = uu____5594;_},uu____5595)
+               (l',uu____5602,uu____5603,uu____5604,uu____5605);
+             FStar_Syntax_Syntax.sigrng = uu____5606;
+             FStar_Syntax_Syntax.sigquals = uu____5607;
+             FStar_Syntax_Syntax.sigmeta = uu____5608;
+             FStar_Syntax_Syntax.sigattrs = uu____5609;
+             FStar_Syntax_Syntax.sigopts = uu____5610;_},uu____5611)
           ->
           let rec aux new_name =
-            let uu____5616 =
+            let uu____5634 =
               FStar_Util.smap_try_find (sigmap env) new_name.FStar_Ident.str
                in
-            match uu____5616 with
+            match uu____5634 with
             | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-            | FStar_Pervasives_Native.Some (s,uu____5637) ->
+            | FStar_Pervasives_Native.Some (s,uu____5655) ->
                 (match s.FStar_Syntax_Syntax.sigel with
                  | FStar_Syntax_Syntax.Sig_new_effect_for_free ne ->
-                     let uu____5648 =
-                       let uu____5649 = FStar_Ident.range_of_lid l  in
+                     let uu____5666 =
+                       let uu____5667 = FStar_Ident.range_of_lid l  in
                        FStar_Ident.set_lid_range ne.FStar_Syntax_Syntax.mname
-                         uu____5649
+                         uu____5667
                         in
-                     FStar_Pervasives_Native.Some uu____5648
+                     FStar_Pervasives_Native.Some uu____5666
                  | FStar_Syntax_Syntax.Sig_new_effect ne ->
-                     let uu____5651 =
-                       let uu____5652 = FStar_Ident.range_of_lid l  in
+                     let uu____5669 =
+                       let uu____5670 = FStar_Ident.range_of_lid l  in
                        FStar_Ident.set_lid_range ne.FStar_Syntax_Syntax.mname
-                         uu____5652
+                         uu____5670
                         in
-                     FStar_Pervasives_Native.Some uu____5651
+                     FStar_Pervasives_Native.Some uu____5669
                  | FStar_Syntax_Syntax.Sig_effect_abbrev
-                     (uu____5653,uu____5654,uu____5655,cmp,uu____5657) ->
+                     (uu____5671,uu____5672,uu____5673,cmp,uu____5675) ->
                      let l'' = FStar_Syntax_Util.comp_effect_name cmp  in
                      aux l''
-                 | uu____5663 -> FStar_Pervasives_Native.None)
+                 | uu____5681 -> FStar_Pervasives_Native.None)
              in
           aux l'
-      | FStar_Pervasives_Native.Some (uu____5664,l') ->
+      | FStar_Pervasives_Native.Some (uu____5682,l') ->
           FStar_Pervasives_Native.Some l'
-      | uu____5670 -> FStar_Pervasives_Native.None
+      | uu____5688 -> FStar_Pervasives_Native.None
   
 let (lookup_letbinding_quals_and_attrs :
   env ->
@@ -1697,25 +1703,26 @@ let (lookup_letbinding_quals_and_attrs :
   =
   fun env  ->
     fun lid  ->
-      let k_global_def lid1 uu___20_5721 =
-        match uu___20_5721 with
+      let k_global_def lid1 uu___20_5739 =
+        match uu___20_5739 with
         | ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ
-               (uu____5737,uu____5738,uu____5739);
-             FStar_Syntax_Syntax.sigrng = uu____5740;
+               (uu____5755,uu____5756,uu____5757);
+             FStar_Syntax_Syntax.sigrng = uu____5758;
              FStar_Syntax_Syntax.sigquals = quals;
-             FStar_Syntax_Syntax.sigmeta = uu____5742;
-             FStar_Syntax_Syntax.sigattrs = attrs;_},uu____5744)
+             FStar_Syntax_Syntax.sigmeta = uu____5760;
+             FStar_Syntax_Syntax.sigattrs = attrs;
+             FStar_Syntax_Syntax.sigopts = uu____5762;_},uu____5763)
             -> FStar_Pervasives_Native.Some (quals, attrs)
-        | uu____5763 -> FStar_Pervasives_Native.None  in
-      let uu____5777 =
+        | uu____5784 -> FStar_Pervasives_Native.None  in
+      let uu____5798 =
         resolve_in_open_namespaces' env lid
-          (fun uu____5797  -> FStar_Pervasives_Native.None)
-          (fun uu____5807  -> FStar_Pervasives_Native.None) k_global_def
+          (fun uu____5818  -> FStar_Pervasives_Native.None)
+          (fun uu____5828  -> FStar_Pervasives_Native.None) k_global_def
          in
-      match uu____5777 with
+      match uu____5798 with
       | FStar_Pervasives_Native.Some qa -> qa
-      | uu____5841 -> ([], [])
+      | uu____5862 -> ([], [])
   
 let (try_lookup_module :
   env ->
@@ -1724,16 +1731,16 @@ let (try_lookup_module :
   =
   fun env  ->
     fun path  ->
-      let uu____5869 =
+      let uu____5890 =
         FStar_List.tryFind
-          (fun uu____5884  ->
-             match uu____5884 with
+          (fun uu____5905  ->
+             match uu____5905 with
              | (mlid,modul) ->
-                 let uu____5892 = FStar_Ident.path_of_lid mlid  in
-                 uu____5892 = path) env.modules
+                 let uu____5913 = FStar_Ident.path_of_lid mlid  in
+                 uu____5913 = path) env.modules
          in
-      match uu____5869 with
-      | FStar_Pervasives_Native.Some (uu____5895,modul) ->
+      match uu____5890 with
+      | FStar_Pervasives_Native.Some (uu____5916,modul) ->
           FStar_Pervasives_Native.Some modul
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
   
@@ -1744,26 +1751,27 @@ let (try_lookup_let :
   =
   fun env  ->
     fun lid  ->
-      let k_global_def lid1 uu___21_5935 =
-        match uu___21_5935 with
+      let k_global_def lid1 uu___21_5956 =
+        match uu___21_5956 with
         | ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
-               ((uu____5943,lbs),uu____5945);
-             FStar_Syntax_Syntax.sigrng = uu____5946;
-             FStar_Syntax_Syntax.sigquals = uu____5947;
-             FStar_Syntax_Syntax.sigmeta = uu____5948;
-             FStar_Syntax_Syntax.sigattrs = uu____5949;_},uu____5950)
+               ((uu____5964,lbs),uu____5966);
+             FStar_Syntax_Syntax.sigrng = uu____5967;
+             FStar_Syntax_Syntax.sigquals = uu____5968;
+             FStar_Syntax_Syntax.sigmeta = uu____5969;
+             FStar_Syntax_Syntax.sigattrs = uu____5970;
+             FStar_Syntax_Syntax.sigopts = uu____5971;_},uu____5972)
             ->
             let fv = lb_fv lbs lid1  in
-            let uu____5968 =
+            let uu____5992 =
               FStar_Syntax_Syntax.fvar lid1 fv.FStar_Syntax_Syntax.fv_delta
                 fv.FStar_Syntax_Syntax.fv_qual
                in
-            FStar_Pervasives_Native.Some uu____5968
-        | uu____5969 -> FStar_Pervasives_Native.None  in
+            FStar_Pervasives_Native.Some uu____5992
+        | uu____5993 -> FStar_Pervasives_Native.None  in
       resolve_in_open_namespaces' env lid
-        (fun uu____5976  -> FStar_Pervasives_Native.None)
-        (fun uu____5978  -> FStar_Pervasives_Native.None) k_global_def
+        (fun uu____6000  -> FStar_Pervasives_Native.None)
+        (fun uu____6002  -> FStar_Pervasives_Native.None) k_global_def
   
 let (try_lookup_definition :
   env ->
@@ -1772,15 +1780,16 @@ let (try_lookup_definition :
   =
   fun env  ->
     fun lid  ->
-      let k_global_def lid1 uu___22_6011 =
-        match uu___22_6011 with
+      let k_global_def lid1 uu___22_6035 =
+        match uu___22_6035 with
         | ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
-               (lbs,uu____6022);
-             FStar_Syntax_Syntax.sigrng = uu____6023;
-             FStar_Syntax_Syntax.sigquals = uu____6024;
-             FStar_Syntax_Syntax.sigmeta = uu____6025;
-             FStar_Syntax_Syntax.sigattrs = uu____6026;_},uu____6027)
+               (lbs,uu____6046);
+             FStar_Syntax_Syntax.sigrng = uu____6047;
+             FStar_Syntax_Syntax.sigquals = uu____6048;
+             FStar_Syntax_Syntax.sigmeta = uu____6049;
+             FStar_Syntax_Syntax.sigattrs = uu____6050;
+             FStar_Syntax_Syntax.sigopts = uu____6051;_},uu____6052)
             ->
             FStar_Util.find_map (FStar_Pervasives_Native.snd lbs)
               (fun lb  ->
@@ -1789,11 +1798,11 @@ let (try_lookup_definition :
                      FStar_Syntax_Syntax.fv_eq_lid fv lid1 ->
                      FStar_Pervasives_Native.Some
                        (lb.FStar_Syntax_Syntax.lbdef)
-                 | uu____6053 -> FStar_Pervasives_Native.None)
-        | uu____6060 -> FStar_Pervasives_Native.None  in
+                 | uu____6080 -> FStar_Pervasives_Native.None)
+        | uu____6087 -> FStar_Pervasives_Native.None  in
       resolve_in_open_namespaces' env lid
-        (fun uu____6071  -> FStar_Pervasives_Native.None)
-        (fun uu____6075  -> FStar_Pervasives_Native.None) k_global_def
+        (fun uu____6098  -> FStar_Pervasives_Native.None)
+        (fun uu____6102  -> FStar_Pervasives_Native.None) k_global_def
   
 let (empty_include_smap :
   FStar_Ident.lident Prims.list FStar_ST.ref FStar_Util.smap) = new_sigmap () 
@@ -1811,12 +1820,12 @@ let (try_lookup_lid' :
     fun exclude_interface  ->
       fun env  ->
         fun lid  ->
-          let uu____6135 = try_lookup_name any_val exclude_interface env lid
+          let uu____6162 = try_lookup_name any_val exclude_interface env lid
              in
-          match uu____6135 with
+          match uu____6162 with
           | FStar_Pervasives_Native.Some (Term_name (e,attrs)) ->
               FStar_Pervasives_Native.Some (e, attrs)
-          | uu____6160 -> FStar_Pervasives_Native.None
+          | uu____6187 -> FStar_Pervasives_Native.None
   
 let (drop_attributes :
   (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.attribute Prims.list)
@@ -1825,7 +1834,7 @@ let (drop_attributes :
   =
   fun x  ->
     match x with
-    | FStar_Pervasives_Native.Some (t,uu____6198) ->
+    | FStar_Pervasives_Native.Some (t,uu____6225) ->
         FStar_Pervasives_Native.Some t
     | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
   
@@ -1842,8 +1851,8 @@ let (try_lookup_lid :
   =
   fun env  ->
     fun l  ->
-      let uu____6256 = try_lookup_lid_with_attributes env l  in
-      FStar_All.pipe_right uu____6256 drop_attributes
+      let uu____6283 = try_lookup_lid_with_attributes env l  in
+      FStar_All.pipe_right uu____6283 drop_attributes
   
 let (resolve_to_fully_qualified_name :
   env ->
@@ -1851,25 +1860,25 @@ let (resolve_to_fully_qualified_name :
   =
   fun env  ->
     fun l  ->
-      let uu____6288 = try_lookup_lid env l  in
-      match uu____6288 with
+      let uu____6315 = try_lookup_lid env l  in
+      match uu____6315 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some e ->
-          let uu____6294 =
-            let uu____6295 = FStar_Syntax_Subst.compress e  in
-            uu____6295.FStar_Syntax_Syntax.n  in
-          (match uu____6294 with
+          let uu____6321 =
+            let uu____6322 = FStar_Syntax_Subst.compress e  in
+            uu____6322.FStar_Syntax_Syntax.n  in
+          (match uu____6321 with
            | FStar_Syntax_Syntax.Tm_fvar fv ->
                FStar_Pervasives_Native.Some
                  ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-           | uu____6301 -> FStar_Pervasives_Native.None)
+           | uu____6328 -> FStar_Pervasives_Native.None)
   
 let (shorten_lid' : env -> FStar_Ident.lident -> FStar_Ident.lident) =
   fun env  ->
     fun lid  ->
-      let uu____6313 = shorten_module_path env lid.FStar_Ident.ns true  in
-      match uu____6313 with
-      | (uu____6323,short) ->
+      let uu____6340 = shorten_module_path env lid.FStar_Ident.ns true  in
+      match uu____6340 with
+      | (uu____6350,short) ->
           FStar_Ident.lid_of_ns_and_id short lid.FStar_Ident.ident
   
 let (shorten_lid : env -> FStar_Ident.lid -> FStar_Ident.lid) =
@@ -1877,15 +1886,15 @@ let (shorten_lid : env -> FStar_Ident.lid -> FStar_Ident.lid) =
     fun lid  ->
       match env.curmodule with
       | FStar_Pervasives_Native.None  -> shorten_lid' env lid
-      | uu____6344 ->
+      | uu____6371 ->
           let lid_without_ns =
             FStar_Ident.lid_of_ns_and_id [] lid.FStar_Ident.ident  in
-          let uu____6348 = resolve_to_fully_qualified_name env lid_without_ns
+          let uu____6375 = resolve_to_fully_qualified_name env lid_without_ns
              in
-          (match uu____6348 with
+          (match uu____6375 with
            | FStar_Pervasives_Native.Some lid' when
                lid'.FStar_Ident.str = lid.FStar_Ident.str -> lid_without_ns
-           | uu____6353 -> shorten_lid' env lid)
+           | uu____6380 -> shorten_lid' env lid)
   
 let (try_lookup_lid_with_attributes_no_resolve :
   env ->
@@ -1896,25 +1905,25 @@ let (try_lookup_lid_with_attributes_no_resolve :
   fun env  ->
     fun l  ->
       let env' =
-        let uu___884_6384 = env  in
+        let uu___893_6411 = env  in
         {
-          curmodule = (uu___884_6384.curmodule);
-          curmonad = (uu___884_6384.curmonad);
-          modules = (uu___884_6384.modules);
+          curmodule = (uu___893_6411.curmodule);
+          curmonad = (uu___893_6411.curmonad);
+          modules = (uu___893_6411.modules);
           scope_mods = [];
           exported_ids = empty_exported_id_smap;
-          trans_exported_ids = (uu___884_6384.trans_exported_ids);
+          trans_exported_ids = (uu___893_6411.trans_exported_ids);
           includes = empty_include_smap;
-          sigaccum = (uu___884_6384.sigaccum);
-          sigmap = (uu___884_6384.sigmap);
-          iface = (uu___884_6384.iface);
-          admitted_iface = (uu___884_6384.admitted_iface);
-          expect_typ = (uu___884_6384.expect_typ);
-          docs = (uu___884_6384.docs);
-          remaining_iface_decls = (uu___884_6384.remaining_iface_decls);
-          syntax_only = (uu___884_6384.syntax_only);
-          ds_hooks = (uu___884_6384.ds_hooks);
-          dep_graph = (uu___884_6384.dep_graph)
+          sigaccum = (uu___893_6411.sigaccum);
+          sigmap = (uu___893_6411.sigmap);
+          iface = (uu___893_6411.iface);
+          admitted_iface = (uu___893_6411.admitted_iface);
+          expect_typ = (uu___893_6411.expect_typ);
+          docs = (uu___893_6411.docs);
+          remaining_iface_decls = (uu___893_6411.remaining_iface_decls);
+          syntax_only = (uu___893_6411.syntax_only);
+          ds_hooks = (uu___893_6411.ds_hooks);
+          dep_graph = (uu___893_6411.dep_graph)
         }  in
       try_lookup_lid_with_attributes env' l
   
@@ -1925,8 +1934,8 @@ let (try_lookup_lid_no_resolve :
   =
   fun env  ->
     fun l  ->
-      let uu____6400 = try_lookup_lid_with_attributes_no_resolve env l  in
-      FStar_All.pipe_right uu____6400 drop_attributes
+      let uu____6427 = try_lookup_lid_with_attributes_no_resolve env l  in
+      FStar_All.pipe_right uu____6427 drop_attributes
   
 let (try_lookup_doc :
   env ->
@@ -1943,47 +1952,49 @@ let (try_lookup_datacon :
         match se with
         | ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ
-               (uu____6470,uu____6471,uu____6472);
-             FStar_Syntax_Syntax.sigrng = uu____6473;
+               (uu____6497,uu____6498,uu____6499);
+             FStar_Syntax_Syntax.sigrng = uu____6500;
              FStar_Syntax_Syntax.sigquals = quals;
-             FStar_Syntax_Syntax.sigmeta = uu____6475;
-             FStar_Syntax_Syntax.sigattrs = uu____6476;_},uu____6477)
+             FStar_Syntax_Syntax.sigmeta = uu____6502;
+             FStar_Syntax_Syntax.sigattrs = uu____6503;
+             FStar_Syntax_Syntax.sigopts = uu____6504;_},uu____6505)
             ->
-            let uu____6484 =
+            let uu____6514 =
               FStar_All.pipe_right quals
                 (FStar_Util.for_some
-                   (fun uu___23_6490  ->
-                      match uu___23_6490 with
+                   (fun uu___23_6520  ->
+                      match uu___23_6520 with
                       | FStar_Syntax_Syntax.Assumption  -> true
-                      | uu____6493 -> false))
+                      | uu____6523 -> false))
                in
-            if uu____6484
+            if uu____6514
             then
-              let uu____6498 =
+              let uu____6528 =
                 FStar_Syntax_Syntax.lid_as_fv lid1
                   FStar_Syntax_Syntax.delta_constant
                   FStar_Pervasives_Native.None
                  in
-              FStar_Pervasives_Native.Some uu____6498
+              FStar_Pervasives_Native.Some uu____6528
             else FStar_Pervasives_Native.None
         | ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-               uu____6501;
-             FStar_Syntax_Syntax.sigrng = uu____6502;
-             FStar_Syntax_Syntax.sigquals = uu____6503;
-             FStar_Syntax_Syntax.sigmeta = uu____6504;
-             FStar_Syntax_Syntax.sigattrs = uu____6505;_},uu____6506)
+               uu____6531;
+             FStar_Syntax_Syntax.sigrng = uu____6532;
+             FStar_Syntax_Syntax.sigquals = uu____6533;
+             FStar_Syntax_Syntax.sigmeta = uu____6534;
+             FStar_Syntax_Syntax.sigattrs = uu____6535;
+             FStar_Syntax_Syntax.sigopts = uu____6536;_},uu____6537)
             ->
             let qual1 = fv_qual_of_se (FStar_Pervasives_Native.fst se)  in
-            let uu____6532 =
+            let uu____6565 =
               FStar_Syntax_Syntax.lid_as_fv lid1
                 FStar_Syntax_Syntax.delta_constant qual1
                in
-            FStar_Pervasives_Native.Some uu____6532
-        | uu____6533 -> FStar_Pervasives_Native.None  in
+            FStar_Pervasives_Native.Some uu____6565
+        | uu____6566 -> FStar_Pervasives_Native.None  in
       resolve_in_open_namespaces' env lid
-        (fun uu____6540  -> FStar_Pervasives_Native.None)
-        (fun uu____6542  -> FStar_Pervasives_Native.None) k_global_def
+        (fun uu____6573  -> FStar_Pervasives_Native.None)
+        (fun uu____6575  -> FStar_Pervasives_Native.None) k_global_def
   
 let (find_all_datacons :
   env ->
@@ -1992,21 +2003,22 @@ let (find_all_datacons :
   =
   fun env  ->
     fun lid  ->
-      let k_global_def lid1 uu___24_6577 =
-        match uu___24_6577 with
+      let k_global_def lid1 uu___24_6610 =
+        match uu___24_6610 with
         | ({
              FStar_Syntax_Syntax.sigel =
                FStar_Syntax_Syntax.Sig_inductive_typ
-               (uu____6587,uu____6588,uu____6589,uu____6590,datas,uu____6592);
-             FStar_Syntax_Syntax.sigrng = uu____6593;
-             FStar_Syntax_Syntax.sigquals = uu____6594;
-             FStar_Syntax_Syntax.sigmeta = uu____6595;
-             FStar_Syntax_Syntax.sigattrs = uu____6596;_},uu____6597)
+               (uu____6620,uu____6621,uu____6622,uu____6623,datas,uu____6625);
+             FStar_Syntax_Syntax.sigrng = uu____6626;
+             FStar_Syntax_Syntax.sigquals = uu____6627;
+             FStar_Syntax_Syntax.sigmeta = uu____6628;
+             FStar_Syntax_Syntax.sigattrs = uu____6629;
+             FStar_Syntax_Syntax.sigopts = uu____6630;_},uu____6631)
             -> FStar_Pervasives_Native.Some datas
-        | uu____6614 -> FStar_Pervasives_Native.None  in
+        | uu____6650 -> FStar_Pervasives_Native.None  in
       resolve_in_open_namespaces' env lid
-        (fun uu____6625  -> FStar_Pervasives_Native.None)
-        (fun uu____6629  -> FStar_Pervasives_Native.None) k_global_def
+        (fun uu____6661  -> FStar_Pervasives_Native.None)
+        (fun uu____6665  -> FStar_Pervasives_Native.None) k_global_def
   
 let (record_cache_aux_with_filter :
   ((((unit -> unit) * (unit -> unit)) * (((unit -> (Prims.int * unit)) *
@@ -2015,45 +2027,45 @@ let (record_cache_aux_with_filter :
     (unit -> unit)))
   =
   let record_cache = FStar_Util.mk_ref [[]]  in
-  let push1 uu____6708 =
-    let uu____6709 =
-      let uu____6714 =
-        let uu____6717 = FStar_ST.op_Bang record_cache  in
-        FStar_List.hd uu____6717  in
-      let uu____6751 = FStar_ST.op_Bang record_cache  in uu____6714 ::
-        uu____6751
+  let push1 uu____6744 =
+    let uu____6745 =
+      let uu____6750 =
+        let uu____6753 = FStar_ST.op_Bang record_cache  in
+        FStar_List.hd uu____6753  in
+      let uu____6787 = FStar_ST.op_Bang record_cache  in uu____6750 ::
+        uu____6787
        in
-    FStar_ST.op_Colon_Equals record_cache uu____6709  in
-  let pop1 uu____6817 =
-    let uu____6818 =
-      let uu____6823 = FStar_ST.op_Bang record_cache  in
-      FStar_List.tl uu____6823  in
-    FStar_ST.op_Colon_Equals record_cache uu____6818  in
-  let snapshot1 uu____6894 = FStar_Common.snapshot push1 record_cache ()  in
+    FStar_ST.op_Colon_Equals record_cache uu____6745  in
+  let pop1 uu____6853 =
+    let uu____6854 =
+      let uu____6859 = FStar_ST.op_Bang record_cache  in
+      FStar_List.tl uu____6859  in
+    FStar_ST.op_Colon_Equals record_cache uu____6854  in
+  let snapshot1 uu____6930 = FStar_Common.snapshot push1 record_cache ()  in
   let rollback1 depth = FStar_Common.rollback pop1 record_cache depth  in
-  let peek1 uu____6918 =
-    let uu____6919 = FStar_ST.op_Bang record_cache  in
-    FStar_List.hd uu____6919  in
+  let peek1 uu____6954 =
+    let uu____6955 = FStar_ST.op_Bang record_cache  in
+    FStar_List.hd uu____6955  in
   let insert r =
-    let uu____6959 =
-      let uu____6964 = let uu____6967 = peek1 ()  in r :: uu____6967  in
-      let uu____6970 =
-        let uu____6975 = FStar_ST.op_Bang record_cache  in
-        FStar_List.tl uu____6975  in
-      uu____6964 :: uu____6970  in
-    FStar_ST.op_Colon_Equals record_cache uu____6959  in
-  let filter1 uu____7043 =
+    let uu____6995 =
+      let uu____7000 = let uu____7003 = peek1 ()  in r :: uu____7003  in
+      let uu____7006 =
+        let uu____7011 = FStar_ST.op_Bang record_cache  in
+        FStar_List.tl uu____7011  in
+      uu____7000 :: uu____7006  in
+    FStar_ST.op_Colon_Equals record_cache uu____6995  in
+  let filter1 uu____7079 =
     let rc = peek1 ()  in
     let filtered =
       FStar_List.filter
         (fun r  -> Prims.op_Negation r.is_private_or_abstract) rc
        in
-    let uu____7052 =
-      let uu____7057 =
-        let uu____7062 = FStar_ST.op_Bang record_cache  in
-        FStar_List.tl uu____7062  in
-      filtered :: uu____7057  in
-    FStar_ST.op_Colon_Equals record_cache uu____7052  in
+    let uu____7088 =
+      let uu____7093 =
+        let uu____7098 = FStar_ST.op_Bang record_cache  in
+        FStar_List.tl uu____7098  in
+      filtered :: uu____7093  in
+    FStar_ST.op_Colon_Equals record_cache uu____7088  in
   let aux = ((push1, pop1), ((snapshot1, rollback1), (peek1, insert)))  in
   (aux, filter1) 
 let (record_cache_aux :
@@ -2096,67 +2108,70 @@ let (extract_record :
     fun new_globs  ->
       fun se  ->
         match se.FStar_Syntax_Syntax.sigel with
-        | FStar_Syntax_Syntax.Sig_bundle (sigs,uu____7988) ->
+        | FStar_Syntax_Syntax.Sig_bundle (sigs,uu____8024) ->
             let is_record =
               FStar_Util.for_some
-                (fun uu___25_8007  ->
-                   match uu___25_8007 with
-                   | FStar_Syntax_Syntax.RecordType uu____8009 -> true
-                   | FStar_Syntax_Syntax.RecordConstructor uu____8019 -> true
-                   | uu____8029 -> false)
+                (fun uu___25_8043  ->
+                   match uu___25_8043 with
+                   | FStar_Syntax_Syntax.RecordType uu____8045 -> true
+                   | FStar_Syntax_Syntax.RecordConstructor uu____8055 -> true
+                   | uu____8065 -> false)
                in
             let find_dc dc =
               FStar_All.pipe_right sigs
                 (FStar_Util.find_opt
-                   (fun uu___26_8054  ->
-                      match uu___26_8054 with
+                   (fun uu___26_8091  ->
+                      match uu___26_8091 with
                       | {
                           FStar_Syntax_Syntax.sigel =
                             FStar_Syntax_Syntax.Sig_datacon
-                            (lid,uu____8057,uu____8058,uu____8059,uu____8060,uu____8061);
-                          FStar_Syntax_Syntax.sigrng = uu____8062;
-                          FStar_Syntax_Syntax.sigquals = uu____8063;
-                          FStar_Syntax_Syntax.sigmeta = uu____8064;
-                          FStar_Syntax_Syntax.sigattrs = uu____8065;_} ->
+                            (lid,uu____8094,uu____8095,uu____8096,uu____8097,uu____8098);
+                          FStar_Syntax_Syntax.sigrng = uu____8099;
+                          FStar_Syntax_Syntax.sigquals = uu____8100;
+                          FStar_Syntax_Syntax.sigmeta = uu____8101;
+                          FStar_Syntax_Syntax.sigattrs = uu____8102;
+                          FStar_Syntax_Syntax.sigopts = uu____8103;_} ->
                           FStar_Ident.lid_equals dc lid
-                      | uu____8076 -> false))
+                      | uu____8116 -> false))
                in
             FStar_All.pipe_right sigs
               (FStar_List.iter
-                 (fun uu___27_8112  ->
-                    match uu___27_8112 with
+                 (fun uu___27_8154  ->
+                    match uu___27_8154 with
                     | {
                         FStar_Syntax_Syntax.sigel =
                           FStar_Syntax_Syntax.Sig_inductive_typ
-                          (typename,univs1,parms,uu____8116,uu____8117,dc::[]);
-                        FStar_Syntax_Syntax.sigrng = uu____8119;
+                          (typename,univs1,parms,uu____8158,uu____8159,dc::[]);
+                        FStar_Syntax_Syntax.sigrng = uu____8161;
                         FStar_Syntax_Syntax.sigquals = typename_quals;
-                        FStar_Syntax_Syntax.sigmeta = uu____8121;
-                        FStar_Syntax_Syntax.sigattrs = uu____8122;_} ->
-                        let uu____8133 =
-                          let uu____8134 = find_dc dc  in
-                          FStar_All.pipe_left FStar_Util.must uu____8134  in
-                        (match uu____8133 with
+                        FStar_Syntax_Syntax.sigmeta = uu____8163;
+                        FStar_Syntax_Syntax.sigattrs = uu____8164;
+                        FStar_Syntax_Syntax.sigopts = uu____8165;_} ->
+                        let uu____8178 =
+                          let uu____8179 = find_dc dc  in
+                          FStar_All.pipe_left FStar_Util.must uu____8179  in
+                        (match uu____8178 with
                          | {
                              FStar_Syntax_Syntax.sigel =
                                FStar_Syntax_Syntax.Sig_datacon
-                               (constrname,uu____8140,t,uu____8142,uu____8143,uu____8144);
-                             FStar_Syntax_Syntax.sigrng = uu____8145;
-                             FStar_Syntax_Syntax.sigquals = uu____8146;
-                             FStar_Syntax_Syntax.sigmeta = uu____8147;
-                             FStar_Syntax_Syntax.sigattrs = uu____8148;_} ->
-                             let uu____8159 =
+                               (constrname,uu____8185,t,uu____8187,uu____8188,uu____8189);
+                             FStar_Syntax_Syntax.sigrng = uu____8190;
+                             FStar_Syntax_Syntax.sigquals = uu____8191;
+                             FStar_Syntax_Syntax.sigmeta = uu____8192;
+                             FStar_Syntax_Syntax.sigattrs = uu____8193;
+                             FStar_Syntax_Syntax.sigopts = uu____8194;_} ->
+                             let uu____8207 =
                                FStar_Syntax_Util.arrow_formals t  in
-                             (match uu____8159 with
-                              | (formals,uu____8175) ->
+                             (match uu____8207 with
+                              | (formals,uu____8223) ->
                                   let is_rec = is_record typename_quals  in
                                   let formals' =
                                     FStar_All.pipe_right formals
                                       (FStar_List.collect
-                                         (fun uu____8229  ->
-                                            match uu____8229 with
+                                         (fun uu____8277  ->
+                                            match uu____8277 with
                                             | (x,q) ->
-                                                let uu____8242 =
+                                                let uu____8290 =
                                                   (FStar_Syntax_Syntax.is_null_bv
                                                      x)
                                                     ||
@@ -2164,15 +2179,15 @@ let (extract_record :
                                                        (FStar_Syntax_Syntax.is_implicit
                                                           q))
                                                    in
-                                                if uu____8242
+                                                if uu____8290
                                                 then []
                                                 else [(x, q)]))
                                      in
                                   let fields' =
                                     FStar_All.pipe_right formals'
                                       (FStar_List.map
-                                         (fun uu____8297  ->
-                                            match uu____8297 with
+                                         (fun uu____8345  ->
+                                            match uu____8345 with
                                             | (x,q) ->
                                                 ((x.FStar_Syntax_Syntax.ppname),
                                                   (x.FStar_Syntax_Syntax.sort))))
@@ -2195,144 +2210,144 @@ let (extract_record :
                                               typename_quals));
                                       is_record = is_rec
                                     }  in
-                                  ((let uu____8321 =
-                                      let uu____8324 =
+                                  ((let uu____8369 =
+                                      let uu____8372 =
                                         FStar_ST.op_Bang new_globs  in
-                                      (Record_or_dc record) :: uu____8324  in
+                                      (Record_or_dc record) :: uu____8372  in
                                     FStar_ST.op_Colon_Equals new_globs
-                                      uu____8321);
+                                      uu____8369);
                                    (match () with
                                     | () ->
-                                        ((let add_field uu____8383 =
-                                            match uu____8383 with
-                                            | (id1,uu____8389) ->
+                                        ((let add_field uu____8431 =
+                                            match uu____8431 with
+                                            | (id1,uu____8437) ->
                                                 let modul =
-                                                  let uu____8392 =
+                                                  let uu____8440 =
                                                     FStar_Ident.lid_of_ids
                                                       constrname.FStar_Ident.ns
                                                      in
-                                                  uu____8392.FStar_Ident.str
+                                                  uu____8440.FStar_Ident.str
                                                    in
-                                                let uu____8393 =
+                                                let uu____8441 =
                                                   get_exported_id_set e modul
                                                    in
-                                                (match uu____8393 with
+                                                (match uu____8441 with
                                                  | FStar_Pervasives_Native.Some
                                                      my_ex ->
                                                      let my_exported_ids =
                                                        my_ex
                                                          Exported_id_field
                                                         in
-                                                     ((let uu____8416 =
-                                                         let uu____8417 =
+                                                     ((let uu____8464 =
+                                                         let uu____8465 =
                                                            FStar_ST.op_Bang
                                                              my_exported_ids
                                                             in
                                                          FStar_Util.set_add
                                                            id1.FStar_Ident.idText
-                                                           uu____8417
+                                                           uu____8465
                                                           in
                                                        FStar_ST.op_Colon_Equals
                                                          my_exported_ids
-                                                         uu____8416);
+                                                         uu____8464);
                                                       (match () with
                                                        | () ->
                                                            let projname =
-                                                             let uu____8462 =
-                                                               let uu____8463
+                                                             let uu____8510 =
+                                                               let uu____8511
                                                                  =
                                                                  FStar_Syntax_Util.mk_field_projector_name_from_ident
                                                                    constrname
                                                                    id1
                                                                   in
-                                                               uu____8463.FStar_Ident.ident
+                                                               uu____8511.FStar_Ident.ident
                                                                 in
-                                                             uu____8462.FStar_Ident.idText
+                                                             uu____8510.FStar_Ident.idText
                                                               in
-                                                           let uu____8465 =
-                                                             let uu____8466 =
+                                                           let uu____8513 =
+                                                             let uu____8514 =
                                                                FStar_ST.op_Bang
                                                                  my_exported_ids
                                                                 in
                                                              FStar_Util.set_add
                                                                projname
-                                                               uu____8466
+                                                               uu____8514
                                                               in
                                                            FStar_ST.op_Colon_Equals
                                                              my_exported_ids
-                                                             uu____8465))
+                                                             uu____8513))
                                                  | FStar_Pervasives_Native.None
                                                       -> ())
                                              in
                                           FStar_List.iter add_field fields');
                                          (match () with
                                           | () -> insert_record_cache record)))))
-                         | uu____8518 -> ())
-                    | uu____8519 -> ()))
-        | uu____8520 -> ()
+                         | uu____8566 -> ())
+                    | uu____8567 -> ()))
+        | uu____8568 -> ()
   
 let (try_lookup_record_or_dc_by_field_name :
   env -> FStar_Ident.lident -> record_or_dc FStar_Pervasives_Native.option) =
   fun env  ->
     fun fieldname  ->
       let find_in_cache fieldname1 =
-        let uu____8542 =
+        let uu____8590 =
           ((fieldname1.FStar_Ident.ns), (fieldname1.FStar_Ident.ident))  in
-        match uu____8542 with
+        match uu____8590 with
         | (ns,id1) ->
-            let uu____8559 = peek_record_cache ()  in
-            FStar_Util.find_map uu____8559
+            let uu____8607 = peek_record_cache ()  in
+            FStar_Util.find_map uu____8607
               (fun record  ->
-                 let uu____8565 =
+                 let uu____8613 =
                    find_in_record ns id1 record (fun r  -> Cont_ok r)  in
                  option_of_cont
-                   (fun uu____8571  -> FStar_Pervasives_Native.None)
-                   uu____8565)
+                   (fun uu____8619  -> FStar_Pervasives_Native.None)
+                   uu____8613)
          in
       resolve_in_open_namespaces'' env fieldname Exported_id_field
-        (fun uu____8573  -> Cont_ignore) (fun uu____8575  -> Cont_ignore)
+        (fun uu____8621  -> Cont_ignore) (fun uu____8623  -> Cont_ignore)
         (fun r  -> Cont_ok r)
         (fun fn  ->
-           let uu____8581 = find_in_cache fn  in
-           cont_of_option Cont_ignore uu____8581)
-        (fun k  -> fun uu____8587  -> k)
+           let uu____8629 = find_in_cache fn  in
+           cont_of_option Cont_ignore uu____8629)
+        (fun k  -> fun uu____8635  -> k)
   
 let (try_lookup_record_by_field_name :
   env -> FStar_Ident.lident -> record_or_dc FStar_Pervasives_Native.option) =
   fun env  ->
     fun fieldname  ->
-      let uu____8603 = try_lookup_record_or_dc_by_field_name env fieldname
+      let uu____8651 = try_lookup_record_or_dc_by_field_name env fieldname
          in
-      match uu____8603 with
+      match uu____8651 with
       | FStar_Pervasives_Native.Some r when r.is_record ->
           FStar_Pervasives_Native.Some r
-      | uu____8609 -> FStar_Pervasives_Native.None
+      | uu____8657 -> FStar_Pervasives_Native.None
   
 let (belongs_to_record :
   env -> FStar_Ident.lident -> record_or_dc -> Prims.bool) =
   fun env  ->
     fun lid  ->
       fun record  ->
-        let uu____8629 = try_lookup_record_by_field_name env lid  in
-        match uu____8629 with
+        let uu____8677 = try_lookup_record_by_field_name env lid  in
+        match uu____8677 with
         | FStar_Pervasives_Native.Some record' when
-            let uu____8634 =
-              let uu____8636 =
+            let uu____8682 =
+              let uu____8684 =
                 FStar_Ident.path_of_ns (record.typename).FStar_Ident.ns  in
-              FStar_Ident.text_of_path uu____8636  in
-            let uu____8637 =
-              let uu____8639 =
+              FStar_Ident.text_of_path uu____8684  in
+            let uu____8685 =
+              let uu____8687 =
                 FStar_Ident.path_of_ns (record'.typename).FStar_Ident.ns  in
-              FStar_Ident.text_of_path uu____8639  in
-            uu____8634 = uu____8637 ->
-            let uu____8641 =
+              FStar_Ident.text_of_path uu____8687  in
+            uu____8682 = uu____8685 ->
+            let uu____8689 =
               find_in_record (record.typename).FStar_Ident.ns
-                lid.FStar_Ident.ident record (fun uu____8645  -> Cont_ok ())
+                lid.FStar_Ident.ident record (fun uu____8693  -> Cont_ok ())
                in
-            (match uu____8641 with
-             | Cont_ok uu____8647 -> true
-             | uu____8649 -> false)
-        | uu____8653 -> false
+            (match uu____8689 with
+             | Cont_ok uu____8695 -> true
+             | uu____8697 -> false)
+        | uu____8701 -> false
   
 let (try_lookup_dc_by_field_name :
   env ->
@@ -2341,35 +2356,35 @@ let (try_lookup_dc_by_field_name :
   =
   fun env  ->
     fun fieldname  ->
-      let uu____8675 = try_lookup_record_or_dc_by_field_name env fieldname
+      let uu____8723 = try_lookup_record_or_dc_by_field_name env fieldname
          in
-      match uu____8675 with
+      match uu____8723 with
       | FStar_Pervasives_Native.Some r ->
-          let uu____8686 =
-            let uu____8692 =
-              let uu____8693 =
+          let uu____8734 =
+            let uu____8740 =
+              let uu____8741 =
                 FStar_Ident.lid_of_ids
                   (FStar_List.append (r.typename).FStar_Ident.ns
                      [r.constrname])
                  in
-              let uu____8694 = FStar_Ident.range_of_lid fieldname  in
-              FStar_Ident.set_lid_range uu____8693 uu____8694  in
-            (uu____8692, (r.is_record))  in
-          FStar_Pervasives_Native.Some uu____8686
-      | uu____8701 -> FStar_Pervasives_Native.None
+              let uu____8742 = FStar_Ident.range_of_lid fieldname  in
+              FStar_Ident.set_lid_range uu____8741 uu____8742  in
+            (uu____8740, (r.is_record))  in
+          FStar_Pervasives_Native.Some uu____8734
+      | uu____8749 -> FStar_Pervasives_Native.None
   
 let (string_set_ref_new : unit -> Prims.string FStar_Util.set FStar_ST.ref) =
-  fun uu____8719  ->
-    let uu____8720 = FStar_Util.new_set FStar_Util.compare  in
-    FStar_Util.mk_ref uu____8720
+  fun uu____8767  ->
+    let uu____8768 = FStar_Util.new_set FStar_Util.compare  in
+    FStar_Util.mk_ref uu____8768
   
 let (exported_id_set_new :
   unit -> exported_id_kind -> Prims.string FStar_Util.set FStar_ST.ref) =
-  fun uu____8741  ->
+  fun uu____8789  ->
     let term_type_set = string_set_ref_new ()  in
     let field_set = string_set_ref_new ()  in
-    fun uu___28_8754  ->
-      match uu___28_8754 with
+    fun uu___28_8802  ->
+      match uu___28_8802 with
       | Exported_id_term_type  -> term_type_set
       | Exported_id_field  -> field_set
   
@@ -2379,61 +2394,61 @@ let (unique :
     fun exclude_interface  ->
       fun env  ->
         fun lid  ->
-          let filter_scope_mods uu___29_8792 =
-            match uu___29_8792 with
-            | Rec_binding uu____8794 -> true
-            | uu____8796 -> false  in
+          let filter_scope_mods uu___29_8840 =
+            match uu___29_8840 with
+            | Rec_binding uu____8842 -> true
+            | uu____8844 -> false  in
           let this_env =
-            let uu___1110_8799 = env  in
-            let uu____8800 =
+            let uu___1125_8847 = env  in
+            let uu____8848 =
               FStar_List.filter filter_scope_mods env.scope_mods  in
             {
-              curmodule = (uu___1110_8799.curmodule);
-              curmonad = (uu___1110_8799.curmonad);
-              modules = (uu___1110_8799.modules);
-              scope_mods = uu____8800;
+              curmodule = (uu___1125_8847.curmodule);
+              curmonad = (uu___1125_8847.curmonad);
+              modules = (uu___1125_8847.modules);
+              scope_mods = uu____8848;
               exported_ids = empty_exported_id_smap;
-              trans_exported_ids = (uu___1110_8799.trans_exported_ids);
+              trans_exported_ids = (uu___1125_8847.trans_exported_ids);
               includes = empty_include_smap;
-              sigaccum = (uu___1110_8799.sigaccum);
-              sigmap = (uu___1110_8799.sigmap);
-              iface = (uu___1110_8799.iface);
-              admitted_iface = (uu___1110_8799.admitted_iface);
-              expect_typ = (uu___1110_8799.expect_typ);
-              docs = (uu___1110_8799.docs);
-              remaining_iface_decls = (uu___1110_8799.remaining_iface_decls);
-              syntax_only = (uu___1110_8799.syntax_only);
-              ds_hooks = (uu___1110_8799.ds_hooks);
-              dep_graph = (uu___1110_8799.dep_graph)
+              sigaccum = (uu___1125_8847.sigaccum);
+              sigmap = (uu___1125_8847.sigmap);
+              iface = (uu___1125_8847.iface);
+              admitted_iface = (uu___1125_8847.admitted_iface);
+              expect_typ = (uu___1125_8847.expect_typ);
+              docs = (uu___1125_8847.docs);
+              remaining_iface_decls = (uu___1125_8847.remaining_iface_decls);
+              syntax_only = (uu___1125_8847.syntax_only);
+              ds_hooks = (uu___1125_8847.ds_hooks);
+              dep_graph = (uu___1125_8847.dep_graph)
             }  in
-          let uu____8803 =
+          let uu____8851 =
             try_lookup_lid' any_val exclude_interface this_env lid  in
-          match uu____8803 with
+          match uu____8851 with
           | FStar_Pervasives_Native.None  -> true
-          | FStar_Pervasives_Native.Some uu____8820 -> false
+          | FStar_Pervasives_Native.Some uu____8868 -> false
   
 let (push_scope_mod : env -> scope_mod -> env) =
   fun env  ->
     fun scope_mod  ->
-      let uu___1118_8845 = env  in
+      let uu___1133_8893 = env  in
       {
-        curmodule = (uu___1118_8845.curmodule);
-        curmonad = (uu___1118_8845.curmonad);
-        modules = (uu___1118_8845.modules);
+        curmodule = (uu___1133_8893.curmodule);
+        curmonad = (uu___1133_8893.curmonad);
+        modules = (uu___1133_8893.modules);
         scope_mods = (scope_mod :: (env.scope_mods));
-        exported_ids = (uu___1118_8845.exported_ids);
-        trans_exported_ids = (uu___1118_8845.trans_exported_ids);
-        includes = (uu___1118_8845.includes);
-        sigaccum = (uu___1118_8845.sigaccum);
-        sigmap = (uu___1118_8845.sigmap);
-        iface = (uu___1118_8845.iface);
-        admitted_iface = (uu___1118_8845.admitted_iface);
-        expect_typ = (uu___1118_8845.expect_typ);
-        docs = (uu___1118_8845.docs);
-        remaining_iface_decls = (uu___1118_8845.remaining_iface_decls);
-        syntax_only = (uu___1118_8845.syntax_only);
-        ds_hooks = (uu___1118_8845.ds_hooks);
-        dep_graph = (uu___1118_8845.dep_graph)
+        exported_ids = (uu___1133_8893.exported_ids);
+        trans_exported_ids = (uu___1133_8893.trans_exported_ids);
+        includes = (uu___1133_8893.includes);
+        sigaccum = (uu___1133_8893.sigaccum);
+        sigmap = (uu___1133_8893.sigmap);
+        iface = (uu___1133_8893.iface);
+        admitted_iface = (uu___1133_8893.admitted_iface);
+        expect_typ = (uu___1133_8893.expect_typ);
+        docs = (uu___1133_8893.docs);
+        remaining_iface_decls = (uu___1133_8893.remaining_iface_decls);
+        syntax_only = (uu___1133_8893.syntax_only);
+        ds_hooks = (uu___1133_8893.ds_hooks);
+        dep_graph = (uu___1133_8893.dep_graph)
       }
   
 let (push_bv : env -> FStar_Ident.ident -> (env * FStar_Syntax_Syntax.bv)) =
@@ -2452,16 +2467,16 @@ let (push_top_level_rec_binding :
     fun x  ->
       fun dd  ->
         let l = qualify env x  in
-        let uu____8879 =
+        let uu____8927 =
           (unique false true env l) || (FStar_Options.interactive ())  in
-        if uu____8879
+        if uu____8927
         then push_scope_mod env (Rec_binding (x, l, dd))
         else
-          (let uu____8886 = FStar_Ident.range_of_lid l  in
+          (let uu____8934 = FStar_Ident.range_of_lid l  in
            FStar_Errors.raise_error
              (FStar_Errors.Fatal_DuplicateTopLevelNames,
                (Prims.op_Hat "Duplicate top-level names " l.FStar_Ident.str))
-             uu____8886)
+             uu____8934)
   
 let (push_sigelt' : Prims.bool -> env -> FStar_Syntax_Syntax.sigelt -> env) =
   fun fail_on_dup  ->
@@ -2472,151 +2487,151 @@ let (push_sigelt' : Prims.bool -> env -> FStar_Syntax_Syntax.sigelt -> env) =
              in
           let r =
             match sopt with
-            | FStar_Pervasives_Native.Some (se,uu____8930) ->
-                let uu____8938 =
+            | FStar_Pervasives_Native.Some (se,uu____8978) ->
+                let uu____8986 =
                   FStar_Util.find_opt (FStar_Ident.lid_equals l)
                     (FStar_Syntax_Util.lids_of_sigelt se)
                    in
-                (match uu____8938 with
+                (match uu____8986 with
                  | FStar_Pervasives_Native.Some l1 ->
-                     let uu____8943 = FStar_Ident.range_of_lid l1  in
+                     let uu____8991 = FStar_Ident.range_of_lid l1  in
                      FStar_All.pipe_left FStar_Range.string_of_range
-                       uu____8943
+                       uu____8991
                  | FStar_Pervasives_Native.None  -> "<unknown>")
             | FStar_Pervasives_Native.None  -> "<unknown>"  in
-          let uu____8952 =
-            let uu____8958 =
-              let uu____8960 = FStar_Ident.text_of_lid l  in
+          let uu____9000 =
+            let uu____9006 =
+              let uu____9008 = FStar_Ident.text_of_lid l  in
               FStar_Util.format2
                 "Duplicate top-level names [%s]; previously declared at %s"
-                uu____8960 r
+                uu____9008 r
                in
-            (FStar_Errors.Fatal_DuplicateTopLevelNames, uu____8958)  in
-          let uu____8964 = FStar_Ident.range_of_lid l  in
-          FStar_Errors.raise_error uu____8952 uu____8964  in
+            (FStar_Errors.Fatal_DuplicateTopLevelNames, uu____9006)  in
+          let uu____9012 = FStar_Ident.range_of_lid l  in
+          FStar_Errors.raise_error uu____9000 uu____9012  in
         let globals = FStar_Util.mk_ref env.scope_mods  in
         let env1 =
-          let uu____8973 =
+          let uu____9021 =
             match s.FStar_Syntax_Syntax.sigel with
-            | FStar_Syntax_Syntax.Sig_let uu____8986 -> (false, true)
-            | FStar_Syntax_Syntax.Sig_bundle uu____8997 -> (false, true)
-            | uu____9010 -> (false, false)  in
-          match uu____8973 with
+            | FStar_Syntax_Syntax.Sig_let uu____9034 -> (false, true)
+            | FStar_Syntax_Syntax.Sig_bundle uu____9045 -> (false, true)
+            | uu____9058 -> (false, false)  in
+          match uu____9021 with
           | (any_val,exclude_interface) ->
               let lids = FStar_Syntax_Util.lids_of_sigelt s  in
-              let uu____9024 =
+              let uu____9072 =
                 FStar_Util.find_map lids
                   (fun l  ->
-                     let uu____9030 =
-                       let uu____9032 =
+                     let uu____9078 =
+                       let uu____9080 =
                          unique any_val exclude_interface env l  in
-                       Prims.op_Negation uu____9032  in
-                     if uu____9030
+                       Prims.op_Negation uu____9080  in
+                     if uu____9078
                      then FStar_Pervasives_Native.Some l
                      else FStar_Pervasives_Native.None)
                  in
-              (match uu____9024 with
+              (match uu____9072 with
                | FStar_Pervasives_Native.Some l when fail_on_dup -> err l
-               | uu____9040 ->
+               | uu____9088 ->
                    (extract_record env globals s;
-                    (let uu___1159_9044 = env  in
+                    (let uu___1174_9092 = env  in
                      {
-                       curmodule = (uu___1159_9044.curmodule);
-                       curmonad = (uu___1159_9044.curmonad);
-                       modules = (uu___1159_9044.modules);
-                       scope_mods = (uu___1159_9044.scope_mods);
-                       exported_ids = (uu___1159_9044.exported_ids);
+                       curmodule = (uu___1174_9092.curmodule);
+                       curmonad = (uu___1174_9092.curmonad);
+                       modules = (uu___1174_9092.modules);
+                       scope_mods = (uu___1174_9092.scope_mods);
+                       exported_ids = (uu___1174_9092.exported_ids);
                        trans_exported_ids =
-                         (uu___1159_9044.trans_exported_ids);
-                       includes = (uu___1159_9044.includes);
+                         (uu___1174_9092.trans_exported_ids);
+                       includes = (uu___1174_9092.includes);
                        sigaccum = (s :: (env.sigaccum));
-                       sigmap = (uu___1159_9044.sigmap);
-                       iface = (uu___1159_9044.iface);
-                       admitted_iface = (uu___1159_9044.admitted_iface);
-                       expect_typ = (uu___1159_9044.expect_typ);
-                       docs = (uu___1159_9044.docs);
+                       sigmap = (uu___1174_9092.sigmap);
+                       iface = (uu___1174_9092.iface);
+                       admitted_iface = (uu___1174_9092.admitted_iface);
+                       expect_typ = (uu___1174_9092.expect_typ);
+                       docs = (uu___1174_9092.docs);
                        remaining_iface_decls =
-                         (uu___1159_9044.remaining_iface_decls);
-                       syntax_only = (uu___1159_9044.syntax_only);
-                       ds_hooks = (uu___1159_9044.ds_hooks);
-                       dep_graph = (uu___1159_9044.dep_graph)
+                         (uu___1174_9092.remaining_iface_decls);
+                       syntax_only = (uu___1174_9092.syntax_only);
+                       ds_hooks = (uu___1174_9092.ds_hooks);
+                       dep_graph = (uu___1174_9092.dep_graph)
                      })))
            in
         let env2 =
-          let uu___1162_9046 = env1  in
-          let uu____9047 = FStar_ST.op_Bang globals  in
+          let uu___1177_9094 = env1  in
+          let uu____9095 = FStar_ST.op_Bang globals  in
           {
-            curmodule = (uu___1162_9046.curmodule);
-            curmonad = (uu___1162_9046.curmonad);
-            modules = (uu___1162_9046.modules);
-            scope_mods = uu____9047;
-            exported_ids = (uu___1162_9046.exported_ids);
-            trans_exported_ids = (uu___1162_9046.trans_exported_ids);
-            includes = (uu___1162_9046.includes);
-            sigaccum = (uu___1162_9046.sigaccum);
-            sigmap = (uu___1162_9046.sigmap);
-            iface = (uu___1162_9046.iface);
-            admitted_iface = (uu___1162_9046.admitted_iface);
-            expect_typ = (uu___1162_9046.expect_typ);
-            docs = (uu___1162_9046.docs);
-            remaining_iface_decls = (uu___1162_9046.remaining_iface_decls);
-            syntax_only = (uu___1162_9046.syntax_only);
-            ds_hooks = (uu___1162_9046.ds_hooks);
-            dep_graph = (uu___1162_9046.dep_graph)
+            curmodule = (uu___1177_9094.curmodule);
+            curmonad = (uu___1177_9094.curmonad);
+            modules = (uu___1177_9094.modules);
+            scope_mods = uu____9095;
+            exported_ids = (uu___1177_9094.exported_ids);
+            trans_exported_ids = (uu___1177_9094.trans_exported_ids);
+            includes = (uu___1177_9094.includes);
+            sigaccum = (uu___1177_9094.sigaccum);
+            sigmap = (uu___1177_9094.sigmap);
+            iface = (uu___1177_9094.iface);
+            admitted_iface = (uu___1177_9094.admitted_iface);
+            expect_typ = (uu___1177_9094.expect_typ);
+            docs = (uu___1177_9094.docs);
+            remaining_iface_decls = (uu___1177_9094.remaining_iface_decls);
+            syntax_only = (uu___1177_9094.syntax_only);
+            ds_hooks = (uu___1177_9094.ds_hooks);
+            dep_graph = (uu___1177_9094.dep_graph)
           }  in
-        let uu____9073 =
+        let uu____9121 =
           match s.FStar_Syntax_Syntax.sigel with
-          | FStar_Syntax_Syntax.Sig_bundle (ses,uu____9099) ->
-              let uu____9108 =
+          | FStar_Syntax_Syntax.Sig_bundle (ses,uu____9147) ->
+              let uu____9156 =
                 FStar_List.map
                   (fun se  -> ((FStar_Syntax_Util.lids_of_sigelt se), se))
                   ses
                  in
-              (env2, uu____9108)
-          | uu____9135 -> (env2, [((FStar_Syntax_Util.lids_of_sigelt s), s)])
+              (env2, uu____9156)
+          | uu____9183 -> (env2, [((FStar_Syntax_Util.lids_of_sigelt s), s)])
            in
-        match uu____9073 with
+        match uu____9121 with
         | (env3,lss) ->
             (FStar_All.pipe_right lss
                (FStar_List.iter
-                  (fun uu____9194  ->
-                     match uu____9194 with
+                  (fun uu____9242  ->
+                     match uu____9242 with
                      | (lids,se) ->
                          FStar_All.pipe_right lids
                            (FStar_List.iter
                               (fun lid  ->
-                                 (let uu____9216 =
-                                    let uu____9219 = FStar_ST.op_Bang globals
+                                 (let uu____9264 =
+                                    let uu____9267 = FStar_ST.op_Bang globals
                                        in
                                     (Top_level_def (lid.FStar_Ident.ident))
-                                      :: uu____9219
+                                      :: uu____9267
                                      in
-                                  FStar_ST.op_Colon_Equals globals uu____9216);
+                                  FStar_ST.op_Colon_Equals globals uu____9264);
                                  (match () with
                                   | () ->
                                       let modul =
-                                        let uu____9270 =
+                                        let uu____9318 =
                                           FStar_Ident.lid_of_ids
                                             lid.FStar_Ident.ns
                                            in
-                                        uu____9270.FStar_Ident.str  in
-                                      ((let uu____9272 =
+                                        uu____9318.FStar_Ident.str  in
+                                      ((let uu____9320 =
                                           get_exported_id_set env3 modul  in
-                                        match uu____9272 with
+                                        match uu____9320 with
                                         | FStar_Pervasives_Native.Some f ->
                                             let my_exported_ids =
                                               f Exported_id_term_type  in
-                                            let uu____9294 =
-                                              let uu____9295 =
+                                            let uu____9342 =
+                                              let uu____9343 =
                                                 FStar_ST.op_Bang
                                                   my_exported_ids
                                                  in
                                               FStar_Util.set_add
                                                 (lid.FStar_Ident.ident).FStar_Ident.idText
-                                                uu____9295
+                                                uu____9343
                                                in
                                             FStar_ST.op_Colon_Equals
-                                              my_exported_ids uu____9294
+                                              my_exported_ids uu____9342
                                         | FStar_Pervasives_Native.None  -> ());
                                        (match () with
                                         | () ->
@@ -2632,27 +2647,27 @@ let (push_sigelt' : Prims.bool -> env -> FStar_Syntax_Syntax.sigelt -> env) =
                                                    (Prims.op_Negation
                                                       env3.admitted_iface))))))))));
              (let env4 =
-                let uu___1187_9352 = env3  in
-                let uu____9353 = FStar_ST.op_Bang globals  in
+                let uu___1202_9400 = env3  in
+                let uu____9401 = FStar_ST.op_Bang globals  in
                 {
-                  curmodule = (uu___1187_9352.curmodule);
-                  curmonad = (uu___1187_9352.curmonad);
-                  modules = (uu___1187_9352.modules);
-                  scope_mods = uu____9353;
-                  exported_ids = (uu___1187_9352.exported_ids);
-                  trans_exported_ids = (uu___1187_9352.trans_exported_ids);
-                  includes = (uu___1187_9352.includes);
-                  sigaccum = (uu___1187_9352.sigaccum);
-                  sigmap = (uu___1187_9352.sigmap);
-                  iface = (uu___1187_9352.iface);
-                  admitted_iface = (uu___1187_9352.admitted_iface);
-                  expect_typ = (uu___1187_9352.expect_typ);
-                  docs = (uu___1187_9352.docs);
+                  curmodule = (uu___1202_9400.curmodule);
+                  curmonad = (uu___1202_9400.curmonad);
+                  modules = (uu___1202_9400.modules);
+                  scope_mods = uu____9401;
+                  exported_ids = (uu___1202_9400.exported_ids);
+                  trans_exported_ids = (uu___1202_9400.trans_exported_ids);
+                  includes = (uu___1202_9400.includes);
+                  sigaccum = (uu___1202_9400.sigaccum);
+                  sigmap = (uu___1202_9400.sigmap);
+                  iface = (uu___1202_9400.iface);
+                  admitted_iface = (uu___1202_9400.admitted_iface);
+                  expect_typ = (uu___1202_9400.expect_typ);
+                  docs = (uu___1202_9400.docs);
                   remaining_iface_decls =
-                    (uu___1187_9352.remaining_iface_decls);
-                  syntax_only = (uu___1187_9352.syntax_only);
-                  ds_hooks = (uu___1187_9352.ds_hooks);
-                  dep_graph = (uu___1187_9352.dep_graph)
+                    (uu___1202_9400.remaining_iface_decls);
+                  syntax_only = (uu___1202_9400.syntax_only);
+                  ds_hooks = (uu___1202_9400.ds_hooks);
+                  dep_graph = (uu___1202_9400.dep_graph)
                 }  in
               env4))
   
@@ -2663,41 +2678,41 @@ let (push_sigelt_force : env -> FStar_Syntax_Syntax.sigelt -> env) =
 let (push_namespace : env -> FStar_Ident.lident -> env) =
   fun env  ->
     fun ns  ->
-      let uu____9414 =
-        let uu____9419 = resolve_module_name env ns false  in
-        match uu____9419 with
+      let uu____9462 =
+        let uu____9467 = resolve_module_name env ns false  in
+        match uu____9467 with
         | FStar_Pervasives_Native.None  ->
             let modules = env.modules  in
-            let uu____9434 =
+            let uu____9482 =
               FStar_All.pipe_right modules
                 (FStar_Util.for_some
-                   (fun uu____9452  ->
-                      match uu____9452 with
-                      | (m,uu____9459) ->
-                          let uu____9460 =
-                            let uu____9462 = FStar_Ident.text_of_lid m  in
-                            Prims.op_Hat uu____9462 "."  in
-                          let uu____9465 =
-                            let uu____9467 = FStar_Ident.text_of_lid ns  in
-                            Prims.op_Hat uu____9467 "."  in
-                          FStar_Util.starts_with uu____9460 uu____9465))
+                   (fun uu____9500  ->
+                      match uu____9500 with
+                      | (m,uu____9507) ->
+                          let uu____9508 =
+                            let uu____9510 = FStar_Ident.text_of_lid m  in
+                            Prims.op_Hat uu____9510 "."  in
+                          let uu____9513 =
+                            let uu____9515 = FStar_Ident.text_of_lid ns  in
+                            Prims.op_Hat uu____9515 "."  in
+                          FStar_Util.starts_with uu____9508 uu____9513))
                in
-            if uu____9434
+            if uu____9482
             then (ns, Open_namespace)
             else
-              (let uu____9477 =
-                 let uu____9483 =
-                   let uu____9485 = FStar_Ident.text_of_lid ns  in
+              (let uu____9525 =
+                 let uu____9531 =
+                   let uu____9533 = FStar_Ident.text_of_lid ns  in
                    FStar_Util.format1 "Namespace %s cannot be found"
-                     uu____9485
+                     uu____9533
                     in
-                 (FStar_Errors.Fatal_NameSpaceNotFound, uu____9483)  in
-               let uu____9489 = FStar_Ident.range_of_lid ns  in
-               FStar_Errors.raise_error uu____9477 uu____9489)
+                 (FStar_Errors.Fatal_NameSpaceNotFound, uu____9531)  in
+               let uu____9537 = FStar_Ident.range_of_lid ns  in
+               FStar_Errors.raise_error uu____9525 uu____9537)
         | FStar_Pervasives_Native.Some ns' ->
             (fail_if_curmodule env ns ns'; (ns', Open_module))
          in
-      match uu____9414 with
+      match uu____9462 with
       | (ns',kd) ->
           ((env.ds_hooks).ds_push_open_hook env (ns', kd);
            push_scope_mod env (Open_module_or_namespace (ns', kd)))
@@ -2706,8 +2721,8 @@ let (push_include : env -> FStar_Ident.lident -> env) =
   fun env  ->
     fun ns  ->
       let ns0 = ns  in
-      let uu____9511 = resolve_module_name env ns false  in
-      match uu____9511 with
+      let uu____9559 = resolve_module_name env ns false  in
+      match uu____9559 with
       | FStar_Pervasives_Native.Some ns1 ->
           ((env.ds_hooks).ds_push_include_hook env ns1;
            fail_if_curmodule env ns0 ns1;
@@ -2716,100 +2731,100 @@ let (push_include : env -> FStar_Ident.lident -> env) =
                 (Open_module_or_namespace (ns1, Open_module))
                in
             let curmod =
-              let uu____9521 = current_module env1  in
-              uu____9521.FStar_Ident.str  in
-            (let uu____9523 = FStar_Util.smap_try_find env1.includes curmod
+              let uu____9569 = current_module env1  in
+              uu____9569.FStar_Ident.str  in
+            (let uu____9571 = FStar_Util.smap_try_find env1.includes curmod
                 in
-             match uu____9523 with
+             match uu____9571 with
              | FStar_Pervasives_Native.None  -> ()
              | FStar_Pervasives_Native.Some incl ->
-                 let uu____9547 =
-                   let uu____9550 = FStar_ST.op_Bang incl  in ns1 ::
-                     uu____9550
+                 let uu____9595 =
+                   let uu____9598 = FStar_ST.op_Bang incl  in ns1 ::
+                     uu____9598
                     in
-                 FStar_ST.op_Colon_Equals incl uu____9547);
+                 FStar_ST.op_Colon_Equals incl uu____9595);
             (match () with
              | () ->
-                 let uu____9599 =
+                 let uu____9647 =
                    get_trans_exported_id_set env1 ns1.FStar_Ident.str  in
-                 (match uu____9599 with
+                 (match uu____9647 with
                   | FStar_Pervasives_Native.Some ns_trans_exports ->
-                      ((let uu____9619 =
-                          let uu____9716 = get_exported_id_set env1 curmod
+                      ((let uu____9667 =
+                          let uu____9764 = get_exported_id_set env1 curmod
                              in
-                          let uu____9763 =
+                          let uu____9811 =
                             get_trans_exported_id_set env1 curmod  in
-                          (uu____9716, uu____9763)  in
-                        match uu____9619 with
+                          (uu____9764, uu____9811)  in
+                        match uu____9667 with
                         | (FStar_Pervasives_Native.Some
                            cur_exports,FStar_Pervasives_Native.Some
                            cur_trans_exports) ->
                             let update_exports k =
                               let ns_ex =
-                                let uu____10179 = ns_trans_exports k  in
-                                FStar_ST.op_Bang uu____10179  in
+                                let uu____10227 = ns_trans_exports k  in
+                                FStar_ST.op_Bang uu____10227  in
                               let ex = cur_exports k  in
-                              (let uu____10280 =
-                                 let uu____10284 = FStar_ST.op_Bang ex  in
-                                 FStar_Util.set_difference uu____10284 ns_ex
+                              (let uu____10328 =
+                                 let uu____10332 = FStar_ST.op_Bang ex  in
+                                 FStar_Util.set_difference uu____10332 ns_ex
                                   in
-                               FStar_ST.op_Colon_Equals ex uu____10280);
+                               FStar_ST.op_Colon_Equals ex uu____10328);
                               (match () with
                                | () ->
                                    let trans_ex = cur_trans_exports k  in
-                                   let uu____10376 =
-                                     let uu____10380 =
+                                   let uu____10424 =
+                                     let uu____10428 =
                                        FStar_ST.op_Bang trans_ex  in
-                                     FStar_Util.set_union uu____10380 ns_ex
+                                     FStar_Util.set_union uu____10428 ns_ex
                                       in
                                    FStar_ST.op_Colon_Equals trans_ex
-                                     uu____10376)
+                                     uu____10424)
                                in
                             FStar_List.iter update_exports
                               all_exported_id_kinds
-                        | uu____10429 -> ());
+                        | uu____10477 -> ());
                        (match () with | () -> env1))
                   | FStar_Pervasives_Native.None  ->
-                      let uu____10531 =
-                        let uu____10537 =
+                      let uu____10579 =
+                        let uu____10585 =
                           FStar_Util.format1
                             "include: Module %s was not prepared"
                             ns1.FStar_Ident.str
                            in
                         (FStar_Errors.Fatal_IncludeModuleNotPrepared,
-                          uu____10537)
+                          uu____10585)
                          in
-                      let uu____10541 = FStar_Ident.range_of_lid ns1  in
-                      FStar_Errors.raise_error uu____10531 uu____10541))))
-      | uu____10542 ->
-          let uu____10545 =
-            let uu____10551 =
+                      let uu____10589 = FStar_Ident.range_of_lid ns1  in
+                      FStar_Errors.raise_error uu____10579 uu____10589))))
+      | uu____10590 ->
+          let uu____10593 =
+            let uu____10599 =
               FStar_Util.format1 "include: Module %s cannot be found"
                 ns.FStar_Ident.str
                in
-            (FStar_Errors.Fatal_ModuleNotFound, uu____10551)  in
-          let uu____10555 = FStar_Ident.range_of_lid ns  in
-          FStar_Errors.raise_error uu____10545 uu____10555
+            (FStar_Errors.Fatal_ModuleNotFound, uu____10599)  in
+          let uu____10603 = FStar_Ident.range_of_lid ns  in
+          FStar_Errors.raise_error uu____10593 uu____10603
   
 let (push_module_abbrev :
   env -> FStar_Ident.ident -> FStar_Ident.lident -> env) =
   fun env  ->
     fun x  ->
       fun l  ->
-        let uu____10572 = module_is_defined env l  in
-        if uu____10572
+        let uu____10620 = module_is_defined env l  in
+        if uu____10620
         then
           (fail_if_curmodule env l l;
            (env.ds_hooks).ds_push_module_abbrev_hook env x l;
            push_scope_mod env (Module_abbrev (x, l)))
         else
-          (let uu____10579 =
-             let uu____10585 =
-               let uu____10587 = FStar_Ident.text_of_lid l  in
-               FStar_Util.format1 "Module %s cannot be found" uu____10587  in
-             (FStar_Errors.Fatal_ModuleNotFound, uu____10585)  in
-           let uu____10591 = FStar_Ident.range_of_lid l  in
-           FStar_Errors.raise_error uu____10579 uu____10591)
+          (let uu____10627 =
+             let uu____10633 =
+               let uu____10635 = FStar_Ident.text_of_lid l  in
+               FStar_Util.format1 "Module %s cannot be found" uu____10635  in
+             (FStar_Errors.Fatal_ModuleNotFound, uu____10633)  in
+           let uu____10639 = FStar_Ident.range_of_lid l  in
+           FStar_Errors.raise_error uu____10627 uu____10639)
   
 let (push_doc :
   env ->
@@ -2822,25 +2837,25 @@ let (push_doc :
         match doc_opt with
         | FStar_Pervasives_Native.None  -> env
         | FStar_Pervasives_Native.Some doc1 ->
-            ((let uu____10614 =
+            ((let uu____10662 =
                 FStar_Util.smap_try_find env.docs l.FStar_Ident.str  in
-              match uu____10614 with
+              match uu____10662 with
               | FStar_Pervasives_Native.None  -> ()
               | FStar_Pervasives_Native.Some old_doc ->
-                  let uu____10618 = FStar_Ident.range_of_lid l  in
-                  let uu____10619 =
-                    let uu____10625 =
-                      let uu____10627 = FStar_Ident.string_of_lid l  in
-                      let uu____10629 =
+                  let uu____10666 = FStar_Ident.range_of_lid l  in
+                  let uu____10667 =
+                    let uu____10673 =
+                      let uu____10675 = FStar_Ident.string_of_lid l  in
+                      let uu____10677 =
                         FStar_Parser_AST.string_of_fsdoc old_doc  in
-                      let uu____10631 = FStar_Parser_AST.string_of_fsdoc doc1
+                      let uu____10679 = FStar_Parser_AST.string_of_fsdoc doc1
                          in
                       FStar_Util.format3
                         "Overwriting doc of %s; old doc was [%s]; new doc are [%s]"
-                        uu____10627 uu____10629 uu____10631
+                        uu____10675 uu____10677 uu____10679
                        in
-                    (FStar_Errors.Warning_DocOverwrite, uu____10625)  in
-                  FStar_Errors.log_issue uu____10618 uu____10619);
+                    (FStar_Errors.Warning_DocOverwrite, uu____10673)  in
+                  FStar_Errors.log_issue uu____10666 uu____10667);
              FStar_Util.smap_add env.docs l.FStar_Ident.str doc1;
              env)
   
@@ -2855,113 +2870,119 @@ let (check_admits :
                 fun se  ->
                   match se.FStar_Syntax_Syntax.sigel with
                   | FStar_Syntax_Syntax.Sig_declare_typ (l,u,t) when
-                      let uu____10677 =
+                      let uu____10726 =
                         FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                           (FStar_List.contains FStar_Syntax_Syntax.Assumption)
                          in
-                      Prims.op_Negation uu____10677 ->
-                      let uu____10682 =
+                      Prims.op_Negation uu____10726 ->
+                      let uu____10731 =
                         FStar_Util.smap_try_find (sigmap env)
                           l.FStar_Ident.str
                          in
-                      (match uu____10682 with
+                      (match uu____10731 with
                        | FStar_Pervasives_Native.Some
                            ({
                               FStar_Syntax_Syntax.sigel =
-                                FStar_Syntax_Syntax.Sig_let uu____10697;
-                              FStar_Syntax_Syntax.sigrng = uu____10698;
-                              FStar_Syntax_Syntax.sigquals = uu____10699;
-                              FStar_Syntax_Syntax.sigmeta = uu____10700;
-                              FStar_Syntax_Syntax.sigattrs = uu____10701;_},uu____10702)
+                                FStar_Syntax_Syntax.Sig_let uu____10746;
+                              FStar_Syntax_Syntax.sigrng = uu____10747;
+                              FStar_Syntax_Syntax.sigquals = uu____10748;
+                              FStar_Syntax_Syntax.sigmeta = uu____10749;
+                              FStar_Syntax_Syntax.sigattrs = uu____10750;
+                              FStar_Syntax_Syntax.sigopts = uu____10751;_},uu____10752)
                            -> lids
                        | FStar_Pervasives_Native.Some
                            ({
                               FStar_Syntax_Syntax.sigel =
                                 FStar_Syntax_Syntax.Sig_inductive_typ
-                                uu____10720;
-                              FStar_Syntax_Syntax.sigrng = uu____10721;
-                              FStar_Syntax_Syntax.sigquals = uu____10722;
-                              FStar_Syntax_Syntax.sigmeta = uu____10723;
-                              FStar_Syntax_Syntax.sigattrs = uu____10724;_},uu____10725)
+                                uu____10772;
+                              FStar_Syntax_Syntax.sigrng = uu____10773;
+                              FStar_Syntax_Syntax.sigquals = uu____10774;
+                              FStar_Syntax_Syntax.sigmeta = uu____10775;
+                              FStar_Syntax_Syntax.sigattrs = uu____10776;
+                              FStar_Syntax_Syntax.sigopts = uu____10777;_},uu____10778)
                            -> lids
-                       | uu____10753 ->
-                           ((let uu____10762 =
-                               let uu____10764 = FStar_Options.interactive ()
+                       | uu____10808 ->
+                           ((let uu____10817 =
+                               let uu____10819 = FStar_Options.interactive ()
                                   in
-                               Prims.op_Negation uu____10764  in
-                             if uu____10762
+                               Prims.op_Negation uu____10819  in
+                             if uu____10817
                              then
-                               let uu____10767 = FStar_Ident.range_of_lid l
+                               let uu____10822 = FStar_Ident.range_of_lid l
                                   in
-                               let uu____10768 =
-                                 let uu____10774 =
-                                   let uu____10776 =
+                               let uu____10823 =
+                                 let uu____10829 =
+                                   let uu____10831 =
                                      FStar_Ident.string_of_lid l  in
                                    FStar_Util.format1
                                      "Admitting %s without a definition"
-                                     uu____10776
+                                     uu____10831
                                     in
                                  (FStar_Errors.Warning_AdmitWithoutDefinition,
-                                   uu____10774)
+                                   uu____10829)
                                   in
-                               FStar_Errors.log_issue uu____10767 uu____10768
+                               FStar_Errors.log_issue uu____10822 uu____10823
                              else ());
                             (let quals = FStar_Syntax_Syntax.Assumption ::
                                (se.FStar_Syntax_Syntax.sigquals)  in
                              FStar_Util.smap_add (sigmap env)
                                l.FStar_Ident.str
-                               ((let uu___1290_10793 = se  in
+                               ((let uu___1307_10848 = se  in
                                  {
                                    FStar_Syntax_Syntax.sigel =
-                                     (uu___1290_10793.FStar_Syntax_Syntax.sigel);
+                                     (uu___1307_10848.FStar_Syntax_Syntax.sigel);
                                    FStar_Syntax_Syntax.sigrng =
-                                     (uu___1290_10793.FStar_Syntax_Syntax.sigrng);
+                                     (uu___1307_10848.FStar_Syntax_Syntax.sigrng);
                                    FStar_Syntax_Syntax.sigquals = quals;
                                    FStar_Syntax_Syntax.sigmeta =
-                                     (uu___1290_10793.FStar_Syntax_Syntax.sigmeta);
+                                     (uu___1307_10848.FStar_Syntax_Syntax.sigmeta);
                                    FStar_Syntax_Syntax.sigattrs =
-                                     (uu___1290_10793.FStar_Syntax_Syntax.sigattrs)
+                                     (uu___1307_10848.FStar_Syntax_Syntax.sigattrs);
+                                   FStar_Syntax_Syntax.sigopts =
+                                     (uu___1307_10848.FStar_Syntax_Syntax.sigopts)
                                  }), false);
                              l
                              ::
                              lids)))
-                  | uu____10795 -> lids) [])
+                  | uu____10850 -> lids) [])
          in
-      let uu___1295_10796 = m  in
-      let uu____10797 =
+      let uu___1312_10851 = m  in
+      let uu____10852 =
         FStar_All.pipe_right m.FStar_Syntax_Syntax.declarations
           (FStar_List.map
              (fun s  ->
                 match s.FStar_Syntax_Syntax.sigel with
                 | FStar_Syntax_Syntax.Sig_declare_typ
-                    (lid,uu____10807,uu____10808) when
+                    (lid,uu____10862,uu____10863) when
                     FStar_List.existsb
                       (fun l  -> FStar_Ident.lid_equals l lid)
                       admitted_sig_lids
                     ->
-                    let uu___1304_10811 = s  in
+                    let uu___1321_10866 = s  in
                     {
                       FStar_Syntax_Syntax.sigel =
-                        (uu___1304_10811.FStar_Syntax_Syntax.sigel);
+                        (uu___1321_10866.FStar_Syntax_Syntax.sigel);
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___1304_10811.FStar_Syntax_Syntax.sigrng);
+                        (uu___1321_10866.FStar_Syntax_Syntax.sigrng);
                       FStar_Syntax_Syntax.sigquals =
                         (FStar_Syntax_Syntax.Assumption ::
                         (s.FStar_Syntax_Syntax.sigquals));
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___1304_10811.FStar_Syntax_Syntax.sigmeta);
+                        (uu___1321_10866.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___1304_10811.FStar_Syntax_Syntax.sigattrs)
+                        (uu___1321_10866.FStar_Syntax_Syntax.sigattrs);
+                      FStar_Syntax_Syntax.sigopts =
+                        (uu___1321_10866.FStar_Syntax_Syntax.sigopts)
                     }
-                | uu____10812 -> s))
+                | uu____10867 -> s))
          in
       {
-        FStar_Syntax_Syntax.name = (uu___1295_10796.FStar_Syntax_Syntax.name);
-        FStar_Syntax_Syntax.declarations = uu____10797;
+        FStar_Syntax_Syntax.name = (uu___1312_10851.FStar_Syntax_Syntax.name);
+        FStar_Syntax_Syntax.declarations = uu____10852;
         FStar_Syntax_Syntax.exports =
-          (uu___1295_10796.FStar_Syntax_Syntax.exports);
+          (uu___1312_10851.FStar_Syntax_Syntax.exports);
         FStar_Syntax_Syntax.is_interface =
-          (uu___1295_10796.FStar_Syntax_Syntax.is_interface)
+          (uu___1312_10851.FStar_Syntax_Syntax.is_interface)
       }
   
 let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
@@ -2972,7 +2993,7 @@ let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
            (fun se  ->
               let quals = se.FStar_Syntax_Syntax.sigquals  in
               match se.FStar_Syntax_Syntax.sigel with
-              | FStar_Syntax_Syntax.Sig_bundle (ses,uu____10836) ->
+              | FStar_Syntax_Syntax.Sig_bundle (ses,uu____10891) ->
                   if
                     (FStar_List.contains FStar_Syntax_Syntax.Private quals)
                       ||
@@ -2983,12 +3004,12 @@ let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
                          (fun se1  ->
                             match se1.FStar_Syntax_Syntax.sigel with
                             | FStar_Syntax_Syntax.Sig_datacon
-                                (lid,uu____10857,uu____10858,uu____10859,uu____10860,uu____10861)
+                                (lid,uu____10912,uu____10913,uu____10914,uu____10915,uu____10916)
                                 ->
                                 FStar_Util.smap_remove (sigmap env)
                                   lid.FStar_Ident.str
                             | FStar_Syntax_Syntax.Sig_inductive_typ
-                                (lid,univ_names,binders,typ,uu____10877,uu____10878)
+                                (lid,univ_names,binders,typ,uu____10932,uu____10933)
                                 ->
                                 (FStar_Util.smap_remove (sigmap env)
                                    lid.FStar_Ident.str;
@@ -2998,58 +3019,60 @@ let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
                                         FStar_Syntax_Syntax.Private quals)
                                  then
                                    (let sigel =
-                                      let uu____10895 =
-                                        let uu____10902 =
-                                          let uu____10903 =
+                                      let uu____10950 =
+                                        let uu____10957 =
+                                          let uu____10958 =
                                             FStar_Ident.range_of_lid lid  in
-                                          let uu____10904 =
-                                            let uu____10911 =
-                                              let uu____10912 =
-                                                let uu____10927 =
+                                          let uu____10959 =
+                                            let uu____10966 =
+                                              let uu____10967 =
+                                                let uu____10982 =
                                                   FStar_Syntax_Syntax.mk_Total
                                                     typ
                                                    in
-                                                (binders, uu____10927)  in
+                                                (binders, uu____10982)  in
                                               FStar_Syntax_Syntax.Tm_arrow
-                                                uu____10912
+                                                uu____10967
                                                in
                                             FStar_Syntax_Syntax.mk
-                                              uu____10911
+                                              uu____10966
                                              in
-                                          uu____10904
+                                          uu____10959
                                             FStar_Pervasives_Native.None
-                                            uu____10903
+                                            uu____10958
                                            in
-                                        (lid, univ_names, uu____10902)  in
+                                        (lid, univ_names, uu____10957)  in
                                       FStar_Syntax_Syntax.Sig_declare_typ
-                                        uu____10895
+                                        uu____10950
                                        in
                                     let se2 =
-                                      let uu___1336_10941 = se1  in
+                                      let uu___1353_10996 = se1  in
                                       {
                                         FStar_Syntax_Syntax.sigel = sigel;
                                         FStar_Syntax_Syntax.sigrng =
-                                          (uu___1336_10941.FStar_Syntax_Syntax.sigrng);
+                                          (uu___1353_10996.FStar_Syntax_Syntax.sigrng);
                                         FStar_Syntax_Syntax.sigquals =
                                           (FStar_Syntax_Syntax.Assumption ::
                                           quals);
                                         FStar_Syntax_Syntax.sigmeta =
-                                          (uu___1336_10941.FStar_Syntax_Syntax.sigmeta);
+                                          (uu___1353_10996.FStar_Syntax_Syntax.sigmeta);
                                         FStar_Syntax_Syntax.sigattrs =
-                                          (uu___1336_10941.FStar_Syntax_Syntax.sigattrs)
+                                          (uu___1353_10996.FStar_Syntax_Syntax.sigattrs);
+                                        FStar_Syntax_Syntax.sigopts =
+                                          (uu___1353_10996.FStar_Syntax_Syntax.sigopts)
                                       }  in
                                     FStar_Util.smap_add (sigmap env)
                                       lid.FStar_Ident.str (se2, false))
                                  else ())
-                            | uu____10951 -> ()))
+                            | uu____11006 -> ()))
                   else ()
               | FStar_Syntax_Syntax.Sig_declare_typ
-                  (lid,uu____10955,uu____10956) ->
+                  (lid,uu____11010,uu____11011) ->
                   if FStar_List.contains FStar_Syntax_Syntax.Private quals
                   then
                     FStar_Util.smap_remove (sigmap env) lid.FStar_Ident.str
                   else ()
-              | FStar_Syntax_Syntax.Sig_let ((uu____10965,lbs),uu____10967)
+              | FStar_Syntax_Syntax.Sig_let ((uu____11020,lbs),uu____11022)
                   ->
                   (if
                      (FStar_List.contains FStar_Syntax_Syntax.Private quals)
@@ -3060,18 +3083,18 @@ let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
                      FStar_All.pipe_right lbs
                        (FStar_List.iter
                           (fun lb  ->
-                             let uu____10985 =
-                               let uu____10987 =
-                                 let uu____10988 =
-                                   let uu____10991 =
+                             let uu____11040 =
+                               let uu____11042 =
+                                 let uu____11043 =
+                                   let uu____11046 =
                                      FStar_Util.right
                                        lb.FStar_Syntax_Syntax.lbname
                                       in
-                                   uu____10991.FStar_Syntax_Syntax.fv_name
+                                   uu____11046.FStar_Syntax_Syntax.fv_name
                                     in
-                                 uu____10988.FStar_Syntax_Syntax.v  in
-                               uu____10987.FStar_Ident.str  in
-                             FStar_Util.smap_remove (sigmap env) uu____10985))
+                                 uu____11043.FStar_Syntax_Syntax.v  in
+                               uu____11042.FStar_Ident.str  in
+                             FStar_Util.smap_remove (sigmap env) uu____11040))
                    else ();
                    if
                      (FStar_List.contains FStar_Syntax_Syntax.Abstract quals)
@@ -3084,128 +3107,130 @@ let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
                        (FStar_List.iter
                           (fun lb  ->
                              let lid =
-                               let uu____11008 =
-                                 let uu____11011 =
+                               let uu____11063 =
+                                 let uu____11066 =
                                    FStar_Util.right
                                      lb.FStar_Syntax_Syntax.lbname
                                     in
-                                 uu____11011.FStar_Syntax_Syntax.fv_name  in
-                               uu____11008.FStar_Syntax_Syntax.v  in
+                                 uu____11066.FStar_Syntax_Syntax.fv_name  in
+                               uu____11063.FStar_Syntax_Syntax.v  in
                              let quals1 = FStar_Syntax_Syntax.Assumption ::
                                quals  in
                              let decl =
-                               let uu___1359_11016 = se  in
+                               let uu___1376_11071 = se  in
                                {
                                  FStar_Syntax_Syntax.sigel =
                                    (FStar_Syntax_Syntax.Sig_declare_typ
                                       (lid, (lb.FStar_Syntax_Syntax.lbunivs),
                                         (lb.FStar_Syntax_Syntax.lbtyp)));
                                  FStar_Syntax_Syntax.sigrng =
-                                   (uu___1359_11016.FStar_Syntax_Syntax.sigrng);
+                                   (uu___1376_11071.FStar_Syntax_Syntax.sigrng);
                                  FStar_Syntax_Syntax.sigquals = quals1;
                                  FStar_Syntax_Syntax.sigmeta =
-                                   (uu___1359_11016.FStar_Syntax_Syntax.sigmeta);
+                                   (uu___1376_11071.FStar_Syntax_Syntax.sigmeta);
                                  FStar_Syntax_Syntax.sigattrs =
-                                   (uu___1359_11016.FStar_Syntax_Syntax.sigattrs)
+                                   (uu___1376_11071.FStar_Syntax_Syntax.sigattrs);
+                                 FStar_Syntax_Syntax.sigopts =
+                                   (uu___1376_11071.FStar_Syntax_Syntax.sigopts)
                                }  in
                              FStar_Util.smap_add (sigmap env)
                                lid.FStar_Ident.str (decl, false)))
                    else ())
-              | uu____11026 -> ()));
+              | uu____11081 -> ()));
       (let curmod =
-         let uu____11029 = current_module env  in uu____11029.FStar_Ident.str
+         let uu____11084 = current_module env  in uu____11084.FStar_Ident.str
           in
-       (let uu____11031 =
-          let uu____11128 = get_exported_id_set env curmod  in
-          let uu____11175 = get_trans_exported_id_set env curmod  in
-          (uu____11128, uu____11175)  in
-        match uu____11031 with
+       (let uu____11086 =
+          let uu____11183 = get_exported_id_set env curmod  in
+          let uu____11230 = get_trans_exported_id_set env curmod  in
+          (uu____11183, uu____11230)  in
+        match uu____11086 with
         | (FStar_Pervasives_Native.Some cur_ex,FStar_Pervasives_Native.Some
            cur_trans_ex) ->
             let update_exports eikind =
               let cur_ex_set =
-                let uu____11594 = cur_ex eikind  in
-                FStar_ST.op_Bang uu____11594  in
+                let uu____11649 = cur_ex eikind  in
+                FStar_ST.op_Bang uu____11649  in
               let cur_trans_ex_set_ref = cur_trans_ex eikind  in
-              let uu____11700 =
-                let uu____11704 = FStar_ST.op_Bang cur_trans_ex_set_ref  in
-                FStar_Util.set_union cur_ex_set uu____11704  in
-              FStar_ST.op_Colon_Equals cur_trans_ex_set_ref uu____11700  in
+              let uu____11755 =
+                let uu____11759 = FStar_ST.op_Bang cur_trans_ex_set_ref  in
+                FStar_Util.set_union cur_ex_set uu____11759  in
+              FStar_ST.op_Colon_Equals cur_trans_ex_set_ref uu____11755  in
             FStar_List.iter update_exports all_exported_id_kinds
-        | uu____11753 -> ());
+        | uu____11808 -> ());
        (match () with
         | () ->
             (filter_record_cache ();
              (match () with
               | () ->
-                  let uu___1377_11851 = env  in
+                  let uu___1394_11906 = env  in
                   {
                     curmodule = FStar_Pervasives_Native.None;
-                    curmonad = (uu___1377_11851.curmonad);
+                    curmonad = (uu___1394_11906.curmonad);
                     modules = (((modul.FStar_Syntax_Syntax.name), modul) ::
                       (env.modules));
                     scope_mods = [];
-                    exported_ids = (uu___1377_11851.exported_ids);
-                    trans_exported_ids = (uu___1377_11851.trans_exported_ids);
-                    includes = (uu___1377_11851.includes);
+                    exported_ids = (uu___1394_11906.exported_ids);
+                    trans_exported_ids = (uu___1394_11906.trans_exported_ids);
+                    includes = (uu___1394_11906.includes);
                     sigaccum = [];
-                    sigmap = (uu___1377_11851.sigmap);
-                    iface = (uu___1377_11851.iface);
-                    admitted_iface = (uu___1377_11851.admitted_iface);
-                    expect_typ = (uu___1377_11851.expect_typ);
-                    docs = (uu___1377_11851.docs);
+                    sigmap = (uu___1394_11906.sigmap);
+                    iface = (uu___1394_11906.iface);
+                    admitted_iface = (uu___1394_11906.admitted_iface);
+                    expect_typ = (uu___1394_11906.expect_typ);
+                    docs = (uu___1394_11906.docs);
                     remaining_iface_decls =
-                      (uu___1377_11851.remaining_iface_decls);
-                    syntax_only = (uu___1377_11851.syntax_only);
-                    ds_hooks = (uu___1377_11851.ds_hooks);
-                    dep_graph = (uu___1377_11851.dep_graph)
+                      (uu___1394_11906.remaining_iface_decls);
+                    syntax_only = (uu___1394_11906.syntax_only);
+                    ds_hooks = (uu___1394_11906.ds_hooks);
+                    dep_graph = (uu___1394_11906.dep_graph)
                   }))))
   
 let (stack : env Prims.list FStar_ST.ref) = FStar_Util.mk_ref [] 
 let (push : env -> env) =
   fun env  ->
     FStar_Util.atomically
-      (fun uu____11878  ->
+      (fun uu____11933  ->
          push_record_cache ();
-         (let uu____11881 =
-            let uu____11884 = FStar_ST.op_Bang stack  in env :: uu____11884
+         (let uu____11936 =
+            let uu____11939 = FStar_ST.op_Bang stack  in env :: uu____11939
              in
-          FStar_ST.op_Colon_Equals stack uu____11881);
-         (let uu___1383_11933 = env  in
-          let uu____11934 = FStar_Util.smap_copy env.exported_ids  in
-          let uu____11939 = FStar_Util.smap_copy env.trans_exported_ids  in
-          let uu____11944 = FStar_Util.smap_copy env.includes  in
-          let uu____11955 = FStar_Util.smap_copy env.sigmap  in
-          let uu____11968 = FStar_Util.smap_copy env.docs  in
+          FStar_ST.op_Colon_Equals stack uu____11936);
+         (let uu___1400_11988 = env  in
+          let uu____11989 = FStar_Util.smap_copy env.exported_ids  in
+          let uu____11994 = FStar_Util.smap_copy env.trans_exported_ids  in
+          let uu____11999 = FStar_Util.smap_copy env.includes  in
+          let uu____12010 = FStar_Util.smap_copy env.sigmap  in
+          let uu____12023 = FStar_Util.smap_copy env.docs  in
           {
-            curmodule = (uu___1383_11933.curmodule);
-            curmonad = (uu___1383_11933.curmonad);
-            modules = (uu___1383_11933.modules);
-            scope_mods = (uu___1383_11933.scope_mods);
-            exported_ids = uu____11934;
-            trans_exported_ids = uu____11939;
-            includes = uu____11944;
-            sigaccum = (uu___1383_11933.sigaccum);
-            sigmap = uu____11955;
-            iface = (uu___1383_11933.iface);
-            admitted_iface = (uu___1383_11933.admitted_iface);
-            expect_typ = (uu___1383_11933.expect_typ);
-            docs = uu____11968;
-            remaining_iface_decls = (uu___1383_11933.remaining_iface_decls);
-            syntax_only = (uu___1383_11933.syntax_only);
-            ds_hooks = (uu___1383_11933.ds_hooks);
-            dep_graph = (uu___1383_11933.dep_graph)
+            curmodule = (uu___1400_11988.curmodule);
+            curmonad = (uu___1400_11988.curmonad);
+            modules = (uu___1400_11988.modules);
+            scope_mods = (uu___1400_11988.scope_mods);
+            exported_ids = uu____11989;
+            trans_exported_ids = uu____11994;
+            includes = uu____11999;
+            sigaccum = (uu___1400_11988.sigaccum);
+            sigmap = uu____12010;
+            iface = (uu___1400_11988.iface);
+            admitted_iface = (uu___1400_11988.admitted_iface);
+            expect_typ = (uu___1400_11988.expect_typ);
+            docs = uu____12023;
+            remaining_iface_decls = (uu___1400_11988.remaining_iface_decls);
+            syntax_only = (uu___1400_11988.syntax_only);
+            ds_hooks = (uu___1400_11988.ds_hooks);
+            dep_graph = (uu___1400_11988.dep_graph)
           }))
   
 let (pop : unit -> env) =
-  fun uu____11976  ->
+  fun uu____12031  ->
     FStar_Util.atomically
-      (fun uu____11983  ->
-         let uu____11984 = FStar_ST.op_Bang stack  in
-         match uu____11984 with
+      (fun uu____12038  ->
+         let uu____12039 = FStar_ST.op_Bang stack  in
+         match uu____12039 with
          | env::tl1 ->
              (pop_record_cache (); FStar_ST.op_Colon_Equals stack tl1; env)
-         | uu____12039 -> failwith "Impossible: Too many pops")
+         | uu____12094 -> failwith "Impossible: Too many pops")
   
 let (snapshot : env -> (Prims.int * env)) =
   fun env  -> FStar_Common.snapshot push stack env 
@@ -3216,8 +3241,8 @@ let (export_interface : FStar_Ident.lident -> env -> env) =
     fun env  ->
       let sigelt_in_m se =
         match FStar_Syntax_Util.lids_of_sigelt se with
-        | l::uu____12086 -> l.FStar_Ident.nsstr = m.FStar_Ident.str
-        | uu____12090 -> false  in
+        | l::uu____12141 -> l.FStar_Ident.nsstr = m.FStar_Ident.str
+        | uu____12145 -> false  in
       let sm = sigmap env  in
       let env1 = pop ()  in
       let keys = FStar_Util.smap_keys sm  in
@@ -3225,31 +3250,33 @@ let (export_interface : FStar_Ident.lident -> env -> env) =
       FStar_All.pipe_right keys
         (FStar_List.iter
            (fun k  ->
-              let uu____12132 = FStar_Util.smap_try_find sm' k  in
-              match uu____12132 with
+              let uu____12187 = FStar_Util.smap_try_find sm' k  in
+              match uu____12187 with
               | FStar_Pervasives_Native.Some (se,true ) when sigelt_in_m se
                   ->
                   (FStar_Util.smap_remove sm' k;
                    (let se1 =
                       match se.FStar_Syntax_Syntax.sigel with
                       | FStar_Syntax_Syntax.Sig_declare_typ (l,u,t) ->
-                          let uu___1418_12163 = se  in
+                          let uu___1435_12218 = se  in
                           {
                             FStar_Syntax_Syntax.sigel =
-                              (uu___1418_12163.FStar_Syntax_Syntax.sigel);
+                              (uu___1435_12218.FStar_Syntax_Syntax.sigel);
                             FStar_Syntax_Syntax.sigrng =
-                              (uu___1418_12163.FStar_Syntax_Syntax.sigrng);
+                              (uu___1435_12218.FStar_Syntax_Syntax.sigrng);
                             FStar_Syntax_Syntax.sigquals =
                               (FStar_Syntax_Syntax.Assumption ::
                               (se.FStar_Syntax_Syntax.sigquals));
                             FStar_Syntax_Syntax.sigmeta =
-                              (uu___1418_12163.FStar_Syntax_Syntax.sigmeta);
+                              (uu___1435_12218.FStar_Syntax_Syntax.sigmeta);
                             FStar_Syntax_Syntax.sigattrs =
-                              (uu___1418_12163.FStar_Syntax_Syntax.sigattrs)
+                              (uu___1435_12218.FStar_Syntax_Syntax.sigattrs);
+                            FStar_Syntax_Syntax.sigopts =
+                              (uu___1435_12218.FStar_Syntax_Syntax.sigopts)
                           }
-                      | uu____12164 -> se  in
+                      | uu____12219 -> se  in
                     FStar_Util.smap_add sm' k (se1, false)))
-              | uu____12172 -> ()));
+              | uu____12227 -> ()));
       env1
   
 let (finish_module_or_interface :
@@ -3260,7 +3287,7 @@ let (finish_module_or_interface :
         if Prims.op_Negation modul.FStar_Syntax_Syntax.is_interface
         then check_admits env modul
         else modul  in
-      let uu____12199 = finish env modul1  in (uu____12199, modul1)
+      let uu____12254 = finish env modul1  in (uu____12254, modul1)
   
 type exported_ids =
   {
@@ -3281,15 +3308,15 @@ let (__proj__Mkexported_ids__item__exported_id_fields :
 let (as_exported_ids : exported_id_set -> exported_ids) =
   fun e  ->
     let terms =
-      let uu____12268 =
-        let uu____12272 = e Exported_id_term_type  in
-        FStar_ST.op_Bang uu____12272  in
-      FStar_Util.set_elements uu____12268  in
+      let uu____12323 =
+        let uu____12327 = e Exported_id_term_type  in
+        FStar_ST.op_Bang uu____12327  in
+      FStar_Util.set_elements uu____12323  in
     let fields =
-      let uu____12335 =
-        let uu____12339 = e Exported_id_field  in
-        FStar_ST.op_Bang uu____12339  in
-      FStar_Util.set_elements uu____12335  in
+      let uu____12390 =
+        let uu____12394 = e Exported_id_field  in
+        FStar_ST.op_Bang uu____12394  in
+      FStar_Util.set_elements uu____12390  in
     { exported_id_terms = terms; exported_id_fields = fields }
   
 let (as_exported_id_set :
@@ -3301,15 +3328,15 @@ let (as_exported_id_set :
     | FStar_Pervasives_Native.None  -> exported_id_set_new ()
     | FStar_Pervasives_Native.Some e1 ->
         let terms =
-          let uu____12431 =
+          let uu____12486 =
             FStar_Util.as_set e1.exported_id_terms FStar_Util.compare  in
-          FStar_Util.mk_ref uu____12431  in
+          FStar_Util.mk_ref uu____12486  in
         let fields =
-          let uu____12445 =
+          let uu____12500 =
             FStar_Util.as_set e1.exported_id_fields FStar_Util.compare  in
-          FStar_Util.mk_ref uu____12445  in
-        (fun uu___30_12453  ->
-           match uu___30_12453 with
+          FStar_Util.mk_ref uu____12500  in
+        (fun uu___30_12508  ->
+           match uu___30_12508 with
            | Exported_id_term_type  -> terms
            | Exported_id_field  -> fields)
   
@@ -3348,12 +3375,12 @@ let (default_mii : module_inclusion_info) =
     mii_includes = FStar_Pervasives_Native.None
   } 
 let as_includes :
-  'Auu____12557 .
-    'Auu____12557 Prims.list FStar_Pervasives_Native.option ->
-      'Auu____12557 Prims.list FStar_ST.ref
+  'Auu____12612 .
+    'Auu____12612 Prims.list FStar_Pervasives_Native.option ->
+      'Auu____12612 Prims.list FStar_ST.ref
   =
-  fun uu___31_12570  ->
-    match uu___31_12570 with
+  fun uu___31_12625  ->
+    match uu___31_12625 with
     | FStar_Pervasives_Native.None  -> FStar_Util.mk_ref []
     | FStar_Pervasives_Native.Some l -> FStar_Util.mk_ref l
   
@@ -3362,17 +3389,17 @@ let (inclusion_info : env -> FStar_Ident.lident -> module_inclusion_info) =
     fun l  ->
       let mname = FStar_Ident.string_of_lid l  in
       let as_ids_opt m =
-        let uu____12613 = FStar_Util.smap_try_find m mname  in
-        FStar_Util.map_opt uu____12613 as_exported_ids  in
-      let uu____12619 = as_ids_opt env.exported_ids  in
-      let uu____12622 = as_ids_opt env.trans_exported_ids  in
-      let uu____12625 =
-        let uu____12630 = FStar_Util.smap_try_find env.includes mname  in
-        FStar_Util.map_opt uu____12630 (fun r  -> FStar_ST.op_Bang r)  in
+        let uu____12668 = FStar_Util.smap_try_find m mname  in
+        FStar_Util.map_opt uu____12668 as_exported_ids  in
+      let uu____12674 = as_ids_opt env.exported_ids  in
+      let uu____12677 = as_ids_opt env.trans_exported_ids  in
+      let uu____12680 =
+        let uu____12685 = FStar_Util.smap_try_find env.includes mname  in
+        FStar_Util.map_opt uu____12685 (fun r  -> FStar_ST.op_Bang r)  in
       {
-        mii_exported_ids = uu____12619;
-        mii_trans_exported_ids = uu____12622;
-        mii_includes = uu____12625
+        mii_exported_ids = uu____12674;
+        mii_trans_exported_ids = uu____12677;
+        mii_includes = uu____12680
       }
   
 let (prepare_module_or_interface :
@@ -3388,52 +3415,52 @@ let (prepare_module_or_interface :
           fun mii  ->
             let prep env1 =
               let filename =
-                let uu____12719 = FStar_Ident.text_of_lid mname  in
-                FStar_Util.strcat uu____12719 ".fst"  in
+                let uu____12774 = FStar_Ident.text_of_lid mname  in
+                FStar_Util.strcat uu____12774 ".fst"  in
               let auto_open =
                 FStar_Parser_Dep.hard_coded_dependencies filename  in
               let auto_open1 =
-                let convert_kind uu___32_12741 =
-                  match uu___32_12741 with
+                let convert_kind uu___32_12796 =
+                  match uu___32_12796 with
                   | FStar_Parser_Dep.Open_namespace  -> Open_namespace
                   | FStar_Parser_Dep.Open_module  -> Open_module  in
                 FStar_List.map
-                  (fun uu____12753  ->
-                     match uu____12753 with
+                  (fun uu____12808  ->
+                     match uu____12808 with
                      | (lid,kind) -> (lid, (convert_kind kind))) auto_open
                  in
               let namespace_of_module =
                 if (FStar_List.length mname.FStar_Ident.ns) > Prims.int_zero
                 then
-                  let uu____12779 =
-                    let uu____12784 =
+                  let uu____12834 =
+                    let uu____12839 =
                       FStar_Ident.lid_of_ids mname.FStar_Ident.ns  in
-                    (uu____12784, Open_namespace)  in
-                  [uu____12779]
+                    (uu____12839, Open_namespace)  in
+                  [uu____12834]
                 else []  in
               let auto_open2 =
                 FStar_List.append namespace_of_module
                   (FStar_List.rev auto_open1)
                  in
-              (let uu____12815 = as_exported_id_set mii.mii_exported_ids  in
+              (let uu____12870 = as_exported_id_set mii.mii_exported_ids  in
                FStar_Util.smap_add env1.exported_ids mname.FStar_Ident.str
-                 uu____12815);
+                 uu____12870);
               (match () with
                | () ->
-                   ((let uu____12820 =
+                   ((let uu____12875 =
                        as_exported_id_set mii.mii_trans_exported_ids  in
                      FStar_Util.smap_add env1.trans_exported_ids
-                       mname.FStar_Ident.str uu____12820);
+                       mname.FStar_Ident.str uu____12875);
                     (match () with
                      | () ->
-                         ((let uu____12825 = as_includes mii.mii_includes  in
+                         ((let uu____12880 = as_includes mii.mii_includes  in
                            FStar_Util.smap_add env1.includes
-                             mname.FStar_Ident.str uu____12825);
+                             mname.FStar_Ident.str uu____12880);
                           (match () with
                            | () ->
                                let env' =
-                                 let uu___1488_12835 = env1  in
-                                 let uu____12836 =
+                                 let uu___1505_12890 = env1  in
+                                 let uu____12891 =
                                    FStar_List.map
                                      (fun x  -> Open_module_or_namespace x)
                                      auto_open2
@@ -3441,26 +3468,26 @@ let (prepare_module_or_interface :
                                  {
                                    curmodule =
                                      (FStar_Pervasives_Native.Some mname);
-                                   curmonad = (uu___1488_12835.curmonad);
-                                   modules = (uu___1488_12835.modules);
-                                   scope_mods = uu____12836;
+                                   curmonad = (uu___1505_12890.curmonad);
+                                   modules = (uu___1505_12890.modules);
+                                   scope_mods = uu____12891;
                                    exported_ids =
-                                     (uu___1488_12835.exported_ids);
+                                     (uu___1505_12890.exported_ids);
                                    trans_exported_ids =
-                                     (uu___1488_12835.trans_exported_ids);
-                                   includes = (uu___1488_12835.includes);
-                                   sigaccum = (uu___1488_12835.sigaccum);
+                                     (uu___1505_12890.trans_exported_ids);
+                                   includes = (uu___1505_12890.includes);
+                                   sigaccum = (uu___1505_12890.sigaccum);
                                    sigmap = (env1.sigmap);
                                    iface = intf;
                                    admitted_iface = admitted;
-                                   expect_typ = (uu___1488_12835.expect_typ);
-                                   docs = (uu___1488_12835.docs);
+                                   expect_typ = (uu___1505_12890.expect_typ);
+                                   docs = (uu___1505_12890.docs);
                                    remaining_iface_decls =
-                                     (uu___1488_12835.remaining_iface_decls);
+                                     (uu___1505_12890.remaining_iface_decls);
                                    syntax_only =
-                                     (uu___1488_12835.syntax_only);
-                                   ds_hooks = (uu___1488_12835.ds_hooks);
-                                   dep_graph = (uu___1488_12835.dep_graph)
+                                     (uu___1505_12890.syntax_only);
+                                   ds_hooks = (uu___1505_12890.ds_hooks);
+                                   dep_graph = (uu___1505_12890.dep_graph)
                                  }  in
                                (FStar_List.iter
                                   (fun op  ->
@@ -3468,40 +3495,40 @@ let (prepare_module_or_interface :
                                        op) (FStar_List.rev auto_open2);
                                 env'))))))
                in
-            let uu____12848 =
+            let uu____12903 =
               FStar_All.pipe_right env.modules
                 (FStar_Util.find_opt
-                   (fun uu____12874  ->
-                      match uu____12874 with
-                      | (l,uu____12881) -> FStar_Ident.lid_equals l mname))
+                   (fun uu____12929  ->
+                      match uu____12929 with
+                      | (l,uu____12936) -> FStar_Ident.lid_equals l mname))
                in
-            match uu____12848 with
+            match uu____12903 with
             | FStar_Pervasives_Native.None  ->
-                let uu____12891 = prep env  in (uu____12891, false)
-            | FStar_Pervasives_Native.Some (uu____12894,m) ->
-                ((let uu____12901 =
-                    (let uu____12905 = FStar_Options.interactive ()  in
-                     Prims.op_Negation uu____12905) &&
+                let uu____12946 = prep env  in (uu____12946, false)
+            | FStar_Pervasives_Native.Some (uu____12949,m) ->
+                ((let uu____12956 =
+                    (let uu____12960 = FStar_Options.interactive ()  in
+                     Prims.op_Negation uu____12960) &&
                       ((Prims.op_Negation m.FStar_Syntax_Syntax.is_interface)
                          || intf)
                      in
-                  if uu____12901
+                  if uu____12956
                   then
-                    let uu____12908 =
-                      let uu____12914 =
+                    let uu____12963 =
+                      let uu____12969 =
                         FStar_Util.format1
                           "Duplicate module or interface name: %s"
                           mname.FStar_Ident.str
                          in
                       (FStar_Errors.Fatal_DuplicateModuleOrInterface,
-                        uu____12914)
+                        uu____12969)
                        in
-                    let uu____12918 = FStar_Ident.range_of_lid mname  in
-                    FStar_Errors.raise_error uu____12908 uu____12918
+                    let uu____12973 = FStar_Ident.range_of_lid mname  in
+                    FStar_Errors.raise_error uu____12963 uu____12973
                   else ());
-                 (let uu____12921 =
-                    let uu____12922 = push env  in prep uu____12922  in
-                  (uu____12921, true)))
+                 (let uu____12976 =
+                    let uu____12977 = push env  in prep uu____12977  in
+                  (uu____12976, true)))
   
 let (enter_monad_scope : env -> FStar_Ident.ident -> env) =
   fun env  ->
@@ -3516,25 +3543,25 @@ let (enter_monad_scope : env -> FStar_Ident.ident -> env) =
                        mname'.FStar_Ident.idText))))
             mname.FStar_Ident.idRange
       | FStar_Pervasives_Native.None  ->
-          let uu___1509_12940 = env  in
+          let uu___1526_12995 = env  in
           {
-            curmodule = (uu___1509_12940.curmodule);
+            curmodule = (uu___1526_12995.curmodule);
             curmonad = (FStar_Pervasives_Native.Some mname);
-            modules = (uu___1509_12940.modules);
-            scope_mods = (uu___1509_12940.scope_mods);
-            exported_ids = (uu___1509_12940.exported_ids);
-            trans_exported_ids = (uu___1509_12940.trans_exported_ids);
-            includes = (uu___1509_12940.includes);
-            sigaccum = (uu___1509_12940.sigaccum);
-            sigmap = (uu___1509_12940.sigmap);
-            iface = (uu___1509_12940.iface);
-            admitted_iface = (uu___1509_12940.admitted_iface);
-            expect_typ = (uu___1509_12940.expect_typ);
-            docs = (uu___1509_12940.docs);
-            remaining_iface_decls = (uu___1509_12940.remaining_iface_decls);
-            syntax_only = (uu___1509_12940.syntax_only);
-            ds_hooks = (uu___1509_12940.ds_hooks);
-            dep_graph = (uu___1509_12940.dep_graph)
+            modules = (uu___1526_12995.modules);
+            scope_mods = (uu___1526_12995.scope_mods);
+            exported_ids = (uu___1526_12995.exported_ids);
+            trans_exported_ids = (uu___1526_12995.trans_exported_ids);
+            includes = (uu___1526_12995.includes);
+            sigaccum = (uu___1526_12995.sigaccum);
+            sigmap = (uu___1526_12995.sigmap);
+            iface = (uu___1526_12995.iface);
+            admitted_iface = (uu___1526_12995.admitted_iface);
+            expect_typ = (uu___1526_12995.expect_typ);
+            docs = (uu___1526_12995.docs);
+            remaining_iface_decls = (uu___1526_12995.remaining_iface_decls);
+            syntax_only = (uu___1526_12995.syntax_only);
+            ds_hooks = (uu___1526_12995.ds_hooks);
+            dep_graph = (uu___1526_12995.dep_graph)
           }
   
 let fail_or :
@@ -3546,30 +3573,30 @@ let fail_or :
   fun env  ->
     fun lookup1  ->
       fun lid  ->
-        let uu____12975 = lookup1 lid  in
-        match uu____12975 with
+        let uu____13030 = lookup1 lid  in
+        match uu____13030 with
         | FStar_Pervasives_Native.None  ->
             let opened_modules =
               FStar_List.map
-                (fun uu____12990  ->
-                   match uu____12990 with
-                   | (lid1,uu____12997) -> FStar_Ident.text_of_lid lid1)
+                (fun uu____13045  ->
+                   match uu____13045 with
+                   | (lid1,uu____13052) -> FStar_Ident.text_of_lid lid1)
                 env.modules
                in
             let msg =
-              let uu____13000 = FStar_Ident.text_of_lid lid  in
-              FStar_Util.format1 "Identifier not found: [%s]" uu____13000  in
+              let uu____13055 = FStar_Ident.text_of_lid lid  in
+              FStar_Util.format1 "Identifier not found: [%s]" uu____13055  in
             let msg1 =
               if (FStar_List.length lid.FStar_Ident.ns) = Prims.int_zero
               then msg
               else
                 (let modul =
-                   let uu____13012 =
+                   let uu____13067 =
                      FStar_Ident.lid_of_ids lid.FStar_Ident.ns  in
-                   let uu____13013 = FStar_Ident.range_of_lid lid  in
-                   FStar_Ident.set_lid_range uu____13012 uu____13013  in
-                 let uu____13014 = resolve_module_name env modul true  in
-                 match uu____13014 with
+                   let uu____13068 = FStar_Ident.range_of_lid lid  in
+                   FStar_Ident.set_lid_range uu____13067 uu____13068  in
+                 let uu____13069 = resolve_module_name env modul true  in
+                 match uu____13069 with
                  | FStar_Pervasives_Native.None  ->
                      let opened_modules1 =
                        FStar_String.concat ", " opened_modules  in
@@ -3594,9 +3621,9 @@ let fail_or :
                        msg modul.FStar_Ident.str modul'.FStar_Ident.str
                        (lid.FStar_Ident.ident).FStar_Ident.idText)
                in
-            let uu____13035 = FStar_Ident.range_of_lid lid  in
+            let uu____13090 = FStar_Ident.range_of_lid lid  in
             FStar_Errors.raise_error
-              (FStar_Errors.Fatal_IdentifierNotFound, msg1) uu____13035
+              (FStar_Errors.Fatal_IdentifierNotFound, msg1) uu____13090
         | FStar_Pervasives_Native.Some r -> r
   
 let fail_or2 :
@@ -3606,8 +3633,8 @@ let fail_or2 :
   =
   fun lookup1  ->
     fun id1  ->
-      let uu____13065 = lookup1 id1  in
-      match uu____13065 with
+      let uu____13120 = lookup1 id1  in
+      match uu____13120 with
       | FStar_Pervasives_Native.None  ->
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_IdentifierNotFound,

--- a/src/ocaml-output/FStar_Syntax_MutRecTy.ml
+++ b/src/ocaml-output/FStar_Syntax_MutRecTy.ml
@@ -46,7 +46,8 @@ let (disentangle_abbrevs_from_bundle :
                  FStar_Syntax_Syntax.sigquals = quals;
                  FStar_Syntax_Syntax.sigmeta =
                    FStar_Syntax_Syntax.default_sigmeta;
-                 FStar_Syntax_Syntax.sigattrs = sigattrs
+                 FStar_Syntax_Syntax.sigattrs = sigattrs;
+                 FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                }, [])
           | uu____116 ->
               let type_abbrevs =
@@ -155,69 +156,70 @@ let (disentangle_abbrevs_from_bundle :
                           FStar_Syntax_Syntax.sigrng = uu____373;
                           FStar_Syntax_Syntax.sigquals = uu____374;
                           FStar_Syntax_Syntax.sigmeta = uu____375;
-                          FStar_Syntax_Syntax.sigattrs = uu____376;_}
+                          FStar_Syntax_Syntax.sigattrs = uu____376;
+                          FStar_Syntax_Syntax.sigopts = uu____377;_}
                         -> FStar_Pervasives_Native.Some tm
-                    | uu____405 -> FStar_Pervasives_Native.None  in
-                  let uu____410 =
-                    let uu____415 =
+                    | uu____408 -> FStar_Pervasives_Native.None  in
+                  let uu____413 =
+                    let uu____418 =
                       FStar_ST.op_Bang rev_unfolded_type_abbrevs  in
-                    FStar_Util.find_map uu____415 replacee_term  in
-                  match uu____410 with
+                    FStar_Util.find_map uu____418 replacee_term  in
+                  match uu____413 with
                   | FStar_Pervasives_Native.Some x -> x
                   | FStar_Pervasives_Native.None  ->
-                      let uu____450 =
+                      let uu____453 =
                         FStar_Util.find_map type_abbrev_sigelts replacee  in
-                      (match uu____450 with
+                      (match uu____453 with
                        | FStar_Pervasives_Native.Some se ->
-                           let uu____454 =
-                             let uu____456 = FStar_ST.op_Bang in_progress  in
+                           let uu____457 =
+                             let uu____459 = FStar_ST.op_Bang in_progress  in
                              FStar_List.existsb
                                (fun x  ->
                                   FStar_Ident.lid_equals x
                                     (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-                               uu____456
+                               uu____459
                               in
-                           if uu____454
+                           if uu____457
                            then
                              let msg =
                                FStar_Util.format1
                                  "Cycle on %s in mutually recursive type abbreviations"
                                  ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
                                 in
-                             let uu____488 =
+                             let uu____491 =
                                FStar_Ident.range_of_lid
                                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                 in
                              FStar_Errors.raise_error
                                (FStar_Errors.Fatal_CycleInRecTypeAbbreviation,
-                                 msg) uu____488
+                                 msg) uu____491
                            else unfold_abbrev se
-                       | uu____492 -> t)
+                       | uu____495 -> t)
                 
                 and unfold_abbrev x =
                   match x.FStar_Syntax_Syntax.sigel with
-                  | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____497)
+                  | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____500)
                       ->
                       let quals1 =
                         FStar_All.pipe_right x.FStar_Syntax_Syntax.sigquals
                           (FStar_List.filter
-                             (fun uu___0_514  ->
-                                match uu___0_514 with
+                             (fun uu___0_517  ->
+                                match uu___0_517 with
                                 | FStar_Syntax_Syntax.Noeq  -> false
-                                | uu____517 -> true))
+                                | uu____520 -> true))
                          in
                       let lid =
                         match lb.FStar_Syntax_Syntax.lbname with
                         | FStar_Util.Inr fv ->
                             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                        | uu____521 ->
+                        | uu____524 ->
                             failwith
                               "mutrecty: disentangle_abbrevs_from_bundle: rename_abbrev: lid: impossible"
                          in
-                      ((let uu____528 =
-                          let uu____531 = FStar_ST.op_Bang in_progress  in
-                          lid :: uu____531  in
-                        FStar_ST.op_Colon_Equals in_progress uu____528);
+                      ((let uu____531 =
+                          let uu____534 = FStar_ST.op_Bang in_progress  in
+                          lid :: uu____534  in
+                        FStar_ST.op_Colon_Equals in_progress uu____531);
                        (match () with
                         | () ->
                             (remove_not_unfolded lid;
@@ -232,67 +234,69 @@ let (disentangle_abbrevs_from_bundle :
                                       lb.FStar_Syntax_Syntax.lbdef
                                      in
                                   let lb' =
-                                    let uu___145_584 = lb  in
+                                    let uu___146_587 = lb  in
                                     {
                                       FStar_Syntax_Syntax.lbname =
-                                        (uu___145_584.FStar_Syntax_Syntax.lbname);
+                                        (uu___146_587.FStar_Syntax_Syntax.lbname);
                                       FStar_Syntax_Syntax.lbunivs =
-                                        (uu___145_584.FStar_Syntax_Syntax.lbunivs);
+                                        (uu___146_587.FStar_Syntax_Syntax.lbunivs);
                                       FStar_Syntax_Syntax.lbtyp = ty';
                                       FStar_Syntax_Syntax.lbeff =
-                                        (uu___145_584.FStar_Syntax_Syntax.lbeff);
+                                        (uu___146_587.FStar_Syntax_Syntax.lbeff);
                                       FStar_Syntax_Syntax.lbdef = tm';
                                       FStar_Syntax_Syntax.lbattrs =
-                                        (uu___145_584.FStar_Syntax_Syntax.lbattrs);
+                                        (uu___146_587.FStar_Syntax_Syntax.lbattrs);
                                       FStar_Syntax_Syntax.lbpos =
-                                        (uu___145_584.FStar_Syntax_Syntax.lbpos)
+                                        (uu___146_587.FStar_Syntax_Syntax.lbpos)
                                     }  in
                                   let sigelt' =
                                     FStar_Syntax_Syntax.Sig_let
                                       ((false, [lb']), [lid])
                                      in
-                                  ((let uu____593 =
-                                      let uu____596 =
+                                  ((let uu____596 =
+                                      let uu____599 =
                                         FStar_ST.op_Bang
                                           rev_unfolded_type_abbrevs
                                          in
-                                      (let uu___149_623 = x  in
+                                      (let uu___150_626 = x  in
                                        {
                                          FStar_Syntax_Syntax.sigel = sigelt';
                                          FStar_Syntax_Syntax.sigrng =
-                                           (uu___149_623.FStar_Syntax_Syntax.sigrng);
+                                           (uu___150_626.FStar_Syntax_Syntax.sigrng);
                                          FStar_Syntax_Syntax.sigquals =
                                            quals1;
                                          FStar_Syntax_Syntax.sigmeta =
-                                           (uu___149_623.FStar_Syntax_Syntax.sigmeta);
+                                           (uu___150_626.FStar_Syntax_Syntax.sigmeta);
                                          FStar_Syntax_Syntax.sigattrs =
-                                           (uu___149_623.FStar_Syntax_Syntax.sigattrs)
-                                       }) :: uu____596
+                                           (uu___150_626.FStar_Syntax_Syntax.sigattrs);
+                                         FStar_Syntax_Syntax.sigopts =
+                                           (uu___150_626.FStar_Syntax_Syntax.sigopts)
+                                       }) :: uu____599
                                        in
                                     FStar_ST.op_Colon_Equals
-                                      rev_unfolded_type_abbrevs uu____593);
+                                      rev_unfolded_type_abbrevs uu____596);
                                    (match () with
                                     | () ->
-                                        ((let uu____648 =
-                                            let uu____651 =
+                                        ((let uu____651 =
+                                            let uu____654 =
                                               FStar_ST.op_Bang in_progress
                                                in
-                                            FStar_List.tl uu____651  in
+                                            FStar_List.tl uu____654  in
                                           FStar_ST.op_Colon_Equals
-                                            in_progress uu____648);
+                                            in_progress uu____651);
                                          (match () with | () -> tm'))))))))
-                  | uu____700 ->
+                  | uu____703 ->
                       failwith
                         "mutrecty: disentangle_abbrevs_from_bundle: rename_abbrev: impossible"
                  in
-                let rec aux uu____709 =
-                  let uu____710 = FStar_ST.op_Bang not_unfolded_yet  in
-                  match uu____710 with
-                  | x::uu____739 -> let _unused = unfold_abbrev x  in aux ()
-                  | uu____743 ->
-                      let uu____746 =
+                let rec aux uu____712 =
+                  let uu____713 = FStar_ST.op_Bang not_unfolded_yet  in
+                  match uu____713 with
+                  | x::uu____742 -> let _unused = unfold_abbrev x  in aux ()
+                  | uu____746 ->
+                      let uu____749 =
                         FStar_ST.op_Bang rev_unfolded_type_abbrevs  in
-                      FStar_List.rev uu____746
+                      FStar_List.rev uu____749
                    in
                 aux ()  in
               let filter_out_type_abbrevs l =
@@ -300,8 +304,8 @@ let (disentangle_abbrevs_from_bundle :
                   (fun lid  ->
                      FStar_List.for_all
                        (fun lid'  ->
-                          let uu____789 = FStar_Ident.lid_equals lid lid'  in
-                          Prims.op_Negation uu____789) type_abbrevs) l
+                          let uu____792 = FStar_Ident.lid_equals lid lid'  in
+                          Prims.op_Negation uu____792) type_abbrevs) l
                  in
               let inductives_with_abbrevs_unfolded =
                 let find_in_unfolded fv =
@@ -309,32 +313,32 @@ let (disentangle_abbrevs_from_bundle :
                     (fun x  ->
                        match x.FStar_Syntax_Syntax.sigel with
                        | FStar_Syntax_Syntax.Sig_let
-                           ((uu____821,{
+                           ((uu____824,{
                                          FStar_Syntax_Syntax.lbname =
                                            FStar_Util.Inr fv';
                                          FStar_Syntax_Syntax.lbunivs =
-                                           uu____823;
+                                           uu____826;
                                          FStar_Syntax_Syntax.lbtyp =
-                                           uu____824;
+                                           uu____827;
                                          FStar_Syntax_Syntax.lbeff =
-                                           uu____825;
+                                           uu____828;
                                          FStar_Syntax_Syntax.lbdef = tm;
                                          FStar_Syntax_Syntax.lbattrs =
-                                           uu____827;
+                                           uu____830;
                                          FStar_Syntax_Syntax.lbpos =
-                                           uu____828;_}::[]),uu____829)
+                                           uu____831;_}::[]),uu____832)
                            when
                            FStar_Ident.lid_equals
                              (fv'.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                            -> FStar_Pervasives_Native.Some tm
-                       | uu____850 -> FStar_Pervasives_Native.None)
+                       | uu____853 -> FStar_Pervasives_Native.None)
                    in
                 let unfold_fv t fv =
-                  let uu____864 = find_in_unfolded fv  in
-                  match uu____864 with
+                  let uu____867 = find_in_unfolded fv  in
+                  match uu____867 with
                   | FStar_Pervasives_Native.Some t' -> t'
-                  | uu____874 -> t  in
+                  | uu____877 -> t  in
                 let unfold_in_sig x =
                   match x.FStar_Syntax_Syntax.sigel with
                   | FStar_Syntax_Syntax.Sig_inductive_typ
@@ -343,40 +347,44 @@ let (disentangle_abbrevs_from_bundle :
                         FStar_Syntax_InstFV.inst_binders unfold_fv bnd  in
                       let ty' = FStar_Syntax_InstFV.inst unfold_fv ty  in
                       let mut' = filter_out_type_abbrevs mut  in
-                      [(let uu___204_909 = x  in
+                      [(let uu___205_912 = x  in
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_inductive_typ
                                (lid, univs, bnd', ty', mut', dc));
                           FStar_Syntax_Syntax.sigrng =
-                            (uu___204_909.FStar_Syntax_Syntax.sigrng);
+                            (uu___205_912.FStar_Syntax_Syntax.sigrng);
                           FStar_Syntax_Syntax.sigquals =
-                            (uu___204_909.FStar_Syntax_Syntax.sigquals);
+                            (uu___205_912.FStar_Syntax_Syntax.sigquals);
                           FStar_Syntax_Syntax.sigmeta =
-                            (uu___204_909.FStar_Syntax_Syntax.sigmeta);
+                            (uu___205_912.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (uu___204_909.FStar_Syntax_Syntax.sigattrs)
+                            (uu___205_912.FStar_Syntax_Syntax.sigattrs);
+                          FStar_Syntax_Syntax.sigopts =
+                            (uu___205_912.FStar_Syntax_Syntax.sigopts)
                         })]
                   | FStar_Syntax_Syntax.Sig_datacon
                       (lid,univs,ty,res,npars,mut) ->
                       let ty' = FStar_Syntax_InstFV.inst unfold_fv ty  in
                       let mut' = filter_out_type_abbrevs mut  in
-                      [(let uu___216_931 = x  in
+                      [(let uu___217_934 = x  in
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_datacon
                                (lid, univs, ty', res, npars, mut'));
                           FStar_Syntax_Syntax.sigrng =
-                            (uu___216_931.FStar_Syntax_Syntax.sigrng);
+                            (uu___217_934.FStar_Syntax_Syntax.sigrng);
                           FStar_Syntax_Syntax.sigquals =
-                            (uu___216_931.FStar_Syntax_Syntax.sigquals);
+                            (uu___217_934.FStar_Syntax_Syntax.sigquals);
                           FStar_Syntax_Syntax.sigmeta =
-                            (uu___216_931.FStar_Syntax_Syntax.sigmeta);
+                            (uu___217_934.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (uu___216_931.FStar_Syntax_Syntax.sigattrs)
+                            (uu___217_934.FStar_Syntax_Syntax.sigattrs);
+                          FStar_Syntax_Syntax.sigopts =
+                            (uu___217_934.FStar_Syntax_Syntax.sigopts)
                         })]
-                  | FStar_Syntax_Syntax.Sig_let (uu____935,uu____936) -> []
-                  | uu____941 ->
+                  | FStar_Syntax_Syntax.Sig_let (uu____938,uu____939) -> []
+                  | uu____944 ->
                       failwith
                         "mutrecty: inductives_with_abbrevs_unfolded: unfold_in_sig: impossible"
                    in
@@ -391,7 +399,8 @@ let (disentangle_abbrevs_from_bundle :
                   FStar_Syntax_Syntax.sigquals = quals;
                   FStar_Syntax_Syntax.sigmeta =
                     FStar_Syntax_Syntax.default_sigmeta;
-                  FStar_Syntax_Syntax.sigattrs = sigattrs
+                  FStar_Syntax_Syntax.sigattrs = sigattrs;
+                  FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                 }  in
               (new_bundle, unfolded_type_abbrevs)
   

--- a/src/ocaml-output/FStar_Syntax_Syntax.ml
+++ b/src/ocaml-output/FStar_Syntax_Syntax.ml
@@ -17,35 +17,35 @@ type pragma =
   | LightOff [@@deriving yojson,show,yojson,show]
 let (uu___is_SetOptions : pragma -> Prims.bool) =
   fun projectee  ->
-    match projectee with | SetOptions _0 -> true | uu____175 -> false
+    match projectee with | SetOptions _0 -> true | uu____176 -> false
   
 let (__proj__SetOptions__item___0 : pragma -> Prims.string) =
   fun projectee  -> match projectee with | SetOptions _0 -> _0 
 let (uu___is_ResetOptions : pragma -> Prims.bool) =
   fun projectee  ->
-    match projectee with | ResetOptions _0 -> true | uu____200 -> false
+    match projectee with | ResetOptions _0 -> true | uu____201 -> false
   
 let (__proj__ResetOptions__item___0 :
   pragma -> Prims.string FStar_Pervasives_Native.option) =
   fun projectee  -> match projectee with | ResetOptions _0 -> _0 
 let (uu___is_PushOptions : pragma -> Prims.bool) =
   fun projectee  ->
-    match projectee with | PushOptions _0 -> true | uu____231 -> false
+    match projectee with | PushOptions _0 -> true | uu____232 -> false
   
 let (__proj__PushOptions__item___0 :
   pragma -> Prims.string FStar_Pervasives_Native.option) =
   fun projectee  -> match projectee with | PushOptions _0 -> _0 
 let (uu___is_PopOptions : pragma -> Prims.bool) =
   fun projectee  ->
-    match projectee with | PopOptions  -> true | uu____258 -> false
+    match projectee with | PopOptions  -> true | uu____259 -> false
   
 let (uu___is_RestartSolver : pragma -> Prims.bool) =
   fun projectee  ->
-    match projectee with | RestartSolver  -> true | uu____269 -> false
+    match projectee with | RestartSolver  -> true | uu____270 -> false
   
 let (uu___is_LightOff : pragma -> Prims.bool) =
   fun projectee  ->
-    match projectee with | LightOff  -> true | uu____280 -> false
+    match projectee with | LightOff  -> true | uu____281 -> false
   
 type 'a memo =
   (('a FStar_Pervasives_Native.option FStar_ST.ref)[@printer
@@ -60,17 +60,17 @@ type emb_typ =
   | ET_app of (Prims.string * emb_typ Prims.list) 
 let (uu___is_ET_abstract : emb_typ -> Prims.bool) =
   fun projectee  ->
-    match projectee with | ET_abstract  -> true | uu____320 -> false
+    match projectee with | ET_abstract  -> true | uu____321 -> false
   
 let (uu___is_ET_fun : emb_typ -> Prims.bool) =
   fun projectee  ->
-    match projectee with | ET_fun _0 -> true | uu____336 -> false
+    match projectee with | ET_fun _0 -> true | uu____337 -> false
   
 let (__proj__ET_fun__item___0 : emb_typ -> (emb_typ * emb_typ)) =
   fun projectee  -> match projectee with | ET_fun _0 -> _0 
 let (uu___is_ET_app : emb_typ -> Prims.bool) =
   fun projectee  ->
-    match projectee with | ET_app _0 -> true | uu____374 -> false
+    match projectee with | ET_app _0 -> true | uu____375 -> false
   
 let (__proj__ET_app__item___0 :
   emb_typ -> (Prims.string * emb_typ Prims.list)) =
@@ -93,35 +93,35 @@ type universe =
   | U_unknown [@@deriving yojson,show,yojson,show]
 let (uu___is_U_zero : universe -> Prims.bool) =
   fun projectee  ->
-    match projectee with | U_zero  -> true | uu____485 -> false
+    match projectee with | U_zero  -> true | uu____486 -> false
   
 let (uu___is_U_succ : universe -> Prims.bool) =
   fun projectee  ->
-    match projectee with | U_succ _0 -> true | uu____497 -> false
+    match projectee with | U_succ _0 -> true | uu____498 -> false
   
 let (__proj__U_succ__item___0 : universe -> universe) =
   fun projectee  -> match projectee with | U_succ _0 -> _0 
 let (uu___is_U_max : universe -> Prims.bool) =
   fun projectee  ->
-    match projectee with | U_max _0 -> true | uu____518 -> false
+    match projectee with | U_max _0 -> true | uu____519 -> false
   
 let (__proj__U_max__item___0 : universe -> universe Prims.list) =
   fun projectee  -> match projectee with | U_max _0 -> _0 
 let (uu___is_U_bvar : universe -> Prims.bool) =
   fun projectee  ->
-    match projectee with | U_bvar _0 -> true | uu____544 -> false
+    match projectee with | U_bvar _0 -> true | uu____545 -> false
   
 let (__proj__U_bvar__item___0 : universe -> Prims.int) =
   fun projectee  -> match projectee with | U_bvar _0 -> _0 
 let (uu___is_U_name : universe -> Prims.bool) =
   fun projectee  ->
-    match projectee with | U_name _0 -> true | uu____566 -> false
+    match projectee with | U_name _0 -> true | uu____567 -> false
   
 let (__proj__U_name__item___0 : universe -> FStar_Ident.ident) =
   fun projectee  -> match projectee with | U_name _0 -> _0 
 let (uu___is_U_unif : universe -> Prims.bool) =
   fun projectee  ->
-    match projectee with | U_unif _0 -> true | uu____593 -> false
+    match projectee with | U_unif _0 -> true | uu____594 -> false
   
 let (__proj__U_unif__item___0 :
   universe ->
@@ -130,7 +130,7 @@ let (__proj__U_unif__item___0 :
   = fun projectee  -> match projectee with | U_unif _0 -> _0 
 let (uu___is_U_unknown : universe -> Prims.bool) =
   fun projectee  ->
-    match projectee with | U_unknown  -> true | uu____635 -> false
+    match projectee with | U_unknown  -> true | uu____636 -> false
   
 type univ_name = FStar_Ident.ident[@@deriving yojson,show]
 type universe_uvar =
@@ -144,22 +144,22 @@ type quote_kind =
   | Quote_dynamic [@@deriving yojson,show,yojson,show]
 let (uu___is_Quote_static : quote_kind -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Quote_static  -> true | uu____658 -> false
+    match projectee with | Quote_static  -> true | uu____659 -> false
   
 let (uu___is_Quote_dynamic : quote_kind -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Quote_dynamic  -> true | uu____669 -> false
+    match projectee with | Quote_dynamic  -> true | uu____670 -> false
   
 type maybe_set_use_range =
   | NoUseRange 
   | SomeUseRange of FStar_Range.range [@@deriving yojson,show,yojson,show]
 let (uu___is_NoUseRange : maybe_set_use_range -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NoUseRange  -> true | uu____685 -> false
+    match projectee with | NoUseRange  -> true | uu____686 -> false
   
 let (uu___is_SomeUseRange : maybe_set_use_range -> Prims.bool) =
   fun projectee  ->
-    match projectee with | SomeUseRange _0 -> true | uu____697 -> false
+    match projectee with | SomeUseRange _0 -> true | uu____698 -> false
   
 let (__proj__SomeUseRange__item___0 :
   maybe_set_use_range -> FStar_Range.range) =
@@ -172,7 +172,7 @@ let (uu___is_Delta_constant_at_level : delta_depth -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | Delta_constant_at_level _0 -> true
-    | uu____734 -> false
+    | uu____735 -> false
   
 let (__proj__Delta_constant_at_level__item___0 : delta_depth -> Prims.int) =
   fun projectee  -> match projectee with | Delta_constant_at_level _0 -> _0 
@@ -180,14 +180,14 @@ let (uu___is_Delta_equational_at_level : delta_depth -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | Delta_equational_at_level _0 -> true
-    | uu____757 -> false
+    | uu____758 -> false
   
 let (__proj__Delta_equational_at_level__item___0 : delta_depth -> Prims.int)
   =
   fun projectee  -> match projectee with | Delta_equational_at_level _0 -> _0 
 let (uu___is_Delta_abstract : delta_depth -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Delta_abstract _0 -> true | uu____779 -> false
+    match projectee with | Delta_abstract _0 -> true | uu____780 -> false
   
 let (__proj__Delta_abstract__item___0 : delta_depth -> delta_depth) =
   fun projectee  -> match projectee with | Delta_abstract _0 -> _0 
@@ -197,15 +197,15 @@ type should_check_uvar =
   | Strict [@@deriving yojson,show,yojson,show]
 let (uu___is_Allow_unresolved : should_check_uvar -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Allow_unresolved  -> true | uu____797 -> false
+    match projectee with | Allow_unresolved  -> true | uu____798 -> false
   
 let (uu___is_Allow_untyped : should_check_uvar -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Allow_untyped  -> true | uu____808 -> false
+    match projectee with | Allow_untyped  -> true | uu____809 -> false
   
 let (uu___is_Strict : should_check_uvar -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Strict  -> true | uu____819 -> false
+    match projectee with | Strict  -> true | uu____820 -> false
   
 type term' =
   | Tm_bvar of bv 
@@ -349,6 +349,7 @@ and lazy_kind =
   | BadLazy 
   | Lazy_bv 
   | Lazy_binder 
+  | Lazy_optionstate 
   | Lazy_fvar 
   | Lazy_comp 
   | Lazy_env 
@@ -368,43 +369,43 @@ and arg_qualifier =
   | Equality 
 let (uu___is_Tm_bvar : term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tm_bvar _0 -> true | uu____1709 -> false
+    match projectee with | Tm_bvar _0 -> true | uu____1710 -> false
   
 let (__proj__Tm_bvar__item___0 : term' -> bv) =
   fun projectee  -> match projectee with | Tm_bvar _0 -> _0 
 let (uu___is_Tm_name : term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tm_name _0 -> true | uu____1728 -> false
+    match projectee with | Tm_name _0 -> true | uu____1729 -> false
   
 let (__proj__Tm_name__item___0 : term' -> bv) =
   fun projectee  -> match projectee with | Tm_name _0 -> _0 
 let (uu___is_Tm_fvar : term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tm_fvar _0 -> true | uu____1747 -> false
+    match projectee with | Tm_fvar _0 -> true | uu____1748 -> false
   
 let (__proj__Tm_fvar__item___0 : term' -> fv) =
   fun projectee  -> match projectee with | Tm_fvar _0 -> _0 
 let (uu___is_Tm_uinst : term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tm_uinst _0 -> true | uu____1772 -> false
+    match projectee with | Tm_uinst _0 -> true | uu____1773 -> false
   
 let (__proj__Tm_uinst__item___0 : term' -> (term' syntax * universes)) =
   fun projectee  -> match projectee with | Tm_uinst _0 -> _0 
 let (uu___is_Tm_constant : term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tm_constant _0 -> true | uu____1809 -> false
+    match projectee with | Tm_constant _0 -> true | uu____1810 -> false
   
 let (__proj__Tm_constant__item___0 : term' -> sconst) =
   fun projectee  -> match projectee with | Tm_constant _0 -> _0 
 let (uu___is_Tm_type : term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tm_type _0 -> true | uu____1828 -> false
+    match projectee with | Tm_type _0 -> true | uu____1829 -> false
   
 let (__proj__Tm_type__item___0 : term' -> universe) =
   fun projectee  -> match projectee with | Tm_type _0 -> _0 
 let (uu___is_Tm_abs : term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tm_abs _0 -> true | uu____1865 -> false
+    match projectee with | Tm_abs _0 -> true | uu____1866 -> false
   
 let (__proj__Tm_abs__item___0 :
   term' ->
@@ -413,7 +414,7 @@ let (__proj__Tm_abs__item___0 :
   = fun projectee  -> match projectee with | Tm_abs _0 -> _0 
 let (uu___is_Tm_arrow : term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tm_arrow _0 -> true | uu____1952 -> false
+    match projectee with | Tm_arrow _0 -> true | uu____1953 -> false
   
 let (__proj__Tm_arrow__item___0 :
   term' ->
@@ -422,13 +423,13 @@ let (__proj__Tm_arrow__item___0 :
   = fun projectee  -> match projectee with | Tm_arrow _0 -> _0 
 let (uu___is_Tm_refine : term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tm_refine _0 -> true | uu____2019 -> false
+    match projectee with | Tm_refine _0 -> true | uu____2020 -> false
   
 let (__proj__Tm_refine__item___0 : term' -> (bv * term' syntax)) =
   fun projectee  -> match projectee with | Tm_refine _0 -> _0 
 let (uu___is_Tm_app : term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tm_app _0 -> true | uu____2072 -> false
+    match projectee with | Tm_app _0 -> true | uu____2073 -> false
   
 let (__proj__Tm_app__item___0 :
   term' ->
@@ -437,7 +438,7 @@ let (__proj__Tm_app__item___0 :
   = fun projectee  -> match projectee with | Tm_app _0 -> _0 
 let (uu___is_Tm_match : term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tm_match _0 -> true | uu____2161 -> false
+    match projectee with | Tm_match _0 -> true | uu____2162 -> false
   
 let (__proj__Tm_match__item___0 :
   term' ->
@@ -446,7 +447,7 @@ let (__proj__Tm_match__item___0 :
   = fun projectee  -> match projectee with | Tm_match _0 -> _0 
 let (uu___is_Tm_ascribed : term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tm_ascribed _0 -> true | uu____2272 -> false
+    match projectee with | Tm_ascribed _0 -> true | uu____2273 -> false
   
 let (__proj__Tm_ascribed__item___0 :
   term' ->
@@ -456,14 +457,14 @@ let (__proj__Tm_ascribed__item___0 :
   = fun projectee  -> match projectee with | Tm_ascribed _0 -> _0 
 let (uu___is_Tm_let : term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tm_let _0 -> true | uu____2382 -> false
+    match projectee with | Tm_let _0 -> true | uu____2383 -> false
   
 let (__proj__Tm_let__item___0 :
   term' -> ((Prims.bool * letbinding Prims.list) * term' syntax)) =
   fun projectee  -> match projectee with | Tm_let _0 -> _0 
 let (uu___is_Tm_uvar : term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tm_uvar _0 -> true | uu____2452 -> false
+    match projectee with | Tm_uvar _0 -> true | uu____2453 -> false
   
 let (__proj__Tm_uvar__item___0 :
   term' ->
@@ -471,7 +472,7 @@ let (__proj__Tm_uvar__item___0 :
   = fun projectee  -> match projectee with | Tm_uvar _0 -> _0 
 let (uu___is_Tm_delayed : term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tm_delayed _0 -> true | uu____2529 -> false
+    match projectee with | Tm_delayed _0 -> true | uu____2530 -> false
   
 let (__proj__Tm_delayed__item___0 :
   term' ->
@@ -480,25 +481,25 @@ let (__proj__Tm_delayed__item___0 :
   = fun projectee  -> match projectee with | Tm_delayed _0 -> _0 
 let (uu___is_Tm_meta : term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tm_meta _0 -> true | uu____2620 -> false
+    match projectee with | Tm_meta _0 -> true | uu____2621 -> false
   
 let (__proj__Tm_meta__item___0 : term' -> (term' syntax * metadata)) =
   fun projectee  -> match projectee with | Tm_meta _0 -> _0 
 let (uu___is_Tm_lazy : term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tm_lazy _0 -> true | uu____2657 -> false
+    match projectee with | Tm_lazy _0 -> true | uu____2658 -> false
   
 let (__proj__Tm_lazy__item___0 : term' -> lazyinfo) =
   fun projectee  -> match projectee with | Tm_lazy _0 -> _0 
 let (uu___is_Tm_quoted : term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tm_quoted _0 -> true | uu____2682 -> false
+    match projectee with | Tm_quoted _0 -> true | uu____2683 -> false
   
 let (__proj__Tm_quoted__item___0 : term' -> (term' syntax * quoteinfo)) =
   fun projectee  -> match projectee with | Tm_quoted _0 -> _0 
 let (uu___is_Tm_unknown : term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Tm_unknown  -> true | uu____2718 -> false
+    match projectee with | Tm_unknown  -> true | uu____2719 -> false
   
 let (__proj__Mkctx_uvar__item__ctx_uvar_head :
   ctx_uvar ->
@@ -569,32 +570,32 @@ let (__proj__Mkctx_uvar__item__ctx_uvar_meta :
   
 let (uu___is_Pat_constant : pat' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Pat_constant _0 -> true | uu____3152 -> false
+    match projectee with | Pat_constant _0 -> true | uu____3153 -> false
   
 let (__proj__Pat_constant__item___0 : pat' -> sconst) =
   fun projectee  -> match projectee with | Pat_constant _0 -> _0 
 let (uu___is_Pat_cons : pat' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Pat_cons _0 -> true | uu____3184 -> false
+    match projectee with | Pat_cons _0 -> true | uu____3185 -> false
   
 let (__proj__Pat_cons__item___0 :
   pat' -> (fv * (pat' withinfo_t * Prims.bool) Prims.list)) =
   fun projectee  -> match projectee with | Pat_cons _0 -> _0 
 let (uu___is_Pat_var : pat' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Pat_var _0 -> true | uu____3242 -> false
+    match projectee with | Pat_var _0 -> true | uu____3243 -> false
   
 let (__proj__Pat_var__item___0 : pat' -> bv) =
   fun projectee  -> match projectee with | Pat_var _0 -> _0 
 let (uu___is_Pat_wild : pat' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Pat_wild _0 -> true | uu____3261 -> false
+    match projectee with | Pat_wild _0 -> true | uu____3262 -> false
   
 let (__proj__Pat_wild__item___0 : pat' -> bv) =
   fun projectee  -> match projectee with | Pat_wild _0 -> _0 
 let (uu___is_Pat_dot_term : pat' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Pat_dot_term _0 -> true | uu____3286 -> false
+    match projectee with | Pat_dot_term _0 -> true | uu____3287 -> false
   
 let (__proj__Pat_dot_term__item___0 : pat' -> (bv * term' syntax)) =
   fun projectee  -> match projectee with | Pat_dot_term _0 -> _0 
@@ -678,69 +679,69 @@ let (__proj__Mkcomp_typ__item__flags : comp_typ -> cflag Prims.list) =
   
 let (uu___is_Total : comp' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Total _0 -> true | uu____3749 -> false
+    match projectee with | Total _0 -> true | uu____3750 -> false
   
 let (__proj__Total__item___0 :
   comp' -> (term' syntax * universe FStar_Pervasives_Native.option)) =
   fun projectee  -> match projectee with | Total _0 -> _0 
 let (uu___is_GTotal : comp' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | GTotal _0 -> true | uu____3800 -> false
+    match projectee with | GTotal _0 -> true | uu____3801 -> false
   
 let (__proj__GTotal__item___0 :
   comp' -> (term' syntax * universe FStar_Pervasives_Native.option)) =
   fun projectee  -> match projectee with | GTotal _0 -> _0 
 let (uu___is_Comp : comp' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Comp _0 -> true | uu____3843 -> false
+    match projectee with | Comp _0 -> true | uu____3844 -> false
   
 let (__proj__Comp__item___0 : comp' -> comp_typ) =
   fun projectee  -> match projectee with | Comp _0 -> _0 
 let (uu___is_TOTAL : cflag -> Prims.bool) =
   fun projectee  ->
-    match projectee with | TOTAL  -> true | uu____3861 -> false
+    match projectee with | TOTAL  -> true | uu____3862 -> false
   
 let (uu___is_MLEFFECT : cflag -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLEFFECT  -> true | uu____3872 -> false
+    match projectee with | MLEFFECT  -> true | uu____3873 -> false
   
 let (uu___is_LEMMA : cflag -> Prims.bool) =
   fun projectee  ->
-    match projectee with | LEMMA  -> true | uu____3883 -> false
+    match projectee with | LEMMA  -> true | uu____3884 -> false
   
 let (uu___is_RETURN : cflag -> Prims.bool) =
   fun projectee  ->
-    match projectee with | RETURN  -> true | uu____3894 -> false
+    match projectee with | RETURN  -> true | uu____3895 -> false
   
 let (uu___is_PARTIAL_RETURN : cflag -> Prims.bool) =
   fun projectee  ->
-    match projectee with | PARTIAL_RETURN  -> true | uu____3905 -> false
+    match projectee with | PARTIAL_RETURN  -> true | uu____3906 -> false
   
 let (uu___is_SOMETRIVIAL : cflag -> Prims.bool) =
   fun projectee  ->
-    match projectee with | SOMETRIVIAL  -> true | uu____3916 -> false
+    match projectee with | SOMETRIVIAL  -> true | uu____3917 -> false
   
 let (uu___is_TRIVIAL_POSTCONDITION : cflag -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | TRIVIAL_POSTCONDITION  -> true
-    | uu____3927 -> false
+    | uu____3928 -> false
   
 let (uu___is_SHOULD_NOT_INLINE : cflag -> Prims.bool) =
   fun projectee  ->
-    match projectee with | SHOULD_NOT_INLINE  -> true | uu____3938 -> false
+    match projectee with | SHOULD_NOT_INLINE  -> true | uu____3939 -> false
   
 let (uu___is_CPS : cflag -> Prims.bool) =
-  fun projectee  -> match projectee with | CPS  -> true | uu____3949 -> false 
+  fun projectee  -> match projectee with | CPS  -> true | uu____3950 -> false 
 let (uu___is_DECREASES : cflag -> Prims.bool) =
   fun projectee  ->
-    match projectee with | DECREASES _0 -> true | uu____3963 -> false
+    match projectee with | DECREASES _0 -> true | uu____3964 -> false
   
 let (__proj__DECREASES__item___0 : cflag -> term' syntax) =
   fun projectee  -> match projectee with | DECREASES _0 -> _0 
 let (uu___is_Meta_pattern : metadata -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Meta_pattern _0 -> true | uu____4008 -> false
+    match projectee with | Meta_pattern _0 -> true | uu____4009 -> false
   
 let (__proj__Meta_pattern__item___0 :
   metadata ->
@@ -749,98 +750,98 @@ let (__proj__Meta_pattern__item___0 :
   = fun projectee  -> match projectee with | Meta_pattern _0 -> _0 
 let (uu___is_Meta_named : metadata -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Meta_named _0 -> true | uu____4087 -> false
+    match projectee with | Meta_named _0 -> true | uu____4088 -> false
   
 let (__proj__Meta_named__item___0 : metadata -> FStar_Ident.lident) =
   fun projectee  -> match projectee with | Meta_named _0 -> _0 
 let (uu___is_Meta_labeled : metadata -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Meta_labeled _0 -> true | uu____4114 -> false
+    match projectee with | Meta_labeled _0 -> true | uu____4115 -> false
   
 let (__proj__Meta_labeled__item___0 :
   metadata -> (Prims.string * FStar_Range.range * Prims.bool)) =
   fun projectee  -> match projectee with | Meta_labeled _0 -> _0 
 let (uu___is_Meta_desugared : metadata -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Meta_desugared _0 -> true | uu____4157 -> false
+    match projectee with | Meta_desugared _0 -> true | uu____4158 -> false
   
 let (__proj__Meta_desugared__item___0 : metadata -> meta_source_info) =
   fun projectee  -> match projectee with | Meta_desugared _0 -> _0 
 let (uu___is_Meta_monadic : metadata -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Meta_monadic _0 -> true | uu____4182 -> false
+    match projectee with | Meta_monadic _0 -> true | uu____4183 -> false
   
 let (__proj__Meta_monadic__item___0 :
   metadata -> (monad_name * term' syntax)) =
   fun projectee  -> match projectee with | Meta_monadic _0 -> _0 
 let (uu___is_Meta_monadic_lift : metadata -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Meta_monadic_lift _0 -> true | uu____4227 -> false
+    match projectee with | Meta_monadic_lift _0 -> true | uu____4228 -> false
   
 let (__proj__Meta_monadic_lift__item___0 :
   metadata -> (monad_name * monad_name * term' syntax)) =
   fun projectee  -> match projectee with | Meta_monadic_lift _0 -> _0 
 let (uu___is_Sequence : meta_source_info -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Sequence  -> true | uu____4269 -> false
+    match projectee with | Sequence  -> true | uu____4270 -> false
   
 let (uu___is_Primop : meta_source_info -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Primop  -> true | uu____4280 -> false
+    match projectee with | Primop  -> true | uu____4281 -> false
   
 let (uu___is_Masked_effect : meta_source_info -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Masked_effect  -> true | uu____4291 -> false
+    match projectee with | Masked_effect  -> true | uu____4292 -> false
   
 let (uu___is_Meta_smt_pat : meta_source_info -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Meta_smt_pat  -> true | uu____4302 -> false
+    match projectee with | Meta_smt_pat  -> true | uu____4303 -> false
   
 let (uu___is_Data_ctor : fv_qual -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Data_ctor  -> true | uu____4313 -> false
+    match projectee with | Data_ctor  -> true | uu____4314 -> false
   
 let (uu___is_Record_projector : fv_qual -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Record_projector _0 -> true | uu____4329 -> false
+    match projectee with | Record_projector _0 -> true | uu____4330 -> false
   
 let (__proj__Record_projector__item___0 :
   fv_qual -> (FStar_Ident.lident * FStar_Ident.ident)) =
   fun projectee  -> match projectee with | Record_projector _0 -> _0 
 let (uu___is_Record_ctor : fv_qual -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Record_ctor _0 -> true | uu____4366 -> false
+    match projectee with | Record_ctor _0 -> true | uu____4367 -> false
   
 let (__proj__Record_ctor__item___0 :
   fv_qual -> (FStar_Ident.lident * FStar_Ident.ident Prims.list)) =
   fun projectee  -> match projectee with | Record_ctor _0 -> _0 
 let (uu___is_DB : subst_elt -> Prims.bool) =
   fun projectee  ->
-    match projectee with | DB _0 -> true | uu____4408 -> false
+    match projectee with | DB _0 -> true | uu____4409 -> false
   
 let (__proj__DB__item___0 : subst_elt -> (Prims.int * bv)) =
   fun projectee  -> match projectee with | DB _0 -> _0 
 let (uu___is_NM : subst_elt -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NM _0 -> true | uu____4447 -> false
+    match projectee with | NM _0 -> true | uu____4448 -> false
   
 let (__proj__NM__item___0 : subst_elt -> (bv * Prims.int)) =
   fun projectee  -> match projectee with | NM _0 -> _0 
 let (uu___is_NT : subst_elt -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NT _0 -> true | uu____4487 -> false
+    match projectee with | NT _0 -> true | uu____4488 -> false
   
 let (__proj__NT__item___0 : subst_elt -> (bv * term' syntax)) =
   fun projectee  -> match projectee with | NT _0 -> _0 
 let (uu___is_UN : subst_elt -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UN _0 -> true | uu____4529 -> false
+    match projectee with | UN _0 -> true | uu____4530 -> false
   
 let (__proj__UN__item___0 : subst_elt -> (Prims.int * universe)) =
   fun projectee  -> match projectee with | UN _0 -> _0 
 let (uu___is_UD : subst_elt -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UD _0 -> true | uu____4568 -> false
+    match projectee with | UD _0 -> true | uu____4569 -> false
   
 let (__proj__UD__item___0 : subst_elt -> (univ_name * Prims.int)) =
   fun projectee  -> match projectee with | UD _0 -> _0 
@@ -933,85 +934,89 @@ let (__proj__Mklazyinfo__item__rng : lazyinfo -> FStar_Range.range) =
   fun projectee  -> match projectee with | { blob; lkind; ltyp; rng;_} -> rng 
 let (uu___is_BadLazy : lazy_kind -> Prims.bool) =
   fun projectee  ->
-    match projectee with | BadLazy  -> true | uu____4939 -> false
+    match projectee with | BadLazy  -> true | uu____4940 -> false
   
 let (uu___is_Lazy_bv : lazy_kind -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Lazy_bv  -> true | uu____4950 -> false
+    match projectee with | Lazy_bv  -> true | uu____4951 -> false
   
 let (uu___is_Lazy_binder : lazy_kind -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Lazy_binder  -> true | uu____4961 -> false
+    match projectee with | Lazy_binder  -> true | uu____4962 -> false
+  
+let (uu___is_Lazy_optionstate : lazy_kind -> Prims.bool) =
+  fun projectee  ->
+    match projectee with | Lazy_optionstate  -> true | uu____4973 -> false
   
 let (uu___is_Lazy_fvar : lazy_kind -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Lazy_fvar  -> true | uu____4972 -> false
+    match projectee with | Lazy_fvar  -> true | uu____4984 -> false
   
 let (uu___is_Lazy_comp : lazy_kind -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Lazy_comp  -> true | uu____4983 -> false
+    match projectee with | Lazy_comp  -> true | uu____4995 -> false
   
 let (uu___is_Lazy_env : lazy_kind -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Lazy_env  -> true | uu____4994 -> false
+    match projectee with | Lazy_env  -> true | uu____5006 -> false
   
 let (uu___is_Lazy_proofstate : lazy_kind -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Lazy_proofstate  -> true | uu____5005 -> false
+    match projectee with | Lazy_proofstate  -> true | uu____5017 -> false
   
 let (uu___is_Lazy_goal : lazy_kind -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Lazy_goal  -> true | uu____5016 -> false
+    match projectee with | Lazy_goal  -> true | uu____5028 -> false
   
 let (uu___is_Lazy_sigelt : lazy_kind -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Lazy_sigelt  -> true | uu____5027 -> false
+    match projectee with | Lazy_sigelt  -> true | uu____5039 -> false
   
 let (uu___is_Lazy_uvar : lazy_kind -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Lazy_uvar  -> true | uu____5038 -> false
+    match projectee with | Lazy_uvar  -> true | uu____5050 -> false
   
 let (uu___is_Lazy_embedding : lazy_kind -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Lazy_embedding _0 -> true | uu____5058 -> false
+    match projectee with | Lazy_embedding _0 -> true | uu____5070 -> false
   
 let (__proj__Lazy_embedding__item___0 :
   lazy_kind -> (emb_typ * term' syntax FStar_Common.thunk)) =
   fun projectee  -> match projectee with | Lazy_embedding _0 -> _0 
 let (uu___is_Binding_var : binding -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Binding_var _0 -> true | uu____5101 -> false
+    match projectee with | Binding_var _0 -> true | uu____5113 -> false
   
 let (__proj__Binding_var__item___0 : binding -> bv) =
   fun projectee  -> match projectee with | Binding_var _0 -> _0 
 let (uu___is_Binding_lid : binding -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Binding_lid _0 -> true | uu____5132 -> false
+    match projectee with | Binding_lid _0 -> true | uu____5144 -> false
   
 let (__proj__Binding_lid__item___0 :
   binding -> (FStar_Ident.lident * (univ_name Prims.list * term' syntax))) =
   fun projectee  -> match projectee with | Binding_lid _0 -> _0 
 let (uu___is_Binding_univ : binding -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Binding_univ _0 -> true | uu____5187 -> false
+    match projectee with | Binding_univ _0 -> true | uu____5199 -> false
   
 let (__proj__Binding_univ__item___0 : binding -> univ_name) =
   fun projectee  -> match projectee with | Binding_univ _0 -> _0 
 let (uu___is_Implicit : arg_qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Implicit _0 -> true | uu____5207 -> false
+    match projectee with | Implicit _0 -> true | uu____5219 -> false
   
 let (__proj__Implicit__item___0 : arg_qualifier -> Prims.bool) =
   fun projectee  -> match projectee with | Implicit _0 -> _0 
 let (uu___is_Meta : arg_qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Meta _0 -> true | uu____5231 -> false
+    match projectee with | Meta _0 -> true | uu____5243 -> false
   
 let (__proj__Meta__item___0 : arg_qualifier -> term' syntax) =
   fun projectee  -> match projectee with | Meta _0 -> _0 
 let (uu___is_Equality : arg_qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Equality  -> true | uu____5255 -> false
+    match projectee with | Equality  -> true | uu____5267 -> false
   
 type subst_ts = (subst_elt Prims.list Prims.list * maybe_set_use_range)
 type ctx_uvar_and_subst =
@@ -1079,13 +1084,13 @@ let (mk_lcomp :
     fun res_typ  ->
       fun cflags  ->
         fun comp_thunk  ->
-          let uu____5615 = FStar_Util.mk_ref (FStar_Util.Inl comp_thunk)  in
-          { eff_name; res_typ; cflags; comp_thunk = uu____5615 }
+          let uu____5627 = FStar_Util.mk_ref (FStar_Util.Inl comp_thunk)  in
+          { eff_name; res_typ; cflags; comp_thunk = uu____5627 }
   
 let (lcomp_comp : lcomp -> comp) =
   fun lc  ->
-    let uu____5641 = FStar_ST.op_Bang lc.comp_thunk  in
-    match uu____5641 with
+    let uu____5653 = FStar_ST.op_Bang lc.comp_thunk  in
+    match uu____5653 with
     | FStar_Util.Inl thunk ->
         let c = thunk ()  in
         (FStar_ST.op_Colon_Equals lc.comp_thunk (FStar_Util.Inr c); c)
@@ -1123,98 +1128,98 @@ type qualifier =
   | OnlyName 
 let (uu___is_Assumption : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Assumption  -> true | uu____5794 -> false
+    match projectee with | Assumption  -> true | uu____5806 -> false
   
 let (uu___is_New : qualifier -> Prims.bool) =
-  fun projectee  -> match projectee with | New  -> true | uu____5805 -> false 
+  fun projectee  -> match projectee with | New  -> true | uu____5817 -> false 
 let (uu___is_Private : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Private  -> true | uu____5816 -> false
+    match projectee with | Private  -> true | uu____5828 -> false
   
 let (uu___is_Unfold_for_unification_and_vcgen : qualifier -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | Unfold_for_unification_and_vcgen  -> true
-    | uu____5827 -> false
+    | uu____5839 -> false
   
 let (uu___is_Visible_default : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Visible_default  -> true | uu____5838 -> false
+    match projectee with | Visible_default  -> true | uu____5850 -> false
   
 let (uu___is_Irreducible : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Irreducible  -> true | uu____5849 -> false
+    match projectee with | Irreducible  -> true | uu____5861 -> false
   
 let (uu___is_Abstract : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Abstract  -> true | uu____5860 -> false
+    match projectee with | Abstract  -> true | uu____5872 -> false
   
 let (uu___is_Inline_for_extraction : qualifier -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | Inline_for_extraction  -> true
-    | uu____5871 -> false
+    | uu____5883 -> false
   
 let (uu___is_NoExtract : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NoExtract  -> true | uu____5882 -> false
+    match projectee with | NoExtract  -> true | uu____5894 -> false
   
 let (uu___is_Noeq : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Noeq  -> true | uu____5893 -> false
+    match projectee with | Noeq  -> true | uu____5905 -> false
   
 let (uu___is_Unopteq : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Unopteq  -> true | uu____5904 -> false
+    match projectee with | Unopteq  -> true | uu____5916 -> false
   
 let (uu___is_TotalEffect : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | TotalEffect  -> true | uu____5915 -> false
+    match projectee with | TotalEffect  -> true | uu____5927 -> false
   
 let (uu___is_Logic : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Logic  -> true | uu____5926 -> false
+    match projectee with | Logic  -> true | uu____5938 -> false
   
 let (uu___is_Reifiable : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Reifiable  -> true | uu____5937 -> false
+    match projectee with | Reifiable  -> true | uu____5949 -> false
   
 let (uu___is_Reflectable : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Reflectable _0 -> true | uu____5949 -> false
+    match projectee with | Reflectable _0 -> true | uu____5961 -> false
   
 let (__proj__Reflectable__item___0 : qualifier -> FStar_Ident.lident) =
   fun projectee  -> match projectee with | Reflectable _0 -> _0 
 let (uu___is_Discriminator : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Discriminator _0 -> true | uu____5968 -> false
+    match projectee with | Discriminator _0 -> true | uu____5980 -> false
   
 let (__proj__Discriminator__item___0 : qualifier -> FStar_Ident.lident) =
   fun projectee  -> match projectee with | Discriminator _0 -> _0 
 let (uu___is_Projector : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Projector _0 -> true | uu____5991 -> false
+    match projectee with | Projector _0 -> true | uu____6003 -> false
   
 let (__proj__Projector__item___0 :
   qualifier -> (FStar_Ident.lident * FStar_Ident.ident)) =
   fun projectee  -> match projectee with | Projector _0 -> _0 
 let (uu___is_RecordType : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | RecordType _0 -> true | uu____6030 -> false
+    match projectee with | RecordType _0 -> true | uu____6042 -> false
   
 let (__proj__RecordType__item___0 :
   qualifier -> (FStar_Ident.ident Prims.list * FStar_Ident.ident Prims.list))
   = fun projectee  -> match projectee with | RecordType _0 -> _0 
 let (uu___is_RecordConstructor : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | RecordConstructor _0 -> true | uu____6081 -> false
+    match projectee with | RecordConstructor _0 -> true | uu____6093 -> false
   
 let (__proj__RecordConstructor__item___0 :
   qualifier -> (FStar_Ident.ident Prims.list * FStar_Ident.ident Prims.list))
   = fun projectee  -> match projectee with | RecordConstructor _0 -> _0 
 let (uu___is_Action : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Action _0 -> true | uu____6124 -> false
+    match projectee with | Action _0 -> true | uu____6136 -> false
   
 let (__proj__Action__item___0 : qualifier -> FStar_Ident.lident) =
   fun projectee  -> match projectee with | Action _0 -> _0 
@@ -1222,19 +1227,19 @@ let (uu___is_ExceptionConstructor : qualifier -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | ExceptionConstructor  -> true
-    | uu____6142 -> false
+    | uu____6154 -> false
   
 let (uu___is_HasMaskedEffect : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | HasMaskedEffect  -> true | uu____6153 -> false
+    match projectee with | HasMaskedEffect  -> true | uu____6165 -> false
   
 let (uu___is_Effect : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Effect  -> true | uu____6164 -> false
+    match projectee with | Effect  -> true | uu____6176 -> false
   
 let (uu___is_OnlyName : qualifier -> Prims.bool) =
   fun projectee  ->
-    match projectee with | OnlyName  -> true | uu____6175 -> false
+    match projectee with | OnlyName  -> true | uu____6187 -> false
   
 type tycon = (FStar_Ident.lident * binders * typ)
 type monad_abbrev = {
@@ -1497,10 +1502,11 @@ and sigelt =
   sigrng: FStar_Range.range ;
   sigquals: qualifier Prims.list ;
   sigmeta: sig_metadata ;
-  sigattrs: attribute Prims.list }
+  sigattrs: attribute Prims.list ;
+  sigopts: FStar_Options.optionstate FStar_Pervasives_Native.option }
 let (uu___is_Sig_inductive_typ : sigelt' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Sig_inductive_typ _0 -> true | uu____7252 -> false
+    match projectee with | Sig_inductive_typ _0 -> true | uu____7271 -> false
   
 let (__proj__Sig_inductive_typ__item___0 :
   sigelt' ->
@@ -1509,14 +1515,14 @@ let (__proj__Sig_inductive_typ__item___0 :
   = fun projectee  -> match projectee with | Sig_inductive_typ _0 -> _0 
 let (uu___is_Sig_bundle : sigelt' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Sig_bundle _0 -> true | uu____7327 -> false
+    match projectee with | Sig_bundle _0 -> true | uu____7346 -> false
   
 let (__proj__Sig_bundle__item___0 :
   sigelt' -> (sigelt Prims.list * FStar_Ident.lident Prims.list)) =
   fun projectee  -> match projectee with | Sig_bundle _0 -> _0 
 let (uu___is_Sig_datacon : sigelt' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Sig_datacon _0 -> true | uu____7385 -> false
+    match projectee with | Sig_datacon _0 -> true | uu____7404 -> false
   
 let (__proj__Sig_datacon__item___0 :
   sigelt' ->
@@ -1525,34 +1531,34 @@ let (__proj__Sig_datacon__item___0 :
   = fun projectee  -> match projectee with | Sig_datacon _0 -> _0 
 let (uu___is_Sig_declare_typ : sigelt' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Sig_declare_typ _0 -> true | uu____7455 -> false
+    match projectee with | Sig_declare_typ _0 -> true | uu____7474 -> false
   
 let (__proj__Sig_declare_typ__item___0 :
   sigelt' -> (FStar_Ident.lident * univ_names * typ)) =
   fun projectee  -> match projectee with | Sig_declare_typ _0 -> _0 
 let (uu___is_Sig_let : sigelt' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Sig_let _0 -> true | uu____7498 -> false
+    match projectee with | Sig_let _0 -> true | uu____7517 -> false
   
 let (__proj__Sig_let__item___0 :
   sigelt' -> (letbindings * FStar_Ident.lident Prims.list)) =
   fun projectee  -> match projectee with | Sig_let _0 -> _0 
 let (uu___is_Sig_main : sigelt' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Sig_main _0 -> true | uu____7535 -> false
+    match projectee with | Sig_main _0 -> true | uu____7554 -> false
   
 let (__proj__Sig_main__item___0 : sigelt' -> term) =
   fun projectee  -> match projectee with | Sig_main _0 -> _0 
 let (uu___is_Sig_assume : sigelt' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Sig_assume _0 -> true | uu____7560 -> false
+    match projectee with | Sig_assume _0 -> true | uu____7579 -> false
   
 let (__proj__Sig_assume__item___0 :
   sigelt' -> (FStar_Ident.lident * univ_names * formula)) =
   fun projectee  -> match projectee with | Sig_assume _0 -> _0 
 let (uu___is_Sig_new_effect : sigelt' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Sig_new_effect _0 -> true | uu____7597 -> false
+    match projectee with | Sig_new_effect _0 -> true | uu____7616 -> false
   
 let (__proj__Sig_new_effect__item___0 : sigelt' -> eff_decl) =
   fun projectee  -> match projectee with | Sig_new_effect _0 -> _0 
@@ -1560,19 +1566,19 @@ let (uu___is_Sig_new_effect_for_free : sigelt' -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | Sig_new_effect_for_free _0 -> true
-    | uu____7616 -> false
+    | uu____7635 -> false
   
 let (__proj__Sig_new_effect_for_free__item___0 : sigelt' -> eff_decl) =
   fun projectee  -> match projectee with | Sig_new_effect_for_free _0 -> _0 
 let (uu___is_Sig_sub_effect : sigelt' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Sig_sub_effect _0 -> true | uu____7635 -> false
+    match projectee with | Sig_sub_effect _0 -> true | uu____7654 -> false
   
 let (__proj__Sig_sub_effect__item___0 : sigelt' -> sub_eff) =
   fun projectee  -> match projectee with | Sig_sub_effect _0 -> _0 
 let (uu___is_Sig_effect_abbrev : sigelt' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Sig_effect_abbrev _0 -> true | uu____7666 -> false
+    match projectee with | Sig_effect_abbrev _0 -> true | uu____7685 -> false
   
 let (__proj__Sig_effect_abbrev__item___0 :
   sigelt' ->
@@ -1580,13 +1586,13 @@ let (__proj__Sig_effect_abbrev__item___0 :
   = fun projectee  -> match projectee with | Sig_effect_abbrev _0 -> _0 
 let (uu___is_Sig_pragma : sigelt' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Sig_pragma _0 -> true | uu____7721 -> false
+    match projectee with | Sig_pragma _0 -> true | uu____7740 -> false
   
 let (__proj__Sig_pragma__item___0 : sigelt' -> pragma) =
   fun projectee  -> match projectee with | Sig_pragma _0 -> _0 
 let (uu___is_Sig_splice : sigelt' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Sig_splice _0 -> true | uu____7746 -> false
+    match projectee with | Sig_splice _0 -> true | uu____7765 -> false
   
 let (__proj__Sig_splice__item___0 :
   sigelt' -> (FStar_Ident.lident Prims.list * term)) =
@@ -1594,27 +1600,33 @@ let (__proj__Sig_splice__item___0 :
 let (__proj__Mksigelt__item__sigel : sigelt -> sigelt') =
   fun projectee  ->
     match projectee with
-    | { sigel; sigrng; sigquals; sigmeta; sigattrs;_} -> sigel
+    | { sigel; sigrng; sigquals; sigmeta; sigattrs; sigopts;_} -> sigel
   
 let (__proj__Mksigelt__item__sigrng : sigelt -> FStar_Range.range) =
   fun projectee  ->
     match projectee with
-    | { sigel; sigrng; sigquals; sigmeta; sigattrs;_} -> sigrng
+    | { sigel; sigrng; sigquals; sigmeta; sigattrs; sigopts;_} -> sigrng
   
 let (__proj__Mksigelt__item__sigquals : sigelt -> qualifier Prims.list) =
   fun projectee  ->
     match projectee with
-    | { sigel; sigrng; sigquals; sigmeta; sigattrs;_} -> sigquals
+    | { sigel; sigrng; sigquals; sigmeta; sigattrs; sigopts;_} -> sigquals
   
 let (__proj__Mksigelt__item__sigmeta : sigelt -> sig_metadata) =
   fun projectee  ->
     match projectee with
-    | { sigel; sigrng; sigquals; sigmeta; sigattrs;_} -> sigmeta
+    | { sigel; sigrng; sigquals; sigmeta; sigattrs; sigopts;_} -> sigmeta
   
 let (__proj__Mksigelt__item__sigattrs : sigelt -> attribute Prims.list) =
   fun projectee  ->
     match projectee with
-    | { sigel; sigrng; sigquals; sigmeta; sigattrs;_} -> sigattrs
+    | { sigel; sigrng; sigquals; sigmeta; sigattrs; sigopts;_} -> sigattrs
+  
+let (__proj__Mksigelt__item__sigopts :
+  sigelt -> FStar_Options.optionstate FStar_Pervasives_Native.option) =
+  fun projectee  ->
+    match projectee with
+    | { sigel; sigrng; sigquals; sigmeta; sigattrs; sigopts;_} -> sigopts
   
 type sigelts = sigelt Prims.list
 type modul =
@@ -1652,10 +1664,10 @@ type mk_t = term' mk_t_a
 let (contains_reflectable : qualifier Prims.list -> Prims.bool) =
   fun l  ->
     FStar_Util.for_some
-      (fun uu___0_7968  ->
-         match uu___0_7968 with
-         | Reflectable uu____7970 -> true
-         | uu____7972 -> false) l
+      (fun uu___0_8024  ->
+         match uu___0_8024 with
+         | Reflectable uu____8026 -> true
+         | uu____8028 -> false) l
   
 let withinfo : 'a . 'a -> FStar_Range.range -> 'a withinfo_t =
   fun v1  -> fun r  -> { v = v1; p = r } 
@@ -1695,13 +1707,13 @@ let (range_of_bv : bv -> FStar_Range.range) =
 let (set_range_of_bv : bv -> FStar_Range.range -> bv) =
   fun x  ->
     fun r  ->
-      let uu___413_8090 = x  in
-      let uu____8091 =
+      let uu___416_8146 = x  in
+      let uu____8147 =
         FStar_Ident.mk_ident (((x.ppname).FStar_Ident.idText), r)  in
       {
-        ppname = uu____8091;
-        index = (uu___413_8090.index);
-        sort = (uu___413_8090.sort)
+        ppname = uu____8147;
+        index = (uu___416_8146.index);
+        sort = (uu___416_8146.sort)
       }
   
 let (on_antiquoted : (term -> term) -> quoteinfo -> quoteinfo) =
@@ -1709,66 +1721,66 @@ let (on_antiquoted : (term -> term) -> quoteinfo -> quoteinfo) =
     fun qi  ->
       let aq =
         FStar_List.map
-          (fun uu____8128  ->
-             match uu____8128 with
-             | (bv,t) -> let uu____8139 = f t  in (bv, uu____8139))
+          (fun uu____8184  ->
+             match uu____8184 with
+             | (bv,t) -> let uu____8195 = f t  in (bv, uu____8195))
           qi.antiquotes
          in
-      let uu___421_8140 = qi  in
-      { qkind = (uu___421_8140.qkind); antiquotes = aq }
+      let uu___424_8196 = qi  in
+      { qkind = (uu___424_8196.qkind); antiquotes = aq }
   
 let (lookup_aq : bv -> antiquotations -> term FStar_Pervasives_Native.option)
   =
   fun bv  ->
     fun aq  ->
-      let uu____8156 =
+      let uu____8212 =
         FStar_List.tryFind
-          (fun uu____8174  ->
-             match uu____8174 with | (bv',uu____8183) -> bv_eq bv bv') aq
+          (fun uu____8230  ->
+             match uu____8230 with | (bv',uu____8239) -> bv_eq bv bv') aq
          in
-      match uu____8156 with
-      | FStar_Pervasives_Native.Some (uu____8190,e) ->
+      match uu____8212 with
+      | FStar_Pervasives_Native.Some (uu____8246,e) ->
           FStar_Pervasives_Native.Some e
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
   
 let syn :
-  'Auu____8221 'Auu____8222 'Auu____8223 .
-    'Auu____8221 ->
-      'Auu____8222 ->
-        ('Auu____8222 -> 'Auu____8221 -> 'Auu____8223) -> 'Auu____8223
+  'Auu____8277 'Auu____8278 'Auu____8279 .
+    'Auu____8277 ->
+      'Auu____8278 ->
+        ('Auu____8278 -> 'Auu____8277 -> 'Auu____8279) -> 'Auu____8279
   = fun p  -> fun k  -> fun f  -> f k p 
 let mk_fvs :
-  'Auu____8254 .
-    unit -> 'Auu____8254 FStar_Pervasives_Native.option FStar_ST.ref
-  = fun uu____8263  -> FStar_Util.mk_ref FStar_Pervasives_Native.None 
+  'Auu____8310 .
+    unit -> 'Auu____8310 FStar_Pervasives_Native.option FStar_ST.ref
+  = fun uu____8319  -> FStar_Util.mk_ref FStar_Pervasives_Native.None 
 let mk_uvs :
-  'Auu____8271 .
-    unit -> 'Auu____8271 FStar_Pervasives_Native.option FStar_ST.ref
-  = fun uu____8280  -> FStar_Util.mk_ref FStar_Pervasives_Native.None 
+  'Auu____8327 .
+    unit -> 'Auu____8327 FStar_Pervasives_Native.option FStar_ST.ref
+  = fun uu____8336  -> FStar_Util.mk_ref FStar_Pervasives_Native.None 
 let (new_bv_set : unit -> bv FStar_Util.set) =
-  fun uu____8290  -> FStar_Util.new_set order_bv 
+  fun uu____8346  -> FStar_Util.new_set order_bv 
 let (new_id_set : unit -> FStar_Ident.ident FStar_Util.set) =
-  fun uu____8300  -> FStar_Util.new_set order_ident 
+  fun uu____8356  -> FStar_Util.new_set order_ident 
 let (new_fv_set : unit -> FStar_Ident.lident FStar_Util.set) =
-  fun uu____8310  -> FStar_Util.new_set order_fv 
+  fun uu____8366  -> FStar_Util.new_set order_fv 
 let (order_univ_name : univ_name -> univ_name -> Prims.int) =
   fun x  ->
     fun y  ->
-      let uu____8325 = FStar_Ident.text_of_id x  in
-      let uu____8327 = FStar_Ident.text_of_id y  in
-      FStar_String.compare uu____8325 uu____8327
+      let uu____8381 = FStar_Ident.text_of_id x  in
+      let uu____8383 = FStar_Ident.text_of_id y  in
+      FStar_String.compare uu____8381 uu____8383
   
 let (new_universe_names_set : unit -> univ_name FStar_Util.set) =
-  fun uu____8336  -> FStar_Util.new_set order_univ_name 
+  fun uu____8392  -> FStar_Util.new_set order_univ_name 
 let (eq_binding : binding -> binding -> Prims.bool) =
   fun b1  ->
     fun b2  ->
       match (b1, b2) with
       | (Binding_var bv1,Binding_var bv2) -> bv_eq bv1 bv2
-      | (Binding_lid (lid1,uu____8355),Binding_lid (lid2,uu____8357)) ->
+      | (Binding_lid (lid1,uu____8411),Binding_lid (lid2,uu____8413)) ->
           FStar_Ident.lid_equals lid1 lid2
       | (Binding_univ u1,Binding_univ u2) -> FStar_Ident.ident_equals u1 u2
-      | uu____8392 -> false
+      | uu____8448 -> false
   
 let (no_names : freenames) = new_bv_set () 
 let (no_fvars : FStar_Ident.lident FStar_Util.set) = new_fv_set () 
@@ -1780,27 +1792,27 @@ let (list_of_freenames : freenames -> bv Prims.list) =
   fun fvs  -> FStar_Util.set_elements fvs 
 let mk : 'a . 'a -> 'a mk_t_a =
   fun t  ->
-    fun uu____8446  ->
+    fun uu____8502  ->
       fun r  ->
-        let uu____8450 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
-        { n = t; pos = r; vars = uu____8450 }
+        let uu____8506 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
+        { n = t; pos = r; vars = uu____8506 }
   
 let (bv_to_tm : bv -> term) =
   fun bv  ->
-    let uu____8461 = range_of_bv bv  in
-    mk (Tm_bvar bv) FStar_Pervasives_Native.None uu____8461
+    let uu____8517 = range_of_bv bv  in
+    mk (Tm_bvar bv) FStar_Pervasives_Native.None uu____8517
   
 let (bv_to_name : bv -> term) =
   fun bv  ->
-    let uu____8468 = range_of_bv bv  in
-    mk (Tm_name bv) FStar_Pervasives_Native.None uu____8468
+    let uu____8524 = range_of_bv bv  in
+    mk (Tm_name bv) FStar_Pervasives_Native.None uu____8524
   
 let (binders_to_names : binders -> term Prims.list) =
   fun bs  ->
     FStar_All.pipe_right bs
       (FStar_List.map
-         (fun uu____8498  ->
-            match uu____8498 with | (x,uu____8506) -> bv_to_name x))
+         (fun uu____8554  ->
+            match uu____8554 with | (x,uu____8562) -> bv_to_name x))
   
 let (mk_Tm_app : term -> args -> mk_t) =
   fun t1  ->
@@ -1809,19 +1821,19 @@ let (mk_Tm_app : term -> args -> mk_t) =
         fun p  ->
           match args with
           | [] -> t1
-          | uu____8536 ->
+          | uu____8592 ->
               mk (Tm_app (t1, args)) FStar_Pervasives_Native.None p
   
 let (mk_Tm_uinst : term -> universes -> term) =
   fun t  ->
-    fun uu___1_8561  ->
-      match uu___1_8561 with
+    fun uu___1_8617  ->
+      match uu___1_8617 with
       | [] -> t
       | us ->
           (match t.n with
-           | Tm_fvar uu____8563 ->
+           | Tm_fvar uu____8619 ->
                mk (Tm_uinst (t, us)) FStar_Pervasives_Native.None t.pos
-           | uu____8566 -> failwith "Unexpected universe instantiation")
+           | uu____8622 -> failwith "Unexpected universe instantiation")
   
 let (extend_app_n : term -> args -> mk_t) =
   fun t  ->
@@ -1831,22 +1843,22 @@ let (extend_app_n : term -> args -> mk_t) =
           match t.n with
           | Tm_app (head1,args) ->
               mk_Tm_app head1 (FStar_List.append args args') kopt r
-          | uu____8625 -> mk_Tm_app t args' kopt r
+          | uu____8681 -> mk_Tm_app t args' kopt r
   
 let (extend_app : term -> arg -> mk_t) =
   fun t  -> fun arg  -> fun kopt  -> fun r  -> extend_app_n t [arg] kopt r 
 let (mk_Tm_delayed : (term * subst_ts) -> FStar_Range.range -> term) =
   fun lr  ->
     fun pos  ->
-      let uu____8682 =
-        let uu____8689 =
-          let uu____8690 =
-            let uu____8713 = FStar_Util.mk_ref FStar_Pervasives_Native.None
+      let uu____8738 =
+        let uu____8745 =
+          let uu____8746 =
+            let uu____8769 = FStar_Util.mk_ref FStar_Pervasives_Native.None
                in
-            (lr, uu____8713)  in
-          Tm_delayed uu____8690  in
-        mk uu____8689  in
-      uu____8682 FStar_Pervasives_Native.None pos
+            (lr, uu____8769)  in
+          Tm_delayed uu____8746  in
+        mk uu____8745  in
+      uu____8738 FStar_Pervasives_Native.None pos
   
 let (mk_Total' : typ -> universe FStar_Pervasives_Native.option -> comp) =
   fun t  -> fun u  -> mk (Total (t, u)) FStar_Pervasives_Native.None t.pos 
@@ -1862,8 +1874,8 @@ let (mk_lb :
   (lbname * univ_name Prims.list * FStar_Ident.lident * typ * term *
     attribute Prims.list * FStar_Range.range) -> letbinding)
   =
-  fun uu____8821  ->
-    match uu____8821 with
+  fun uu____8877  ->
+    match uu____8877 with
     | (x,univs,eff,t,e,attrs,pos) ->
         {
           lbname = x;
@@ -1884,7 +1896,8 @@ let (mk_sigelt : sigelt' -> sigelt) =
       sigrng = FStar_Range.dummyRange;
       sigquals = [];
       sigmeta = default_sigmeta;
-      sigattrs = []
+      sigattrs = [];
+      sigopts = FStar_Pervasives_Native.None
     }
   
 let (mk_subst : subst_t -> subst_t) = fun s  -> s 
@@ -1902,10 +1915,10 @@ let (is_teff : term -> Prims.bool) =
   fun t  ->
     match t.n with
     | Tm_constant (FStar_Const.Const_effect ) -> true
-    | uu____8906 -> false
+    | uu____8962 -> false
   
 let (is_type : term -> Prims.bool) =
-  fun t  -> match t.n with | Tm_type uu____8916 -> true | uu____8918 -> false 
+  fun t  -> match t.n with | Tm_type uu____8972 -> true | uu____8974 -> false 
 let (null_id : FStar_Ident.ident) =
   FStar_Ident.mk_ident ("_", FStar_Range.dummyRange) 
 let (null_bv : term -> bv) =
@@ -1913,7 +1926,7 @@ let (null_bv : term -> bv) =
 let (mk_binder : bv -> binder) = fun a  -> (a, FStar_Pervasives_Native.None) 
 let (null_binder : term -> binder) =
   fun t  ->
-    let uu____8944 = null_bv t  in (uu____8944, FStar_Pervasives_Native.None)
+    let uu____9000 = null_bv t  in (uu____9000, FStar_Pervasives_Native.None)
   
 let (imp_tag : arg_qualifier) = Implicit false 
 let (iarg : term -> arg) =
@@ -1924,19 +1937,19 @@ let (is_null_bv : bv -> Prims.bool) =
 let (is_null_binder : binder -> Prims.bool) =
   fun b  -> is_null_bv (FStar_Pervasives_Native.fst b) 
 let (is_top_level : letbinding Prims.list -> Prims.bool) =
-  fun uu___2_8994  ->
-    match uu___2_8994 with
-    | { lbname = FStar_Util.Inr uu____8998; lbunivs = uu____8999;
-        lbtyp = uu____9000; lbeff = uu____9001; lbdef = uu____9002;
-        lbattrs = uu____9003; lbpos = uu____9004;_}::uu____9005 -> true
-    | uu____9019 -> false
+  fun uu___2_9050  ->
+    match uu___2_9050 with
+    | { lbname = FStar_Util.Inr uu____9054; lbunivs = uu____9055;
+        lbtyp = uu____9056; lbeff = uu____9057; lbdef = uu____9058;
+        lbattrs = uu____9059; lbpos = uu____9060;_}::uu____9061 -> true
+    | uu____9075 -> false
   
 let (freenames_of_binders : binders -> freenames) =
   fun bs  ->
     FStar_List.fold_right
-      (fun uu____9041  ->
+      (fun uu____9097  ->
          fun out  ->
-           match uu____9041 with | (x,uu____9054) -> FStar_Util.set_add x out)
+           match uu____9097 with | (x,uu____9110) -> FStar_Util.set_add x out)
       bs no_names
   
 let (binders_of_list : bv Prims.list -> binders) =
@@ -1946,18 +1959,18 @@ let (binders_of_list : bv Prims.list -> binders) =
   
 let (binders_of_freenames : freenames -> binders) =
   fun fvs  ->
-    let uu____9087 = FStar_Util.set_elements fvs  in
-    FStar_All.pipe_right uu____9087 binders_of_list
+    let uu____9143 = FStar_Util.set_elements fvs  in
+    FStar_All.pipe_right uu____9143 binders_of_list
   
 let (is_implicit : aqual -> Prims.bool) =
-  fun uu___3_9098  ->
-    match uu___3_9098 with
-    | FStar_Pervasives_Native.Some (Implicit uu____9100) -> true
-    | uu____9103 -> false
+  fun uu___3_9154  ->
+    match uu___3_9154 with
+    | FStar_Pervasives_Native.Some (Implicit uu____9156) -> true
+    | uu____9159 -> false
   
 let (as_implicit : Prims.bool -> aqual) =
-  fun uu___4_9111  ->
-    if uu___4_9111
+  fun uu___4_9167  ->
+    if uu___4_9167
     then FStar_Pervasives_Native.Some imp_tag
     else FStar_Pervasives_Native.None
   
@@ -1965,23 +1978,23 @@ let (pat_bvs : pat -> bv Prims.list) =
   fun p  ->
     let rec aux b p1 =
       match p1.v with
-      | Pat_dot_term uu____9149 -> b
-      | Pat_constant uu____9156 -> b
+      | Pat_dot_term uu____9205 -> b
+      | Pat_constant uu____9212 -> b
       | Pat_wild x -> x :: b
       | Pat_var x -> x :: b
-      | Pat_cons (uu____9159,pats) ->
+      | Pat_cons (uu____9215,pats) ->
           FStar_List.fold_left
             (fun b1  ->
-               fun uu____9193  ->
-                 match uu____9193 with | (p2,uu____9206) -> aux b1 p2) b pats
+               fun uu____9249  ->
+                 match uu____9249 with | (p2,uu____9262) -> aux b1 p2) b pats
        in
-    let uu____9213 = aux [] p  in
-    FStar_All.pipe_left FStar_List.rev uu____9213
+    let uu____9269 = aux [] p  in
+    FStar_All.pipe_left FStar_List.rev uu____9269
   
 let (range_of_ropt :
   FStar_Range.range FStar_Pervasives_Native.option -> FStar_Range.range) =
-  fun uu___5_9227  ->
-    match uu___5_9227 with
+  fun uu___5_9283  ->
+    match uu___5_9283 with
     | FStar_Pervasives_Native.None  -> FStar_Range.dummyRange
     | FStar_Pervasives_Native.Some r -> r
   
@@ -1993,45 +2006,45 @@ let (gen_bv :
     fun r  ->
       fun t  ->
         let id1 = FStar_Ident.mk_ident (s, (range_of_ropt r))  in
-        let uu____9267 = FStar_Ident.next_id ()  in
-        { ppname = id1; index = uu____9267; sort = t }
+        let uu____9323 = FStar_Ident.next_id ()  in
+        { ppname = id1; index = uu____9323; sort = t }
   
 let (new_bv : FStar_Range.range FStar_Pervasives_Native.option -> typ -> bv)
   = fun ropt  -> fun t  -> gen_bv FStar_Ident.reserved_prefix ropt t 
 let (freshen_bv : bv -> bv) =
   fun bv  ->
-    let uu____9290 = is_null_bv bv  in
-    if uu____9290
+    let uu____9346 = is_null_bv bv  in
+    if uu____9346
     then
-      let uu____9293 =
-        let uu____9296 = range_of_bv bv  in
-        FStar_Pervasives_Native.Some uu____9296  in
-      new_bv uu____9293 bv.sort
+      let uu____9349 =
+        let uu____9352 = range_of_bv bv  in
+        FStar_Pervasives_Native.Some uu____9352  in
+      new_bv uu____9349 bv.sort
     else
-      (let uu___602_9299 = bv  in
-       let uu____9300 = FStar_Ident.next_id ()  in
+      (let uu___605_9355 = bv  in
+       let uu____9356 = FStar_Ident.next_id ()  in
        {
-         ppname = (uu___602_9299.ppname);
-         index = uu____9300;
-         sort = (uu___602_9299.sort)
+         ppname = (uu___605_9355.ppname);
+         index = uu____9356;
+         sort = (uu___605_9355.sort)
        })
   
 let (freshen_binder : binder -> binder) =
   fun b  ->
-    let uu____9308 = b  in
-    match uu____9308 with
-    | (bv,aq) -> let uu____9315 = freshen_bv bv  in (uu____9315, aq)
+    let uu____9364 = b  in
+    match uu____9364 with
+    | (bv,aq) -> let uu____9371 = freshen_bv bv  in (uu____9371, aq)
   
 let (new_univ_name :
   FStar_Range.range FStar_Pervasives_Native.option -> univ_name) =
   fun ropt  ->
     let id1 = FStar_Ident.next_id ()  in
-    let uu____9330 =
-      let uu____9336 =
-        let uu____9338 = FStar_Util.string_of_int id1  in
-        Prims.op_Hat FStar_Ident.reserved_prefix uu____9338  in
-      (uu____9336, (range_of_ropt ropt))  in
-    FStar_Ident.mk_ident uu____9330
+    let uu____9386 =
+      let uu____9392 =
+        let uu____9394 = FStar_Util.string_of_int id1  in
+        Prims.op_Hat FStar_Ident.reserved_prefix uu____9394  in
+      (uu____9392, (range_of_ropt ropt))  in
+    FStar_Ident.mk_ident uu____9386
   
 let (mkbv : FStar_Ident.ident -> Prims.int -> term' syntax -> bv) =
   fun x  -> fun y  -> fun t  -> { ppname = x; index = y; sort = t } 
@@ -2044,7 +2057,7 @@ let (lbname_eq :
       match (l1, l2) with
       | (FStar_Util.Inl x,FStar_Util.Inl y) -> bv_eq x y
       | (FStar_Util.Inr l,FStar_Util.Inr m) -> FStar_Ident.lid_equals l m
-      | uu____9420 -> false
+      | uu____9476 -> false
   
 let (fv_eq : fv -> fv -> Prims.bool) =
   fun fv1  ->
@@ -2055,13 +2068,13 @@ let (fv_eq_lid : fv -> FStar_Ident.lident -> Prims.bool) =
 let (set_bv_range : bv -> FStar_Range.range -> bv) =
   fun bv  ->
     fun r  ->
-      let uu___632_9469 = bv  in
-      let uu____9470 =
+      let uu___635_9525 = bv  in
+      let uu____9526 =
         FStar_Ident.mk_ident (((bv.ppname).FStar_Ident.idText), r)  in
       {
-        ppname = uu____9470;
-        index = (uu___632_9469.index);
-        sort = (uu___632_9469.sort)
+        ppname = uu____9526;
+        index = (uu___635_9525.index);
+        sort = (uu___635_9525.sort)
       }
   
 let (lid_as_fv :
@@ -2071,15 +2084,15 @@ let (lid_as_fv :
   fun l  ->
     fun dd  ->
       fun dq  ->
-        let uu____9492 =
-          let uu____9493 = FStar_Ident.range_of_lid l  in
-          withinfo l uu____9493  in
-        { fv_name = uu____9492; fv_delta = dd; fv_qual = dq }
+        let uu____9548 =
+          let uu____9549 = FStar_Ident.range_of_lid l  in
+          withinfo l uu____9549  in
+        { fv_name = uu____9548; fv_delta = dd; fv_qual = dq }
   
 let (fv_to_tm : fv -> term) =
   fun fv  ->
-    let uu____9500 = FStar_Ident.range_of_lid (fv.fv_name).v  in
-    mk (Tm_fvar fv) FStar_Pervasives_Native.None uu____9500
+    let uu____9556 = FStar_Ident.range_of_lid (fv.fv_name).v  in
+    mk (Tm_fvar fv) FStar_Pervasives_Native.None uu____9556
   
 let (fvar :
   FStar_Ident.lident ->
@@ -2087,38 +2100,38 @@ let (fvar :
   =
   fun l  ->
     fun dd  ->
-      fun dq  -> let uu____9521 = lid_as_fv l dd dq  in fv_to_tm uu____9521
+      fun dq  -> let uu____9577 = lid_as_fv l dd dq  in fv_to_tm uu____9577
   
 let (lid_of_fv : fv -> FStar_Ident.lid) = fun fv  -> (fv.fv_name).v 
 let (range_of_fv : fv -> FStar_Range.range) =
   fun fv  ->
-    let uu____9534 = lid_of_fv fv  in FStar_Ident.range_of_lid uu____9534
+    let uu____9590 = lid_of_fv fv  in FStar_Ident.range_of_lid uu____9590
   
 let (set_range_of_fv : fv -> FStar_Range.range -> fv) =
   fun fv  ->
     fun r  ->
-      let uu___645_9546 = fv  in
-      let uu____9547 =
-        let uu___647_9548 = fv.fv_name  in
-        let uu____9549 =
-          let uu____9550 = lid_of_fv fv  in
-          FStar_Ident.set_lid_range uu____9550 r  in
-        { v = uu____9549; p = (uu___647_9548.p) }  in
+      let uu___648_9602 = fv  in
+      let uu____9603 =
+        let uu___650_9604 = fv.fv_name  in
+        let uu____9605 =
+          let uu____9606 = lid_of_fv fv  in
+          FStar_Ident.set_lid_range uu____9606 r  in
+        { v = uu____9605; p = (uu___650_9604.p) }  in
       {
-        fv_name = uu____9547;
-        fv_delta = (uu___645_9546.fv_delta);
-        fv_qual = (uu___645_9546.fv_qual)
+        fv_name = uu____9603;
+        fv_delta = (uu___648_9602.fv_delta);
+        fv_qual = (uu___648_9602.fv_qual)
       }
   
 let (has_simple_attribute : term Prims.list -> Prims.string -> Prims.bool) =
   fun l  ->
     fun s  ->
       FStar_List.existsb
-        (fun uu___6_9576  ->
-           match uu___6_9576 with
-           | { n = Tm_constant (FStar_Const.Const_string (data,uu____9581));
-               pos = uu____9582; vars = uu____9583;_} when data = s -> true
-           | uu____9590 -> false) l
+        (fun uu___6_9632  ->
+           match uu___6_9632 with
+           | { n = Tm_constant (FStar_Const.Const_string (data,uu____9637));
+               pos = uu____9638; vars = uu____9639;_} when data = s -> true
+           | uu____9646 -> false) l
   
 let rec (eq_pat : pat -> pat -> Prims.bool) =
   fun p1  ->
@@ -2126,20 +2139,20 @@ let rec (eq_pat : pat -> pat -> Prims.bool) =
       match ((p1.v), (p2.v)) with
       | (Pat_constant c1,Pat_constant c2) -> FStar_Const.eq_const c1 c2
       | (Pat_cons (fv1,as1),Pat_cons (fv2,as2)) ->
-          let uu____9649 = fv_eq fv1 fv2  in
-          if uu____9649
+          let uu____9705 = fv_eq fv1 fv2  in
+          if uu____9705
           then
-            let uu____9654 = FStar_List.zip as1 as2  in
-            FStar_All.pipe_right uu____9654
+            let uu____9710 = FStar_List.zip as1 as2  in
+            FStar_All.pipe_right uu____9710
               (FStar_List.for_all
-                 (fun uu____9721  ->
-                    match uu____9721 with
+                 (fun uu____9777  ->
+                    match uu____9777 with
                     | ((p11,b1),(p21,b2)) -> (b1 = b2) && (eq_pat p11 p21)))
           else false
-      | (Pat_var uu____9759,Pat_var uu____9760) -> true
-      | (Pat_wild uu____9762,Pat_wild uu____9763) -> true
+      | (Pat_var uu____9815,Pat_var uu____9816) -> true
+      | (Pat_wild uu____9818,Pat_wild uu____9819) -> true
       | (Pat_dot_term (bv1,t1),Pat_dot_term (bv2,t2)) -> true
-      | (uu____9778,uu____9779) -> false
+      | (uu____9834,uu____9835) -> false
   
 let (delta_constant : delta_depth) = Delta_constant_at_level Prims.int_zero 
 let (delta_equational : delta_depth) =
@@ -2148,28 +2161,28 @@ let (fvconst : FStar_Ident.lident -> fv) =
   fun l  -> lid_as_fv l delta_constant FStar_Pervasives_Native.None 
 let (tconst : FStar_Ident.lident -> term) =
   fun l  ->
-    let uu____9797 =
-      let uu____9804 = let uu____9805 = fvconst l  in Tm_fvar uu____9805  in
-      mk uu____9804  in
-    uu____9797 FStar_Pervasives_Native.None FStar_Range.dummyRange
+    let uu____9853 =
+      let uu____9860 = let uu____9861 = fvconst l  in Tm_fvar uu____9861  in
+      mk uu____9860  in
+    uu____9853 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (tabbrev : FStar_Ident.lident -> term) =
   fun l  ->
-    let uu____9812 =
-      let uu____9819 =
-        let uu____9820 =
+    let uu____9868 =
+      let uu____9875 =
+        let uu____9876 =
           lid_as_fv l (Delta_constant_at_level Prims.int_one)
             FStar_Pervasives_Native.None
            in
-        Tm_fvar uu____9820  in
-      mk uu____9819  in
-    uu____9812 FStar_Pervasives_Native.None FStar_Range.dummyRange
+        Tm_fvar uu____9876  in
+      mk uu____9875  in
+    uu____9868 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (tdataconstr : FStar_Ident.lident -> term) =
   fun l  ->
-    let uu____9828 =
+    let uu____9884 =
       lid_as_fv l delta_constant (FStar_Pervasives_Native.Some Data_ctor)  in
-    fv_to_tm uu____9828
+    fv_to_tm uu____9884
   
 let (t_unit : term) = tconst FStar_Parser_Const.unit_lid 
 let (t_bool : term) = tconst FStar_Parser_Const.bool_lid 
@@ -2189,60 +2202,60 @@ let (t_bv : term) = tconst FStar_Parser_Const.bv_lid
 let (t_fv : term) = tconst FStar_Parser_Const.fv_lid 
 let (t_norm_step : term) = tconst FStar_Parser_Const.norm_step_lid 
 let (t_tactic_unit : term) =
-  let uu____9847 =
-    let uu____9852 =
-      let uu____9853 = tabbrev FStar_Parser_Const.tactic_lid  in
-      mk_Tm_uinst uu____9853 [U_zero]  in
-    let uu____9854 = let uu____9855 = as_arg t_unit  in [uu____9855]  in
-    mk_Tm_app uu____9852 uu____9854  in
-  uu____9847 FStar_Pervasives_Native.None FStar_Range.dummyRange 
+  let uu____9903 =
+    let uu____9908 =
+      let uu____9909 = tabbrev FStar_Parser_Const.tactic_lid  in
+      mk_Tm_uinst uu____9909 [U_zero]  in
+    let uu____9910 = let uu____9911 = as_arg t_unit  in [uu____9911]  in
+    mk_Tm_app uu____9908 uu____9910  in
+  uu____9903 FStar_Pervasives_Native.None FStar_Range.dummyRange 
 let (t_list_of : term -> term) =
   fun t  ->
-    let uu____9886 =
-      let uu____9891 =
-        let uu____9892 = tabbrev FStar_Parser_Const.list_lid  in
-        mk_Tm_uinst uu____9892 [U_zero]  in
-      let uu____9893 = let uu____9894 = as_arg t  in [uu____9894]  in
-      mk_Tm_app uu____9891 uu____9893  in
-    uu____9886 FStar_Pervasives_Native.None FStar_Range.dummyRange
+    let uu____9942 =
+      let uu____9947 =
+        let uu____9948 = tabbrev FStar_Parser_Const.list_lid  in
+        mk_Tm_uinst uu____9948 [U_zero]  in
+      let uu____9949 = let uu____9950 = as_arg t  in [uu____9950]  in
+      mk_Tm_app uu____9947 uu____9949  in
+    uu____9942 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (t_option_of : term -> term) =
   fun t  ->
-    let uu____9925 =
-      let uu____9930 =
-        let uu____9931 = tabbrev FStar_Parser_Const.option_lid  in
-        mk_Tm_uinst uu____9931 [U_zero]  in
-      let uu____9932 = let uu____9933 = as_arg t  in [uu____9933]  in
-      mk_Tm_app uu____9930 uu____9932  in
-    uu____9925 FStar_Pervasives_Native.None FStar_Range.dummyRange
+    let uu____9981 =
+      let uu____9986 =
+        let uu____9987 = tabbrev FStar_Parser_Const.option_lid  in
+        mk_Tm_uinst uu____9987 [U_zero]  in
+      let uu____9988 = let uu____9989 = as_arg t  in [uu____9989]  in
+      mk_Tm_app uu____9986 uu____9988  in
+    uu____9981 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (t_tuple2_of : term -> term -> term) =
   fun t1  ->
     fun t2  ->
-      let uu____9969 =
-        let uu____9974 =
-          let uu____9975 = tabbrev FStar_Parser_Const.lid_tuple2  in
-          mk_Tm_uinst uu____9975 [U_zero; U_zero]  in
-        let uu____9976 =
-          let uu____9977 = as_arg t1  in
-          let uu____9986 = let uu____9997 = as_arg t2  in [uu____9997]  in
-          uu____9977 :: uu____9986  in
-        mk_Tm_app uu____9974 uu____9976  in
-      uu____9969 FStar_Pervasives_Native.None FStar_Range.dummyRange
+      let uu____10025 =
+        let uu____10030 =
+          let uu____10031 = tabbrev FStar_Parser_Const.lid_tuple2  in
+          mk_Tm_uinst uu____10031 [U_zero; U_zero]  in
+        let uu____10032 =
+          let uu____10033 = as_arg t1  in
+          let uu____10042 = let uu____10053 = as_arg t2  in [uu____10053]  in
+          uu____10033 :: uu____10042  in
+        mk_Tm_app uu____10030 uu____10032  in
+      uu____10025 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (t_either_of : term -> term -> term) =
   fun t1  ->
     fun t2  ->
-      let uu____10041 =
-        let uu____10046 =
-          let uu____10047 = tabbrev FStar_Parser_Const.either_lid  in
-          mk_Tm_uinst uu____10047 [U_zero; U_zero]  in
-        let uu____10048 =
-          let uu____10049 = as_arg t1  in
-          let uu____10058 = let uu____10069 = as_arg t2  in [uu____10069]  in
-          uu____10049 :: uu____10058  in
-        mk_Tm_app uu____10046 uu____10048  in
-      uu____10041 FStar_Pervasives_Native.None FStar_Range.dummyRange
+      let uu____10097 =
+        let uu____10102 =
+          let uu____10103 = tabbrev FStar_Parser_Const.either_lid  in
+          mk_Tm_uinst uu____10103 [U_zero; U_zero]  in
+        let uu____10104 =
+          let uu____10105 = as_arg t1  in
+          let uu____10114 = let uu____10125 = as_arg t2  in [uu____10125]  in
+          uu____10105 :: uu____10114  in
+        mk_Tm_app uu____10102 uu____10104  in
+      uu____10097 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (unit_const : term) =
   mk (Tm_constant FStar_Const.Const_unit) FStar_Pervasives_Native.None

--- a/src/ocaml-output/FStar_Syntax_Util.ml
+++ b/src/ocaml-output/FStar_Syntax_Util.ml
@@ -887,6 +887,8 @@ let (eq_lazy_kind :
       | (FStar_Syntax_Syntax.Lazy_bv ,FStar_Syntax_Syntax.Lazy_bv ) -> true
       | (FStar_Syntax_Syntax.Lazy_binder ,FStar_Syntax_Syntax.Lazy_binder )
           -> true
+      | (FStar_Syntax_Syntax.Lazy_optionstate
+         ,FStar_Syntax_Syntax.Lazy_optionstate ) -> true
       | (FStar_Syntax_Syntax.Lazy_fvar ,FStar_Syntax_Syntax.Lazy_fvar ) ->
           true
       | (FStar_Syntax_Syntax.Lazy_comp ,FStar_Syntax_Syntax.Lazy_comp ) ->
@@ -900,24 +902,24 @@ let (eq_lazy_kind :
           -> true
       | (FStar_Syntax_Syntax.Lazy_uvar ,FStar_Syntax_Syntax.Lazy_uvar ) ->
           true
-      | uu____2892 -> false
+      | uu____2893 -> false
   
 let rec unlazy_as_t :
-  'Auu____2905 .
-    FStar_Syntax_Syntax.lazy_kind -> FStar_Syntax_Syntax.term -> 'Auu____2905
+  'Auu____2906 .
+    FStar_Syntax_Syntax.lazy_kind -> FStar_Syntax_Syntax.term -> 'Auu____2906
   =
   fun k  ->
     fun t  ->
-      let uu____2916 =
-        let uu____2917 = FStar_Syntax_Subst.compress t  in
-        uu____2917.FStar_Syntax_Syntax.n  in
-      match uu____2916 with
+      let uu____2917 =
+        let uu____2918 = FStar_Syntax_Subst.compress t  in
+        uu____2918.FStar_Syntax_Syntax.n  in
+      match uu____2917 with
       | FStar_Syntax_Syntax.Tm_lazy
           { FStar_Syntax_Syntax.blob = v1; FStar_Syntax_Syntax.lkind = k';
-            FStar_Syntax_Syntax.ltyp = uu____2922;
-            FStar_Syntax_Syntax.rng = uu____2923;_}
+            FStar_Syntax_Syntax.ltyp = uu____2923;
+            FStar_Syntax_Syntax.rng = uu____2924;_}
           when eq_lazy_kind k k' -> FStar_Dyn.undyn v1
-      | uu____2926 -> failwith "Not a Tm_lazy of the expected kind"
+      | uu____2927 -> failwith "Not a Tm_lazy of the expected kind"
   
 let mk_lazy :
   'a .
@@ -936,9 +938,9 @@ let mk_lazy :
             | FStar_Pervasives_Native.Some r1 -> r1
             | FStar_Pervasives_Native.None  -> FStar_Range.dummyRange  in
           let i =
-            let uu____2967 = FStar_Dyn.mkdyn t  in
+            let uu____2968 = FStar_Dyn.mkdyn t  in
             {
-              FStar_Syntax_Syntax.blob = uu____2967;
+              FStar_Syntax_Syntax.blob = uu____2968;
               FStar_Syntax_Syntax.lkind = k;
               FStar_Syntax_Syntax.ltyp = typ;
               FStar_Syntax_Syntax.rng = rng
@@ -951,9 +953,9 @@ let (canon_app :
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   fun t  ->
-    let uu____2980 =
-      let uu____2995 = unascribe t  in head_and_args' uu____2995  in
-    match uu____2980 with
+    let uu____2981 =
+      let uu____2996 = unascribe t  in head_and_args' uu____2996  in
+    match uu____2981 with
     | (hd1,args) ->
         FStar_Syntax_Syntax.mk_Tm_app hd1 args FStar_Pervasives_Native.None
           t.FStar_Syntax_Syntax.pos
@@ -964,15 +966,15 @@ type eq_result =
   | Unknown 
 let (uu___is_Equal : eq_result -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Equal  -> true | uu____3029 -> false
+    match projectee with | Equal  -> true | uu____3030 -> false
   
 let (uu___is_NotEqual : eq_result -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NotEqual  -> true | uu____3040 -> false
+    match projectee with | NotEqual  -> true | uu____3041 -> false
   
 let (uu___is_Unknown : eq_result -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Unknown  -> true | uu____3051 -> false
+    match projectee with | Unknown  -> true | uu____3052 -> false
   
 let (injectives : Prims.string Prims.list) =
   ["FStar.Int8.int_to_t";
@@ -996,10 +998,10 @@ let (eq_inj : eq_result -> eq_result -> eq_result) =
     fun g  ->
       match (f, g) with
       | (Equal ,Equal ) -> Equal
-      | (NotEqual ,uu____3101) -> NotEqual
-      | (uu____3102,NotEqual ) -> NotEqual
-      | (Unknown ,uu____3103) -> Unknown
-      | (uu____3104,Unknown ) -> Unknown
+      | (NotEqual ,uu____3102) -> NotEqual
+      | (uu____3103,NotEqual ) -> NotEqual
+      | (Unknown ,uu____3104) -> Unknown
+      | (uu____3105,Unknown ) -> Unknown
   
 let rec (eq_tm :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> eq_result) =
@@ -1007,45 +1009,45 @@ let rec (eq_tm :
     fun t2  ->
       let t11 = canon_app t1  in
       let t21 = canon_app t2  in
-      let equal_if uu___9_3225 = if uu___9_3225 then Equal else Unknown  in
-      let equal_iff uu___10_3236 = if uu___10_3236 then Equal else NotEqual
+      let equal_if uu___9_3226 = if uu___9_3226 then Equal else Unknown  in
+      let equal_iff uu___10_3237 = if uu___10_3237 then Equal else NotEqual
          in
-      let eq_and f g = match f with | Equal  -> g () | uu____3257 -> Unknown
+      let eq_and f g = match f with | Equal  -> g () | uu____3258 -> Unknown
          in
       let equal_data f1 args1 f2 args2 =
-        let uu____3279 = FStar_Syntax_Syntax.fv_eq f1 f2  in
-        if uu____3279
+        let uu____3280 = FStar_Syntax_Syntax.fv_eq f1 f2  in
+        if uu____3280
         then
-          let uu____3283 = FStar_List.zip args1 args2  in
+          let uu____3284 = FStar_List.zip args1 args2  in
           FStar_All.pipe_left
             (FStar_List.fold_left
                (fun acc  ->
-                  fun uu____3360  ->
-                    match uu____3360 with
+                  fun uu____3361  ->
+                    match uu____3361 with
                     | ((a1,q1),(a2,q2)) ->
-                        let uu____3401 = eq_tm a1 a2  in
-                        eq_inj acc uu____3401) Equal) uu____3283
+                        let uu____3402 = eq_tm a1 a2  in
+                        eq_inj acc uu____3402) Equal) uu____3284
         else NotEqual  in
       let heads_and_args_in_case_both_data =
-        let uu____3415 =
-          let uu____3432 = FStar_All.pipe_right t11 unmeta  in
-          FStar_All.pipe_right uu____3432 head_and_args  in
-        match uu____3415 with
+        let uu____3416 =
+          let uu____3433 = FStar_All.pipe_right t11 unmeta  in
+          FStar_All.pipe_right uu____3433 head_and_args  in
+        match uu____3416 with
         | (head1,args1) ->
-            let uu____3485 =
-              let uu____3502 = FStar_All.pipe_right t21 unmeta  in
-              FStar_All.pipe_right uu____3502 head_and_args  in
-            (match uu____3485 with
+            let uu____3486 =
+              let uu____3503 = FStar_All.pipe_right t21 unmeta  in
+              FStar_All.pipe_right uu____3503 head_and_args  in
+            (match uu____3486 with
              | (head2,args2) ->
-                 let uu____3555 =
-                   let uu____3560 =
-                     let uu____3561 = un_uinst head1  in
-                     uu____3561.FStar_Syntax_Syntax.n  in
-                   let uu____3564 =
-                     let uu____3565 = un_uinst head2  in
-                     uu____3565.FStar_Syntax_Syntax.n  in
-                   (uu____3560, uu____3564)  in
-                 (match uu____3555 with
+                 let uu____3556 =
+                   let uu____3561 =
+                     let uu____3562 = un_uinst head1  in
+                     uu____3562.FStar_Syntax_Syntax.n  in
+                   let uu____3565 =
+                     let uu____3566 = un_uinst head2  in
+                     uu____3566.FStar_Syntax_Syntax.n  in
+                   (uu____3561, uu____3565)  in
+                 (match uu____3556 with
                   | (FStar_Syntax_Syntax.Tm_fvar
                      f,FStar_Syntax_Syntax.Tm_fvar g) when
                       (f.FStar_Syntax_Syntax.fv_qual =
@@ -1056,111 +1058,111 @@ let rec (eq_tm :
                            (FStar_Pervasives_Native.Some
                               FStar_Syntax_Syntax.Data_ctor))
                       -> FStar_Pervasives_Native.Some (f, args1, g, args2)
-                  | uu____3592 -> FStar_Pervasives_Native.None))
+                  | uu____3593 -> FStar_Pervasives_Native.None))
          in
-      let uu____3605 =
-        let uu____3610 =
-          let uu____3611 = unmeta t11  in uu____3611.FStar_Syntax_Syntax.n
+      let uu____3606 =
+        let uu____3611 =
+          let uu____3612 = unmeta t11  in uu____3612.FStar_Syntax_Syntax.n
            in
-        let uu____3614 =
-          let uu____3615 = unmeta t21  in uu____3615.FStar_Syntax_Syntax.n
+        let uu____3615 =
+          let uu____3616 = unmeta t21  in uu____3616.FStar_Syntax_Syntax.n
            in
-        (uu____3610, uu____3614)  in
-      match uu____3605 with
+        (uu____3611, uu____3615)  in
+      match uu____3606 with
       | (FStar_Syntax_Syntax.Tm_bvar bv1,FStar_Syntax_Syntax.Tm_bvar bv2) ->
           equal_if
             (bv1.FStar_Syntax_Syntax.index = bv2.FStar_Syntax_Syntax.index)
-      | (FStar_Syntax_Syntax.Tm_lazy uu____3621,uu____3622) ->
-          let uu____3623 = unlazy t11  in eq_tm uu____3623 t21
-      | (uu____3624,FStar_Syntax_Syntax.Tm_lazy uu____3625) ->
-          let uu____3626 = unlazy t21  in eq_tm t11 uu____3626
+      | (FStar_Syntax_Syntax.Tm_lazy uu____3622,uu____3623) ->
+          let uu____3624 = unlazy t11  in eq_tm uu____3624 t21
+      | (uu____3625,FStar_Syntax_Syntax.Tm_lazy uu____3626) ->
+          let uu____3627 = unlazy t21  in eq_tm t11 uu____3627
       | (FStar_Syntax_Syntax.Tm_name a,FStar_Syntax_Syntax.Tm_name b) ->
           equal_if (FStar_Syntax_Syntax.bv_eq a b)
-      | uu____3629 when
+      | uu____3630 when
           FStar_All.pipe_right heads_and_args_in_case_both_data
             FStar_Util.is_some
           ->
-          let uu____3653 =
+          let uu____3654 =
             FStar_All.pipe_right heads_and_args_in_case_both_data
               FStar_Util.must
              in
-          FStar_All.pipe_right uu____3653
-            (fun uu____3701  ->
-               match uu____3701 with
+          FStar_All.pipe_right uu____3654
+            (fun uu____3702  ->
+               match uu____3702 with
                | (f,args1,g,args2) -> equal_data f args1 g args2)
       | (FStar_Syntax_Syntax.Tm_fvar f,FStar_Syntax_Syntax.Tm_fvar g) ->
-          let uu____3716 = FStar_Syntax_Syntax.fv_eq f g  in
-          equal_if uu____3716
+          let uu____3717 = FStar_Syntax_Syntax.fv_eq f g  in
+          equal_if uu____3717
       | (FStar_Syntax_Syntax.Tm_uinst (f,us),FStar_Syntax_Syntax.Tm_uinst
          (g,vs)) ->
-          let uu____3730 = eq_tm f g  in
-          eq_and uu____3730
-            (fun uu____3733  ->
-               let uu____3734 = eq_univs_list us vs  in equal_if uu____3734)
+          let uu____3731 = eq_tm f g  in
+          eq_and uu____3731
+            (fun uu____3734  ->
+               let uu____3735 = eq_univs_list us vs  in equal_if uu____3735)
       | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range
-         uu____3736),uu____3737) -> Unknown
-      | (uu____3738,FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range
-         uu____3739)) -> Unknown
+         uu____3737),uu____3738) -> Unknown
+      | (uu____3739,FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range
+         uu____3740)) -> Unknown
       | (FStar_Syntax_Syntax.Tm_constant c,FStar_Syntax_Syntax.Tm_constant d)
           ->
-          let uu____3742 = FStar_Const.eq_const c d  in equal_iff uu____3742
+          let uu____3743 = FStar_Const.eq_const c d  in equal_iff uu____3743
       | (FStar_Syntax_Syntax.Tm_uvar
-         (u1,([],uu____3745)),FStar_Syntax_Syntax.Tm_uvar
-         (u2,([],uu____3747))) ->
-          let uu____3776 =
+         (u1,([],uu____3746)),FStar_Syntax_Syntax.Tm_uvar
+         (u2,([],uu____3748))) ->
+          let uu____3777 =
             FStar_Syntax_Unionfind.equiv u1.FStar_Syntax_Syntax.ctx_uvar_head
               u2.FStar_Syntax_Syntax.ctx_uvar_head
              in
-          equal_if uu____3776
+          equal_if uu____3777
       | (FStar_Syntax_Syntax.Tm_app (h1,args1),FStar_Syntax_Syntax.Tm_app
          (h2,args2)) ->
-          let uu____3830 =
-            let uu____3835 =
-              let uu____3836 = un_uinst h1  in
-              uu____3836.FStar_Syntax_Syntax.n  in
-            let uu____3839 =
-              let uu____3840 = un_uinst h2  in
-              uu____3840.FStar_Syntax_Syntax.n  in
-            (uu____3835, uu____3839)  in
-          (match uu____3830 with
+          let uu____3831 =
+            let uu____3836 =
+              let uu____3837 = un_uinst h1  in
+              uu____3837.FStar_Syntax_Syntax.n  in
+            let uu____3840 =
+              let uu____3841 = un_uinst h2  in
+              uu____3841.FStar_Syntax_Syntax.n  in
+            (uu____3836, uu____3840)  in
+          (match uu____3831 with
            | (FStar_Syntax_Syntax.Tm_fvar f1,FStar_Syntax_Syntax.Tm_fvar f2)
                when
                (FStar_Syntax_Syntax.fv_eq f1 f2) &&
-                 (let uu____3846 =
-                    let uu____3848 = FStar_Syntax_Syntax.lid_of_fv f1  in
-                    FStar_Ident.string_of_lid uu____3848  in
-                  FStar_List.mem uu____3846 injectives)
+                 (let uu____3847 =
+                    let uu____3849 = FStar_Syntax_Syntax.lid_of_fv f1  in
+                    FStar_Ident.string_of_lid uu____3849  in
+                  FStar_List.mem uu____3847 injectives)
                -> equal_data f1 args1 f2 args2
-           | uu____3850 ->
-               let uu____3855 = eq_tm h1 h2  in
-               eq_and uu____3855 (fun uu____3857  -> eq_args args1 args2))
+           | uu____3851 ->
+               let uu____3856 = eq_tm h1 h2  in
+               eq_and uu____3856 (fun uu____3858  -> eq_args args1 args2))
       | (FStar_Syntax_Syntax.Tm_match (t12,bs1),FStar_Syntax_Syntax.Tm_match
          (t22,bs2)) ->
           if (FStar_List.length bs1) = (FStar_List.length bs2)
           then
-            let uu____3963 = FStar_List.zip bs1 bs2  in
-            let uu____4026 = eq_tm t12 t22  in
+            let uu____3964 = FStar_List.zip bs1 bs2  in
+            let uu____4027 = eq_tm t12 t22  in
             FStar_List.fold_right
-              (fun uu____4063  ->
+              (fun uu____4064  ->
                  fun a  ->
-                   match uu____4063 with
+                   match uu____4064 with
                    | (b1,b2) ->
-                       eq_and a (fun uu____4156  -> branch_matches b1 b2))
-              uu____3963 uu____4026
+                       eq_and a (fun uu____4157  -> branch_matches b1 b2))
+              uu____3964 uu____4027
           else Unknown
       | (FStar_Syntax_Syntax.Tm_type u,FStar_Syntax_Syntax.Tm_type v1) ->
-          let uu____4161 = eq_univs u v1  in equal_if uu____4161
+          let uu____4162 = eq_univs u v1  in equal_if uu____4162
       | (FStar_Syntax_Syntax.Tm_quoted (t12,q1),FStar_Syntax_Syntax.Tm_quoted
          (t22,q2)) ->
-          let uu____4175 = eq_quoteinfo q1 q2  in
-          eq_and uu____4175 (fun uu____4177  -> eq_tm t12 t22)
+          let uu____4176 = eq_quoteinfo q1 q2  in
+          eq_and uu____4176 (fun uu____4178  -> eq_tm t12 t22)
       | (FStar_Syntax_Syntax.Tm_refine
          (t12,phi1),FStar_Syntax_Syntax.Tm_refine (t22,phi2)) ->
-          let uu____4190 =
+          let uu____4191 =
             eq_tm t12.FStar_Syntax_Syntax.sort t22.FStar_Syntax_Syntax.sort
              in
-          eq_and uu____4190 (fun uu____4192  -> eq_tm phi1 phi2)
-      | uu____4193 -> Unknown
+          eq_and uu____4191 (fun uu____4193  -> eq_tm phi1 phi2)
+      | uu____4194 -> Unknown
 
 and (eq_quoteinfo :
   FStar_Syntax_Syntax.quoteinfo -> FStar_Syntax_Syntax.quoteinfo -> eq_result)
@@ -1183,20 +1185,20 @@ and (eq_antiquotes :
     fun a2  ->
       match (a1, a2) with
       | ([],[]) -> Equal
-      | ([],uu____4265) -> NotEqual
-      | (uu____4296,[]) -> NotEqual
+      | ([],uu____4266) -> NotEqual
+      | (uu____4297,[]) -> NotEqual
       | ((x1,t1)::a11,(x2,t2)::a21) ->
           if Prims.op_Negation (FStar_Syntax_Syntax.bv_eq x1 x2)
           then NotEqual
           else
-            (let uu____4388 = eq_tm t1 t2  in
-             match uu____4388 with
+            (let uu____4389 = eq_tm t1 t2  in
+             match uu____4389 with
              | NotEqual  -> NotEqual
              | Unknown  ->
-                 let uu____4389 = eq_antiquotes a11 a21  in
-                 (match uu____4389 with
+                 let uu____4390 = eq_antiquotes a11 a21  in
+                 (match uu____4390 with
                   | NotEqual  -> NotEqual
-                  | uu____4390 -> Unknown)
+                  | uu____4391 -> Unknown)
              | Equal  -> eq_antiquotes a11 a21)
 
 and (eq_aqual :
@@ -1209,8 +1211,8 @@ and (eq_aqual :
       match (a1, a2) with
       | (FStar_Pervasives_Native.None ,FStar_Pervasives_Native.None ) ->
           Equal
-      | (FStar_Pervasives_Native.None ,uu____4405) -> NotEqual
-      | (uu____4412,FStar_Pervasives_Native.None ) -> NotEqual
+      | (FStar_Pervasives_Native.None ,uu____4406) -> NotEqual
+      | (uu____4413,FStar_Pervasives_Native.None ) -> NotEqual
       | (FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit
          b1),FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit b2))
           when b1 = b2 -> Equal
@@ -1220,7 +1222,7 @@ and (eq_aqual :
       | (FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Equality
          ),FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Equality )) ->
           Equal
-      | uu____4442 -> NotEqual
+      | uu____4443 -> NotEqual
 
 and (branch_matches :
   (FStar_Syntax_Syntax.pat' FStar_Syntax_Syntax.withinfo_t *
@@ -1240,25 +1242,25 @@ and (branch_matches :
             true
         | (FStar_Pervasives_Native.Some x,FStar_Pervasives_Native.Some y) ->
             f x y
-        | (uu____4534,uu____4535) -> false  in
-      let uu____4545 = b1  in
-      match uu____4545 with
+        | (uu____4535,uu____4536) -> false  in
+      let uu____4546 = b1  in
+      match uu____4546 with
       | (p1,w1,t1) ->
-          let uu____4579 = b2  in
-          (match uu____4579 with
+          let uu____4580 = b2  in
+          (match uu____4580 with
            | (p2,w2,t2) ->
-               let uu____4613 = FStar_Syntax_Syntax.eq_pat p1 p2  in
-               if uu____4613
+               let uu____4614 = FStar_Syntax_Syntax.eq_pat p1 p2  in
+               if uu____4614
                then
-                 let uu____4616 =
-                   (let uu____4620 = eq_tm t1 t2  in uu____4620 = Equal) &&
+                 let uu____4617 =
+                   (let uu____4621 = eq_tm t1 t2  in uu____4621 = Equal) &&
                      (related_by
                         (fun t11  ->
                            fun t21  ->
-                             let uu____4629 = eq_tm t11 t21  in
-                             uu____4629 = Equal) w1 w2)
+                             let uu____4630 = eq_tm t11 t21  in
+                             uu____4630 = Equal) w1 w2)
                     in
-                 (if uu____4616 then Equal else Unknown)
+                 (if uu____4617 then Equal else Unknown)
                else Unknown)
 
 and (eq_args :
@@ -1267,12 +1269,12 @@ and (eq_args :
     fun a2  ->
       match (a1, a2) with
       | ([],[]) -> Equal
-      | ((a,uu____4694)::a11,(b,uu____4697)::b1) ->
-          let uu____4771 = eq_tm a b  in
-          (match uu____4771 with
+      | ((a,uu____4695)::a11,(b,uu____4698)::b1) ->
+          let uu____4772 = eq_tm a b  in
+          (match uu____4772 with
            | Equal  -> eq_args a11 b1
-           | uu____4772 -> Unknown)
-      | uu____4773 -> Unknown
+           | uu____4773 -> Unknown)
+      | uu____4774 -> Unknown
 
 and (eq_univs_list :
   FStar_Syntax_Syntax.universes ->
@@ -1287,97 +1289,97 @@ let rec (unrefine : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
     let t1 = FStar_Syntax_Subst.compress t  in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_refine (x,uu____4809) ->
+    | FStar_Syntax_Syntax.Tm_refine (x,uu____4810) ->
         unrefine x.FStar_Syntax_Syntax.sort
-    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____4815,uu____4816) ->
+    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____4816,uu____4817) ->
         unrefine t2
-    | uu____4857 -> t1
+    | uu____4858 -> t1
   
 let rec (is_uvar : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____4865 =
-      let uu____4866 = FStar_Syntax_Subst.compress t  in
-      uu____4866.FStar_Syntax_Syntax.n  in
-    match uu____4865 with
-    | FStar_Syntax_Syntax.Tm_uvar uu____4870 -> true
-    | FStar_Syntax_Syntax.Tm_uinst (t1,uu____4885) -> is_uvar t1
-    | FStar_Syntax_Syntax.Tm_app uu____4890 ->
-        let uu____4907 =
-          let uu____4908 = FStar_All.pipe_right t head_and_args  in
-          FStar_All.pipe_right uu____4908 FStar_Pervasives_Native.fst  in
-        FStar_All.pipe_right uu____4907 is_uvar
-    | FStar_Syntax_Syntax.Tm_ascribed (t1,uu____4971,uu____4972) ->
+    let uu____4866 =
+      let uu____4867 = FStar_Syntax_Subst.compress t  in
+      uu____4867.FStar_Syntax_Syntax.n  in
+    match uu____4866 with
+    | FStar_Syntax_Syntax.Tm_uvar uu____4871 -> true
+    | FStar_Syntax_Syntax.Tm_uinst (t1,uu____4886) -> is_uvar t1
+    | FStar_Syntax_Syntax.Tm_app uu____4891 ->
+        let uu____4908 =
+          let uu____4909 = FStar_All.pipe_right t head_and_args  in
+          FStar_All.pipe_right uu____4909 FStar_Pervasives_Native.fst  in
+        FStar_All.pipe_right uu____4908 is_uvar
+    | FStar_Syntax_Syntax.Tm_ascribed (t1,uu____4972,uu____4973) ->
         is_uvar t1
-    | uu____5013 -> false
+    | uu____5014 -> false
   
 let rec (is_unit : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____5022 =
-      let uu____5023 = unrefine t  in uu____5023.FStar_Syntax_Syntax.n  in
-    match uu____5022 with
+    let uu____5023 =
+      let uu____5024 = unrefine t  in uu____5024.FStar_Syntax_Syntax.n  in
+    match uu____5023 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         ((FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.unit_lid) ||
            (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid))
           ||
           (FStar_Syntax_Syntax.fv_eq_lid fv
              FStar_Parser_Const.auto_squash_lid)
-    | FStar_Syntax_Syntax.Tm_app (head1,uu____5029) -> is_unit head1
-    | FStar_Syntax_Syntax.Tm_uinst (t1,uu____5055) -> is_unit t1
-    | uu____5060 -> false
+    | FStar_Syntax_Syntax.Tm_app (head1,uu____5030) -> is_unit head1
+    | FStar_Syntax_Syntax.Tm_uinst (t1,uu____5056) -> is_unit t1
+    | uu____5061 -> false
   
 let (is_eqtype_no_unrefine : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____5069 =
-      let uu____5070 = FStar_Syntax_Subst.compress t  in
-      uu____5070.FStar_Syntax_Syntax.n  in
-    match uu____5069 with
+    let uu____5070 =
+      let uu____5071 = FStar_Syntax_Subst.compress t  in
+      uu____5071.FStar_Syntax_Syntax.n  in
+    match uu____5070 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.eqtype_lid
-    | uu____5075 -> false
+    | uu____5076 -> false
   
 let rec (non_informative : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____5084 =
-      let uu____5085 = unrefine t  in uu____5085.FStar_Syntax_Syntax.n  in
-    match uu____5084 with
-    | FStar_Syntax_Syntax.Tm_type uu____5089 -> true
+    let uu____5085 =
+      let uu____5086 = unrefine t  in uu____5086.FStar_Syntax_Syntax.n  in
+    match uu____5085 with
+    | FStar_Syntax_Syntax.Tm_type uu____5090 -> true
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         ((FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.unit_lid) ||
            (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid))
           || (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.erased_lid)
-    | FStar_Syntax_Syntax.Tm_app (head1,uu____5093) -> non_informative head1
-    | FStar_Syntax_Syntax.Tm_uinst (t1,uu____5119) -> non_informative t1
-    | FStar_Syntax_Syntax.Tm_arrow (uu____5124,c) ->
+    | FStar_Syntax_Syntax.Tm_app (head1,uu____5094) -> non_informative head1
+    | FStar_Syntax_Syntax.Tm_uinst (t1,uu____5120) -> non_informative t1
+    | FStar_Syntax_Syntax.Tm_arrow (uu____5125,c) ->
         (is_tot_or_gtot_comp c) && (non_informative (comp_result c))
-    | uu____5146 -> false
+    | uu____5147 -> false
   
 let (is_fun : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun e  ->
-    let uu____5155 =
-      let uu____5156 = FStar_Syntax_Subst.compress e  in
-      uu____5156.FStar_Syntax_Syntax.n  in
-    match uu____5155 with
-    | FStar_Syntax_Syntax.Tm_abs uu____5160 -> true
-    | uu____5180 -> false
+    let uu____5156 =
+      let uu____5157 = FStar_Syntax_Subst.compress e  in
+      uu____5157.FStar_Syntax_Syntax.n  in
+    match uu____5156 with
+    | FStar_Syntax_Syntax.Tm_abs uu____5161 -> true
+    | uu____5181 -> false
   
 let (is_function_typ : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____5189 =
-      let uu____5190 = FStar_Syntax_Subst.compress t  in
-      uu____5190.FStar_Syntax_Syntax.n  in
-    match uu____5189 with
-    | FStar_Syntax_Syntax.Tm_arrow uu____5194 -> true
-    | uu____5210 -> false
+    let uu____5190 =
+      let uu____5191 = FStar_Syntax_Subst.compress t  in
+      uu____5191.FStar_Syntax_Syntax.n  in
+    match uu____5190 with
+    | FStar_Syntax_Syntax.Tm_arrow uu____5195 -> true
+    | uu____5211 -> false
   
 let rec (pre_typ : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
     let t1 = FStar_Syntax_Subst.compress t  in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_refine (x,uu____5220) ->
+    | FStar_Syntax_Syntax.Tm_refine (x,uu____5221) ->
         pre_typ x.FStar_Syntax_Syntax.sort
-    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____5226,uu____5227) ->
+    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____5227,uu____5228) ->
         pre_typ t2
-    | uu____5268 -> t1
+    | uu____5269 -> t1
   
 let (destruct :
   FStar_Syntax_Syntax.term ->
@@ -1389,46 +1391,46 @@ let (destruct :
   fun typ  ->
     fun lid  ->
       let typ1 = FStar_Syntax_Subst.compress typ  in
-      let uu____5293 =
-        let uu____5294 = un_uinst typ1  in uu____5294.FStar_Syntax_Syntax.n
+      let uu____5294 =
+        let uu____5295 = un_uinst typ1  in uu____5295.FStar_Syntax_Syntax.n
          in
-      match uu____5293 with
+      match uu____5294 with
       | FStar_Syntax_Syntax.Tm_app (head1,args) ->
           let head2 = un_uinst head1  in
           (match head2.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Tm_fvar tc when
                FStar_Syntax_Syntax.fv_eq_lid tc lid ->
                FStar_Pervasives_Native.Some args
-           | uu____5359 -> FStar_Pervasives_Native.None)
+           | uu____5360 -> FStar_Pervasives_Native.None)
       | FStar_Syntax_Syntax.Tm_fvar tc when
           FStar_Syntax_Syntax.fv_eq_lid tc lid ->
           FStar_Pervasives_Native.Some []
-      | uu____5389 -> FStar_Pervasives_Native.None
+      | uu____5390 -> FStar_Pervasives_Native.None
   
 let (lids_of_sigelt :
   FStar_Syntax_Syntax.sigelt -> FStar_Ident.lident Prims.list) =
   fun se  ->
     match se.FStar_Syntax_Syntax.sigel with
-    | FStar_Syntax_Syntax.Sig_let (uu____5410,lids) -> lids
-    | FStar_Syntax_Syntax.Sig_splice (lids,uu____5417) -> lids
-    | FStar_Syntax_Syntax.Sig_bundle (uu____5422,lids) -> lids
+    | FStar_Syntax_Syntax.Sig_let (uu____5411,lids) -> lids
+    | FStar_Syntax_Syntax.Sig_splice (lids,uu____5418) -> lids
+    | FStar_Syntax_Syntax.Sig_bundle (uu____5423,lids) -> lids
     | FStar_Syntax_Syntax.Sig_inductive_typ
-        (lid,uu____5433,uu____5434,uu____5435,uu____5436,uu____5437) -> 
+        (lid,uu____5434,uu____5435,uu____5436,uu____5437,uu____5438) -> 
         [lid]
     | FStar_Syntax_Syntax.Sig_effect_abbrev
-        (lid,uu____5447,uu____5448,uu____5449,uu____5450) -> [lid]
+        (lid,uu____5448,uu____5449,uu____5450,uu____5451) -> [lid]
     | FStar_Syntax_Syntax.Sig_datacon
-        (lid,uu____5456,uu____5457,uu____5458,uu____5459,uu____5460) -> 
+        (lid,uu____5457,uu____5458,uu____5459,uu____5460,uu____5461) -> 
         [lid]
-    | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____5468,uu____5469) ->
+    | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____5469,uu____5470) ->
         [lid]
-    | FStar_Syntax_Syntax.Sig_assume (lid,uu____5471,uu____5472) -> [lid]
+    | FStar_Syntax_Syntax.Sig_assume (lid,uu____5472,uu____5473) -> [lid]
     | FStar_Syntax_Syntax.Sig_new_effect_for_free n1 ->
         [n1.FStar_Syntax_Syntax.mname]
     | FStar_Syntax_Syntax.Sig_new_effect n1 -> [n1.FStar_Syntax_Syntax.mname]
-    | FStar_Syntax_Syntax.Sig_sub_effect uu____5475 -> []
-    | FStar_Syntax_Syntax.Sig_pragma uu____5476 -> []
-    | FStar_Syntax_Syntax.Sig_main uu____5477 -> []
+    | FStar_Syntax_Syntax.Sig_sub_effect uu____5476 -> []
+    | FStar_Syntax_Syntax.Sig_pragma uu____5477 -> []
+    | FStar_Syntax_Syntax.Sig_main uu____5478 -> []
   
 let (lid_of_sigelt :
   FStar_Syntax_Syntax.sigelt ->
@@ -1437,7 +1439,7 @@ let (lid_of_sigelt :
   fun se  ->
     match lids_of_sigelt se with
     | l::[] -> FStar_Pervasives_Native.Some l
-    | uu____5491 -> FStar_Pervasives_Native.None
+    | uu____5492 -> FStar_Pervasives_Native.None
   
 let (quals_of_sigelt :
   FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.qualifier Prims.list) =
@@ -1448,24 +1450,24 @@ let (range_of_lbname :
   (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.fv) FStar_Util.either ->
     FStar_Range.range)
   =
-  fun uu___11_5517  ->
-    match uu___11_5517 with
+  fun uu___11_5518  ->
+    match uu___11_5518 with
     | FStar_Util.Inl x -> FStar_Syntax_Syntax.range_of_bv x
     | FStar_Util.Inr fv ->
         FStar_Ident.range_of_lid
           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
   
 let range_of_arg :
-  'Auu____5531 'Auu____5532 .
-    ('Auu____5531 FStar_Syntax_Syntax.syntax * 'Auu____5532) ->
+  'Auu____5532 'Auu____5533 .
+    ('Auu____5532 FStar_Syntax_Syntax.syntax * 'Auu____5533) ->
       FStar_Range.range
   =
-  fun uu____5543  ->
-    match uu____5543 with | (hd1,uu____5551) -> hd1.FStar_Syntax_Syntax.pos
+  fun uu____5544  ->
+    match uu____5544 with | (hd1,uu____5552) -> hd1.FStar_Syntax_Syntax.pos
   
 let range_of_args :
-  'Auu____5565 'Auu____5566 .
-    ('Auu____5565 FStar_Syntax_Syntax.syntax * 'Auu____5566) Prims.list ->
+  'Auu____5566 'Auu____5567 .
+    ('Auu____5566 FStar_Syntax_Syntax.syntax * 'Auu____5567) Prims.list ->
       FStar_Range.range -> FStar_Range.range
   =
   fun args  ->
@@ -1485,7 +1487,7 @@ let (mk_app :
     fun args  ->
       match args with
       | [] -> f
-      | uu____5664 ->
+      | uu____5665 ->
           let r = range_of_args args f.FStar_Syntax_Syntax.pos  in
           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (f, args))
             FStar_Pervasives_Native.None r
@@ -1498,15 +1500,15 @@ let (mk_app_binders :
   =
   fun f  ->
     fun bs  ->
-      let uu____5723 =
+      let uu____5724 =
         FStar_List.map
-          (fun uu____5750  ->
-             match uu____5750 with
+          (fun uu____5751  ->
+             match uu____5751 with
              | (bv,aq) ->
-                 let uu____5769 = FStar_Syntax_Syntax.bv_to_name bv  in
-                 (uu____5769, aq)) bs
+                 let uu____5770 = FStar_Syntax_Syntax.bv_to_name bv  in
+                 (uu____5770, aq)) bs
          in
-      mk_app f uu____5723
+      mk_app f uu____5724
   
 let (mk_data :
   FStar_Ident.lident ->
@@ -1520,21 +1522,21 @@ let (mk_data :
     fun args  ->
       match args with
       | [] ->
-          let uu____5819 = FStar_Ident.range_of_lid l  in
-          let uu____5820 =
-            let uu____5829 =
+          let uu____5820 = FStar_Ident.range_of_lid l  in
+          let uu____5821 =
+            let uu____5830 =
               FStar_Syntax_Syntax.fvar l FStar_Syntax_Syntax.delta_constant
                 (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
                in
-            FStar_Syntax_Syntax.mk uu____5829  in
-          uu____5820 FStar_Pervasives_Native.None uu____5819
-      | uu____5834 ->
+            FStar_Syntax_Syntax.mk uu____5830  in
+          uu____5821 FStar_Pervasives_Native.None uu____5820
+      | uu____5835 ->
           let e =
-            let uu____5848 =
+            let uu____5849 =
               FStar_Syntax_Syntax.fvar l FStar_Syntax_Syntax.delta_constant
                 (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
                in
-            mk_app uu____5848 args  in
+            mk_app uu____5849 args  in
           FStar_Syntax_Syntax.mk e FStar_Pervasives_Native.None
             e.FStar_Syntax_Syntax.pos
   
@@ -1574,57 +1576,57 @@ let (mk_field_projector_name :
     fun x  ->
       fun i  ->
         let nm =
-          let uu____5925 = FStar_Syntax_Syntax.is_null_bv x  in
-          if uu____5925
+          let uu____5926 = FStar_Syntax_Syntax.is_null_bv x  in
+          if uu____5926
           then
-            let uu____5928 =
-              let uu____5934 =
-                let uu____5936 = FStar_Util.string_of_int i  in
-                Prims.op_Hat "_" uu____5936  in
-              let uu____5939 = FStar_Syntax_Syntax.range_of_bv x  in
-              (uu____5934, uu____5939)  in
-            FStar_Ident.mk_ident uu____5928
+            let uu____5929 =
+              let uu____5935 =
+                let uu____5937 = FStar_Util.string_of_int i  in
+                Prims.op_Hat "_" uu____5937  in
+              let uu____5940 = FStar_Syntax_Syntax.range_of_bv x  in
+              (uu____5935, uu____5940)  in
+            FStar_Ident.mk_ident uu____5929
           else x.FStar_Syntax_Syntax.ppname  in
         let y =
-          let uu___993_5944 = x  in
+          let uu___996_5945 = x  in
           {
             FStar_Syntax_Syntax.ppname = nm;
             FStar_Syntax_Syntax.index =
-              (uu___993_5944.FStar_Syntax_Syntax.index);
+              (uu___996_5945.FStar_Syntax_Syntax.index);
             FStar_Syntax_Syntax.sort =
-              (uu___993_5944.FStar_Syntax_Syntax.sort)
+              (uu___996_5945.FStar_Syntax_Syntax.sort)
           }  in
-        let uu____5945 = mk_field_projector_name_from_ident lid nm  in
-        (uu____5945, y)
+        let uu____5946 = mk_field_projector_name_from_ident lid nm  in
+        (uu____5946, y)
   
 let (ses_of_sigbundle :
   FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt Prims.list) =
   fun se  ->
     match se.FStar_Syntax_Syntax.sigel with
-    | FStar_Syntax_Syntax.Sig_bundle (ses,uu____5957) -> ses
-    | uu____5966 -> failwith "ses_of_sigbundle: not a Sig_bundle"
+    | FStar_Syntax_Syntax.Sig_bundle (ses,uu____5958) -> ses
+    | uu____5967 -> failwith "ses_of_sigbundle: not a Sig_bundle"
   
 let (eff_decl_of_new_effect :
   FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.eff_decl) =
   fun se  ->
     match se.FStar_Syntax_Syntax.sigel with
     | FStar_Syntax_Syntax.Sig_new_effect ne -> ne
-    | uu____5977 -> failwith "eff_decl_of_new_effect: not a Sig_new_effect"
+    | uu____5978 -> failwith "eff_decl_of_new_effect: not a Sig_new_effect"
   
 let (set_uvar : FStar_Syntax_Syntax.uvar -> FStar_Syntax_Syntax.term -> unit)
   =
   fun uv  ->
     fun t  ->
-      let uu____5990 = FStar_Syntax_Unionfind.find uv  in
-      match uu____5990 with
-      | FStar_Pervasives_Native.Some uu____5993 ->
-          let uu____5994 =
-            let uu____5996 =
-              let uu____5998 = FStar_Syntax_Unionfind.uvar_id uv  in
-              FStar_All.pipe_left FStar_Util.string_of_int uu____5998  in
-            FStar_Util.format1 "Changing a fixed uvar! ?%s\n" uu____5996  in
-          failwith uu____5994
-      | uu____6003 -> FStar_Syntax_Unionfind.change uv t
+      let uu____5991 = FStar_Syntax_Unionfind.find uv  in
+      match uu____5991 with
+      | FStar_Pervasives_Native.Some uu____5994 ->
+          let uu____5995 =
+            let uu____5997 =
+              let uu____5999 = FStar_Syntax_Unionfind.uvar_id uv  in
+              FStar_All.pipe_left FStar_Util.string_of_int uu____5999  in
+            FStar_Util.format1 "Changing a fixed uvar! ?%s\n" uu____5997  in
+          failwith uu____5995
+      | uu____6004 -> FStar_Syntax_Unionfind.change uv t
   
 let (qualifier_equal :
   FStar_Syntax_Syntax.qualifier ->
@@ -1666,7 +1668,7 @@ let (qualifier_equal :
                (fun x1  ->
                   fun x2  -> x1.FStar_Ident.idText = x2.FStar_Ident.idText)
                f1 f2)
-      | uu____6086 -> q1 = q2
+      | uu____6087 -> q1 = q2
   
 let (abs :
   FStar_Syntax_Syntax.binders ->
@@ -1681,53 +1683,53 @@ let (abs :
           match lopt1 with
           | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
           | FStar_Pervasives_Native.Some rc ->
-              let uu____6132 =
-                let uu___1054_6133 = rc  in
-                let uu____6134 =
+              let uu____6133 =
+                let uu___1057_6134 = rc  in
+                let uu____6135 =
                   FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
                     (FStar_Syntax_Subst.close bs)
                    in
                 {
                   FStar_Syntax_Syntax.residual_effect =
-                    (uu___1054_6133.FStar_Syntax_Syntax.residual_effect);
-                  FStar_Syntax_Syntax.residual_typ = uu____6134;
+                    (uu___1057_6134.FStar_Syntax_Syntax.residual_effect);
+                  FStar_Syntax_Syntax.residual_typ = uu____6135;
                   FStar_Syntax_Syntax.residual_flags =
-                    (uu___1054_6133.FStar_Syntax_Syntax.residual_flags)
+                    (uu___1057_6134.FStar_Syntax_Syntax.residual_flags)
                 }  in
-              FStar_Pervasives_Native.Some uu____6132
+              FStar_Pervasives_Native.Some uu____6133
            in
         match bs with
         | [] -> t
-        | uu____6151 ->
+        | uu____6152 ->
             let body =
-              let uu____6153 = FStar_Syntax_Subst.close bs t  in
-              FStar_Syntax_Subst.compress uu____6153  in
+              let uu____6154 = FStar_Syntax_Subst.close bs t  in
+              FStar_Syntax_Subst.compress uu____6154  in
             (match body.FStar_Syntax_Syntax.n with
              | FStar_Syntax_Syntax.Tm_abs (bs',t1,lopt') ->
-                 let uu____6183 =
-                   let uu____6190 =
-                     let uu____6191 =
-                       let uu____6210 =
-                         let uu____6219 = FStar_Syntax_Subst.close_binders bs
+                 let uu____6184 =
+                   let uu____6191 =
+                     let uu____6192 =
+                       let uu____6211 =
+                         let uu____6220 = FStar_Syntax_Subst.close_binders bs
                             in
-                         FStar_List.append uu____6219 bs'  in
-                       let uu____6234 = close_lopt lopt'  in
-                       (uu____6210, t1, uu____6234)  in
-                     FStar_Syntax_Syntax.Tm_abs uu____6191  in
-                   FStar_Syntax_Syntax.mk uu____6190  in
-                 uu____6183 FStar_Pervasives_Native.None
+                         FStar_List.append uu____6220 bs'  in
+                       let uu____6235 = close_lopt lopt'  in
+                       (uu____6211, t1, uu____6235)  in
+                     FStar_Syntax_Syntax.Tm_abs uu____6192  in
+                   FStar_Syntax_Syntax.mk uu____6191  in
+                 uu____6184 FStar_Pervasives_Native.None
                    t1.FStar_Syntax_Syntax.pos
-             | uu____6249 ->
-                 let uu____6250 =
-                   let uu____6257 =
-                     let uu____6258 =
-                       let uu____6277 = FStar_Syntax_Subst.close_binders bs
+             | uu____6250 ->
+                 let uu____6251 =
+                   let uu____6258 =
+                     let uu____6259 =
+                       let uu____6278 = FStar_Syntax_Subst.close_binders bs
                           in
-                       let uu____6286 = close_lopt lopt  in
-                       (uu____6277, body, uu____6286)  in
-                     FStar_Syntax_Syntax.Tm_abs uu____6258  in
-                   FStar_Syntax_Syntax.mk uu____6257  in
-                 uu____6250 FStar_Pervasives_Native.None
+                       let uu____6287 = close_lopt lopt  in
+                       (uu____6278, body, uu____6287)  in
+                     FStar_Syntax_Syntax.Tm_abs uu____6259  in
+                   FStar_Syntax_Syntax.mk uu____6258  in
+                 uu____6251 FStar_Pervasives_Native.None
                    t.FStar_Syntax_Syntax.pos)
   
 let (arrow :
@@ -1740,16 +1742,16 @@ let (arrow :
     fun c  ->
       match bs with
       | [] -> comp_result c
-      | uu____6342 ->
-          let uu____6351 =
-            let uu____6358 =
-              let uu____6359 =
-                let uu____6374 = FStar_Syntax_Subst.close_binders bs  in
-                let uu____6383 = FStar_Syntax_Subst.close_comp bs c  in
-                (uu____6374, uu____6383)  in
-              FStar_Syntax_Syntax.Tm_arrow uu____6359  in
-            FStar_Syntax_Syntax.mk uu____6358  in
-          uu____6351 FStar_Pervasives_Native.None c.FStar_Syntax_Syntax.pos
+      | uu____6343 ->
+          let uu____6352 =
+            let uu____6359 =
+              let uu____6360 =
+                let uu____6375 = FStar_Syntax_Subst.close_binders bs  in
+                let uu____6384 = FStar_Syntax_Subst.close_comp bs c  in
+                (uu____6375, uu____6384)  in
+              FStar_Syntax_Syntax.Tm_arrow uu____6360  in
+            FStar_Syntax_Syntax.mk uu____6359  in
+          uu____6352 FStar_Pervasives_Native.None c.FStar_Syntax_Syntax.pos
   
 let (flat_arrow :
   (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.arg_qualifier
@@ -1760,25 +1762,25 @@ let (flat_arrow :
   fun bs  ->
     fun c  ->
       let t = arrow bs c  in
-      let uu____6432 =
-        let uu____6433 = FStar_Syntax_Subst.compress t  in
-        uu____6433.FStar_Syntax_Syntax.n  in
-      match uu____6432 with
+      let uu____6433 =
+        let uu____6434 = FStar_Syntax_Subst.compress t  in
+        uu____6434.FStar_Syntax_Syntax.n  in
+      match uu____6433 with
       | FStar_Syntax_Syntax.Tm_arrow (bs1,c1) ->
           (match c1.FStar_Syntax_Syntax.n with
-           | FStar_Syntax_Syntax.Total (tres,uu____6463) ->
-               let uu____6472 =
-                 let uu____6473 = FStar_Syntax_Subst.compress tres  in
-                 uu____6473.FStar_Syntax_Syntax.n  in
-               (match uu____6472 with
+           | FStar_Syntax_Syntax.Total (tres,uu____6464) ->
+               let uu____6473 =
+                 let uu____6474 = FStar_Syntax_Subst.compress tres  in
+                 uu____6474.FStar_Syntax_Syntax.n  in
+               (match uu____6473 with
                 | FStar_Syntax_Syntax.Tm_arrow (bs',c') ->
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_arrow
                          ((FStar_List.append bs1 bs'), c'))
                       FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
-                | uu____6516 -> t)
-           | uu____6517 -> t)
-      | uu____6518 -> t
+                | uu____6517 -> t)
+           | uu____6518 -> t)
+      | uu____6519 -> t
   
 let (refine :
   FStar_Syntax_Syntax.bv ->
@@ -1787,21 +1789,21 @@ let (refine :
   =
   fun b  ->
     fun t  ->
-      let uu____6536 =
-        let uu____6537 = FStar_Syntax_Syntax.range_of_bv b  in
-        FStar_Range.union_ranges uu____6537 t.FStar_Syntax_Syntax.pos  in
-      let uu____6538 =
-        let uu____6545 =
-          let uu____6546 =
-            let uu____6553 =
-              let uu____6556 =
-                let uu____6557 = FStar_Syntax_Syntax.mk_binder b  in
-                [uu____6557]  in
-              FStar_Syntax_Subst.close uu____6556 t  in
-            (b, uu____6553)  in
-          FStar_Syntax_Syntax.Tm_refine uu____6546  in
-        FStar_Syntax_Syntax.mk uu____6545  in
-      uu____6538 FStar_Pervasives_Native.None uu____6536
+      let uu____6537 =
+        let uu____6538 = FStar_Syntax_Syntax.range_of_bv b  in
+        FStar_Range.union_ranges uu____6538 t.FStar_Syntax_Syntax.pos  in
+      let uu____6539 =
+        let uu____6546 =
+          let uu____6547 =
+            let uu____6554 =
+              let uu____6557 =
+                let uu____6558 = FStar_Syntax_Syntax.mk_binder b  in
+                [uu____6558]  in
+              FStar_Syntax_Subst.close uu____6557 t  in
+            (b, uu____6554)  in
+          FStar_Syntax_Syntax.Tm_refine uu____6547  in
+        FStar_Syntax_Syntax.mk uu____6546  in
+      uu____6539 FStar_Pervasives_Native.None uu____6537
   
 let (branch : FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch) =
   fun b  -> FStar_Syntax_Subst.close_branch b 
@@ -1814,39 +1816,39 @@ let rec (arrow_formals_comp :
     let k1 = FStar_Syntax_Subst.compress k  in
     match k1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-        let uu____6637 = FStar_Syntax_Subst.open_comp bs c  in
-        (match uu____6637 with
+        let uu____6638 = FStar_Syntax_Subst.open_comp bs c  in
+        (match uu____6638 with
          | (bs1,c1) ->
-             let uu____6656 = is_total_comp c1  in
-             if uu____6656
+             let uu____6657 = is_total_comp c1  in
+             if uu____6657
              then
-               let uu____6671 = arrow_formals_comp (comp_result c1)  in
-               (match uu____6671 with
+               let uu____6672 = arrow_formals_comp (comp_result c1)  in
+               (match uu____6672 with
                 | (bs',k2) -> ((FStar_List.append bs1 bs'), k2))
              else (bs1, c1))
     | FStar_Syntax_Syntax.Tm_refine
-        ({ FStar_Syntax_Syntax.ppname = uu____6738;
-           FStar_Syntax_Syntax.index = uu____6739;
-           FStar_Syntax_Syntax.sort = s;_},uu____6741)
+        ({ FStar_Syntax_Syntax.ppname = uu____6739;
+           FStar_Syntax_Syntax.index = uu____6740;
+           FStar_Syntax_Syntax.sort = s;_},uu____6742)
         ->
         let rec aux s1 k2 =
-          let uu____6772 =
-            let uu____6773 = FStar_Syntax_Subst.compress s1  in
-            uu____6773.FStar_Syntax_Syntax.n  in
-          match uu____6772 with
-          | FStar_Syntax_Syntax.Tm_arrow uu____6788 -> arrow_formals_comp s1
+          let uu____6773 =
+            let uu____6774 = FStar_Syntax_Subst.compress s1  in
+            uu____6774.FStar_Syntax_Syntax.n  in
+          match uu____6773 with
+          | FStar_Syntax_Syntax.Tm_arrow uu____6789 -> arrow_formals_comp s1
           | FStar_Syntax_Syntax.Tm_refine
-              ({ FStar_Syntax_Syntax.ppname = uu____6803;
-                 FStar_Syntax_Syntax.index = uu____6804;
-                 FStar_Syntax_Syntax.sort = s2;_},uu____6806)
+              ({ FStar_Syntax_Syntax.ppname = uu____6804;
+                 FStar_Syntax_Syntax.index = uu____6805;
+                 FStar_Syntax_Syntax.sort = s2;_},uu____6807)
               -> aux s2 k2
-          | uu____6814 ->
-              let uu____6815 = FStar_Syntax_Syntax.mk_Total k2  in
-              ([], uu____6815)
+          | uu____6815 ->
+              let uu____6816 = FStar_Syntax_Syntax.mk_Total k2  in
+              ([], uu____6816)
            in
         aux s k1
-    | uu____6830 ->
-        let uu____6831 = FStar_Syntax_Syntax.mk_Total k1  in ([], uu____6831)
+    | uu____6831 ->
+        let uu____6832 = FStar_Syntax_Syntax.mk_Total k1  in ([], uu____6832)
   
 let rec (arrow_formals :
   FStar_Syntax_Syntax.term ->
@@ -1855,8 +1857,8 @@ let rec (arrow_formals :
       FStar_Syntax_Syntax.syntax))
   =
   fun k  ->
-    let uu____6866 = arrow_formals_comp k  in
-    match uu____6866 with | (bs,c) -> (bs, (comp_result c))
+    let uu____6867 = arrow_formals_comp k  in
+    match uu____6867 with | (bs,c) -> (bs, (comp_result c))
   
 let (let_rec_arity :
   FStar_Syntax_Syntax.letbinding ->
@@ -1867,56 +1869,56 @@ let (let_rec_arity :
       let k1 = FStar_Syntax_Subst.compress k  in
       match k1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____7008 = FStar_Syntax_Subst.open_comp bs c  in
-          (match uu____7008 with
+          let uu____7009 = FStar_Syntax_Subst.open_comp bs c  in
+          (match uu____7009 with
            | (bs1,c1) ->
                let ct = comp_to_comp_typ c1  in
-               let uu____7032 =
+               let uu____7033 =
                  FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags
                    (FStar_Util.find_opt
-                      (fun uu___12_7041  ->
-                         match uu___12_7041 with
-                         | FStar_Syntax_Syntax.DECREASES uu____7043 -> true
-                         | uu____7047 -> false))
+                      (fun uu___12_7042  ->
+                         match uu___12_7042 with
+                         | FStar_Syntax_Syntax.DECREASES uu____7044 -> true
+                         | uu____7048 -> false))
                   in
-               (match uu____7032 with
+               (match uu____7033 with
                 | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.DECREASES
                     d) -> (bs1, (FStar_Pervasives_Native.Some d))
-                | uu____7082 ->
-                    let uu____7085 = is_total_comp c1  in
-                    if uu____7085
+                | uu____7083 ->
+                    let uu____7086 = is_total_comp c1  in
+                    if uu____7086
                     then
-                      let uu____7104 = arrow_until_decreases (comp_result c1)
+                      let uu____7105 = arrow_until_decreases (comp_result c1)
                          in
-                      (match uu____7104 with
+                      (match uu____7105 with
                        | (bs',d) -> ((FStar_List.append bs1 bs'), d))
                     else (bs1, FStar_Pervasives_Native.None)))
       | FStar_Syntax_Syntax.Tm_refine
-          ({ FStar_Syntax_Syntax.ppname = uu____7197;
-             FStar_Syntax_Syntax.index = uu____7198;
-             FStar_Syntax_Syntax.sort = k2;_},uu____7200)
+          ({ FStar_Syntax_Syntax.ppname = uu____7198;
+             FStar_Syntax_Syntax.index = uu____7199;
+             FStar_Syntax_Syntax.sort = k2;_},uu____7201)
           -> arrow_until_decreases k2
-      | uu____7208 -> ([], FStar_Pervasives_Native.None)  in
-    let uu____7229 = arrow_until_decreases lb.FStar_Syntax_Syntax.lbtyp  in
-    match uu____7229 with
+      | uu____7209 -> ([], FStar_Pervasives_Native.None)  in
+    let uu____7230 = arrow_until_decreases lb.FStar_Syntax_Syntax.lbtyp  in
+    match uu____7230 with
     | (bs,dopt) ->
         let n_univs = FStar_List.length lb.FStar_Syntax_Syntax.lbunivs  in
-        let uu____7283 =
+        let uu____7284 =
           FStar_Util.map_opt dopt
             (fun d  ->
                let d_bvs = FStar_Syntax_Free.names d  in
-               let uu____7304 =
-                 FStar_Common.tabulate n_univs (fun uu____7310  -> false)  in
-               let uu____7313 =
+               let uu____7305 =
+                 FStar_Common.tabulate n_univs (fun uu____7311  -> false)  in
+               let uu____7314 =
                  FStar_All.pipe_right bs
                    (FStar_List.map
-                      (fun uu____7338  ->
-                         match uu____7338 with
-                         | (x,uu____7347) -> FStar_Util.set_mem x d_bvs))
+                      (fun uu____7339  ->
+                         match uu____7339 with
+                         | (x,uu____7348) -> FStar_Util.set_mem x d_bvs))
                   in
-               FStar_List.append uu____7304 uu____7313)
+               FStar_List.append uu____7305 uu____7314)
            in
-        ((n_univs + (FStar_List.length bs)), uu____7283)
+        ((n_univs + (FStar_List.length bs)), uu____7284)
   
 let (abs_formals :
   FStar_Syntax_Syntax.term ->
@@ -1927,38 +1929,38 @@ let (abs_formals :
     let subst_lcomp_opt s l =
       match l with
       | FStar_Pervasives_Native.Some rc ->
-          let uu____7403 =
-            let uu___1176_7404 = rc  in
-            let uu____7405 =
+          let uu____7404 =
+            let uu___1179_7405 = rc  in
+            let uu____7406 =
               FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
                 (FStar_Syntax_Subst.subst s)
                in
             {
               FStar_Syntax_Syntax.residual_effect =
-                (uu___1176_7404.FStar_Syntax_Syntax.residual_effect);
-              FStar_Syntax_Syntax.residual_typ = uu____7405;
+                (uu___1179_7405.FStar_Syntax_Syntax.residual_effect);
+              FStar_Syntax_Syntax.residual_typ = uu____7406;
               FStar_Syntax_Syntax.residual_flags =
-                (uu___1176_7404.FStar_Syntax_Syntax.residual_flags)
+                (uu___1179_7405.FStar_Syntax_Syntax.residual_flags)
             }  in
-          FStar_Pervasives_Native.Some uu____7403
-      | uu____7414 -> l  in
+          FStar_Pervasives_Native.Some uu____7404
+      | uu____7415 -> l  in
     let rec aux t1 abs_body_lcomp =
-      let uu____7448 =
-        let uu____7449 =
-          let uu____7452 = FStar_Syntax_Subst.compress t1  in
-          FStar_All.pipe_left unascribe uu____7452  in
-        uu____7449.FStar_Syntax_Syntax.n  in
-      match uu____7448 with
+      let uu____7449 =
+        let uu____7450 =
+          let uu____7453 = FStar_Syntax_Subst.compress t1  in
+          FStar_All.pipe_left unascribe uu____7453  in
+        uu____7450.FStar_Syntax_Syntax.n  in
+      match uu____7449 with
       | FStar_Syntax_Syntax.Tm_abs (bs,t2,what) ->
-          let uu____7498 = aux t2 what  in
-          (match uu____7498 with
+          let uu____7499 = aux t2 what  in
+          (match uu____7499 with
            | (bs',t3,what1) -> ((FStar_List.append bs bs'), t3, what1))
-      | uu____7570 -> ([], t1, abs_body_lcomp)  in
-    let uu____7587 = aux t FStar_Pervasives_Native.None  in
-    match uu____7587 with
+      | uu____7571 -> ([], t1, abs_body_lcomp)  in
+    let uu____7588 = aux t FStar_Pervasives_Native.None  in
+    match uu____7588 with
     | (bs,t1,abs_body_lcomp) ->
-        let uu____7635 = FStar_Syntax_Subst.open_term' bs t1  in
-        (match uu____7635 with
+        let uu____7636 = FStar_Syntax_Subst.open_term' bs t1  in
+        (match uu____7636 with
          | (bs1,t2,opening) ->
              let abs_body_lcomp1 = subst_lcomp_opt opening abs_body_lcomp  in
              (bs1, t2, abs_body_lcomp1))
@@ -2009,14 +2011,14 @@ let (close_univs_and_mk_letbinding :
                 fun pos  ->
                   let def1 =
                     match (recs, univ_vars) with
-                    | (FStar_Pervasives_Native.None ,uu____7798) -> def
-                    | (uu____7809,[]) -> def
-                    | (FStar_Pervasives_Native.Some fvs,uu____7821) ->
+                    | (FStar_Pervasives_Native.None ,uu____7799) -> def
+                    | (uu____7810,[]) -> def
+                    | (FStar_Pervasives_Native.Some fvs,uu____7822) ->
                         let universes =
                           FStar_All.pipe_right univ_vars
                             (FStar_List.map
-                               (fun _7837  ->
-                                  FStar_Syntax_Syntax.U_name _7837))
+                               (fun _7838  ->
+                                  FStar_Syntax_Syntax.U_name _7838))
                            in
                         let inst1 =
                           FStar_All.pipe_right fvs
@@ -2047,20 +2049,20 @@ let (open_univ_vars_binders_and_comp :
       fun c  ->
         match binders with
         | [] ->
-            let uu____7919 = FStar_Syntax_Subst.open_univ_vars_comp uvs c  in
-            (match uu____7919 with | (uvs1,c1) -> (uvs1, [], c1))
-        | uu____7954 ->
+            let uu____7920 = FStar_Syntax_Subst.open_univ_vars_comp uvs c  in
+            (match uu____7920 with | (uvs1,c1) -> (uvs1, [], c1))
+        | uu____7955 ->
             let t' = arrow binders c  in
-            let uu____7966 = FStar_Syntax_Subst.open_univ_vars uvs t'  in
-            (match uu____7966 with
+            let uu____7967 = FStar_Syntax_Subst.open_univ_vars uvs t'  in
+            (match uu____7967 with
              | (uvs1,t'1) ->
-                 let uu____7987 =
-                   let uu____7988 = FStar_Syntax_Subst.compress t'1  in
-                   uu____7988.FStar_Syntax_Syntax.n  in
-                 (match uu____7987 with
+                 let uu____7988 =
+                   let uu____7989 = FStar_Syntax_Subst.compress t'1  in
+                   uu____7989.FStar_Syntax_Syntax.n  in
+                 (match uu____7988 with
                   | FStar_Syntax_Syntax.Tm_arrow (binders1,c1) ->
                       (uvs1, binders1, c1)
-                  | uu____8037 -> failwith "Impossible"))
+                  | uu____8038 -> failwith "Impossible"))
   
 let (is_tuple_constructor : FStar_Syntax_Syntax.typ -> Prims.bool) =
   fun t  ->
@@ -2068,7 +2070,7 @@ let (is_tuple_constructor : FStar_Syntax_Syntax.typ -> Prims.bool) =
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Parser_Const.is_tuple_constructor_string
           ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
-    | uu____8062 -> false
+    | uu____8063 -> false
   
 let (is_dtuple_constructor : FStar_Syntax_Syntax.typ -> Prims.bool) =
   fun t  ->
@@ -2076,7 +2078,7 @@ let (is_dtuple_constructor : FStar_Syntax_Syntax.typ -> Prims.bool) =
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Parser_Const.is_dtuple_constructor_lid
           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-    | uu____8073 -> false
+    | uu____8074 -> false
   
 let (is_lid_equality : FStar_Ident.lident -> Prims.bool) =
   fun x  -> FStar_Ident.lid_equals x FStar_Parser_Const.eq2_lid 
@@ -2101,27 +2103,27 @@ let (is_constructor :
   FStar_Syntax_Syntax.term -> FStar_Ident.lident -> Prims.bool) =
   fun t  ->
     fun lid  ->
-      let uu____8136 =
-        let uu____8137 = pre_typ t  in uu____8137.FStar_Syntax_Syntax.n  in
-      match uu____8136 with
+      let uu____8137 =
+        let uu____8138 = pre_typ t  in uu____8138.FStar_Syntax_Syntax.n  in
+      match uu____8137 with
       | FStar_Syntax_Syntax.Tm_fvar tc ->
           FStar_Ident.lid_equals
             (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v lid
-      | uu____8142 -> false
+      | uu____8143 -> false
   
 let rec (is_constructed_typ :
   FStar_Syntax_Syntax.term -> FStar_Ident.lident -> Prims.bool) =
   fun t  ->
     fun lid  ->
-      let uu____8156 =
-        let uu____8157 = pre_typ t  in uu____8157.FStar_Syntax_Syntax.n  in
-      match uu____8156 with
-      | FStar_Syntax_Syntax.Tm_fvar uu____8161 -> is_constructor t lid
-      | FStar_Syntax_Syntax.Tm_app (t1,uu____8163) ->
+      let uu____8157 =
+        let uu____8158 = pre_typ t  in uu____8158.FStar_Syntax_Syntax.n  in
+      match uu____8157 with
+      | FStar_Syntax_Syntax.Tm_fvar uu____8162 -> is_constructor t lid
+      | FStar_Syntax_Syntax.Tm_app (t1,uu____8164) ->
           is_constructed_typ t1 lid
-      | FStar_Syntax_Syntax.Tm_uinst (t1,uu____8189) ->
+      | FStar_Syntax_Syntax.Tm_uinst (t1,uu____8190) ->
           is_constructed_typ t1 lid
-      | uu____8194 -> false
+      | uu____8195 -> false
   
 let rec (get_tycon :
   FStar_Syntax_Syntax.term ->
@@ -2130,36 +2132,36 @@ let rec (get_tycon :
   fun t  ->
     let t1 = pre_typ t  in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_bvar uu____8207 ->
+    | FStar_Syntax_Syntax.Tm_bvar uu____8208 ->
         FStar_Pervasives_Native.Some t1
-    | FStar_Syntax_Syntax.Tm_name uu____8208 ->
+    | FStar_Syntax_Syntax.Tm_name uu____8209 ->
         FStar_Pervasives_Native.Some t1
-    | FStar_Syntax_Syntax.Tm_fvar uu____8209 ->
+    | FStar_Syntax_Syntax.Tm_fvar uu____8210 ->
         FStar_Pervasives_Native.Some t1
-    | FStar_Syntax_Syntax.Tm_app (t2,uu____8211) -> get_tycon t2
-    | uu____8236 -> FStar_Pervasives_Native.None
+    | FStar_Syntax_Syntax.Tm_app (t2,uu____8212) -> get_tycon t2
+    | uu____8237 -> FStar_Pervasives_Native.None
   
 let (is_fstar_tactics_by_tactic : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____8244 =
-      let uu____8245 = un_uinst t  in uu____8245.FStar_Syntax_Syntax.n  in
-    match uu____8244 with
+    let uu____8245 =
+      let uu____8246 = un_uinst t  in uu____8246.FStar_Syntax_Syntax.n  in
+    match uu____8245 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.by_tactic_lid
-    | uu____8250 -> false
+    | uu____8251 -> false
   
 let (is_builtin_tactic : FStar_Ident.lident -> Prims.bool) =
   fun md  ->
     let path = FStar_Ident.path_of_lid md  in
     if (FStar_List.length path) > (Prims.of_int (2))
     then
-      let uu____8264 =
-        let uu____8268 = FStar_List.splitAt (Prims.of_int (2)) path  in
-        FStar_Pervasives_Native.fst uu____8268  in
-      match uu____8264 with
+      let uu____8265 =
+        let uu____8269 = FStar_List.splitAt (Prims.of_int (2)) path  in
+        FStar_Pervasives_Native.fst uu____8269  in
+      match uu____8265 with
       | "FStar"::"Tactics"::[] -> true
       | "FStar"::"Reflection"::[] -> true
-      | uu____8300 -> false
+      | uu____8301 -> false
     else false
   
 let (ktype : FStar_Syntax_Syntax.term) =
@@ -2174,40 +2176,40 @@ let (ktype0 : FStar_Syntax_Syntax.term) =
   
 let (type_u :
   unit -> (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.universe)) =
-  fun uu____8319  ->
+  fun uu____8320  ->
     let u =
-      let uu____8325 = FStar_Syntax_Unionfind.univ_fresh ()  in
-      FStar_All.pipe_left (fun _8342  -> FStar_Syntax_Syntax.U_unif _8342)
-        uu____8325
+      let uu____8326 = FStar_Syntax_Unionfind.univ_fresh ()  in
+      FStar_All.pipe_left (fun _8343  -> FStar_Syntax_Syntax.U_unif _8343)
+        uu____8326
        in
-    let uu____8343 =
+    let uu____8344 =
       FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u)
         FStar_Pervasives_Native.None FStar_Range.dummyRange
        in
-    (uu____8343, u)
+    (uu____8344, u)
   
 let (attr_eq :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun a  ->
     fun a'  ->
-      let uu____8356 = eq_tm a a'  in
-      match uu____8356 with | Equal  -> true | uu____8359 -> false
+      let uu____8357 = eq_tm a a'  in
+      match uu____8357 with | Equal  -> true | uu____8360 -> false
   
 let (attr_substitute : FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
-  let uu____8364 =
-    let uu____8371 =
-      let uu____8372 =
-        let uu____8373 =
+  let uu____8365 =
+    let uu____8372 =
+      let uu____8373 =
+        let uu____8374 =
           FStar_Ident.lid_of_path ["FStar"; "Pervasives"; "Substitute"]
             FStar_Range.dummyRange
            in
-        FStar_Syntax_Syntax.lid_as_fv uu____8373
+        FStar_Syntax_Syntax.lid_as_fv uu____8374
           FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
          in
-      FStar_Syntax_Syntax.Tm_fvar uu____8372  in
-    FStar_Syntax_Syntax.mk uu____8371  in
-  uu____8364 FStar_Pervasives_Native.None FStar_Range.dummyRange 
+      FStar_Syntax_Syntax.Tm_fvar uu____8373  in
+    FStar_Syntax_Syntax.mk uu____8372  in
+  uu____8365 FStar_Pervasives_Native.None FStar_Range.dummyRange 
 let (exp_true_bool : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.mk
     (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool true))
@@ -2291,25 +2293,25 @@ let (mk_conj_opt :
       match phi1 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.Some phi2
       | FStar_Pervasives_Native.Some phi11 ->
-          let uu____8485 =
-            let uu____8488 =
+          let uu____8486 =
+            let uu____8489 =
               FStar_Range.union_ranges phi11.FStar_Syntax_Syntax.pos
                 phi2.FStar_Syntax_Syntax.pos
                in
-            let uu____8489 =
-              let uu____8496 =
-                let uu____8497 =
-                  let uu____8514 =
-                    let uu____8525 = FStar_Syntax_Syntax.as_arg phi11  in
-                    let uu____8534 =
-                      let uu____8545 = FStar_Syntax_Syntax.as_arg phi2  in
-                      [uu____8545]  in
-                    uu____8525 :: uu____8534  in
-                  (tand, uu____8514)  in
-                FStar_Syntax_Syntax.Tm_app uu____8497  in
-              FStar_Syntax_Syntax.mk uu____8496  in
-            uu____8489 FStar_Pervasives_Native.None uu____8488  in
-          FStar_Pervasives_Native.Some uu____8485
+            let uu____8490 =
+              let uu____8497 =
+                let uu____8498 =
+                  let uu____8515 =
+                    let uu____8526 = FStar_Syntax_Syntax.as_arg phi11  in
+                    let uu____8535 =
+                      let uu____8546 = FStar_Syntax_Syntax.as_arg phi2  in
+                      [uu____8546]  in
+                    uu____8526 :: uu____8535  in
+                  (tand, uu____8515)  in
+                FStar_Syntax_Syntax.Tm_app uu____8498  in
+              FStar_Syntax_Syntax.mk uu____8497  in
+            uu____8490 FStar_Pervasives_Native.None uu____8489  in
+          FStar_Pervasives_Native.Some uu____8486
   
 let (mk_binop :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2320,39 +2322,39 @@ let (mk_binop :
   fun op_t  ->
     fun phi1  ->
       fun phi2  ->
-        let uu____8622 =
+        let uu____8623 =
           FStar_Range.union_ranges phi1.FStar_Syntax_Syntax.pos
             phi2.FStar_Syntax_Syntax.pos
            in
-        let uu____8623 =
-          let uu____8630 =
-            let uu____8631 =
-              let uu____8648 =
-                let uu____8659 = FStar_Syntax_Syntax.as_arg phi1  in
-                let uu____8668 =
-                  let uu____8679 = FStar_Syntax_Syntax.as_arg phi2  in
-                  [uu____8679]  in
-                uu____8659 :: uu____8668  in
-              (op_t, uu____8648)  in
-            FStar_Syntax_Syntax.Tm_app uu____8631  in
-          FStar_Syntax_Syntax.mk uu____8630  in
-        uu____8623 FStar_Pervasives_Native.None uu____8622
+        let uu____8624 =
+          let uu____8631 =
+            let uu____8632 =
+              let uu____8649 =
+                let uu____8660 = FStar_Syntax_Syntax.as_arg phi1  in
+                let uu____8669 =
+                  let uu____8680 = FStar_Syntax_Syntax.as_arg phi2  in
+                  [uu____8680]  in
+                uu____8660 :: uu____8669  in
+              (op_t, uu____8649)  in
+            FStar_Syntax_Syntax.Tm_app uu____8632  in
+          FStar_Syntax_Syntax.mk uu____8631  in
+        uu____8624 FStar_Pervasives_Native.None uu____8623
   
 let (mk_neg :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   fun phi  ->
-    let uu____8736 =
-      let uu____8743 =
-        let uu____8744 =
-          let uu____8761 =
-            let uu____8772 = FStar_Syntax_Syntax.as_arg phi  in [uu____8772]
+    let uu____8737 =
+      let uu____8744 =
+        let uu____8745 =
+          let uu____8762 =
+            let uu____8773 = FStar_Syntax_Syntax.as_arg phi  in [uu____8773]
              in
-          (t_not, uu____8761)  in
-        FStar_Syntax_Syntax.Tm_app uu____8744  in
-      FStar_Syntax_Syntax.mk uu____8743  in
-    uu____8736 FStar_Pervasives_Native.None phi.FStar_Syntax_Syntax.pos
+          (t_not, uu____8762)  in
+        FStar_Syntax_Syntax.Tm_app uu____8745  in
+      FStar_Syntax_Syntax.mk uu____8744  in
+    uu____8737 FStar_Pervasives_Native.None phi.FStar_Syntax_Syntax.pos
   
 let (mk_conj :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2399,44 +2401,44 @@ let (b2t :
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   fun e  ->
-    let uu____8969 =
-      let uu____8976 =
-        let uu____8977 =
-          let uu____8994 =
-            let uu____9005 = FStar_Syntax_Syntax.as_arg e  in [uu____9005]
+    let uu____8970 =
+      let uu____8977 =
+        let uu____8978 =
+          let uu____8995 =
+            let uu____9006 = FStar_Syntax_Syntax.as_arg e  in [uu____9006]
              in
-          (b2t_v, uu____8994)  in
-        FStar_Syntax_Syntax.Tm_app uu____8977  in
-      FStar_Syntax_Syntax.mk uu____8976  in
-    uu____8969 FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
+          (b2t_v, uu____8995)  in
+        FStar_Syntax_Syntax.Tm_app uu____8978  in
+      FStar_Syntax_Syntax.mk uu____8977  in
+    uu____8970 FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
   
 let (unb2t :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
   =
   fun e  ->
-    let uu____9052 = head_and_args e  in
-    match uu____9052 with
+    let uu____9053 = head_and_args e  in
+    match uu____9053 with
     | (hd1,args) ->
-        let uu____9097 =
-          let uu____9112 =
-            let uu____9113 = FStar_Syntax_Subst.compress hd1  in
-            uu____9113.FStar_Syntax_Syntax.n  in
-          (uu____9112, args)  in
-        (match uu____9097 with
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(e1,uu____9130)::[]) when
+        let uu____9098 =
+          let uu____9113 =
+            let uu____9114 = FStar_Syntax_Subst.compress hd1  in
+            uu____9114.FStar_Syntax_Syntax.n  in
+          (uu____9113, args)  in
+        (match uu____9098 with
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(e1,uu____9131)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.b2t_lid ->
              FStar_Pervasives_Native.Some e1
-         | uu____9165 -> FStar_Pervasives_Native.None)
+         | uu____9166 -> FStar_Pervasives_Native.None)
   
 let (is_t_true : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____9187 =
-      let uu____9188 = unmeta t  in uu____9188.FStar_Syntax_Syntax.n  in
-    match uu____9187 with
+    let uu____9188 =
+      let uu____9189 = unmeta t  in uu____9189.FStar_Syntax_Syntax.n  in
+    match uu____9188 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.true_lid
-    | uu____9193 -> false
+    | uu____9194 -> false
   
 let (mk_conj_simp :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2445,12 +2447,12 @@ let (mk_conj_simp :
   =
   fun t1  ->
     fun t2  ->
-      let uu____9216 = is_t_true t1  in
-      if uu____9216
+      let uu____9217 = is_t_true t1  in
+      if uu____9217
       then t2
       else
-        (let uu____9223 = is_t_true t2  in
-         if uu____9223 then t1 else mk_conj t1 t2)
+        (let uu____9224 = is_t_true t2  in
+         if uu____9224 then t1 else mk_conj t1 t2)
   
 let (mk_disj_simp :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2459,12 +2461,12 @@ let (mk_disj_simp :
   =
   fun t1  ->
     fun t2  ->
-      let uu____9251 = is_t_true t1  in
-      if uu____9251
+      let uu____9252 = is_t_true t1  in
+      if uu____9252
       then t_true
       else
-        (let uu____9258 = is_t_true t2  in
-         if uu____9258 then t_true else mk_disj t1 t2)
+        (let uu____9259 = is_t_true t2  in
+         if uu____9259 then t_true else mk_disj t1 t2)
   
 let (teq : FStar_Syntax_Syntax.term) = fvar_const FStar_Parser_Const.eq2_lid 
 let (mk_untyped_eq2 :
@@ -2474,23 +2476,23 @@ let (mk_untyped_eq2 :
   =
   fun e1  ->
     fun e2  ->
-      let uu____9287 =
+      let uu____9288 =
         FStar_Range.union_ranges e1.FStar_Syntax_Syntax.pos
           e2.FStar_Syntax_Syntax.pos
          in
-      let uu____9288 =
-        let uu____9295 =
-          let uu____9296 =
-            let uu____9313 =
-              let uu____9324 = FStar_Syntax_Syntax.as_arg e1  in
-              let uu____9333 =
-                let uu____9344 = FStar_Syntax_Syntax.as_arg e2  in
-                [uu____9344]  in
-              uu____9324 :: uu____9333  in
-            (teq, uu____9313)  in
-          FStar_Syntax_Syntax.Tm_app uu____9296  in
-        FStar_Syntax_Syntax.mk uu____9295  in
-      uu____9288 FStar_Pervasives_Native.None uu____9287
+      let uu____9289 =
+        let uu____9296 =
+          let uu____9297 =
+            let uu____9314 =
+              let uu____9325 = FStar_Syntax_Syntax.as_arg e1  in
+              let uu____9334 =
+                let uu____9345 = FStar_Syntax_Syntax.as_arg e2  in
+                [uu____9345]  in
+              uu____9325 :: uu____9334  in
+            (teq, uu____9314)  in
+          FStar_Syntax_Syntax.Tm_app uu____9297  in
+        FStar_Syntax_Syntax.mk uu____9296  in
+      uu____9289 FStar_Pervasives_Native.None uu____9288
   
 let (mk_eq2 :
   FStar_Syntax_Syntax.universe ->
@@ -2503,26 +2505,26 @@ let (mk_eq2 :
       fun e1  ->
         fun e2  ->
           let eq_inst = FStar_Syntax_Syntax.mk_Tm_uinst teq [u]  in
-          let uu____9411 =
+          let uu____9412 =
             FStar_Range.union_ranges e1.FStar_Syntax_Syntax.pos
               e2.FStar_Syntax_Syntax.pos
              in
-          let uu____9412 =
-            let uu____9419 =
-              let uu____9420 =
-                let uu____9437 =
-                  let uu____9448 = FStar_Syntax_Syntax.iarg t  in
-                  let uu____9457 =
-                    let uu____9468 = FStar_Syntax_Syntax.as_arg e1  in
-                    let uu____9477 =
-                      let uu____9488 = FStar_Syntax_Syntax.as_arg e2  in
-                      [uu____9488]  in
-                    uu____9468 :: uu____9477  in
-                  uu____9448 :: uu____9457  in
-                (eq_inst, uu____9437)  in
-              FStar_Syntax_Syntax.Tm_app uu____9420  in
-            FStar_Syntax_Syntax.mk uu____9419  in
-          uu____9412 FStar_Pervasives_Native.None uu____9411
+          let uu____9413 =
+            let uu____9420 =
+              let uu____9421 =
+                let uu____9438 =
+                  let uu____9449 = FStar_Syntax_Syntax.iarg t  in
+                  let uu____9458 =
+                    let uu____9469 = FStar_Syntax_Syntax.as_arg e1  in
+                    let uu____9478 =
+                      let uu____9489 = FStar_Syntax_Syntax.as_arg e2  in
+                      [uu____9489]  in
+                    uu____9469 :: uu____9478  in
+                  uu____9449 :: uu____9458  in
+                (eq_inst, uu____9438)  in
+              FStar_Syntax_Syntax.Tm_app uu____9421  in
+            FStar_Syntax_Syntax.mk uu____9420  in
+          uu____9413 FStar_Pervasives_Native.None uu____9412
   
 let (mk_has_type :
   FStar_Syntax_Syntax.term ->
@@ -2541,22 +2543,22 @@ let (mk_has_type :
                  [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]))
             FStar_Pervasives_Native.None FStar_Range.dummyRange
            in
-        let uu____9565 =
-          let uu____9572 =
-            let uu____9573 =
-              let uu____9590 =
-                let uu____9601 = FStar_Syntax_Syntax.iarg t  in
-                let uu____9610 =
-                  let uu____9621 = FStar_Syntax_Syntax.as_arg x  in
-                  let uu____9630 =
-                    let uu____9641 = FStar_Syntax_Syntax.as_arg t'  in
-                    [uu____9641]  in
-                  uu____9621 :: uu____9630  in
-                uu____9601 :: uu____9610  in
-              (t_has_type1, uu____9590)  in
-            FStar_Syntax_Syntax.Tm_app uu____9573  in
-          FStar_Syntax_Syntax.mk uu____9572  in
-        uu____9565 FStar_Pervasives_Native.None FStar_Range.dummyRange
+        let uu____9566 =
+          let uu____9573 =
+            let uu____9574 =
+              let uu____9591 =
+                let uu____9602 = FStar_Syntax_Syntax.iarg t  in
+                let uu____9611 =
+                  let uu____9622 = FStar_Syntax_Syntax.as_arg x  in
+                  let uu____9631 =
+                    let uu____9642 = FStar_Syntax_Syntax.as_arg t'  in
+                    [uu____9642]  in
+                  uu____9622 :: uu____9631  in
+                uu____9602 :: uu____9611  in
+              (t_has_type1, uu____9591)  in
+            FStar_Syntax_Syntax.Tm_app uu____9574  in
+          FStar_Syntax_Syntax.mk uu____9573  in
+        uu____9566 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (mk_with_type :
   FStar_Syntax_Syntax.universe ->
@@ -2576,35 +2578,35 @@ let (mk_with_type :
             (FStar_Syntax_Syntax.Tm_uinst (t_with_type, [u]))
             FStar_Pervasives_Native.None FStar_Range.dummyRange
            in
-        let uu____9718 =
-          let uu____9725 =
-            let uu____9726 =
-              let uu____9743 =
-                let uu____9754 = FStar_Syntax_Syntax.iarg t  in
-                let uu____9763 =
-                  let uu____9774 = FStar_Syntax_Syntax.as_arg e  in
-                  [uu____9774]  in
-                uu____9754 :: uu____9763  in
-              (t_with_type1, uu____9743)  in
-            FStar_Syntax_Syntax.Tm_app uu____9726  in
-          FStar_Syntax_Syntax.mk uu____9725  in
-        uu____9718 FStar_Pervasives_Native.None FStar_Range.dummyRange
+        let uu____9719 =
+          let uu____9726 =
+            let uu____9727 =
+              let uu____9744 =
+                let uu____9755 = FStar_Syntax_Syntax.iarg t  in
+                let uu____9764 =
+                  let uu____9775 = FStar_Syntax_Syntax.as_arg e  in
+                  [uu____9775]  in
+                uu____9755 :: uu____9764  in
+              (t_with_type1, uu____9744)  in
+            FStar_Syntax_Syntax.Tm_app uu____9727  in
+          FStar_Syntax_Syntax.mk uu____9726  in
+        uu____9719 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (lex_t : FStar_Syntax_Syntax.term) =
   fvar_const FStar_Parser_Const.lex_t_lid 
 let (lex_top : FStar_Syntax_Syntax.term) =
-  let uu____9821 =
-    let uu____9828 =
-      let uu____9829 =
-        let uu____9836 =
+  let uu____9822 =
+    let uu____9829 =
+      let uu____9830 =
+        let uu____9837 =
           FStar_Syntax_Syntax.fvar FStar_Parser_Const.lextop_lid
             FStar_Syntax_Syntax.delta_constant
             (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
            in
-        (uu____9836, [FStar_Syntax_Syntax.U_zero])  in
-      FStar_Syntax_Syntax.Tm_uinst uu____9829  in
-    FStar_Syntax_Syntax.mk uu____9828  in
-  uu____9821 FStar_Pervasives_Native.None FStar_Range.dummyRange 
+        (uu____9837, [FStar_Syntax_Syntax.U_zero])  in
+      FStar_Syntax_Syntax.Tm_uinst uu____9830  in
+    FStar_Syntax_Syntax.mk uu____9829  in
+  uu____9822 FStar_Pervasives_Native.None FStar_Range.dummyRange 
 let (lex_pair : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.fvar FStar_Parser_Const.lexcons_lid
     FStar_Syntax_Syntax.delta_constant
@@ -2621,21 +2623,21 @@ let (t_haseq : FStar_Syntax_Syntax.term) =
   
 let (lcomp_of_comp : FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.lcomp) =
   fun c0  ->
-    let uu____9851 =
+    let uu____9852 =
       match c0.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Total uu____9864 ->
+      | FStar_Syntax_Syntax.Total uu____9865 ->
           (FStar_Parser_Const.effect_Tot_lid, [FStar_Syntax_Syntax.TOTAL])
-      | FStar_Syntax_Syntax.GTotal uu____9875 ->
+      | FStar_Syntax_Syntax.GTotal uu____9876 ->
           (FStar_Parser_Const.effect_GTot_lid,
             [FStar_Syntax_Syntax.SOMETRIVIAL])
       | FStar_Syntax_Syntax.Comp c ->
           ((c.FStar_Syntax_Syntax.effect_name),
             (c.FStar_Syntax_Syntax.flags))
        in
-    match uu____9851 with
+    match uu____9852 with
     | (eff_name,flags) ->
         FStar_Syntax_Syntax.mk_lcomp eff_name (comp_result c0) flags
-          (fun uu____9896  -> c0)
+          (fun uu____9897  -> c0)
   
 let (mk_residual_comp :
   FStar_Ident.lident ->
@@ -2693,28 +2695,28 @@ let (mk_forall_aux :
   fun fa  ->
     fun x  ->
       fun body  ->
-        let uu____9979 =
-          let uu____9986 =
-            let uu____9987 =
-              let uu____10004 =
-                let uu____10015 =
+        let uu____9980 =
+          let uu____9987 =
+            let uu____9988 =
+              let uu____10005 =
+                let uu____10016 =
                   FStar_Syntax_Syntax.iarg x.FStar_Syntax_Syntax.sort  in
-                let uu____10024 =
-                  let uu____10035 =
-                    let uu____10044 =
-                      let uu____10045 =
-                        let uu____10046 = FStar_Syntax_Syntax.mk_binder x  in
-                        [uu____10046]  in
-                      abs uu____10045 body
+                let uu____10025 =
+                  let uu____10036 =
+                    let uu____10045 =
+                      let uu____10046 =
+                        let uu____10047 = FStar_Syntax_Syntax.mk_binder x  in
+                        [uu____10047]  in
+                      abs uu____10046 body
                         (FStar_Pervasives_Native.Some (residual_tot ktype0))
                        in
-                    FStar_Syntax_Syntax.as_arg uu____10044  in
-                  [uu____10035]  in
-                uu____10015 :: uu____10024  in
-              (fa, uu____10004)  in
-            FStar_Syntax_Syntax.Tm_app uu____9987  in
-          FStar_Syntax_Syntax.mk uu____9986  in
-        uu____9979 FStar_Pervasives_Native.None FStar_Range.dummyRange
+                    FStar_Syntax_Syntax.as_arg uu____10045  in
+                  [uu____10036]  in
+                uu____10016 :: uu____10025  in
+              (fa, uu____10005)  in
+            FStar_Syntax_Syntax.Tm_app uu____9988  in
+          FStar_Syntax_Syntax.mk uu____9987  in
+        uu____9980 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (mk_forall_no_univ :
   FStar_Syntax_Syntax.bv ->
@@ -2741,8 +2743,8 @@ let (close_forall_no_univs :
       FStar_List.fold_right
         (fun b  ->
            fun f1  ->
-             let uu____10173 = FStar_Syntax_Syntax.is_null_binder b  in
-             if uu____10173
+             let uu____10174 = FStar_Syntax_Syntax.is_null_binder b  in
+             if uu____10174
              then f1
              else mk_forall_no_univ (FStar_Pervasives_Native.fst b) f1) bs f
   
@@ -2750,8 +2752,8 @@ let rec (is_wild_pat :
   FStar_Syntax_Syntax.pat' FStar_Syntax_Syntax.withinfo_t -> Prims.bool) =
   fun p  ->
     match p.FStar_Syntax_Syntax.v with
-    | FStar_Syntax_Syntax.Pat_wild uu____10192 -> true
-    | uu____10194 -> false
+    | FStar_Syntax_Syntax.Pat_wild uu____10193 -> true
+    | uu____10195 -> false
   
 let (if_then_else :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2763,28 +2765,28 @@ let (if_then_else :
     fun t1  ->
       fun t2  ->
         let then_branch =
-          let uu____10241 =
+          let uu____10242 =
             FStar_Syntax_Syntax.withinfo
               (FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_bool true))
               t1.FStar_Syntax_Syntax.pos
              in
-          (uu____10241, FStar_Pervasives_Native.None, t1)  in
+          (uu____10242, FStar_Pervasives_Native.None, t1)  in
         let else_branch =
-          let uu____10270 =
+          let uu____10271 =
             FStar_Syntax_Syntax.withinfo
               (FStar_Syntax_Syntax.Pat_constant
                  (FStar_Const.Const_bool false)) t2.FStar_Syntax_Syntax.pos
              in
-          (uu____10270, FStar_Pervasives_Native.None, t2)  in
-        let uu____10284 =
-          let uu____10285 =
+          (uu____10271, FStar_Pervasives_Native.None, t2)  in
+        let uu____10285 =
+          let uu____10286 =
             FStar_Range.union_ranges t1.FStar_Syntax_Syntax.pos
               t2.FStar_Syntax_Syntax.pos
              in
-          FStar_Range.union_ranges b.FStar_Syntax_Syntax.pos uu____10285  in
+          FStar_Range.union_ranges b.FStar_Syntax_Syntax.pos uu____10286  in
         FStar_Syntax_Syntax.mk
           (FStar_Syntax_Syntax.Tm_match (b, [then_branch; else_branch]))
-          FStar_Pervasives_Native.None uu____10284
+          FStar_Pervasives_Native.None uu____10285
   
 let (mk_squash :
   FStar_Syntax_Syntax.universe ->
@@ -2798,10 +2800,10 @@ let (mk_squash :
           (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one)
           FStar_Pervasives_Native.None
          in
-      let uu____10361 = FStar_Syntax_Syntax.mk_Tm_uinst sq [u]  in
-      let uu____10364 =
-        let uu____10375 = FStar_Syntax_Syntax.as_arg p  in [uu____10375]  in
-      mk_app uu____10361 uu____10364
+      let uu____10362 = FStar_Syntax_Syntax.mk_Tm_uinst sq [u]  in
+      let uu____10365 =
+        let uu____10376 = FStar_Syntax_Syntax.as_arg p  in [uu____10376]  in
+      mk_app uu____10362 uu____10365
   
 let (mk_auto_squash :
   FStar_Syntax_Syntax.universe ->
@@ -2815,10 +2817,10 @@ let (mk_auto_squash :
           (FStar_Syntax_Syntax.Delta_constant_at_level (Prims.of_int (2)))
           FStar_Pervasives_Native.None
          in
-      let uu____10415 = FStar_Syntax_Syntax.mk_Tm_uinst sq [u]  in
-      let uu____10418 =
-        let uu____10429 = FStar_Syntax_Syntax.as_arg p  in [uu____10429]  in
-      mk_app uu____10415 uu____10418
+      let uu____10416 = FStar_Syntax_Syntax.mk_Tm_uinst sq [u]  in
+      let uu____10419 =
+        let uu____10430 = FStar_Syntax_Syntax.as_arg p  in [uu____10430]  in
+      mk_app uu____10416 uu____10419
   
 let (un_squash :
   FStar_Syntax_Syntax.term ->
@@ -2826,18 +2828,18 @@ let (un_squash :
       FStar_Pervasives_Native.option)
   =
   fun t  ->
-    let uu____10464 = head_and_args t  in
-    match uu____10464 with
+    let uu____10465 = head_and_args t  in
+    match uu____10465 with
     | (head1,args) ->
         let head2 = unascribe head1  in
         let head3 = un_uinst head2  in
-        let uu____10513 =
-          let uu____10528 =
-            let uu____10529 = FStar_Syntax_Subst.compress head3  in
-            uu____10529.FStar_Syntax_Syntax.n  in
-          (uu____10528, args)  in
-        (match uu____10513 with
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(p,uu____10548)::[]) when
+        let uu____10514 =
+          let uu____10529 =
+            let uu____10530 = FStar_Syntax_Subst.compress head3  in
+            uu____10530.FStar_Syntax_Syntax.n  in
+          (uu____10529, args)  in
+        (match uu____10514 with
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(p,uu____10549)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid
              -> FStar_Pervasives_Native.Some p
          | (FStar_Syntax_Syntax.Tm_refine (b,p),[]) ->
@@ -2846,27 +2848,27 @@ let (un_squash :
                   FStar_Syntax_Syntax.fv_eq_lid fv
                     FStar_Parser_Const.unit_lid
                   ->
-                  let uu____10614 =
-                    let uu____10619 =
-                      let uu____10620 = FStar_Syntax_Syntax.mk_binder b  in
-                      [uu____10620]  in
-                    FStar_Syntax_Subst.open_term uu____10619 p  in
-                  (match uu____10614 with
+                  let uu____10615 =
+                    let uu____10620 =
+                      let uu____10621 = FStar_Syntax_Syntax.mk_binder b  in
+                      [uu____10621]  in
+                    FStar_Syntax_Subst.open_term uu____10620 p  in
+                  (match uu____10615 with
                    | (bs,p1) ->
                        let b1 =
                          match bs with
                          | b1::[] -> b1
-                         | uu____10677 -> failwith "impossible"  in
-                       let uu____10685 =
-                         let uu____10687 = FStar_Syntax_Free.names p1  in
+                         | uu____10678 -> failwith "impossible"  in
+                       let uu____10686 =
+                         let uu____10688 = FStar_Syntax_Free.names p1  in
                          FStar_Util.set_mem (FStar_Pervasives_Native.fst b1)
-                           uu____10687
+                           uu____10688
                           in
-                       if uu____10685
+                       if uu____10686
                        then FStar_Pervasives_Native.None
                        else FStar_Pervasives_Native.Some p1)
-              | uu____10703 -> FStar_Pervasives_Native.None)
-         | uu____10706 -> FStar_Pervasives_Native.None)
+              | uu____10704 -> FStar_Pervasives_Native.None)
+         | uu____10707 -> FStar_Pervasives_Native.None)
   
 let (is_squash :
   FStar_Syntax_Syntax.term ->
@@ -2874,23 +2876,23 @@ let (is_squash :
       FStar_Syntax_Syntax.syntax) FStar_Pervasives_Native.option)
   =
   fun t  ->
-    let uu____10737 = head_and_args t  in
-    match uu____10737 with
+    let uu____10738 = head_and_args t  in
+    match uu____10738 with
     | (head1,args) ->
-        let uu____10788 =
-          let uu____10803 =
-            let uu____10804 = FStar_Syntax_Subst.compress head1  in
-            uu____10804.FStar_Syntax_Syntax.n  in
-          (uu____10803, args)  in
-        (match uu____10788 with
+        let uu____10789 =
+          let uu____10804 =
+            let uu____10805 = FStar_Syntax_Subst.compress head1  in
+            uu____10805.FStar_Syntax_Syntax.n  in
+          (uu____10804, args)  in
+        (match uu____10789 with
          | (FStar_Syntax_Syntax.Tm_uinst
             ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-               FStar_Syntax_Syntax.pos = uu____10826;
-               FStar_Syntax_Syntax.vars = uu____10827;_},u::[]),(t1,uu____10830)::[])
+               FStar_Syntax_Syntax.pos = uu____10827;
+               FStar_Syntax_Syntax.vars = uu____10828;_},u::[]),(t1,uu____10831)::[])
              when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid
              -> FStar_Pervasives_Native.Some (u, t1)
-         | uu____10877 -> FStar_Pervasives_Native.None)
+         | uu____10878 -> FStar_Pervasives_Native.None)
   
 let (is_auto_squash :
   FStar_Syntax_Syntax.term ->
@@ -2898,35 +2900,35 @@ let (is_auto_squash :
       FStar_Syntax_Syntax.syntax) FStar_Pervasives_Native.option)
   =
   fun t  ->
-    let uu____10912 = head_and_args t  in
-    match uu____10912 with
+    let uu____10913 = head_and_args t  in
+    match uu____10913 with
     | (head1,args) ->
-        let uu____10963 =
-          let uu____10978 =
-            let uu____10979 = FStar_Syntax_Subst.compress head1  in
-            uu____10979.FStar_Syntax_Syntax.n  in
-          (uu____10978, args)  in
-        (match uu____10963 with
+        let uu____10964 =
+          let uu____10979 =
+            let uu____10980 = FStar_Syntax_Subst.compress head1  in
+            uu____10980.FStar_Syntax_Syntax.n  in
+          (uu____10979, args)  in
+        (match uu____10964 with
          | (FStar_Syntax_Syntax.Tm_uinst
             ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-               FStar_Syntax_Syntax.pos = uu____11001;
-               FStar_Syntax_Syntax.vars = uu____11002;_},u::[]),(t1,uu____11005)::[])
+               FStar_Syntax_Syntax.pos = uu____11002;
+               FStar_Syntax_Syntax.vars = uu____11003;_},u::[]),(t1,uu____11006)::[])
              when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Parser_Const.auto_squash_lid
              -> FStar_Pervasives_Native.Some (u, t1)
-         | uu____11052 -> FStar_Pervasives_Native.None)
+         | uu____11053 -> FStar_Pervasives_Native.None)
   
 let (is_sub_singleton : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____11080 =
-      let uu____11097 = unmeta t  in head_and_args uu____11097  in
-    match uu____11080 with
-    | (head1,uu____11100) ->
-        let uu____11125 =
-          let uu____11126 = un_uinst head1  in
-          uu____11126.FStar_Syntax_Syntax.n  in
-        (match uu____11125 with
+    let uu____11081 =
+      let uu____11098 = unmeta t  in head_and_args uu____11098  in
+    match uu____11081 with
+    | (head1,uu____11101) ->
+        let uu____11126 =
+          let uu____11127 = un_uinst head1  in
+          uu____11127.FStar_Syntax_Syntax.n  in
+        (match uu____11126 with
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              (((((((((((((((((FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.squash_lid)
@@ -2981,7 +2983,7 @@ let (is_sub_singleton : FStar_Syntax_Syntax.term -> Prims.bool) =
                ||
                (FStar_Syntax_Syntax.fv_eq_lid fv
                   FStar_Parser_Const.precedes_lid)
-         | uu____11131 -> false)
+         | uu____11132 -> false)
   
 let (arrow_one :
   FStar_Syntax_Syntax.typ ->
@@ -2989,34 +2991,34 @@ let (arrow_one :
       FStar_Pervasives_Native.option)
   =
   fun t  ->
-    let uu____11151 =
-      let uu____11164 =
-        let uu____11165 = FStar_Syntax_Subst.compress t  in
-        uu____11165.FStar_Syntax_Syntax.n  in
-      match uu____11164 with
+    let uu____11152 =
+      let uu____11165 =
+        let uu____11166 = FStar_Syntax_Subst.compress t  in
+        uu____11166.FStar_Syntax_Syntax.n  in
+      match uu____11165 with
       | FStar_Syntax_Syntax.Tm_arrow ([],c) ->
           failwith "fatal: empty binders on arrow?"
       | FStar_Syntax_Syntax.Tm_arrow (b::[],c) ->
           FStar_Pervasives_Native.Some (b, c)
       | FStar_Syntax_Syntax.Tm_arrow (b::bs,c) ->
-          let uu____11295 =
-            let uu____11306 =
-              let uu____11307 = arrow bs c  in
-              FStar_Syntax_Syntax.mk_Total uu____11307  in
-            (b, uu____11306)  in
-          FStar_Pervasives_Native.Some uu____11295
-      | uu____11324 -> FStar_Pervasives_Native.None  in
-    FStar_Util.bind_opt uu____11151
-      (fun uu____11362  ->
-         match uu____11362 with
+          let uu____11296 =
+            let uu____11307 =
+              let uu____11308 = arrow bs c  in
+              FStar_Syntax_Syntax.mk_Total uu____11308  in
+            (b, uu____11307)  in
+          FStar_Pervasives_Native.Some uu____11296
+      | uu____11325 -> FStar_Pervasives_Native.None  in
+    FStar_Util.bind_opt uu____11152
+      (fun uu____11363  ->
+         match uu____11363 with
          | (b,c) ->
-             let uu____11399 = FStar_Syntax_Subst.open_comp [b] c  in
-             (match uu____11399 with
+             let uu____11400 = FStar_Syntax_Subst.open_comp [b] c  in
+             (match uu____11400 with
               | (bs,c1) ->
                   let b1 =
                     match bs with
                     | b1::[] -> b1
-                    | uu____11462 ->
+                    | uu____11463 ->
                         failwith
                           "impossible: open_comp returned different amount of binders"
                      in
@@ -3026,8 +3028,8 @@ let (is_free_in :
   FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun bv  ->
     fun t  ->
-      let uu____11499 = FStar_Syntax_Free.names t  in
-      FStar_Util.set_mem bv uu____11499
+      let uu____11500 = FStar_Syntax_Free.names t  in
+      FStar_Util.set_mem bv uu____11500
   
 type qpats = FStar_Syntax_Syntax.args Prims.list
 type connective =
@@ -3036,7 +3038,7 @@ type connective =
   | BaseConn of (FStar_Ident.lident * FStar_Syntax_Syntax.args) 
 let (uu___is_QAll : connective -> Prims.bool) =
   fun projectee  ->
-    match projectee with | QAll _0 -> true | uu____11551 -> false
+    match projectee with | QAll _0 -> true | uu____11552 -> false
   
 let (__proj__QAll__item___0 :
   connective ->
@@ -3044,7 +3046,7 @@ let (__proj__QAll__item___0 :
   = fun projectee  -> match projectee with | QAll _0 -> _0 
 let (uu___is_QEx : connective -> Prims.bool) =
   fun projectee  ->
-    match projectee with | QEx _0 -> true | uu____11594 -> false
+    match projectee with | QEx _0 -> true | uu____11595 -> false
   
 let (__proj__QEx__item___0 :
   connective ->
@@ -3052,7 +3054,7 @@ let (__proj__QEx__item___0 :
   = fun projectee  -> match projectee with | QEx _0 -> _0 
 let (uu___is_BaseConn : connective -> Prims.bool) =
   fun projectee  ->
-    match projectee with | BaseConn _0 -> true | uu____11635 -> false
+    match projectee with | BaseConn _0 -> true | uu____11636 -> false
   
 let (__proj__BaseConn__item___0 :
   connective -> (FStar_Ident.lident * FStar_Syntax_Syntax.args)) =
@@ -3099,26 +3101,26 @@ let (destruct_typ_as_formula :
       let f2 = FStar_Syntax_Subst.compress f1  in
       match f2.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_meta
-          (t,FStar_Syntax_Syntax.Meta_monadic uu____12021) ->
+          (t,FStar_Syntax_Syntax.Meta_monadic uu____12022) ->
           unmeta_monadic t
       | FStar_Syntax_Syntax.Tm_meta
-          (t,FStar_Syntax_Syntax.Meta_monadic_lift uu____12033) ->
+          (t,FStar_Syntax_Syntax.Meta_monadic_lift uu____12034) ->
           unmeta_monadic t
-      | uu____12046 -> f2  in
+      | uu____12047 -> f2  in
     let lookup_arity_lid table target_lid args =
       let arg_len = FStar_List.length args  in
-      let aux uu____12115 =
-        match uu____12115 with
+      let aux uu____12116 =
+        match uu____12116 with
         | (arity,lids) ->
             if arg_len = arity
             then
               FStar_Util.find_map lids
-                (fun uu____12153  ->
-                   match uu____12153 with
+                (fun uu____12154  ->
+                   match uu____12154 with
                    | (lid,out_lid) ->
-                       let uu____12162 =
+                       let uu____12163 =
                          FStar_Ident.lid_equals target_lid lid  in
-                       if uu____12162
+                       if uu____12163
                        then
                          FStar_Pervasives_Native.Some
                            (BaseConn (out_lid, args))
@@ -3127,43 +3129,43 @@ let (destruct_typ_as_formula :
          in
       FStar_Util.find_map table aux  in
     let destruct_base_conn t =
-      let uu____12189 = head_and_args t  in
-      match uu____12189 with
+      let uu____12190 = head_and_args t  in
+      match uu____12190 with
       | (hd1,args) ->
-          let uu____12234 =
-            let uu____12235 = un_uinst hd1  in
-            uu____12235.FStar_Syntax_Syntax.n  in
-          (match uu____12234 with
+          let uu____12235 =
+            let uu____12236 = un_uinst hd1  in
+            uu____12236.FStar_Syntax_Syntax.n  in
+          (match uu____12235 with
            | FStar_Syntax_Syntax.Tm_fvar fv ->
                lookup_arity_lid destruct_base_table
                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v args
-           | uu____12241 -> FStar_Pervasives_Native.None)
+           | uu____12242 -> FStar_Pervasives_Native.None)
        in
     let destruct_sq_base_conn t =
-      let uu____12250 = un_squash t  in
-      FStar_Util.bind_opt uu____12250
+      let uu____12251 = un_squash t  in
+      FStar_Util.bind_opt uu____12251
         (fun t1  ->
-           let uu____12266 = head_and_args' t1  in
-           match uu____12266 with
+           let uu____12267 = head_and_args' t1  in
+           match uu____12267 with
            | (hd1,args) ->
-               let uu____12305 =
-                 let uu____12306 = un_uinst hd1  in
-                 uu____12306.FStar_Syntax_Syntax.n  in
-               (match uu____12305 with
+               let uu____12306 =
+                 let uu____12307 = un_uinst hd1  in
+                 uu____12307.FStar_Syntax_Syntax.n  in
+               (match uu____12306 with
                 | FStar_Syntax_Syntax.Tm_fvar fv ->
                     lookup_arity_lid destruct_sq_base_table
                       (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                       args
-                | uu____12312 -> FStar_Pervasives_Native.None))
+                | uu____12313 -> FStar_Pervasives_Native.None))
        in
     let patterns t =
       let t1 = FStar_Syntax_Subst.compress t  in
       match t1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_meta
-          (t2,FStar_Syntax_Syntax.Meta_pattern (uu____12353,pats)) ->
-          let uu____12391 = FStar_Syntax_Subst.compress t2  in
-          (pats, uu____12391)
-      | uu____12404 -> ([], t1)  in
+          (t2,FStar_Syntax_Syntax.Meta_pattern (uu____12354,pats)) ->
+          let uu____12392 = FStar_Syntax_Subst.compress t2  in
+          (pats, uu____12392)
+      | uu____12405 -> ([], t1)  in
     let destruct_q_conn t =
       let is_q fa fv =
         if fa
@@ -3171,226 +3173,226 @@ let (destruct_typ_as_formula :
         else is_exists (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
          in
       let flat t1 =
-        let uu____12471 = head_and_args t1  in
-        match uu____12471 with
+        let uu____12472 = head_and_args t1  in
+        match uu____12472 with
         | (t2,args) ->
-            let uu____12526 = un_uinst t2  in
-            let uu____12527 =
+            let uu____12527 = un_uinst t2  in
+            let uu____12528 =
               FStar_All.pipe_right args
                 (FStar_List.map
-                   (fun uu____12568  ->
-                      match uu____12568 with
+                   (fun uu____12569  ->
+                      match uu____12569 with
                       | (t3,imp) ->
-                          let uu____12587 = unascribe t3  in
-                          (uu____12587, imp)))
+                          let uu____12588 = unascribe t3  in
+                          (uu____12588, imp)))
                in
-            (uu____12526, uu____12527)
+            (uu____12527, uu____12528)
          in
       let rec aux qopt out t1 =
-        let uu____12638 = let uu____12662 = flat t1  in (qopt, uu____12662)
+        let uu____12639 = let uu____12663 = flat t1  in (qopt, uu____12663)
            in
-        match uu____12638 with
+        match uu____12639 with
         | (FStar_Pervasives_Native.Some
            fa,({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-                 FStar_Syntax_Syntax.pos = uu____12702;
-                 FStar_Syntax_Syntax.vars = uu____12703;_},({
+                 FStar_Syntax_Syntax.pos = uu____12703;
+                 FStar_Syntax_Syntax.vars = uu____12704;_},({
                                                               FStar_Syntax_Syntax.n
                                                                 =
                                                                 FStar_Syntax_Syntax.Tm_abs
-                                                                (b::[],t2,uu____12706);
+                                                                (b::[],t2,uu____12707);
                                                               FStar_Syntax_Syntax.pos
-                                                                = uu____12707;
+                                                                = uu____12708;
                                                               FStar_Syntax_Syntax.vars
-                                                                = uu____12708;_},uu____12709)::[]))
+                                                                = uu____12709;_},uu____12710)::[]))
             when is_q fa tc -> aux qopt (b :: out) t2
         | (FStar_Pervasives_Native.Some
            fa,({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-                 FStar_Syntax_Syntax.pos = uu____12811;
-                 FStar_Syntax_Syntax.vars = uu____12812;_},uu____12813::
+                 FStar_Syntax_Syntax.pos = uu____12812;
+                 FStar_Syntax_Syntax.vars = uu____12813;_},uu____12814::
                ({
                   FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs
-                    (b::[],t2,uu____12816);
-                  FStar_Syntax_Syntax.pos = uu____12817;
-                  FStar_Syntax_Syntax.vars = uu____12818;_},uu____12819)::[]))
+                    (b::[],t2,uu____12817);
+                  FStar_Syntax_Syntax.pos = uu____12818;
+                  FStar_Syntax_Syntax.vars = uu____12819;_},uu____12820)::[]))
             when is_q fa tc -> aux qopt (b :: out) t2
         | (FStar_Pervasives_Native.None
            ,({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-               FStar_Syntax_Syntax.pos = uu____12936;
-               FStar_Syntax_Syntax.vars = uu____12937;_},({
+               FStar_Syntax_Syntax.pos = uu____12937;
+               FStar_Syntax_Syntax.vars = uu____12938;_},({
                                                             FStar_Syntax_Syntax.n
                                                               =
                                                               FStar_Syntax_Syntax.Tm_abs
-                                                              (b::[],t2,uu____12940);
+                                                              (b::[],t2,uu____12941);
                                                             FStar_Syntax_Syntax.pos
-                                                              = uu____12941;
+                                                              = uu____12942;
                                                             FStar_Syntax_Syntax.vars
-                                                              = uu____12942;_},uu____12943)::[]))
+                                                              = uu____12943;_},uu____12944)::[]))
             when
             is_qlid (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v ->
-            let uu____13036 =
-              let uu____13040 =
+            let uu____13037 =
+              let uu____13041 =
                 is_forall
                   (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                  in
-              FStar_Pervasives_Native.Some uu____13040  in
-            aux uu____13036 (b :: out) t2
+              FStar_Pervasives_Native.Some uu____13041  in
+            aux uu____13037 (b :: out) t2
         | (FStar_Pervasives_Native.None
            ,({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-               FStar_Syntax_Syntax.pos = uu____13050;
-               FStar_Syntax_Syntax.vars = uu____13051;_},uu____13052::
+               FStar_Syntax_Syntax.pos = uu____13051;
+               FStar_Syntax_Syntax.vars = uu____13052;_},uu____13053::
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs
-                  (b::[],t2,uu____13055);
-                FStar_Syntax_Syntax.pos = uu____13056;
-                FStar_Syntax_Syntax.vars = uu____13057;_},uu____13058)::[]))
+                  (b::[],t2,uu____13056);
+                FStar_Syntax_Syntax.pos = uu____13057;
+                FStar_Syntax_Syntax.vars = uu____13058;_},uu____13059)::[]))
             when
             is_qlid (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v ->
-            let uu____13167 =
-              let uu____13171 =
+            let uu____13168 =
+              let uu____13172 =
                 is_forall
                   (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                  in
-              FStar_Pervasives_Native.Some uu____13171  in
-            aux uu____13167 (b :: out) t2
-        | (FStar_Pervasives_Native.Some b,uu____13181) ->
+              FStar_Pervasives_Native.Some uu____13172  in
+            aux uu____13168 (b :: out) t2
+        | (FStar_Pervasives_Native.Some b,uu____13182) ->
             let bs = FStar_List.rev out  in
-            let uu____13234 = FStar_Syntax_Subst.open_term bs t1  in
-            (match uu____13234 with
+            let uu____13235 = FStar_Syntax_Subst.open_term bs t1  in
+            (match uu____13235 with
              | (bs1,t2) ->
-                 let uu____13243 = patterns t2  in
-                 (match uu____13243 with
+                 let uu____13244 = patterns t2  in
+                 (match uu____13244 with
                   | (pats,body) ->
                       if b
                       then
                         FStar_Pervasives_Native.Some (QAll (bs1, pats, body))
                       else
                         FStar_Pervasives_Native.Some (QEx (bs1, pats, body))))
-        | uu____13293 -> FStar_Pervasives_Native.None  in
+        | uu____13294 -> FStar_Pervasives_Native.None  in
       aux FStar_Pervasives_Native.None [] t  in
     let rec destruct_sq_forall t =
-      let uu____13348 = un_squash t  in
-      FStar_Util.bind_opt uu____13348
+      let uu____13349 = un_squash t  in
+      FStar_Util.bind_opt uu____13349
         (fun t1  ->
-           let uu____13363 = arrow_one t1  in
-           match uu____13363 with
+           let uu____13364 = arrow_one t1  in
+           match uu____13364 with
            | FStar_Pervasives_Native.Some (b,c) ->
-               let uu____13378 =
-                 let uu____13380 = is_tot_or_gtot_comp c  in
-                 Prims.op_Negation uu____13380  in
-               if uu____13378
+               let uu____13379 =
+                 let uu____13381 = is_tot_or_gtot_comp c  in
+                 Prims.op_Negation uu____13381  in
+               if uu____13379
                then FStar_Pervasives_Native.None
                else
                  (let q =
-                    let uu____13390 = comp_to_comp_typ_nouniv c  in
-                    uu____13390.FStar_Syntax_Syntax.result_typ  in
-                  let uu____13391 =
+                    let uu____13391 = comp_to_comp_typ_nouniv c  in
+                    uu____13391.FStar_Syntax_Syntax.result_typ  in
+                  let uu____13392 =
                     is_free_in (FStar_Pervasives_Native.fst b) q  in
-                  if uu____13391
+                  if uu____13392
                   then
-                    let uu____13398 = patterns q  in
-                    match uu____13398 with
+                    let uu____13399 = patterns q  in
+                    match uu____13399 with
                     | (pats,q1) ->
                         FStar_All.pipe_left maybe_collect
                           (FStar_Pervasives_Native.Some
                              (QAll ([b], pats, q1)))
                   else
-                    (let uu____13461 =
-                       let uu____13462 =
-                         let uu____13467 =
-                           let uu____13468 =
+                    (let uu____13462 =
+                       let uu____13463 =
+                         let uu____13468 =
+                           let uu____13469 =
                              FStar_Syntax_Syntax.as_arg
                                (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
                               in
-                           let uu____13479 =
-                             let uu____13490 = FStar_Syntax_Syntax.as_arg q
+                           let uu____13480 =
+                             let uu____13491 = FStar_Syntax_Syntax.as_arg q
                                 in
-                             [uu____13490]  in
-                           uu____13468 :: uu____13479  in
-                         (FStar_Parser_Const.imp_lid, uu____13467)  in
-                       BaseConn uu____13462  in
-                     FStar_Pervasives_Native.Some uu____13461))
-           | uu____13523 -> FStar_Pervasives_Native.None)
+                             [uu____13491]  in
+                           uu____13469 :: uu____13480  in
+                         (FStar_Parser_Const.imp_lid, uu____13468)  in
+                       BaseConn uu____13463  in
+                     FStar_Pervasives_Native.Some uu____13462))
+           | uu____13524 -> FStar_Pervasives_Native.None)
     
     and destruct_sq_exists t =
-      let uu____13531 = un_squash t  in
-      FStar_Util.bind_opt uu____13531
+      let uu____13532 = un_squash t  in
+      FStar_Util.bind_opt uu____13532
         (fun t1  ->
-           let uu____13562 = head_and_args' t1  in
-           match uu____13562 with
+           let uu____13563 = head_and_args' t1  in
+           match uu____13563 with
            | (hd1,args) ->
-               let uu____13601 =
-                 let uu____13616 =
-                   let uu____13617 = un_uinst hd1  in
-                   uu____13617.FStar_Syntax_Syntax.n  in
-                 (uu____13616, args)  in
-               (match uu____13601 with
+               let uu____13602 =
+                 let uu____13617 =
+                   let uu____13618 = un_uinst hd1  in
+                   uu____13618.FStar_Syntax_Syntax.n  in
+                 (uu____13617, args)  in
+               (match uu____13602 with
                 | (FStar_Syntax_Syntax.Tm_fvar
-                   fv,(a1,uu____13634)::(a2,uu____13636)::[]) when
+                   fv,(a1,uu____13635)::(a2,uu____13637)::[]) when
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.dtuple2_lid
                     ->
-                    let uu____13687 =
-                      let uu____13688 = FStar_Syntax_Subst.compress a2  in
-                      uu____13688.FStar_Syntax_Syntax.n  in
-                    (match uu____13687 with
-                     | FStar_Syntax_Syntax.Tm_abs (b::[],q,uu____13695) ->
-                         let uu____13730 = FStar_Syntax_Subst.open_term [b] q
+                    let uu____13688 =
+                      let uu____13689 = FStar_Syntax_Subst.compress a2  in
+                      uu____13689.FStar_Syntax_Syntax.n  in
+                    (match uu____13688 with
+                     | FStar_Syntax_Syntax.Tm_abs (b::[],q,uu____13696) ->
+                         let uu____13731 = FStar_Syntax_Subst.open_term [b] q
                             in
-                         (match uu____13730 with
+                         (match uu____13731 with
                           | (bs,q1) ->
                               let b1 =
                                 match bs with
                                 | b1::[] -> b1
-                                | uu____13783 -> failwith "impossible"  in
-                              let uu____13791 = patterns q1  in
-                              (match uu____13791 with
+                                | uu____13784 -> failwith "impossible"  in
+                              let uu____13792 = patterns q1  in
+                              (match uu____13792 with
                                | (pats,q2) ->
                                    FStar_All.pipe_left maybe_collect
                                      (FStar_Pervasives_Native.Some
                                         (QEx ([b1], pats, q2)))))
-                     | uu____13852 -> FStar_Pervasives_Native.None)
-                | uu____13853 -> FStar_Pervasives_Native.None))
+                     | uu____13853 -> FStar_Pervasives_Native.None)
+                | uu____13854 -> FStar_Pervasives_Native.None))
     
     and maybe_collect f1 =
       match f1 with
       | FStar_Pervasives_Native.Some (QAll (bs,pats,phi)) ->
-          let uu____13876 = destruct_sq_forall phi  in
-          (match uu____13876 with
+          let uu____13877 = destruct_sq_forall phi  in
+          (match uu____13877 with
            | FStar_Pervasives_Native.Some (QAll (bs',pats',psi)) ->
                FStar_All.pipe_left
-                 (fun _13886  -> FStar_Pervasives_Native.Some _13886)
+                 (fun _13887  -> FStar_Pervasives_Native.Some _13887)
                  (QAll
                     ((FStar_List.append bs bs'),
                       (FStar_List.append pats pats'), psi))
-           | uu____13893 -> f1)
+           | uu____13894 -> f1)
       | FStar_Pervasives_Native.Some (QEx (bs,pats,phi)) ->
-          let uu____13899 = destruct_sq_exists phi  in
-          (match uu____13899 with
+          let uu____13900 = destruct_sq_exists phi  in
+          (match uu____13900 with
            | FStar_Pervasives_Native.Some (QEx (bs',pats',psi)) ->
                FStar_All.pipe_left
-                 (fun _13909  -> FStar_Pervasives_Native.Some _13909)
+                 (fun _13910  -> FStar_Pervasives_Native.Some _13910)
                  (QEx
                     ((FStar_List.append bs bs'),
                       (FStar_List.append pats pats'), psi))
-           | uu____13916 -> f1)
-      | uu____13919 -> f1
+           | uu____13917 -> f1)
+      | uu____13920 -> f1
      in
     let phi = unmeta_monadic f  in
-    let uu____13923 = destruct_base_conn phi  in
-    FStar_Util.catch_opt uu____13923
-      (fun uu____13928  ->
-         let uu____13929 = destruct_q_conn phi  in
-         FStar_Util.catch_opt uu____13929
-           (fun uu____13934  ->
-              let uu____13935 = destruct_sq_base_conn phi  in
-              FStar_Util.catch_opt uu____13935
-                (fun uu____13940  ->
-                   let uu____13941 = destruct_sq_forall phi  in
-                   FStar_Util.catch_opt uu____13941
-                     (fun uu____13946  ->
-                        let uu____13947 = destruct_sq_exists phi  in
-                        FStar_Util.catch_opt uu____13947
-                          (fun uu____13951  -> FStar_Pervasives_Native.None)))))
+    let uu____13924 = destruct_base_conn phi  in
+    FStar_Util.catch_opt uu____13924
+      (fun uu____13929  ->
+         let uu____13930 = destruct_q_conn phi  in
+         FStar_Util.catch_opt uu____13930
+           (fun uu____13935  ->
+              let uu____13936 = destruct_sq_base_conn phi  in
+              FStar_Util.catch_opt uu____13936
+                (fun uu____13941  ->
+                   let uu____13942 = destruct_sq_forall phi  in
+                   FStar_Util.catch_opt uu____13942
+                     (fun uu____13947  ->
+                        let uu____13948 = destruct_sq_exists phi  in
+                        FStar_Util.catch_opt uu____13948
+                          (fun uu____13952  -> FStar_Pervasives_Native.None)))))
   
 let (action_as_lb :
   FStar_Ident.lident ->
@@ -3401,25 +3403,25 @@ let (action_as_lb :
     fun a  ->
       fun pos  ->
         let lb =
-          let uu____13969 =
-            let uu____13974 =
+          let uu____13970 =
+            let uu____13975 =
               FStar_Syntax_Syntax.lid_as_fv a.FStar_Syntax_Syntax.action_name
                 FStar_Syntax_Syntax.delta_equational
                 FStar_Pervasives_Native.None
                in
-            FStar_Util.Inr uu____13974  in
-          let uu____13975 =
-            let uu____13976 =
+            FStar_Util.Inr uu____13975  in
+          let uu____13976 =
+            let uu____13977 =
               FStar_Syntax_Syntax.mk_Total a.FStar_Syntax_Syntax.action_typ
                in
-            arrow a.FStar_Syntax_Syntax.action_params uu____13976  in
-          let uu____13979 =
+            arrow a.FStar_Syntax_Syntax.action_params uu____13977  in
+          let uu____13980 =
             abs a.FStar_Syntax_Syntax.action_params
               a.FStar_Syntax_Syntax.action_defn FStar_Pervasives_Native.None
              in
           close_univs_and_mk_letbinding FStar_Pervasives_Native.None
-            uu____13969 a.FStar_Syntax_Syntax.action_univs uu____13975
-            FStar_Parser_Const.effect_Tot_lid uu____13979 [] pos
+            uu____13970 a.FStar_Syntax_Syntax.action_univs uu____13976
+            FStar_Parser_Const.effect_Tot_lid uu____13980 [] pos
            in
         {
           FStar_Syntax_Syntax.sigel =
@@ -3431,7 +3433,8 @@ let (action_as_lb :
             [FStar_Syntax_Syntax.Visible_default;
             FStar_Syntax_Syntax.Action eff_lid];
           FStar_Syntax_Syntax.sigmeta = FStar_Syntax_Syntax.default_sigmeta;
-          FStar_Syntax_Syntax.sigattrs = []
+          FStar_Syntax_Syntax.sigattrs = [];
+          FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
         }
   
 let (mk_reify :
@@ -3444,16 +3447,16 @@ let (mk_reify :
         (FStar_Syntax_Syntax.Tm_constant FStar_Const.Const_reify)
         FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
        in
-    let uu____14005 =
-      let uu____14012 =
-        let uu____14013 =
-          let uu____14030 =
-            let uu____14041 = FStar_Syntax_Syntax.as_arg t  in [uu____14041]
+    let uu____14006 =
+      let uu____14013 =
+        let uu____14014 =
+          let uu____14031 =
+            let uu____14042 = FStar_Syntax_Syntax.as_arg t  in [uu____14042]
              in
-          (reify_1, uu____14030)  in
-        FStar_Syntax_Syntax.Tm_app uu____14013  in
-      FStar_Syntax_Syntax.mk uu____14012  in
-    uu____14005 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
+          (reify_1, uu____14031)  in
+        FStar_Syntax_Syntax.Tm_app uu____14014  in
+      FStar_Syntax_Syntax.mk uu____14013  in
+    uu____14006 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
   
 let (mk_reflect :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -3461,64 +3464,64 @@ let (mk_reflect :
   =
   fun t  ->
     let reflect_ =
-      let uu____14093 =
-        let uu____14100 =
-          let uu____14101 =
-            let uu____14102 = FStar_Ident.lid_of_str "Bogus.Effect"  in
-            FStar_Const.Const_reflect uu____14102  in
-          FStar_Syntax_Syntax.Tm_constant uu____14101  in
-        FStar_Syntax_Syntax.mk uu____14100  in
-      uu____14093 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos  in
-    let uu____14104 =
-      let uu____14111 =
-        let uu____14112 =
-          let uu____14129 =
-            let uu____14140 = FStar_Syntax_Syntax.as_arg t  in [uu____14140]
+      let uu____14094 =
+        let uu____14101 =
+          let uu____14102 =
+            let uu____14103 = FStar_Ident.lid_of_str "Bogus.Effect"  in
+            FStar_Const.Const_reflect uu____14103  in
+          FStar_Syntax_Syntax.Tm_constant uu____14102  in
+        FStar_Syntax_Syntax.mk uu____14101  in
+      uu____14094 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos  in
+    let uu____14105 =
+      let uu____14112 =
+        let uu____14113 =
+          let uu____14130 =
+            let uu____14141 = FStar_Syntax_Syntax.as_arg t  in [uu____14141]
              in
-          (reflect_, uu____14129)  in
-        FStar_Syntax_Syntax.Tm_app uu____14112  in
-      FStar_Syntax_Syntax.mk uu____14111  in
-    uu____14104 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
+          (reflect_, uu____14130)  in
+        FStar_Syntax_Syntax.Tm_app uu____14113  in
+      FStar_Syntax_Syntax.mk uu____14112  in
+    uu____14105 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
   
 let rec (delta_qualifier :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.delta_depth) =
   fun t  ->
     let t1 = FStar_Syntax_Subst.compress t  in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____14184 -> failwith "Impossible"
+    | FStar_Syntax_Syntax.Tm_delayed uu____14185 -> failwith "Impossible"
     | FStar_Syntax_Syntax.Tm_lazy i ->
-        let uu____14209 = unfold_lazy i  in delta_qualifier uu____14209
+        let uu____14210 = unfold_lazy i  in delta_qualifier uu____14210
     | FStar_Syntax_Syntax.Tm_fvar fv -> fv.FStar_Syntax_Syntax.fv_delta
-    | FStar_Syntax_Syntax.Tm_bvar uu____14211 ->
+    | FStar_Syntax_Syntax.Tm_bvar uu____14212 ->
         FStar_Syntax_Syntax.delta_equational
-    | FStar_Syntax_Syntax.Tm_name uu____14212 ->
+    | FStar_Syntax_Syntax.Tm_name uu____14213 ->
         FStar_Syntax_Syntax.delta_equational
-    | FStar_Syntax_Syntax.Tm_match uu____14213 ->
+    | FStar_Syntax_Syntax.Tm_match uu____14214 ->
         FStar_Syntax_Syntax.delta_equational
-    | FStar_Syntax_Syntax.Tm_uvar uu____14236 ->
+    | FStar_Syntax_Syntax.Tm_uvar uu____14237 ->
         FStar_Syntax_Syntax.delta_equational
     | FStar_Syntax_Syntax.Tm_unknown  -> FStar_Syntax_Syntax.delta_equational
-    | FStar_Syntax_Syntax.Tm_type uu____14249 ->
+    | FStar_Syntax_Syntax.Tm_type uu____14250 ->
         FStar_Syntax_Syntax.delta_constant
-    | FStar_Syntax_Syntax.Tm_quoted uu____14250 ->
+    | FStar_Syntax_Syntax.Tm_quoted uu____14251 ->
         FStar_Syntax_Syntax.delta_constant
-    | FStar_Syntax_Syntax.Tm_constant uu____14257 ->
+    | FStar_Syntax_Syntax.Tm_constant uu____14258 ->
         FStar_Syntax_Syntax.delta_constant
-    | FStar_Syntax_Syntax.Tm_arrow uu____14258 ->
+    | FStar_Syntax_Syntax.Tm_arrow uu____14259 ->
         FStar_Syntax_Syntax.delta_constant
-    | FStar_Syntax_Syntax.Tm_uinst (t2,uu____14274) -> delta_qualifier t2
+    | FStar_Syntax_Syntax.Tm_uinst (t2,uu____14275) -> delta_qualifier t2
     | FStar_Syntax_Syntax.Tm_refine
-        ({ FStar_Syntax_Syntax.ppname = uu____14279;
-           FStar_Syntax_Syntax.index = uu____14280;
-           FStar_Syntax_Syntax.sort = t2;_},uu____14282)
+        ({ FStar_Syntax_Syntax.ppname = uu____14280;
+           FStar_Syntax_Syntax.index = uu____14281;
+           FStar_Syntax_Syntax.sort = t2;_},uu____14283)
         -> delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_meta (t2,uu____14291) -> delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____14297,uu____14298) ->
+    | FStar_Syntax_Syntax.Tm_meta (t2,uu____14292) -> delta_qualifier t2
+    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____14298,uu____14299) ->
         delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_app (t2,uu____14340) -> delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_abs (uu____14365,t2,uu____14367) ->
+    | FStar_Syntax_Syntax.Tm_app (t2,uu____14341) -> delta_qualifier t2
+    | FStar_Syntax_Syntax.Tm_abs (uu____14366,t2,uu____14368) ->
         delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_let (uu____14392,t2) -> delta_qualifier t2
+    | FStar_Syntax_Syntax.Tm_let (uu____14393,t2) -> delta_qualifier t2
   
 let rec (incr_delta_depth :
   FStar_Syntax_Syntax.delta_depth -> FStar_Syntax_Syntax.delta_depth) =
@@ -3533,28 +3536,28 @@ let rec (incr_delta_depth :
 let (incr_delta_qualifier :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.delta_depth) =
   fun t  ->
-    let uu____14431 = delta_qualifier t  in incr_delta_depth uu____14431
+    let uu____14432 = delta_qualifier t  in incr_delta_depth uu____14432
   
 let (is_unknown : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____14439 =
-      let uu____14440 = FStar_Syntax_Subst.compress t  in
-      uu____14440.FStar_Syntax_Syntax.n  in
-    match uu____14439 with
+    let uu____14440 =
+      let uu____14441 = FStar_Syntax_Subst.compress t  in
+      uu____14441.FStar_Syntax_Syntax.n  in
+    match uu____14440 with
     | FStar_Syntax_Syntax.Tm_unknown  -> true
-    | uu____14445 -> false
+    | uu____14446 -> false
   
 let rec apply_last :
-  'Auu____14454 .
-    ('Auu____14454 -> 'Auu____14454) ->
-      'Auu____14454 Prims.list -> 'Auu____14454 Prims.list
+  'Auu____14455 .
+    ('Auu____14455 -> 'Auu____14455) ->
+      'Auu____14455 Prims.list -> 'Auu____14455 Prims.list
   =
   fun f  ->
     fun l  ->
       match l with
       | [] -> failwith "apply_last: got empty list"
-      | a::[] -> let uu____14480 = f a  in [uu____14480]
-      | x::xs -> let uu____14485 = apply_last f xs  in x :: uu____14485
+      | a::[] -> let uu____14481 = f a  in [uu____14481]
+      | x::xs -> let uu____14486 = apply_last f xs  in x :: uu____14486
   
 let (dm4f_lid :
   FStar_Syntax_Syntax.eff_decl -> Prims.string -> FStar_Ident.lident) =
@@ -3578,52 +3581,52 @@ let rec (mk_list :
     fun rng  ->
       fun l  ->
         let ctor l1 =
-          let uu____14540 =
-            let uu____14547 =
-              let uu____14548 =
+          let uu____14541 =
+            let uu____14548 =
+              let uu____14549 =
                 FStar_Syntax_Syntax.lid_as_fv l1
                   FStar_Syntax_Syntax.delta_constant
                   (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
                  in
-              FStar_Syntax_Syntax.Tm_fvar uu____14548  in
-            FStar_Syntax_Syntax.mk uu____14547  in
-          uu____14540 FStar_Pervasives_Native.None rng  in
+              FStar_Syntax_Syntax.Tm_fvar uu____14549  in
+            FStar_Syntax_Syntax.mk uu____14548  in
+          uu____14541 FStar_Pervasives_Native.None rng  in
         let cons1 args pos =
-          let uu____14562 =
-            let uu____14567 =
-              let uu____14568 = ctor FStar_Parser_Const.cons_lid  in
-              FStar_Syntax_Syntax.mk_Tm_uinst uu____14568
+          let uu____14563 =
+            let uu____14568 =
+              let uu____14569 = ctor FStar_Parser_Const.cons_lid  in
+              FStar_Syntax_Syntax.mk_Tm_uinst uu____14569
                 [FStar_Syntax_Syntax.U_zero]
                in
-            FStar_Syntax_Syntax.mk_Tm_app uu____14567 args  in
-          uu____14562 FStar_Pervasives_Native.None pos  in
+            FStar_Syntax_Syntax.mk_Tm_app uu____14568 args  in
+          uu____14563 FStar_Pervasives_Native.None pos  in
         let nil args pos =
-          let uu____14582 =
-            let uu____14587 =
-              let uu____14588 = ctor FStar_Parser_Const.nil_lid  in
-              FStar_Syntax_Syntax.mk_Tm_uinst uu____14588
+          let uu____14583 =
+            let uu____14588 =
+              let uu____14589 = ctor FStar_Parser_Const.nil_lid  in
+              FStar_Syntax_Syntax.mk_Tm_uinst uu____14589
                 [FStar_Syntax_Syntax.U_zero]
                in
-            FStar_Syntax_Syntax.mk_Tm_app uu____14587 args  in
-          uu____14582 FStar_Pervasives_Native.None pos  in
-        let uu____14589 =
-          let uu____14590 =
-            let uu____14591 = FStar_Syntax_Syntax.iarg typ  in [uu____14591]
+            FStar_Syntax_Syntax.mk_Tm_app uu____14588 args  in
+          uu____14583 FStar_Pervasives_Native.None pos  in
+        let uu____14590 =
+          let uu____14591 =
+            let uu____14592 = FStar_Syntax_Syntax.iarg typ  in [uu____14592]
              in
-          nil uu____14590 rng  in
+          nil uu____14591 rng  in
         FStar_List.fold_right
           (fun t  ->
              fun a  ->
-               let uu____14625 =
-                 let uu____14626 = FStar_Syntax_Syntax.iarg typ  in
-                 let uu____14635 =
-                   let uu____14646 = FStar_Syntax_Syntax.as_arg t  in
-                   let uu____14655 =
-                     let uu____14666 = FStar_Syntax_Syntax.as_arg a  in
-                     [uu____14666]  in
-                   uu____14646 :: uu____14655  in
-                 uu____14626 :: uu____14635  in
-               cons1 uu____14625 t.FStar_Syntax_Syntax.pos) l uu____14589
+               let uu____14626 =
+                 let uu____14627 = FStar_Syntax_Syntax.iarg typ  in
+                 let uu____14636 =
+                   let uu____14647 = FStar_Syntax_Syntax.as_arg t  in
+                   let uu____14656 =
+                     let uu____14667 = FStar_Syntax_Syntax.as_arg a  in
+                     [uu____14667]  in
+                   uu____14647 :: uu____14656  in
+                 uu____14627 :: uu____14636  in
+               cons1 uu____14626 t.FStar_Syntax_Syntax.pos) l uu____14590
   
 let rec eqlist :
   'a .
@@ -3635,7 +3638,7 @@ let rec eqlist :
         match (xs, ys) with
         | ([],[]) -> true
         | (x::xs1,y::ys1) -> (eq1 x y) && (eqlist eq1 xs1 ys1)
-        | uu____14775 -> false
+        | uu____14776 -> false
   
 let eqsum :
   'a 'b .
@@ -3650,7 +3653,7 @@ let eqsum :
           match (x, y) with
           | (FStar_Util.Inl x1,FStar_Util.Inl y1) -> e1 x1 y1
           | (FStar_Util.Inr x1,FStar_Util.Inr y1) -> e2 x1 y1
-          | uu____14889 -> false
+          | uu____14890 -> false
   
 let eqprod :
   'a 'b .
@@ -3675,7 +3678,7 @@ let eqopt :
         match (x, y) with
         | (FStar_Pervasives_Native.Some x1,FStar_Pervasives_Native.Some y1)
             -> e x1 y1
-        | uu____15055 -> false
+        | uu____15056 -> false
   
 let (debug_term_eq : Prims.bool FStar_ST.ref) = FStar_Util.mk_ref false 
 let (check : Prims.string -> Prims.bool -> Prims.bool) =
@@ -3684,8 +3687,8 @@ let (check : Prims.string -> Prims.bool -> Prims.bool) =
       if cond
       then true
       else
-        ((let uu____15093 = FStar_ST.op_Bang debug_term_eq  in
-          if uu____15093
+        ((let uu____15094 = FStar_ST.op_Bang debug_term_eq  in
+          if uu____15094
           then FStar_Util.print1 ">>> term_eq failing: %s\n" msg
           else ());
          false)
@@ -3698,34 +3701,34 @@ let rec (term_eq_dbg :
   fun dbg  ->
     fun t1  ->
       fun t2  ->
-        let t11 = let uu____15315 = unmeta_safe t1  in canon_app uu____15315
+        let t11 = let uu____15316 = unmeta_safe t1  in canon_app uu____15316
            in
-        let t21 = let uu____15321 = unmeta_safe t2  in canon_app uu____15321
+        let t21 = let uu____15322 = unmeta_safe t2  in canon_app uu____15322
            in
-        let uu____15324 =
-          let uu____15329 =
-            let uu____15330 =
-              let uu____15333 = un_uinst t11  in
-              FStar_Syntax_Subst.compress uu____15333  in
-            uu____15330.FStar_Syntax_Syntax.n  in
-          let uu____15334 =
-            let uu____15335 =
-              let uu____15338 = un_uinst t21  in
-              FStar_Syntax_Subst.compress uu____15338  in
-            uu____15335.FStar_Syntax_Syntax.n  in
-          (uu____15329, uu____15334)  in
-        match uu____15324 with
-        | (FStar_Syntax_Syntax.Tm_uinst uu____15340,uu____15341) ->
+        let uu____15325 =
+          let uu____15330 =
+            let uu____15331 =
+              let uu____15334 = un_uinst t11  in
+              FStar_Syntax_Subst.compress uu____15334  in
+            uu____15331.FStar_Syntax_Syntax.n  in
+          let uu____15335 =
+            let uu____15336 =
+              let uu____15339 = un_uinst t21  in
+              FStar_Syntax_Subst.compress uu____15339  in
+            uu____15336.FStar_Syntax_Syntax.n  in
+          (uu____15330, uu____15335)  in
+        match uu____15325 with
+        | (FStar_Syntax_Syntax.Tm_uinst uu____15341,uu____15342) ->
             failwith "term_eq: impossible, should have been removed"
-        | (uu____15350,FStar_Syntax_Syntax.Tm_uinst uu____15351) ->
+        | (uu____15351,FStar_Syntax_Syntax.Tm_uinst uu____15352) ->
             failwith "term_eq: impossible, should have been removed"
-        | (FStar_Syntax_Syntax.Tm_delayed uu____15360,uu____15361) ->
+        | (FStar_Syntax_Syntax.Tm_delayed uu____15361,uu____15362) ->
             failwith "term_eq: impossible, should have been removed"
-        | (uu____15386,FStar_Syntax_Syntax.Tm_delayed uu____15387) ->
+        | (uu____15387,FStar_Syntax_Syntax.Tm_delayed uu____15388) ->
             failwith "term_eq: impossible, should have been removed"
-        | (FStar_Syntax_Syntax.Tm_ascribed uu____15412,uu____15413) ->
+        | (FStar_Syntax_Syntax.Tm_ascribed uu____15413,uu____15414) ->
             failwith "term_eq: impossible, should have been removed"
-        | (uu____15442,FStar_Syntax_Syntax.Tm_ascribed uu____15443) ->
+        | (uu____15443,FStar_Syntax_Syntax.Tm_ascribed uu____15444) ->
             failwith "term_eq: impossible, should have been removed"
         | (FStar_Syntax_Syntax.Tm_bvar x,FStar_Syntax_Syntax.Tm_bvar y) ->
             check "bvar"
@@ -3734,152 +3737,152 @@ let rec (term_eq_dbg :
             check "name"
               (x.FStar_Syntax_Syntax.index = y.FStar_Syntax_Syntax.index)
         | (FStar_Syntax_Syntax.Tm_fvar x,FStar_Syntax_Syntax.Tm_fvar y) ->
-            let uu____15482 = FStar_Syntax_Syntax.fv_eq x y  in
-            check "fvar" uu____15482
+            let uu____15483 = FStar_Syntax_Syntax.fv_eq x y  in
+            check "fvar" uu____15483
         | (FStar_Syntax_Syntax.Tm_constant c1,FStar_Syntax_Syntax.Tm_constant
            c2) ->
-            let uu____15487 = FStar_Const.eq_const c1 c2  in
-            check "const" uu____15487
+            let uu____15488 = FStar_Const.eq_const c1 c2  in
+            check "const" uu____15488
         | (FStar_Syntax_Syntax.Tm_type
-           uu____15490,FStar_Syntax_Syntax.Tm_type uu____15491) -> true
+           uu____15491,FStar_Syntax_Syntax.Tm_type uu____15492) -> true
         | (FStar_Syntax_Syntax.Tm_abs (b1,t12,k1),FStar_Syntax_Syntax.Tm_abs
            (b2,t22,k2)) ->
-            (let uu____15549 = eqlist (binder_eq_dbg dbg) b1 b2  in
-             check "abs binders" uu____15549) &&
-              (let uu____15559 = term_eq_dbg dbg t12 t22  in
-               check "abs bodies" uu____15559)
+            (let uu____15550 = eqlist (binder_eq_dbg dbg) b1 b2  in
+             check "abs binders" uu____15550) &&
+              (let uu____15560 = term_eq_dbg dbg t12 t22  in
+               check "abs bodies" uu____15560)
         | (FStar_Syntax_Syntax.Tm_arrow (b1,c1),FStar_Syntax_Syntax.Tm_arrow
            (b2,c2)) ->
-            (let uu____15608 = eqlist (binder_eq_dbg dbg) b1 b2  in
-             check "arrow binders" uu____15608) &&
-              (let uu____15618 = comp_eq_dbg dbg c1 c2  in
-               check "arrow comp" uu____15618)
+            (let uu____15609 = eqlist (binder_eq_dbg dbg) b1 b2  in
+             check "arrow binders" uu____15609) &&
+              (let uu____15619 = comp_eq_dbg dbg c1 c2  in
+               check "arrow comp" uu____15619)
         | (FStar_Syntax_Syntax.Tm_refine
            (b1,t12),FStar_Syntax_Syntax.Tm_refine (b2,t22)) ->
-            (let uu____15635 =
+            (let uu____15636 =
                term_eq_dbg dbg b1.FStar_Syntax_Syntax.sort
                  b2.FStar_Syntax_Syntax.sort
                 in
-             check "refine bv sort" uu____15635) &&
-              (let uu____15639 = term_eq_dbg dbg t12 t22  in
-               check "refine formula" uu____15639)
+             check "refine bv sort" uu____15636) &&
+              (let uu____15640 = term_eq_dbg dbg t12 t22  in
+               check "refine formula" uu____15640)
         | (FStar_Syntax_Syntax.Tm_app (f1,a1),FStar_Syntax_Syntax.Tm_app
            (f2,a2)) ->
-            (let uu____15696 = term_eq_dbg dbg f1 f2  in
-             check "app head" uu____15696) &&
-              (let uu____15700 = eqlist (arg_eq_dbg dbg) a1 a2  in
-               check "app args" uu____15700)
+            (let uu____15697 = term_eq_dbg dbg f1 f2  in
+             check "app head" uu____15697) &&
+              (let uu____15701 = eqlist (arg_eq_dbg dbg) a1 a2  in
+               check "app args" uu____15701)
         | (FStar_Syntax_Syntax.Tm_match
            (t12,bs1),FStar_Syntax_Syntax.Tm_match (t22,bs2)) ->
-            (let uu____15789 = term_eq_dbg dbg t12 t22  in
-             check "match head" uu____15789) &&
-              (let uu____15793 = eqlist (branch_eq_dbg dbg) bs1 bs2  in
-               check "match branches" uu____15793)
-        | (FStar_Syntax_Syntax.Tm_lazy uu____15810,uu____15811) ->
-            let uu____15812 =
-              let uu____15814 = unlazy t11  in
-              term_eq_dbg dbg uu____15814 t21  in
-            check "lazy_l" uu____15812
-        | (uu____15816,FStar_Syntax_Syntax.Tm_lazy uu____15817) ->
-            let uu____15818 =
-              let uu____15820 = unlazy t21  in
-              term_eq_dbg dbg t11 uu____15820  in
-            check "lazy_r" uu____15818
+            (let uu____15790 = term_eq_dbg dbg t12 t22  in
+             check "match head" uu____15790) &&
+              (let uu____15794 = eqlist (branch_eq_dbg dbg) bs1 bs2  in
+               check "match branches" uu____15794)
+        | (FStar_Syntax_Syntax.Tm_lazy uu____15811,uu____15812) ->
+            let uu____15813 =
+              let uu____15815 = unlazy t11  in
+              term_eq_dbg dbg uu____15815 t21  in
+            check "lazy_l" uu____15813
+        | (uu____15817,FStar_Syntax_Syntax.Tm_lazy uu____15818) ->
+            let uu____15819 =
+              let uu____15821 = unlazy t21  in
+              term_eq_dbg dbg t11 uu____15821  in
+            check "lazy_r" uu____15819
         | (FStar_Syntax_Syntax.Tm_let
            ((b1,lbs1),t12),FStar_Syntax_Syntax.Tm_let ((b2,lbs2),t22)) ->
             ((check "let flag" (b1 = b2)) &&
-               (let uu____15865 = eqlist (letbinding_eq_dbg dbg) lbs1 lbs2
+               (let uu____15866 = eqlist (letbinding_eq_dbg dbg) lbs1 lbs2
                    in
-                check "let lbs" uu____15865))
+                check "let lbs" uu____15866))
               &&
-              (let uu____15869 = term_eq_dbg dbg t12 t22  in
-               check "let body" uu____15869)
+              (let uu____15870 = term_eq_dbg dbg t12 t22  in
+               check "let body" uu____15870)
         | (FStar_Syntax_Syntax.Tm_uvar
-           (u1,uu____15873),FStar_Syntax_Syntax.Tm_uvar (u2,uu____15875)) ->
+           (u1,uu____15874),FStar_Syntax_Syntax.Tm_uvar (u2,uu____15876)) ->
             check "uvar"
               (u1.FStar_Syntax_Syntax.ctx_uvar_head =
                  u2.FStar_Syntax_Syntax.ctx_uvar_head)
         | (FStar_Syntax_Syntax.Tm_quoted
            (qt1,qi1),FStar_Syntax_Syntax.Tm_quoted (qt2,qi2)) ->
-            (let uu____15933 =
-               let uu____15935 = eq_quoteinfo qi1 qi2  in uu____15935 = Equal
+            (let uu____15934 =
+               let uu____15936 = eq_quoteinfo qi1 qi2  in uu____15936 = Equal
                 in
-             check "tm_quoted qi" uu____15933) &&
-              (let uu____15938 = term_eq_dbg dbg qt1 qt2  in
-               check "tm_quoted payload" uu____15938)
+             check "tm_quoted qi" uu____15934) &&
+              (let uu____15939 = term_eq_dbg dbg qt1 qt2  in
+               check "tm_quoted payload" uu____15939)
         | (FStar_Syntax_Syntax.Tm_meta (t12,m1),FStar_Syntax_Syntax.Tm_meta
            (t22,m2)) ->
             (match (m1, m2) with
              | (FStar_Syntax_Syntax.Meta_monadic
                 (n1,ty1),FStar_Syntax_Syntax.Meta_monadic (n2,ty2)) ->
-                 (let uu____15968 = FStar_Ident.lid_equals n1 n2  in
-                  check "meta_monadic lid" uu____15968) &&
-                   (let uu____15972 = term_eq_dbg dbg ty1 ty2  in
-                    check "meta_monadic type" uu____15972)
+                 (let uu____15969 = FStar_Ident.lid_equals n1 n2  in
+                  check "meta_monadic lid" uu____15969) &&
+                   (let uu____15973 = term_eq_dbg dbg ty1 ty2  in
+                    check "meta_monadic type" uu____15973)
              | (FStar_Syntax_Syntax.Meta_monadic_lift
                 (s1,t13,ty1),FStar_Syntax_Syntax.Meta_monadic_lift
                 (s2,t23,ty2)) ->
-                 ((let uu____15991 = FStar_Ident.lid_equals s1 s2  in
-                   check "meta_monadic_lift src" uu____15991) &&
-                    (let uu____15995 = FStar_Ident.lid_equals t13 t23  in
-                     check "meta_monadic_lift tgt" uu____15995))
+                 ((let uu____15992 = FStar_Ident.lid_equals s1 s2  in
+                   check "meta_monadic_lift src" uu____15992) &&
+                    (let uu____15996 = FStar_Ident.lid_equals t13 t23  in
+                     check "meta_monadic_lift tgt" uu____15996))
                    &&
-                   (let uu____15999 = term_eq_dbg dbg ty1 ty2  in
-                    check "meta_monadic_lift type" uu____15999)
-             | uu____16002 -> fail "metas")
-        | (FStar_Syntax_Syntax.Tm_unknown ,uu____16008) -> fail "unk"
-        | (uu____16010,FStar_Syntax_Syntax.Tm_unknown ) -> fail "unk"
-        | (FStar_Syntax_Syntax.Tm_bvar uu____16012,uu____16013) ->
+                   (let uu____16000 = term_eq_dbg dbg ty1 ty2  in
+                    check "meta_monadic_lift type" uu____16000)
+             | uu____16003 -> fail "metas")
+        | (FStar_Syntax_Syntax.Tm_unknown ,uu____16009) -> fail "unk"
+        | (uu____16011,FStar_Syntax_Syntax.Tm_unknown ) -> fail "unk"
+        | (FStar_Syntax_Syntax.Tm_bvar uu____16013,uu____16014) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_name uu____16015,uu____16016) ->
+        | (FStar_Syntax_Syntax.Tm_name uu____16016,uu____16017) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_fvar uu____16018,uu____16019) ->
+        | (FStar_Syntax_Syntax.Tm_fvar uu____16019,uu____16020) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_constant uu____16021,uu____16022) ->
+        | (FStar_Syntax_Syntax.Tm_constant uu____16022,uu____16023) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_type uu____16024,uu____16025) ->
+        | (FStar_Syntax_Syntax.Tm_type uu____16025,uu____16026) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_abs uu____16027,uu____16028) ->
+        | (FStar_Syntax_Syntax.Tm_abs uu____16028,uu____16029) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_arrow uu____16048,uu____16049) ->
+        | (FStar_Syntax_Syntax.Tm_arrow uu____16049,uu____16050) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_refine uu____16065,uu____16066) ->
+        | (FStar_Syntax_Syntax.Tm_refine uu____16066,uu____16067) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_app uu____16074,uu____16075) ->
+        | (FStar_Syntax_Syntax.Tm_app uu____16075,uu____16076) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_match uu____16093,uu____16094) ->
+        | (FStar_Syntax_Syntax.Tm_match uu____16094,uu____16095) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_let uu____16118,uu____16119) ->
+        | (FStar_Syntax_Syntax.Tm_let uu____16119,uu____16120) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_uvar uu____16134,uu____16135) ->
+        | (FStar_Syntax_Syntax.Tm_uvar uu____16135,uu____16136) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_meta uu____16149,uu____16150) ->
+        | (FStar_Syntax_Syntax.Tm_meta uu____16150,uu____16151) ->
             fail "bottom"
-        | (uu____16158,FStar_Syntax_Syntax.Tm_bvar uu____16159) ->
+        | (uu____16159,FStar_Syntax_Syntax.Tm_bvar uu____16160) ->
             fail "bottom"
-        | (uu____16161,FStar_Syntax_Syntax.Tm_name uu____16162) ->
+        | (uu____16162,FStar_Syntax_Syntax.Tm_name uu____16163) ->
             fail "bottom"
-        | (uu____16164,FStar_Syntax_Syntax.Tm_fvar uu____16165) ->
+        | (uu____16165,FStar_Syntax_Syntax.Tm_fvar uu____16166) ->
             fail "bottom"
-        | (uu____16167,FStar_Syntax_Syntax.Tm_constant uu____16168) ->
+        | (uu____16168,FStar_Syntax_Syntax.Tm_constant uu____16169) ->
             fail "bottom"
-        | (uu____16170,FStar_Syntax_Syntax.Tm_type uu____16171) ->
+        | (uu____16171,FStar_Syntax_Syntax.Tm_type uu____16172) ->
             fail "bottom"
-        | (uu____16173,FStar_Syntax_Syntax.Tm_abs uu____16174) ->
+        | (uu____16174,FStar_Syntax_Syntax.Tm_abs uu____16175) ->
             fail "bottom"
-        | (uu____16194,FStar_Syntax_Syntax.Tm_arrow uu____16195) ->
+        | (uu____16195,FStar_Syntax_Syntax.Tm_arrow uu____16196) ->
             fail "bottom"
-        | (uu____16211,FStar_Syntax_Syntax.Tm_refine uu____16212) ->
+        | (uu____16212,FStar_Syntax_Syntax.Tm_refine uu____16213) ->
             fail "bottom"
-        | (uu____16220,FStar_Syntax_Syntax.Tm_app uu____16221) ->
+        | (uu____16221,FStar_Syntax_Syntax.Tm_app uu____16222) ->
             fail "bottom"
-        | (uu____16239,FStar_Syntax_Syntax.Tm_match uu____16240) ->
+        | (uu____16240,FStar_Syntax_Syntax.Tm_match uu____16241) ->
             fail "bottom"
-        | (uu____16264,FStar_Syntax_Syntax.Tm_let uu____16265) ->
+        | (uu____16265,FStar_Syntax_Syntax.Tm_let uu____16266) ->
             fail "bottom"
-        | (uu____16280,FStar_Syntax_Syntax.Tm_uvar uu____16281) ->
+        | (uu____16281,FStar_Syntax_Syntax.Tm_uvar uu____16282) ->
             fail "bottom"
-        | (uu____16295,FStar_Syntax_Syntax.Tm_meta uu____16296) ->
+        | (uu____16296,FStar_Syntax_Syntax.Tm_meta uu____16297) ->
             fail "bottom"
 
 and (arg_eq_dbg :
@@ -3896,13 +3899,13 @@ and (arg_eq_dbg :
         eqprod
           (fun t1  ->
              fun t2  ->
-               let uu____16331 = term_eq_dbg dbg t1 t2  in
-               check "arg tm" uu____16331)
+               let uu____16332 = term_eq_dbg dbg t1 t2  in
+               check "arg tm" uu____16332)
           (fun q1  ->
              fun q2  ->
-               let uu____16343 =
-                 let uu____16345 = eq_aqual q1 q2  in uu____16345 = Equal  in
-               check "arg qual" uu____16343) a1 a2
+               let uu____16344 =
+                 let uu____16346 = eq_aqual q1 q2  in uu____16346 = Equal  in
+               check "arg qual" uu____16344) a1 a2
 
 and (binder_eq_dbg :
   Prims.bool ->
@@ -3917,16 +3920,16 @@ and (binder_eq_dbg :
         eqprod
           (fun b11  ->
              fun b21  ->
-               let uu____16370 =
+               let uu____16371 =
                  term_eq_dbg dbg b11.FStar_Syntax_Syntax.sort
                    b21.FStar_Syntax_Syntax.sort
                   in
-               check "binder sort" uu____16370)
+               check "binder sort" uu____16371)
           (fun q1  ->
              fun q2  ->
-               let uu____16382 =
-                 let uu____16384 = eq_aqual q1 q2  in uu____16384 = Equal  in
-               check "binder qual" uu____16382) b1 b2
+               let uu____16383 =
+                 let uu____16385 = eq_aqual q1 q2  in uu____16385 = Equal  in
+               check "binder qual" uu____16383) b1 b2
 
 and (lcomp_eq_dbg :
   FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.lcomp -> Prims.bool) =
@@ -3947,16 +3950,16 @@ and (comp_eq_dbg :
       fun c2  ->
         let c11 = comp_to_comp_typ_nouniv c1  in
         let c21 = comp_to_comp_typ_nouniv c2  in
-        ((let uu____16404 =
+        ((let uu____16405 =
             FStar_Ident.lid_equals c11.FStar_Syntax_Syntax.effect_name
               c21.FStar_Syntax_Syntax.effect_name
              in
-          check "comp eff" uu____16404) &&
-           (let uu____16408 =
+          check "comp eff" uu____16405) &&
+           (let uu____16409 =
               term_eq_dbg dbg c11.FStar_Syntax_Syntax.result_typ
                 c21.FStar_Syntax_Syntax.result_typ
                in
-            check "comp result typ" uu____16408))
+            check "comp result typ" uu____16409))
           && true
 
 and (eq_flags_dbg :
@@ -3976,23 +3979,23 @@ and (branch_eq_dbg :
         FStar_Syntax_Syntax.syntax) -> Prims.bool)
   =
   fun dbg  ->
-    fun uu____16418  ->
-      fun uu____16419  ->
-        match (uu____16418, uu____16419) with
+    fun uu____16419  ->
+      fun uu____16420  ->
+        match (uu____16419, uu____16420) with
         | ((p1,w1,t1),(p2,w2,t2)) ->
-            ((let uu____16546 = FStar_Syntax_Syntax.eq_pat p1 p2  in
-              check "branch pat" uu____16546) &&
-               (let uu____16550 = term_eq_dbg dbg t1 t2  in
-                check "branch body" uu____16550))
+            ((let uu____16547 = FStar_Syntax_Syntax.eq_pat p1 p2  in
+              check "branch pat" uu____16547) &&
+               (let uu____16551 = term_eq_dbg dbg t1 t2  in
+                check "branch body" uu____16551))
               &&
-              (let uu____16554 =
+              (let uu____16555 =
                  match (w1, w2) with
                  | (FStar_Pervasives_Native.Some
                     x,FStar_Pervasives_Native.Some y) -> term_eq_dbg dbg x y
                  | (FStar_Pervasives_Native.None
                     ,FStar_Pervasives_Native.None ) -> true
-                 | uu____16596 -> false  in
-               check "branch when" uu____16554)
+                 | uu____16597 -> false  in
+               check "branch when" uu____16555)
 
 and (letbinding_eq_dbg :
   Prims.bool ->
@@ -4002,85 +4005,85 @@ and (letbinding_eq_dbg :
   fun dbg  ->
     fun lb1  ->
       fun lb2  ->
-        ((let uu____16617 =
+        ((let uu____16618 =
             eqsum (fun bv1  -> fun bv2  -> true) FStar_Syntax_Syntax.fv_eq
               lb1.FStar_Syntax_Syntax.lbname lb2.FStar_Syntax_Syntax.lbname
              in
-          check "lb bv" uu____16617) &&
-           (let uu____16626 =
+          check "lb bv" uu____16618) &&
+           (let uu____16627 =
               term_eq_dbg dbg lb1.FStar_Syntax_Syntax.lbtyp
                 lb2.FStar_Syntax_Syntax.lbtyp
                in
-            check "lb typ" uu____16626))
+            check "lb typ" uu____16627))
           &&
-          (let uu____16630 =
+          (let uu____16631 =
              term_eq_dbg dbg lb1.FStar_Syntax_Syntax.lbdef
                lb2.FStar_Syntax_Syntax.lbdef
               in
-           check "lb def" uu____16630)
+           check "lb def" uu____16631)
 
 let (term_eq :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t1  ->
     fun t2  ->
       let r =
-        let uu____16647 = FStar_ST.op_Bang debug_term_eq  in
-        term_eq_dbg uu____16647 t1 t2  in
+        let uu____16648 = FStar_ST.op_Bang debug_term_eq  in
+        term_eq_dbg uu____16648 t1 t2  in
       FStar_ST.op_Colon_Equals debug_term_eq false; r
   
 let rec (sizeof : FStar_Syntax_Syntax.term -> Prims.int) =
   fun t  ->
     match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____16701 ->
-        let uu____16724 =
-          let uu____16726 = FStar_Syntax_Subst.compress t  in
-          sizeof uu____16726  in
-        Prims.int_one + uu____16724
+    | FStar_Syntax_Syntax.Tm_delayed uu____16702 ->
+        let uu____16725 =
+          let uu____16727 = FStar_Syntax_Subst.compress t  in
+          sizeof uu____16727  in
+        Prims.int_one + uu____16725
     | FStar_Syntax_Syntax.Tm_bvar bv ->
-        let uu____16729 = sizeof bv.FStar_Syntax_Syntax.sort  in
-        Prims.int_one + uu____16729
+        let uu____16730 = sizeof bv.FStar_Syntax_Syntax.sort  in
+        Prims.int_one + uu____16730
     | FStar_Syntax_Syntax.Tm_name bv ->
-        let uu____16733 = sizeof bv.FStar_Syntax_Syntax.sort  in
-        Prims.int_one + uu____16733
+        let uu____16734 = sizeof bv.FStar_Syntax_Syntax.sort  in
+        Prims.int_one + uu____16734
     | FStar_Syntax_Syntax.Tm_uinst (t1,us) ->
-        let uu____16742 = sizeof t1  in (FStar_List.length us) + uu____16742
-    | FStar_Syntax_Syntax.Tm_abs (bs,t1,uu____16746) ->
-        let uu____16771 = sizeof t1  in
-        let uu____16773 =
+        let uu____16743 = sizeof t1  in (FStar_List.length us) + uu____16743
+    | FStar_Syntax_Syntax.Tm_abs (bs,t1,uu____16747) ->
+        let uu____16772 = sizeof t1  in
+        let uu____16774 =
           FStar_List.fold_left
             (fun acc  ->
-               fun uu____16788  ->
-                 match uu____16788 with
-                 | (bv,uu____16798) ->
-                     let uu____16803 = sizeof bv.FStar_Syntax_Syntax.sort  in
-                     acc + uu____16803) Prims.int_zero bs
+               fun uu____16789  ->
+                 match uu____16789 with
+                 | (bv,uu____16799) ->
+                     let uu____16804 = sizeof bv.FStar_Syntax_Syntax.sort  in
+                     acc + uu____16804) Prims.int_zero bs
            in
-        uu____16771 + uu____16773
+        uu____16772 + uu____16774
     | FStar_Syntax_Syntax.Tm_app (hd1,args) ->
-        let uu____16832 = sizeof hd1  in
-        let uu____16834 =
+        let uu____16833 = sizeof hd1  in
+        let uu____16835 =
           FStar_List.fold_left
             (fun acc  ->
-               fun uu____16849  ->
-                 match uu____16849 with
-                 | (arg,uu____16859) ->
-                     let uu____16864 = sizeof arg  in acc + uu____16864)
+               fun uu____16850  ->
+                 match uu____16850 with
+                 | (arg,uu____16860) ->
+                     let uu____16865 = sizeof arg  in acc + uu____16865)
             Prims.int_zero args
            in
-        uu____16832 + uu____16834
-    | uu____16867 -> Prims.int_one
+        uu____16833 + uu____16835
+    | uu____16868 -> Prims.int_one
   
 let (is_fvar : FStar_Ident.lident -> FStar_Syntax_Syntax.term -> Prims.bool)
   =
   fun lid  ->
     fun t  ->
-      let uu____16881 =
-        let uu____16882 = un_uinst t  in uu____16882.FStar_Syntax_Syntax.n
+      let uu____16882 =
+        let uu____16883 = un_uinst t  in uu____16883.FStar_Syntax_Syntax.n
          in
-      match uu____16881 with
+      match uu____16882 with
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           FStar_Syntax_Syntax.fv_eq_lid fv lid
-      | uu____16887 -> false
+      | uu____16888 -> false
   
 let (is_synth_by_tactic : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  -> is_fvar FStar_Parser_Const.synth_lid t 
@@ -4088,13 +4091,34 @@ let (has_attribute :
   FStar_Syntax_Syntax.attribute Prims.list ->
     FStar_Ident.lident -> Prims.bool)
   = fun attrs  -> fun attr  -> FStar_Util.for_some (is_fvar attr) attrs 
+let (get_attribute :
+  FStar_Ident.lident ->
+    FStar_Syntax_Syntax.attribute Prims.list ->
+      FStar_Syntax_Syntax.args FStar_Pervasives_Native.option)
+  =
+  fun attr  ->
+    fun attrs  ->
+      FStar_List.tryPick
+        (fun t  ->
+           let uu____16949 = head_and_args t  in
+           match uu____16949 with
+           | (head1,args) ->
+               let uu____17004 =
+                 let uu____17005 = FStar_Syntax_Subst.compress head1  in
+                 uu____17005.FStar_Syntax_Syntax.n  in
+               (match uu____17004 with
+                | FStar_Syntax_Syntax.Tm_fvar fv when
+                    FStar_Syntax_Syntax.fv_eq_lid fv attr ->
+                    FStar_Pervasives_Native.Some args
+                | uu____17031 -> FStar_Pervasives_Native.None)) attrs
+  
 let (process_pragma :
   FStar_Syntax_Syntax.pragma -> FStar_Range.range -> unit) =
   fun p  ->
     fun r  ->
       let set_options1 s =
-        let uu____16931 = FStar_Options.set_options s  in
-        match uu____16931 with
+        let uu____17061 = FStar_Options.set_options s  in
+        match uu____17061 with
         | FStar_Getopt.Success  -> ()
         | FStar_Getopt.Help  ->
             FStar_Errors.raise_error
@@ -4110,9 +4134,9 @@ let (process_pragma :
       | FStar_Syntax_Syntax.LightOff  -> FStar_Options.set_ml_ish ()
       | FStar_Syntax_Syntax.SetOptions o -> set_options1 o
       | FStar_Syntax_Syntax.ResetOptions sopt ->
-          ((let uu____16945 = FStar_Options.restore_cmd_line_options false
+          ((let uu____17075 = FStar_Options.restore_cmd_line_options false
                in
-            FStar_All.pipe_right uu____16945 (fun a1  -> ()));
+            FStar_All.pipe_right uu____17075 (fun a1  -> ()));
            (match sopt with
             | FStar_Pervasives_Native.None  -> ()
             | FStar_Pervasives_Native.Some s -> set_options1 s))
@@ -4123,8 +4147,8 @@ let (process_pragma :
             | FStar_Pervasives_Native.Some s -> set_options1 s))
       | FStar_Syntax_Syntax.RestartSolver  -> ()
       | FStar_Syntax_Syntax.PopOptions  ->
-          let uu____16960 = FStar_Options.internal_pop ()  in
-          if uu____16960
+          let uu____17090 = FStar_Options.internal_pop ()  in
+          if uu____17090
           then ()
           else
             FStar_Errors.raise_error
@@ -4138,153 +4162,153 @@ let rec (unbound_variables :
   fun tm  ->
     let t = FStar_Syntax_Subst.compress tm  in
     match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____16992 -> failwith "Impossible"
+    | FStar_Syntax_Syntax.Tm_delayed uu____17122 -> failwith "Impossible"
     | FStar_Syntax_Syntax.Tm_name x -> []
-    | FStar_Syntax_Syntax.Tm_uvar uu____17019 -> []
+    | FStar_Syntax_Syntax.Tm_uvar uu____17149 -> []
     | FStar_Syntax_Syntax.Tm_type u -> []
     | FStar_Syntax_Syntax.Tm_bvar x -> [x]
-    | FStar_Syntax_Syntax.Tm_fvar uu____17034 -> []
-    | FStar_Syntax_Syntax.Tm_constant uu____17035 -> []
-    | FStar_Syntax_Syntax.Tm_lazy uu____17036 -> []
+    | FStar_Syntax_Syntax.Tm_fvar uu____17164 -> []
+    | FStar_Syntax_Syntax.Tm_constant uu____17165 -> []
+    | FStar_Syntax_Syntax.Tm_lazy uu____17166 -> []
     | FStar_Syntax_Syntax.Tm_unknown  -> []
     | FStar_Syntax_Syntax.Tm_uinst (t1,us) -> unbound_variables t1
-    | FStar_Syntax_Syntax.Tm_abs (bs,t1,uu____17045) ->
-        let uu____17070 = FStar_Syntax_Subst.open_term bs t1  in
-        (match uu____17070 with
+    | FStar_Syntax_Syntax.Tm_abs (bs,t1,uu____17175) ->
+        let uu____17200 = FStar_Syntax_Subst.open_term bs t1  in
+        (match uu____17200 with
          | (bs1,t2) ->
-             let uu____17079 =
+             let uu____17209 =
                FStar_List.collect
-                 (fun uu____17091  ->
-                    match uu____17091 with
-                    | (b,uu____17101) ->
+                 (fun uu____17221  ->
+                    match uu____17221 with
+                    | (b,uu____17231) ->
                         unbound_variables b.FStar_Syntax_Syntax.sort) bs1
                 in
-             let uu____17106 = unbound_variables t2  in
-             FStar_List.append uu____17079 uu____17106)
+             let uu____17236 = unbound_variables t2  in
+             FStar_List.append uu____17209 uu____17236)
     | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-        let uu____17131 = FStar_Syntax_Subst.open_comp bs c  in
-        (match uu____17131 with
+        let uu____17261 = FStar_Syntax_Subst.open_comp bs c  in
+        (match uu____17261 with
          | (bs1,c1) ->
-             let uu____17140 =
+             let uu____17270 =
                FStar_List.collect
-                 (fun uu____17152  ->
-                    match uu____17152 with
-                    | (b,uu____17162) ->
+                 (fun uu____17282  ->
+                    match uu____17282 with
+                    | (b,uu____17292) ->
                         unbound_variables b.FStar_Syntax_Syntax.sort) bs1
                 in
-             let uu____17167 = unbound_variables_comp c1  in
-             FStar_List.append uu____17140 uu____17167)
+             let uu____17297 = unbound_variables_comp c1  in
+             FStar_List.append uu____17270 uu____17297)
     | FStar_Syntax_Syntax.Tm_refine (b,t1) ->
-        let uu____17176 =
+        let uu____17306 =
           FStar_Syntax_Subst.open_term [(b, FStar_Pervasives_Native.None)] t1
            in
-        (match uu____17176 with
+        (match uu____17306 with
          | (bs,t2) ->
-             let uu____17199 =
+             let uu____17329 =
                FStar_List.collect
-                 (fun uu____17211  ->
-                    match uu____17211 with
-                    | (b1,uu____17221) ->
+                 (fun uu____17341  ->
+                    match uu____17341 with
+                    | (b1,uu____17351) ->
                         unbound_variables b1.FStar_Syntax_Syntax.sort) bs
                 in
-             let uu____17226 = unbound_variables t2  in
-             FStar_List.append uu____17199 uu____17226)
+             let uu____17356 = unbound_variables t2  in
+             FStar_List.append uu____17329 uu____17356)
     | FStar_Syntax_Syntax.Tm_app (t1,args) ->
-        let uu____17255 =
+        let uu____17385 =
           FStar_List.collect
-            (fun uu____17269  ->
-               match uu____17269 with
-               | (x,uu____17281) -> unbound_variables x) args
+            (fun uu____17399  ->
+               match uu____17399 with
+               | (x,uu____17411) -> unbound_variables x) args
            in
-        let uu____17290 = unbound_variables t1  in
-        FStar_List.append uu____17255 uu____17290
+        let uu____17420 = unbound_variables t1  in
+        FStar_List.append uu____17385 uu____17420
     | FStar_Syntax_Syntax.Tm_match (t1,pats) ->
-        let uu____17331 = unbound_variables t1  in
-        let uu____17334 =
+        let uu____17461 = unbound_variables t1  in
+        let uu____17464 =
           FStar_All.pipe_right pats
             (FStar_List.collect
                (fun br  ->
-                  let uu____17349 = FStar_Syntax_Subst.open_branch br  in
-                  match uu____17349 with
+                  let uu____17479 = FStar_Syntax_Subst.open_branch br  in
+                  match uu____17479 with
                   | (p,wopt,t2) ->
-                      let uu____17371 = unbound_variables t2  in
-                      let uu____17374 =
+                      let uu____17501 = unbound_variables t2  in
+                      let uu____17504 =
                         match wopt with
                         | FStar_Pervasives_Native.None  -> []
                         | FStar_Pervasives_Native.Some t3 ->
                             unbound_variables t3
                          in
-                      FStar_List.append uu____17371 uu____17374))
+                      FStar_List.append uu____17501 uu____17504))
            in
-        FStar_List.append uu____17331 uu____17334
-    | FStar_Syntax_Syntax.Tm_ascribed (t1,asc,uu____17388) ->
-        let uu____17429 = unbound_variables t1  in
-        let uu____17432 =
-          let uu____17435 =
+        FStar_List.append uu____17461 uu____17464
+    | FStar_Syntax_Syntax.Tm_ascribed (t1,asc,uu____17518) ->
+        let uu____17559 = unbound_variables t1  in
+        let uu____17562 =
+          let uu____17565 =
             match FStar_Pervasives_Native.fst asc with
             | FStar_Util.Inl t2 -> unbound_variables t2
             | FStar_Util.Inr c2 -> unbound_variables_comp c2  in
-          let uu____17466 =
+          let uu____17596 =
             match FStar_Pervasives_Native.snd asc with
             | FStar_Pervasives_Native.None  -> []
             | FStar_Pervasives_Native.Some tac -> unbound_variables tac  in
-          FStar_List.append uu____17435 uu____17466  in
-        FStar_List.append uu____17429 uu____17432
+          FStar_List.append uu____17565 uu____17596  in
+        FStar_List.append uu____17559 uu____17562
     | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),t1) ->
-        let uu____17507 = unbound_variables lb.FStar_Syntax_Syntax.lbtyp  in
-        let uu____17510 =
-          let uu____17513 = unbound_variables lb.FStar_Syntax_Syntax.lbdef
+        let uu____17637 = unbound_variables lb.FStar_Syntax_Syntax.lbtyp  in
+        let uu____17640 =
+          let uu____17643 = unbound_variables lb.FStar_Syntax_Syntax.lbdef
              in
-          let uu____17516 =
+          let uu____17646 =
             match lb.FStar_Syntax_Syntax.lbname with
-            | FStar_Util.Inr uu____17521 -> unbound_variables t1
+            | FStar_Util.Inr uu____17651 -> unbound_variables t1
             | FStar_Util.Inl bv ->
-                let uu____17523 =
+                let uu____17653 =
                   FStar_Syntax_Subst.open_term
                     [(bv, FStar_Pervasives_Native.None)] t1
                    in
-                (match uu____17523 with
-                 | (uu____17544,t2) -> unbound_variables t2)
+                (match uu____17653 with
+                 | (uu____17674,t2) -> unbound_variables t2)
              in
-          FStar_List.append uu____17513 uu____17516  in
-        FStar_List.append uu____17507 uu____17510
-    | FStar_Syntax_Syntax.Tm_let ((uu____17546,lbs),t1) ->
-        let uu____17566 = FStar_Syntax_Subst.open_let_rec lbs t1  in
-        (match uu____17566 with
+          FStar_List.append uu____17643 uu____17646  in
+        FStar_List.append uu____17637 uu____17640
+    | FStar_Syntax_Syntax.Tm_let ((uu____17676,lbs),t1) ->
+        let uu____17696 = FStar_Syntax_Subst.open_let_rec lbs t1  in
+        (match uu____17696 with
          | (lbs1,t2) ->
-             let uu____17581 = unbound_variables t2  in
-             let uu____17584 =
+             let uu____17711 = unbound_variables t2  in
+             let uu____17714 =
                FStar_List.collect
                  (fun lb  ->
-                    let uu____17591 =
+                    let uu____17721 =
                       unbound_variables lb.FStar_Syntax_Syntax.lbtyp  in
-                    let uu____17594 =
+                    let uu____17724 =
                       unbound_variables lb.FStar_Syntax_Syntax.lbdef  in
-                    FStar_List.append uu____17591 uu____17594) lbs1
+                    FStar_List.append uu____17721 uu____17724) lbs1
                 in
-             FStar_List.append uu____17581 uu____17584)
+             FStar_List.append uu____17711 uu____17714)
     | FStar_Syntax_Syntax.Tm_quoted (tm1,qi) ->
         (match qi.FStar_Syntax_Syntax.qkind with
          | FStar_Syntax_Syntax.Quote_static  -> []
          | FStar_Syntax_Syntax.Quote_dynamic  -> unbound_variables tm1)
     | FStar_Syntax_Syntax.Tm_meta (t1,m) ->
-        let uu____17611 = unbound_variables t1  in
-        let uu____17614 =
+        let uu____17741 = unbound_variables t1  in
+        let uu____17744 =
           match m with
-          | FStar_Syntax_Syntax.Meta_pattern (uu____17619,args) ->
+          | FStar_Syntax_Syntax.Meta_pattern (uu____17749,args) ->
               FStar_List.collect
                 (FStar_List.collect
-                   (fun uu____17674  ->
-                      match uu____17674 with
-                      | (a,uu____17686) -> unbound_variables a)) args
+                   (fun uu____17804  ->
+                      match uu____17804 with
+                      | (a,uu____17816) -> unbound_variables a)) args
           | FStar_Syntax_Syntax.Meta_monadic_lift
-              (uu____17695,uu____17696,t') -> unbound_variables t'
-          | FStar_Syntax_Syntax.Meta_monadic (uu____17702,t') ->
+              (uu____17825,uu____17826,t') -> unbound_variables t'
+          | FStar_Syntax_Syntax.Meta_monadic (uu____17832,t') ->
               unbound_variables t'
-          | FStar_Syntax_Syntax.Meta_labeled uu____17708 -> []
-          | FStar_Syntax_Syntax.Meta_desugared uu____17717 -> []
-          | FStar_Syntax_Syntax.Meta_named uu____17718 -> []  in
-        FStar_List.append uu____17611 uu____17614
+          | FStar_Syntax_Syntax.Meta_labeled uu____17838 -> []
+          | FStar_Syntax_Syntax.Meta_desugared uu____17847 -> []
+          | FStar_Syntax_Syntax.Meta_named uu____17848 -> []  in
+        FStar_List.append uu____17741 uu____17744
 
 and (unbound_variables_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
@@ -4292,19 +4316,19 @@ and (unbound_variables_comp :
   =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.GTotal (t,uu____17725) -> unbound_variables t
-    | FStar_Syntax_Syntax.Total (t,uu____17735) -> unbound_variables t
+    | FStar_Syntax_Syntax.GTotal (t,uu____17855) -> unbound_variables t
+    | FStar_Syntax_Syntax.Total (t,uu____17865) -> unbound_variables t
     | FStar_Syntax_Syntax.Comp ct ->
-        let uu____17745 = unbound_variables ct.FStar_Syntax_Syntax.result_typ
+        let uu____17875 = unbound_variables ct.FStar_Syntax_Syntax.result_typ
            in
-        let uu____17748 =
+        let uu____17878 =
           FStar_List.collect
-            (fun uu____17762  ->
-               match uu____17762 with
-               | (a,uu____17774) -> unbound_variables a)
+            (fun uu____17892  ->
+               match uu____17892 with
+               | (a,uu____17904) -> unbound_variables a)
             ct.FStar_Syntax_Syntax.effect_args
            in
-        FStar_List.append uu____17745 uu____17748
+        FStar_List.append uu____17875 uu____17878
 
 let (extract_attr' :
   FStar_Ident.lid ->
@@ -4318,18 +4342,18 @@ let (extract_attr' :
         match attrs1 with
         | [] -> FStar_Pervasives_Native.None
         | h::t ->
-            let uu____17889 = head_and_args h  in
-            (match uu____17889 with
+            let uu____18019 = head_and_args h  in
+            (match uu____18019 with
              | (head1,args) ->
-                 let uu____17950 =
-                   let uu____17951 = FStar_Syntax_Subst.compress head1  in
-                   uu____17951.FStar_Syntax_Syntax.n  in
-                 (match uu____17950 with
+                 let uu____18080 =
+                   let uu____18081 = FStar_Syntax_Subst.compress head1  in
+                   uu____18081.FStar_Syntax_Syntax.n  in
+                 (match uu____18080 with
                   | FStar_Syntax_Syntax.Tm_fvar fv when
                       FStar_Syntax_Syntax.fv_eq_lid fv attr_lid ->
                       let attrs' = FStar_List.rev_acc acc t  in
                       FStar_Pervasives_Native.Some (attrs', args)
-                  | uu____18004 -> aux (h :: acc) t))
+                  | uu____18134 -> aux (h :: acc) t))
          in
       aux [] attrs
   
@@ -4341,112 +4365,114 @@ let (extract_attr :
   =
   fun attr_lid  ->
     fun se  ->
-      let uu____18028 =
+      let uu____18158 =
         extract_attr' attr_lid se.FStar_Syntax_Syntax.sigattrs  in
-      match uu____18028 with
+      match uu____18158 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some (attrs',t) ->
           FStar_Pervasives_Native.Some
-            ((let uu___2519_18070 = se  in
+            ((let uu___2531_18200 = se  in
               {
                 FStar_Syntax_Syntax.sigel =
-                  (uu___2519_18070.FStar_Syntax_Syntax.sigel);
+                  (uu___2531_18200.FStar_Syntax_Syntax.sigel);
                 FStar_Syntax_Syntax.sigrng =
-                  (uu___2519_18070.FStar_Syntax_Syntax.sigrng);
+                  (uu___2531_18200.FStar_Syntax_Syntax.sigrng);
                 FStar_Syntax_Syntax.sigquals =
-                  (uu___2519_18070.FStar_Syntax_Syntax.sigquals);
+                  (uu___2531_18200.FStar_Syntax_Syntax.sigquals);
                 FStar_Syntax_Syntax.sigmeta =
-                  (uu___2519_18070.FStar_Syntax_Syntax.sigmeta);
-                FStar_Syntax_Syntax.sigattrs = attrs'
+                  (uu___2531_18200.FStar_Syntax_Syntax.sigmeta);
+                FStar_Syntax_Syntax.sigattrs = attrs';
+                FStar_Syntax_Syntax.sigopts =
+                  (uu___2531_18200.FStar_Syntax_Syntax.sigopts)
               }), t)
   
 let (is_smt_lemma : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____18078 =
-      let uu____18079 = FStar_Syntax_Subst.compress t  in
-      uu____18079.FStar_Syntax_Syntax.n  in
-    match uu____18078 with
-    | FStar_Syntax_Syntax.Tm_arrow (uu____18083,c) ->
+    let uu____18208 =
+      let uu____18209 = FStar_Syntax_Subst.compress t  in
+      uu____18209.FStar_Syntax_Syntax.n  in
+    match uu____18208 with
+    | FStar_Syntax_Syntax.Tm_arrow (uu____18213,c) ->
         (match c.FStar_Syntax_Syntax.n with
          | FStar_Syntax_Syntax.Comp ct when
              FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
                FStar_Parser_Const.effect_Lemma_lid
              ->
              (match ct.FStar_Syntax_Syntax.effect_args with
-              | _req::_ens::(pats,uu____18111)::uu____18112 ->
+              | _req::_ens::(pats,uu____18241)::uu____18242 ->
                   let pats' = unmeta pats  in
-                  let uu____18172 = head_and_args pats'  in
-                  (match uu____18172 with
-                   | (head1,uu____18191) ->
-                       let uu____18216 =
-                         let uu____18217 = un_uinst head1  in
-                         uu____18217.FStar_Syntax_Syntax.n  in
-                       (match uu____18216 with
+                  let uu____18302 = head_and_args pats'  in
+                  (match uu____18302 with
+                   | (head1,uu____18321) ->
+                       let uu____18346 =
+                         let uu____18347 = un_uinst head1  in
+                         uu____18347.FStar_Syntax_Syntax.n  in
+                       (match uu____18346 with
                         | FStar_Syntax_Syntax.Tm_fvar fv ->
                             FStar_Syntax_Syntax.fv_eq_lid fv
                               FStar_Parser_Const.cons_lid
-                        | uu____18222 -> false))
-              | uu____18224 -> false)
-         | uu____18236 -> false)
-    | uu____18238 -> false
+                        | uu____18352 -> false))
+              | uu____18354 -> false)
+         | uu____18366 -> false)
+    | uu____18368 -> false
   
 let rec (list_elements :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term Prims.list FStar_Pervasives_Native.option)
   =
   fun e  ->
-    let uu____18254 =
-      let uu____18271 = unmeta e  in head_and_args uu____18271  in
-    match uu____18254 with
+    let uu____18384 =
+      let uu____18401 = unmeta e  in head_and_args uu____18401  in
+    match uu____18384 with
     | (head1,args) ->
-        let uu____18302 =
-          let uu____18317 =
-            let uu____18318 = un_uinst head1  in
-            uu____18318.FStar_Syntax_Syntax.n  in
-          (uu____18317, args)  in
-        (match uu____18302 with
-         | (FStar_Syntax_Syntax.Tm_fvar fv,uu____18336) when
+        let uu____18432 =
+          let uu____18447 =
+            let uu____18448 = un_uinst head1  in
+            uu____18448.FStar_Syntax_Syntax.n  in
+          (uu____18447, args)  in
+        (match uu____18432 with
+         | (FStar_Syntax_Syntax.Tm_fvar fv,uu____18466) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.nil_lid ->
              FStar_Pervasives_Native.Some []
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,uu____18360::(hd1,uu____18362)::(tl1,uu____18364)::[]) when
+            fv,uu____18490::(hd1,uu____18492)::(tl1,uu____18494)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.cons_lid ->
-             let uu____18431 =
-               let uu____18434 =
-                 let uu____18437 = list_elements tl1  in
-                 FStar_Util.must uu____18437  in
-               hd1 :: uu____18434  in
-             FStar_Pervasives_Native.Some uu____18431
-         | uu____18446 -> FStar_Pervasives_Native.None)
+             let uu____18561 =
+               let uu____18564 =
+                 let uu____18567 = list_elements tl1  in
+                 FStar_Util.must uu____18567  in
+               hd1 :: uu____18564  in
+             FStar_Pervasives_Native.Some uu____18561
+         | uu____18576 -> FStar_Pervasives_Native.None)
   
 let (unthunk_lemma_post :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   fun t  ->
-    let uu____18475 =
-      let uu____18476 = FStar_Syntax_Subst.compress t  in
-      uu____18476.FStar_Syntax_Syntax.n  in
-    match uu____18475 with
-    | FStar_Syntax_Syntax.Tm_abs (b::[],e,uu____18483) ->
-        let uu____18518 = FStar_Syntax_Subst.open_term [b] e  in
-        (match uu____18518 with
+    let uu____18605 =
+      let uu____18606 = FStar_Syntax_Subst.compress t  in
+      uu____18606.FStar_Syntax_Syntax.n  in
+    match uu____18605 with
+    | FStar_Syntax_Syntax.Tm_abs (b::[],e,uu____18613) ->
+        let uu____18648 = FStar_Syntax_Subst.open_term [b] e  in
+        (match uu____18648 with
          | (bs,e1) ->
              let b1 = FStar_List.hd bs  in
-             let uu____18552 = is_free_in (FStar_Pervasives_Native.fst b1) e1
+             let uu____18682 = is_free_in (FStar_Pervasives_Native.fst b1) e1
                 in
-             if uu____18552
+             if uu____18682
              then
-               let uu____18559 =
-                 let uu____18570 = FStar_Syntax_Syntax.as_arg exp_unit  in
-                 [uu____18570]  in
-               mk_app t uu____18559
+               let uu____18689 =
+                 let uu____18700 = FStar_Syntax_Syntax.as_arg exp_unit  in
+                 [uu____18700]  in
+               mk_app t uu____18689
              else e1)
-    | uu____18597 ->
-        let uu____18598 =
-          let uu____18609 = FStar_Syntax_Syntax.as_arg exp_unit  in
-          [uu____18609]  in
-        mk_app t uu____18598
+    | uu____18727 ->
+        let uu____18728 =
+          let uu____18739 = FStar_Syntax_Syntax.as_arg exp_unit  in
+          [uu____18739]  in
+        mk_app t uu____18728
   
 let (smt_lemma_as_forall :
   FStar_Syntax_Syntax.term ->
@@ -4456,8 +4482,8 @@ let (smt_lemma_as_forall :
   fun t  ->
     fun universe_of_binders  ->
       let list_elements1 e =
-        let uu____18664 = list_elements e  in
-        match uu____18664 with
+        let uu____18794 = list_elements e  in
+        match uu____18794 with
         | FStar_Pervasives_Native.Some l -> l
         | FStar_Pervasives_Native.None  ->
             (FStar_Errors.log_issue e.FStar_Syntax_Syntax.pos
@@ -4466,115 +4492,115 @@ let (smt_lemma_as_forall :
              [])
          in
       let one_pat p =
-        let uu____18695 =
-          let uu____18712 = unmeta p  in
-          FStar_All.pipe_right uu____18712 head_and_args  in
-        match uu____18695 with
+        let uu____18825 =
+          let uu____18842 = unmeta p  in
+          FStar_All.pipe_right uu____18842 head_and_args  in
+        match uu____18825 with
         | (head1,args) ->
-            let uu____18763 =
-              let uu____18778 =
-                let uu____18779 = un_uinst head1  in
-                uu____18779.FStar_Syntax_Syntax.n  in
-              (uu____18778, args)  in
-            (match uu____18763 with
+            let uu____18893 =
+              let uu____18908 =
+                let uu____18909 = un_uinst head1  in
+                uu____18909.FStar_Syntax_Syntax.n  in
+              (uu____18908, args)  in
+            (match uu____18893 with
              | (FStar_Syntax_Syntax.Tm_fvar
-                fv,(uu____18801,uu____18802)::arg::[]) when
+                fv,(uu____18931,uu____18932)::arg::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.smtpat_lid
                  -> arg
-             | uu____18854 -> failwith "Unexpected pattern term")
+             | uu____18984 -> failwith "Unexpected pattern term")
          in
       let lemma_pats p =
         let elts = list_elements1 p  in
         let smt_pat_or1 t1 =
-          let uu____18909 =
-            let uu____18926 = unmeta t1  in
-            FStar_All.pipe_right uu____18926 head_and_args  in
-          match uu____18909 with
+          let uu____19039 =
+            let uu____19056 = unmeta t1  in
+            FStar_All.pipe_right uu____19056 head_and_args  in
+          match uu____19039 with
           | (head1,args) ->
-              let uu____18973 =
-                let uu____18988 =
-                  let uu____18989 = un_uinst head1  in
-                  uu____18989.FStar_Syntax_Syntax.n  in
-                (uu____18988, args)  in
-              (match uu____18973 with
-               | (FStar_Syntax_Syntax.Tm_fvar fv,(e,uu____19008)::[]) when
+              let uu____19103 =
+                let uu____19118 =
+                  let uu____19119 = un_uinst head1  in
+                  uu____19119.FStar_Syntax_Syntax.n  in
+                (uu____19118, args)  in
+              (match uu____19103 with
+               | (FStar_Syntax_Syntax.Tm_fvar fv,(e,uu____19138)::[]) when
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.smtpatOr_lid
                    -> FStar_Pervasives_Native.Some e
-               | uu____19045 -> FStar_Pervasives_Native.None)
+               | uu____19175 -> FStar_Pervasives_Native.None)
            in
         match elts with
         | t1::[] ->
-            let uu____19075 = smt_pat_or1 t1  in
-            (match uu____19075 with
+            let uu____19205 = smt_pat_or1 t1  in
+            (match uu____19205 with
              | FStar_Pervasives_Native.Some e ->
-                 let uu____19097 = list_elements1 e  in
-                 FStar_All.pipe_right uu____19097
+                 let uu____19227 = list_elements1 e  in
+                 FStar_All.pipe_right uu____19227
                    (FStar_List.map
                       (fun branch1  ->
-                         let uu____19127 = list_elements1 branch1  in
-                         FStar_All.pipe_right uu____19127
+                         let uu____19257 = list_elements1 branch1  in
+                         FStar_All.pipe_right uu____19257
                            (FStar_List.map one_pat)))
-             | uu____19150 ->
-                 let uu____19155 =
+             | uu____19280 ->
+                 let uu____19285 =
                    FStar_All.pipe_right elts (FStar_List.map one_pat)  in
-                 [uu____19155])
-        | uu____19206 ->
-            let uu____19209 =
+                 [uu____19285])
+        | uu____19336 ->
+            let uu____19339 =
               FStar_All.pipe_right elts (FStar_List.map one_pat)  in
-            [uu____19209]
+            [uu____19339]
          in
-      let uu____19260 =
-        let uu____19293 =
-          let uu____19294 = FStar_Syntax_Subst.compress t  in
-          uu____19294.FStar_Syntax_Syntax.n  in
-        match uu____19293 with
+      let uu____19390 =
+        let uu____19423 =
+          let uu____19424 = FStar_Syntax_Subst.compress t  in
+          uu____19424.FStar_Syntax_Syntax.n  in
+        match uu____19423 with
         | FStar_Syntax_Syntax.Tm_arrow (binders,c) ->
-            let uu____19351 = FStar_Syntax_Subst.open_comp binders c  in
-            (match uu____19351 with
+            let uu____19481 = FStar_Syntax_Subst.open_comp binders c  in
+            (match uu____19481 with
              | (binders1,c1) ->
                  (match c1.FStar_Syntax_Syntax.n with
                   | FStar_Syntax_Syntax.Comp
-                      { FStar_Syntax_Syntax.comp_univs = uu____19422;
-                        FStar_Syntax_Syntax.effect_name = uu____19423;
-                        FStar_Syntax_Syntax.result_typ = uu____19424;
+                      { FStar_Syntax_Syntax.comp_univs = uu____19552;
+                        FStar_Syntax_Syntax.effect_name = uu____19553;
+                        FStar_Syntax_Syntax.result_typ = uu____19554;
                         FStar_Syntax_Syntax.effect_args =
-                          (pre,uu____19426)::(post,uu____19428)::(pats,uu____19430)::[];
-                        FStar_Syntax_Syntax.flags = uu____19431;_}
+                          (pre,uu____19556)::(post,uu____19558)::(pats,uu____19560)::[];
+                        FStar_Syntax_Syntax.flags = uu____19561;_}
                       ->
-                      let uu____19492 = lemma_pats pats  in
-                      (binders1, pre, post, uu____19492)
-                  | uu____19529 -> failwith "impos"))
-        | uu____19563 -> failwith "Impos"  in
-      match uu____19260 with
+                      let uu____19622 = lemma_pats pats  in
+                      (binders1, pre, post, uu____19622)
+                  | uu____19659 -> failwith "impos"))
+        | uu____19693 -> failwith "Impos"  in
+      match uu____19390 with
       | (binders,pre,post,patterns) ->
           let post1 = unthunk_lemma_post post  in
           let body =
-            let uu____19655 =
-              let uu____19662 =
-                let uu____19663 =
-                  let uu____19670 = mk_imp pre post1  in
-                  let uu____19673 =
-                    let uu____19674 =
-                      let uu____19695 =
+            let uu____19785 =
+              let uu____19792 =
+                let uu____19793 =
+                  let uu____19800 = mk_imp pre post1  in
+                  let uu____19803 =
+                    let uu____19804 =
+                      let uu____19825 =
                         FStar_Syntax_Syntax.binders_to_names binders  in
-                      (uu____19695, patterns)  in
-                    FStar_Syntax_Syntax.Meta_pattern uu____19674  in
-                  (uu____19670, uu____19673)  in
-                FStar_Syntax_Syntax.Tm_meta uu____19663  in
-              FStar_Syntax_Syntax.mk uu____19662  in
-            uu____19655 FStar_Pervasives_Native.None
+                      (uu____19825, patterns)  in
+                    FStar_Syntax_Syntax.Meta_pattern uu____19804  in
+                  (uu____19800, uu____19803)  in
+                FStar_Syntax_Syntax.Tm_meta uu____19793  in
+              FStar_Syntax_Syntax.mk uu____19792  in
+            uu____19785 FStar_Pervasives_Native.None
               t.FStar_Syntax_Syntax.pos
              in
           let quant =
-            let uu____19719 = universe_of_binders binders  in
+            let uu____19849 = universe_of_binders binders  in
             FStar_List.fold_right2
               (fun b  ->
                  fun u  ->
                    fun out  ->
                      mk_forall u (FStar_Pervasives_Native.fst b) out) binders
-              uu____19719 body
+              uu____19849 body
              in
           quant
   

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -6872,13 +6872,15 @@ let rec (inspect :
                 FStar_Reflection_Data.Pat_Constant uu____14879
             | FStar_Syntax_Syntax.Pat_cons (fv,ps) ->
                 let uu____14900 =
-                  let uu____14907 =
+                  let uu____14912 =
                     FStar_List.map
-                      (fun uu____14920  ->
-                         match uu____14920 with
-                         | (p1,uu____14929) -> inspect_pat p1) ps
+                      (fun uu____14936  ->
+                         match uu____14936 with
+                         | (p1,b) ->
+                             let uu____14957 = inspect_pat p1  in
+                             (uu____14957, b)) ps
                      in
-                  (fv, uu____14907)  in
+                  (fv, uu____14912)  in
                 FStar_Reflection_Data.Pat_Cons uu____14900
             | FStar_Syntax_Syntax.Pat_var bv ->
                 FStar_Reflection_Data.Pat_Var bv
@@ -6890,26 +6892,26 @@ let rec (inspect :
           let brs1 = FStar_List.map FStar_Syntax_Subst.open_branch brs  in
           let brs2 =
             FStar_List.map
-              (fun uu___6_15025  ->
-                 match uu___6_15025 with
-                 | (pat,uu____15047,t5) ->
-                     let uu____15065 = inspect_pat pat  in (uu____15065, t5))
+              (fun uu___6_15053  ->
+                 match uu___6_15053 with
+                 | (pat,uu____15075,t5) ->
+                     let uu____15093 = inspect_pat pat  in (uu____15093, t5))
               brs1
              in
           FStar_All.pipe_left ret (FStar_Reflection_Data.Tv_Match (t4, brs2))
       | FStar_Syntax_Syntax.Tm_unknown  ->
           FStar_All.pipe_left ret FStar_Reflection_Data.Tv_Unknown
-      | uu____15074 ->
-          ((let uu____15076 =
-              let uu____15082 =
-                let uu____15084 = FStar_Syntax_Print.tag_of_term t3  in
-                let uu____15086 = FStar_Syntax_Print.term_to_string t3  in
+      | uu____15102 ->
+          ((let uu____15104 =
+              let uu____15110 =
+                let uu____15112 = FStar_Syntax_Print.tag_of_term t3  in
+                let uu____15114 = FStar_Syntax_Print.term_to_string t3  in
                 FStar_Util.format2
                   "inspect: outside of expected syntax (%s, %s)\n"
-                  uu____15084 uu____15086
+                  uu____15112 uu____15114
                  in
-              (FStar_Errors.Warning_CantInspect, uu____15082)  in
-            FStar_Errors.log_issue t3.FStar_Syntax_Syntax.pos uu____15076);
+              (FStar_Errors.Warning_CantInspect, uu____15110)  in
+            FStar_Errors.log_issue t3.FStar_Syntax_Syntax.pos uu____15104);
            FStar_All.pipe_left ret FStar_Reflection_Data.Tv_Unknown)
        in
     wrap_err "inspect" uu____14255
@@ -6919,80 +6921,80 @@ let (pack : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term tac)
   fun tv  ->
     match tv with
     | FStar_Reflection_Data.Tv_Var bv ->
-        let uu____15104 = FStar_Syntax_Syntax.bv_to_name bv  in
-        FStar_All.pipe_left ret uu____15104
+        let uu____15132 = FStar_Syntax_Syntax.bv_to_name bv  in
+        FStar_All.pipe_left ret uu____15132
     | FStar_Reflection_Data.Tv_BVar bv ->
-        let uu____15108 = FStar_Syntax_Syntax.bv_to_tm bv  in
-        FStar_All.pipe_left ret uu____15108
+        let uu____15136 = FStar_Syntax_Syntax.bv_to_tm bv  in
+        FStar_All.pipe_left ret uu____15136
     | FStar_Reflection_Data.Tv_FVar fv ->
-        let uu____15112 = FStar_Syntax_Syntax.fv_to_tm fv  in
-        FStar_All.pipe_left ret uu____15112
+        let uu____15140 = FStar_Syntax_Syntax.fv_to_tm fv  in
+        FStar_All.pipe_left ret uu____15140
     | FStar_Reflection_Data.Tv_App (l,(r,q)) ->
         let q' = FStar_Reflection_Basic.pack_aqual q  in
-        let uu____15119 = FStar_Syntax_Util.mk_app l [(r, q')]  in
-        FStar_All.pipe_left ret uu____15119
+        let uu____15147 = FStar_Syntax_Util.mk_app l [(r, q')]  in
+        FStar_All.pipe_left ret uu____15147
     | FStar_Reflection_Data.Tv_Abs (b,t) ->
-        let uu____15144 =
+        let uu____15172 =
           FStar_Syntax_Util.abs [b] t FStar_Pervasives_Native.None  in
-        FStar_All.pipe_left ret uu____15144
+        FStar_All.pipe_left ret uu____15172
     | FStar_Reflection_Data.Tv_Arrow (b,c) ->
-        let uu____15161 = FStar_Syntax_Util.arrow [b] c  in
-        FStar_All.pipe_left ret uu____15161
+        let uu____15189 = FStar_Syntax_Util.arrow [b] c  in
+        FStar_All.pipe_left ret uu____15189
     | FStar_Reflection_Data.Tv_Type () ->
         FStar_All.pipe_left ret FStar_Syntax_Util.ktype
     | FStar_Reflection_Data.Tv_Refine (bv,t) ->
-        let uu____15180 = FStar_Syntax_Util.refine bv t  in
-        FStar_All.pipe_left ret uu____15180
+        let uu____15208 = FStar_Syntax_Util.refine bv t  in
+        FStar_All.pipe_left ret uu____15208
     | FStar_Reflection_Data.Tv_Const c ->
-        let uu____15184 =
-          let uu____15185 =
-            let uu____15192 =
-              let uu____15193 = FStar_Reflection_Basic.pack_const c  in
-              FStar_Syntax_Syntax.Tm_constant uu____15193  in
-            FStar_Syntax_Syntax.mk uu____15192  in
-          uu____15185 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
-        FStar_All.pipe_left ret uu____15184
+        let uu____15212 =
+          let uu____15213 =
+            let uu____15220 =
+              let uu____15221 = FStar_Reflection_Basic.pack_const c  in
+              FStar_Syntax_Syntax.Tm_constant uu____15221  in
+            FStar_Syntax_Syntax.mk uu____15220  in
+          uu____15213 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
+        FStar_All.pipe_left ret uu____15212
     | FStar_Reflection_Data.Tv_Uvar (_u,ctx_u_s) ->
-        let uu____15198 =
+        let uu____15226 =
           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_uvar ctx_u_s)
             FStar_Pervasives_Native.None FStar_Range.dummyRange
            in
-        FStar_All.pipe_left ret uu____15198
+        FStar_All.pipe_left ret uu____15226
     | FStar_Reflection_Data.Tv_Let (false ,bv,t1,t2) ->
         let lb =
           FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl bv) []
             bv.FStar_Syntax_Syntax.sort FStar_Parser_Const.effect_Tot_lid t1
             [] FStar_Range.dummyRange
            in
-        let uu____15209 =
-          let uu____15210 =
-            let uu____15217 =
-              let uu____15218 =
-                let uu____15232 =
-                  let uu____15235 =
-                    let uu____15236 = FStar_Syntax_Syntax.mk_binder bv  in
-                    [uu____15236]  in
-                  FStar_Syntax_Subst.close uu____15235 t2  in
-                ((false, [lb]), uu____15232)  in
-              FStar_Syntax_Syntax.Tm_let uu____15218  in
-            FStar_Syntax_Syntax.mk uu____15217  in
-          uu____15210 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
-        FStar_All.pipe_left ret uu____15209
+        let uu____15237 =
+          let uu____15238 =
+            let uu____15245 =
+              let uu____15246 =
+                let uu____15260 =
+                  let uu____15263 =
+                    let uu____15264 = FStar_Syntax_Syntax.mk_binder bv  in
+                    [uu____15264]  in
+                  FStar_Syntax_Subst.close uu____15263 t2  in
+                ((false, [lb]), uu____15260)  in
+              FStar_Syntax_Syntax.Tm_let uu____15246  in
+            FStar_Syntax_Syntax.mk uu____15245  in
+          uu____15238 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
+        FStar_All.pipe_left ret uu____15237
     | FStar_Reflection_Data.Tv_Let (true ,bv,t1,t2) ->
         let lb =
           FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl bv) []
             bv.FStar_Syntax_Syntax.sort FStar_Parser_Const.effect_Tot_lid t1
             [] FStar_Range.dummyRange
            in
-        let uu____15278 = FStar_Syntax_Subst.close_let_rec [lb] t2  in
-        (match uu____15278 with
+        let uu____15306 = FStar_Syntax_Subst.close_let_rec [lb] t2  in
+        (match uu____15306 with
          | (lbs,body) ->
-             let uu____15293 =
+             let uu____15321 =
                FStar_Syntax_Syntax.mk
                  (FStar_Syntax_Syntax.Tm_let ((true, lbs), body))
                  FStar_Pervasives_Native.None FStar_Range.dummyRange
                 in
-             FStar_All.pipe_left ret uu____15293)
+             FStar_All.pipe_left ret uu____15321)
     | FStar_Reflection_Data.Tv_Match (t,brs) ->
         let wrap v1 =
           {
@@ -7002,22 +7004,24 @@ let (pack : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term tac)
         let rec pack_pat p =
           match p with
           | FStar_Reflection_Data.Pat_Constant c ->
-              let uu____15330 =
-                let uu____15331 = FStar_Reflection_Basic.pack_const c  in
-                FStar_Syntax_Syntax.Pat_constant uu____15331  in
-              FStar_All.pipe_left wrap uu____15330
+              let uu____15358 =
+                let uu____15359 = FStar_Reflection_Basic.pack_const c  in
+                FStar_Syntax_Syntax.Pat_constant uu____15359  in
+              FStar_All.pipe_left wrap uu____15358
           | FStar_Reflection_Data.Pat_Cons (fv,ps) ->
-              let uu____15338 =
-                let uu____15339 =
-                  let uu____15353 =
+              let uu____15376 =
+                let uu____15377 =
+                  let uu____15391 =
                     FStar_List.map
-                      (fun p1  ->
-                         let uu____15371 = pack_pat p1  in
-                         (uu____15371, false)) ps
+                      (fun uu____15415  ->
+                         match uu____15415 with
+                         | (p1,b) ->
+                             let uu____15430 = pack_pat p1  in
+                             (uu____15430, b)) ps
                      in
-                  (fv, uu____15353)  in
-                FStar_Syntax_Syntax.Pat_cons uu____15339  in
-              FStar_All.pipe_left wrap uu____15338
+                  (fv, uu____15391)  in
+                FStar_Syntax_Syntax.Pat_cons uu____15377  in
+              FStar_All.pipe_left wrap uu____15376
           | FStar_Reflection_Data.Pat_Var bv ->
               FStar_All.pipe_left wrap (FStar_Syntax_Syntax.Pat_var bv)
           | FStar_Reflection_Data.Pat_Wild bv ->
@@ -7028,59 +7032,59 @@ let (pack : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term tac)
            in
         let brs1 =
           FStar_List.map
-            (fun uu___7_15420  ->
-               match uu___7_15420 with
+            (fun uu___7_15478  ->
+               match uu___7_15478 with
                | (pat,t1) ->
-                   let uu____15437 = pack_pat pat  in
-                   (uu____15437, FStar_Pervasives_Native.None, t1)) brs
+                   let uu____15495 = pack_pat pat  in
+                   (uu____15495, FStar_Pervasives_Native.None, t1)) brs
            in
         let brs2 = FStar_List.map FStar_Syntax_Subst.close_branch brs1  in
-        let uu____15485 =
+        let uu____15543 =
           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_match (t, brs2))
             FStar_Pervasives_Native.None FStar_Range.dummyRange
            in
-        FStar_All.pipe_left ret uu____15485
+        FStar_All.pipe_left ret uu____15543
     | FStar_Reflection_Data.Tv_AscribedT (e,t,tacopt) ->
-        let uu____15513 =
+        let uu____15571 =
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_ascribed
                (e, ((FStar_Util.Inl t), tacopt),
                  FStar_Pervasives_Native.None)) FStar_Pervasives_Native.None
             FStar_Range.dummyRange
            in
-        FStar_All.pipe_left ret uu____15513
+        FStar_All.pipe_left ret uu____15571
     | FStar_Reflection_Data.Tv_AscribedC (e,c,tacopt) ->
-        let uu____15559 =
+        let uu____15617 =
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_ascribed
                (e, ((FStar_Util.Inr c), tacopt),
                  FStar_Pervasives_Native.None)) FStar_Pervasives_Native.None
             FStar_Range.dummyRange
            in
-        FStar_All.pipe_left ret uu____15559
+        FStar_All.pipe_left ret uu____15617
     | FStar_Reflection_Data.Tv_Unknown  ->
-        let uu____15598 =
+        let uu____15656 =
           FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
             FStar_Pervasives_Native.None FStar_Range.dummyRange
            in
-        FStar_All.pipe_left ret uu____15598
+        FStar_All.pipe_left ret uu____15656
   
 let (lget :
   FStar_Reflection_Data.typ -> Prims.string -> FStar_Syntax_Syntax.term tac)
   =
   fun ty  ->
     fun k  ->
-      let uu____15618 =
+      let uu____15676 =
         bind get
           (fun ps  ->
-             let uu____15624 =
+             let uu____15682 =
                FStar_Util.psmap_try_find ps.FStar_Tactics_Types.local_state k
                 in
-             match uu____15624 with
+             match uu____15682 with
              | FStar_Pervasives_Native.None  -> fail "not found"
              | FStar_Pervasives_Native.Some t -> unquote ty t)
          in
-      FStar_All.pipe_left (wrap_err "lget") uu____15618
+      FStar_All.pipe_left (wrap_err "lget") uu____15676
   
 let (lset :
   FStar_Reflection_Data.typ ->
@@ -7089,45 +7093,45 @@ let (lset :
   fun _ty  ->
     fun k  ->
       fun t  ->
-        let uu____15658 =
+        let uu____15716 =
           bind get
             (fun ps  ->
                let ps1 =
-                 let uu___2193_15665 = ps  in
-                 let uu____15666 =
+                 let uu___2195_15723 = ps  in
+                 let uu____15724 =
                    FStar_Util.psmap_add ps.FStar_Tactics_Types.local_state k
                      t
                     in
                  {
                    FStar_Tactics_Types.main_context =
-                     (uu___2193_15665.FStar_Tactics_Types.main_context);
+                     (uu___2195_15723.FStar_Tactics_Types.main_context);
                    FStar_Tactics_Types.main_goal =
-                     (uu___2193_15665.FStar_Tactics_Types.main_goal);
+                     (uu___2195_15723.FStar_Tactics_Types.main_goal);
                    FStar_Tactics_Types.all_implicits =
-                     (uu___2193_15665.FStar_Tactics_Types.all_implicits);
+                     (uu___2195_15723.FStar_Tactics_Types.all_implicits);
                    FStar_Tactics_Types.goals =
-                     (uu___2193_15665.FStar_Tactics_Types.goals);
+                     (uu___2195_15723.FStar_Tactics_Types.goals);
                    FStar_Tactics_Types.smt_goals =
-                     (uu___2193_15665.FStar_Tactics_Types.smt_goals);
+                     (uu___2195_15723.FStar_Tactics_Types.smt_goals);
                    FStar_Tactics_Types.depth =
-                     (uu___2193_15665.FStar_Tactics_Types.depth);
+                     (uu___2195_15723.FStar_Tactics_Types.depth);
                    FStar_Tactics_Types.__dump =
-                     (uu___2193_15665.FStar_Tactics_Types.__dump);
+                     (uu___2195_15723.FStar_Tactics_Types.__dump);
                    FStar_Tactics_Types.psc =
-                     (uu___2193_15665.FStar_Tactics_Types.psc);
+                     (uu___2195_15723.FStar_Tactics_Types.psc);
                    FStar_Tactics_Types.entry_range =
-                     (uu___2193_15665.FStar_Tactics_Types.entry_range);
+                     (uu___2195_15723.FStar_Tactics_Types.entry_range);
                    FStar_Tactics_Types.guard_policy =
-                     (uu___2193_15665.FStar_Tactics_Types.guard_policy);
+                     (uu___2195_15723.FStar_Tactics_Types.guard_policy);
                    FStar_Tactics_Types.freshness =
-                     (uu___2193_15665.FStar_Tactics_Types.freshness);
+                     (uu___2195_15723.FStar_Tactics_Types.freshness);
                    FStar_Tactics_Types.tac_verb_dbg =
-                     (uu___2193_15665.FStar_Tactics_Types.tac_verb_dbg);
-                   FStar_Tactics_Types.local_state = uu____15666
+                     (uu___2195_15723.FStar_Tactics_Types.tac_verb_dbg);
+                   FStar_Tactics_Types.local_state = uu____15724
                  }  in
                set ps1)
            in
-        FStar_All.pipe_left (wrap_err "lset") uu____15658
+        FStar_All.pipe_left (wrap_err "lset") uu____15716
   
 let (goal_of_goal_ty :
   env ->
@@ -7136,18 +7140,18 @@ let (goal_of_goal_ty :
   =
   fun env  ->
     fun typ  ->
-      let uu____15693 =
+      let uu____15751 =
         FStar_TypeChecker_Util.new_implicit_var "proofstate_of_goal_ty"
           typ.FStar_Syntax_Syntax.pos env typ
          in
-      match uu____15693 with
+      match uu____15751 with
       | (u,ctx_uvars,g_u) ->
-          let uu____15726 = FStar_List.hd ctx_uvars  in
-          (match uu____15726 with
-           | (ctx_uvar,uu____15740) ->
+          let uu____15784 = FStar_List.hd ctx_uvars  in
+          (match uu____15784 with
+           | (ctx_uvar,uu____15798) ->
                let g =
-                 let uu____15742 = FStar_Options.peek ()  in
-                 FStar_Tactics_Types.mk_goal env ctx_uvar uu____15742 false
+                 let uu____15800 = FStar_Options.peek ()  in
+                 FStar_Tactics_Types.mk_goal env ctx_uvar uu____15800 false
                    ""
                   in
                (g, g_u))
@@ -7161,15 +7165,15 @@ let (proofstate_of_goal_ty :
   fun rng  ->
     fun env  ->
       fun typ  ->
-        let uu____15765 = goal_of_goal_ty env typ  in
-        match uu____15765 with
+        let uu____15823 = goal_of_goal_ty env typ  in
+        match uu____15823 with
         | (g,g_u) ->
             let ps =
-              let uu____15777 =
+              let uu____15835 =
                 FStar_TypeChecker_Env.debug env
                   (FStar_Options.Other "TacVerbose")
                  in
-              let uu____15780 = FStar_Util.psmap_empty ()  in
+              let uu____15838 = FStar_Util.psmap_empty ()  in
               {
                 FStar_Tactics_Types.main_context = env;
                 FStar_Tactics_Types.main_goal = g;
@@ -7183,9 +7187,9 @@ let (proofstate_of_goal_ty :
                 FStar_Tactics_Types.entry_range = rng;
                 FStar_Tactics_Types.guard_policy = FStar_Tactics_Types.SMT;
                 FStar_Tactics_Types.freshness = Prims.int_zero;
-                FStar_Tactics_Types.tac_verb_dbg = uu____15777;
-                FStar_Tactics_Types.local_state = uu____15780
+                FStar_Tactics_Types.tac_verb_dbg = uu____15835;
+                FStar_Tactics_Types.local_state = uu____15838
               }  in
-            let uu____15785 = FStar_Tactics_Types.goal_witness g  in
-            (ps, uu____15785)
+            let uu____15843 = FStar_Tactics_Types.goal_witness g  in
+            (ps, uu____15843)
   

--- a/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
+++ b/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
@@ -3336,123 +3336,123 @@ and (desugar_term_maybe_top :
             uu____11607 env1 e
         | FStar_Parser_AST.Let (qual,lbs,body) ->
             let is_rec = qual = FStar_Parser_AST.Rec  in
-            let ds_let_rec_or_app uu____11679 =
+            let ds_let_rec_or_app uu____11687 =
               let bindings = lbs  in
               let funs =
                 FStar_All.pipe_right bindings
                   (FStar_List.map
-                     (fun uu____11822  ->
-                        match uu____11822 with
+                     (fun uu____11830  ->
+                        match uu____11830 with
                         | (attr_opt,(p,def)) ->
-                            let uu____11880 = is_app_pattern p  in
-                            if uu____11880
+                            let uu____11888 = is_app_pattern p  in
+                            if uu____11888
                             then
-                              let uu____11913 =
+                              let uu____11921 =
                                 destruct_app_pattern env top_level p  in
-                              (attr_opt, uu____11913, def)
+                              (attr_opt, uu____11921, def)
                             else
                               (match FStar_Parser_AST.un_function p def with
                                | FStar_Pervasives_Native.Some (p1,def1) ->
-                                   let uu____11996 =
+                                   let uu____12004 =
                                      destruct_app_pattern env top_level p1
                                       in
-                                   (attr_opt, uu____11996, def1)
-                               | uu____12041 ->
+                                   (attr_opt, uu____12004, def1)
+                               | uu____12049 ->
                                    (match p.FStar_Parser_AST.pat with
                                     | FStar_Parser_AST.PatAscribed
                                         ({
                                            FStar_Parser_AST.pat =
                                              FStar_Parser_AST.PatVar
-                                             (id1,uu____12079);
+                                             (id1,uu____12087);
                                            FStar_Parser_AST.prange =
-                                             uu____12080;_},t)
+                                             uu____12088;_},t)
                                         ->
                                         if top_level
                                         then
-                                          let uu____12129 =
-                                            let uu____12150 =
-                                              let uu____12155 =
+                                          let uu____12137 =
+                                            let uu____12158 =
+                                              let uu____12163 =
                                                 FStar_Syntax_DsEnv.qualify
                                                   env id1
                                                  in
-                                              FStar_Util.Inr uu____12155  in
-                                            (uu____12150, [],
+                                              FStar_Util.Inr uu____12163  in
+                                            (uu____12158, [],
                                               (FStar_Pervasives_Native.Some t))
                                              in
-                                          (attr_opt, uu____12129, def)
+                                          (attr_opt, uu____12137, def)
                                         else
                                           (attr_opt,
                                             ((FStar_Util.Inl id1), [],
                                               (FStar_Pervasives_Native.Some t)),
                                             def)
                                     | FStar_Parser_AST.PatVar
-                                        (id1,uu____12247) ->
+                                        (id1,uu____12255) ->
                                         if top_level
                                         then
-                                          let uu____12283 =
-                                            let uu____12304 =
-                                              let uu____12309 =
+                                          let uu____12291 =
+                                            let uu____12312 =
+                                              let uu____12317 =
                                                 FStar_Syntax_DsEnv.qualify
                                                   env id1
                                                  in
-                                              FStar_Util.Inr uu____12309  in
-                                            (uu____12304, [],
+                                              FStar_Util.Inr uu____12317  in
+                                            (uu____12312, [],
                                               FStar_Pervasives_Native.None)
                                              in
-                                          (attr_opt, uu____12283, def)
+                                          (attr_opt, uu____12291, def)
                                         else
                                           (attr_opt,
                                             ((FStar_Util.Inl id1), [],
                                               FStar_Pervasives_Native.None),
                                             def)
-                                    | uu____12400 ->
+                                    | uu____12408 ->
                                         FStar_Errors.raise_error
                                           (FStar_Errors.Fatal_UnexpectedLetBinding,
                                             "Unexpected let binding")
                                           p.FStar_Parser_AST.prange))))
                  in
-              let uu____12433 =
+              let uu____12441 =
                 FStar_List.fold_left
-                  (fun uu____12506  ->
-                     fun uu____12507  ->
-                       match (uu____12506, uu____12507) with
-                       | ((env1,fnames,rec_bindings),(_attr_opt,(f,uu____12615,uu____12616),uu____12617))
+                  (fun uu____12514  ->
+                     fun uu____12515  ->
+                       match (uu____12514, uu____12515) with
+                       | ((env1,fnames,rec_bindings),(_attr_opt,(f,uu____12623,uu____12624),uu____12625))
                            ->
-                           let uu____12734 =
+                           let uu____12742 =
                              match f with
                              | FStar_Util.Inl x ->
-                                 let uu____12760 =
+                                 let uu____12768 =
                                    FStar_Syntax_DsEnv.push_bv env1 x  in
-                                 (match uu____12760 with
+                                 (match uu____12768 with
                                   | (env2,xx) ->
-                                      let uu____12779 =
-                                        let uu____12782 =
+                                      let uu____12787 =
+                                        let uu____12790 =
                                           FStar_Syntax_Syntax.mk_binder xx
                                            in
-                                        uu____12782 :: rec_bindings  in
+                                        uu____12790 :: rec_bindings  in
                                       (env2, (FStar_Util.Inl xx),
-                                        uu____12779))
+                                        uu____12787))
                              | FStar_Util.Inr l ->
-                                 let uu____12790 =
+                                 let uu____12798 =
                                    FStar_Syntax_DsEnv.push_top_level_rec_binding
                                      env1 l.FStar_Ident.ident
                                      FStar_Syntax_Syntax.delta_equational
                                     in
-                                 (uu____12790, (FStar_Util.Inr l),
+                                 (uu____12798, (FStar_Util.Inr l),
                                    rec_bindings)
                               in
-                           (match uu____12734 with
+                           (match uu____12742 with
                             | (env2,lbname,rec_bindings1) ->
                                 (env2, (lbname :: fnames), rec_bindings1)))
                   (env, [], []) funs
                  in
-              match uu____12433 with
+              match uu____12441 with
               | (env',fnames,rec_bindings) ->
                   let fnames1 = FStar_List.rev fnames  in
                   let rec_bindings1 = FStar_List.rev rec_bindings  in
-                  let desugar_one_def env1 lbname uu____12938 =
-                    match uu____12938 with
-                    | (attrs_opt,(uu____12974,args,result_t),def) ->
+                  let desugar_one_def env1 lbname uu____12958 =
+                    match uu____12958 with
+                    | (attrs_opt,(uu____12998,args,result_t),def) ->
                         let args1 =
                           FStar_All.pipe_right args
                             (FStar_List.map replace_unit_pattern)
@@ -3463,18 +3463,18 @@ and (desugar_term_maybe_top :
                           | FStar_Pervasives_Native.None  -> def
                           | FStar_Pervasives_Native.Some (t,tacopt) ->
                               let t1 =
-                                let uu____13062 = is_comp_type env1 t  in
-                                if uu____13062
+                                let uu____13090 = is_comp_type env1 t  in
+                                if uu____13090
                                 then
-                                  ((let uu____13066 =
+                                  ((let uu____13094 =
                                       FStar_All.pipe_right args1
                                         (FStar_List.tryFind
                                            (fun x  ->
-                                              let uu____13076 =
+                                              let uu____13104 =
                                                 is_var_pattern x  in
-                                              Prims.op_Negation uu____13076))
+                                              Prims.op_Negation uu____13104))
                                        in
-                                    match uu____13066 with
+                                    match uu____13094 with
                                     | FStar_Pervasives_Native.None  -> ()
                                     | FStar_Pervasives_Native.Some p ->
                                         FStar_Errors.raise_error
@@ -3483,20 +3483,20 @@ and (desugar_term_maybe_top :
                                           p.FStar_Parser_AST.prange);
                                    t)
                                 else
-                                  (let uu____13083 =
+                                  (let uu____13111 =
                                      ((FStar_Options.ml_ish ()) &&
-                                        (let uu____13086 =
+                                        (let uu____13114 =
                                            FStar_Syntax_DsEnv.try_lookup_effect_name
                                              env1
                                              FStar_Parser_Const.effect_ML_lid
                                             in
-                                         FStar_Option.isSome uu____13086))
+                                         FStar_Option.isSome uu____13114))
                                        &&
                                        ((Prims.op_Negation is_rec) ||
                                           ((FStar_List.length args1) <>
                                              Prims.int_zero))
                                       in
-                                   if uu____13083
+                                   if uu____13111
                                    then FStar_Parser_AST.ml_comp t
                                    else FStar_Parser_AST.tot_comp t)
                                  in
@@ -3508,59 +3508,69 @@ and (desugar_term_maybe_top :
                         let def2 =
                           match args1 with
                           | [] -> def1
-                          | uu____13097 ->
+                          | uu____13125 ->
                               FStar_Parser_AST.mk_term
                                 (FStar_Parser_AST.un_curry_abs args1 def1)
                                 top.FStar_Parser_AST.range
                                 top.FStar_Parser_AST.level
                            in
-                        let body1 = desugar_term env1 def2  in
-                        let lbname1 =
-                          match lbname with
-                          | FStar_Util.Inl x -> FStar_Util.Inl x
-                          | FStar_Util.Inr l ->
-                              let uu____13112 =
-                                let uu____13113 =
-                                  FStar_Syntax_Util.incr_delta_qualifier
-                                    body1
-                                   in
-                                FStar_Syntax_Syntax.lid_as_fv l uu____13113
-                                  FStar_Pervasives_Native.None
-                                 in
-                              FStar_Util.Inr uu____13112
-                           in
-                        let body2 =
-                          if is_rec
-                          then FStar_Syntax_Subst.close rec_bindings1 body1
-                          else body1  in
-                        let attrs =
-                          match attrs_opt with
-                          | FStar_Pervasives_Native.None  -> []
-                          | FStar_Pervasives_Native.Some l ->
-                              FStar_List.map (desugar_term env1) l
-                           in
-                        mk_lb
-                          (attrs, lbname1, FStar_Syntax_Syntax.tun, body2,
-                            pos)
-                     in
-                  let lbs1 =
-                    FStar_List.map2
-                      (desugar_one_def (if is_rec then env' else env))
-                      fnames1 funs
-                     in
-                  let uu____13194 = desugar_term_aq env' body  in
-                  (match uu____13194 with
-                   | (body1,aq) ->
-                       let uu____13207 =
-                         let uu____13210 =
-                           let uu____13211 =
-                             let uu____13225 =
-                               FStar_Syntax_Subst.close rec_bindings1 body1
+                        let uu____13128 = desugar_term_aq env1 def2  in
+                        (match uu____13128 with
+                         | (body1,aq) ->
+                             let lbname1 =
+                               match lbname with
+                               | FStar_Util.Inl x -> FStar_Util.Inl x
+                               | FStar_Util.Inr l ->
+                                   let uu____13150 =
+                                     let uu____13151 =
+                                       FStar_Syntax_Util.incr_delta_qualifier
+                                         body1
+                                        in
+                                     FStar_Syntax_Syntax.lid_as_fv l
+                                       uu____13151
+                                       FStar_Pervasives_Native.None
+                                      in
+                                   FStar_Util.Inr uu____13150
                                 in
-                             ((is_rec, lbs1), uu____13225)  in
-                           FStar_Syntax_Syntax.Tm_let uu____13211  in
-                         FStar_All.pipe_left mk1 uu____13210  in
-                       (uu____13207, aq))
+                             let body2 =
+                               if is_rec
+                               then
+                                 FStar_Syntax_Subst.close rec_bindings1 body1
+                               else body1  in
+                             let attrs =
+                               match attrs_opt with
+                               | FStar_Pervasives_Native.None  -> []
+                               | FStar_Pervasives_Native.Some l ->
+                                   FStar_List.map (desugar_term env1) l
+                                in
+                             ((mk_lb
+                                 (attrs, lbname1, FStar_Syntax_Syntax.tun,
+                                   body2, pos)), aq))
+                     in
+                  let uu____13192 =
+                    let uu____13209 =
+                      FStar_List.map2
+                        (desugar_one_def (if is_rec then env' else env))
+                        fnames1 funs
+                       in
+                    FStar_All.pipe_right uu____13209 FStar_List.unzip  in
+                  (match uu____13192 with
+                   | (lbs1,aqss) ->
+                       let uu____13351 = desugar_term_aq env' body  in
+                       (match uu____13351 with
+                        | (body1,aq) ->
+                            let uu____13372 =
+                              let uu____13375 =
+                                let uu____13376 =
+                                  let uu____13390 =
+                                    FStar_Syntax_Subst.close rec_bindings1
+                                      body1
+                                     in
+                                  ((is_rec, lbs1), uu____13390)  in
+                                FStar_Syntax_Syntax.Tm_let uu____13376  in
+                              FStar_All.pipe_left mk1 uu____13375  in
+                            (uu____13372,
+                              (FStar_List.append aq (FStar_List.flatten aqss)))))
                in
             let ds_non_rec attrs_opt pat t1 t2 =
               let attrs =
@@ -3569,97 +3579,109 @@ and (desugar_term_maybe_top :
                 | FStar_Pervasives_Native.Some l ->
                     FStar_List.map (desugar_term env) l
                  in
-              let t11 = desugar_term env t1  in
-              let uu____13300 =
-                desugar_binding_pat_maybe_top top_level env pat  in
-              match uu____13300 with
-              | (env1,binder,pat1) ->
-                  let uu____13322 =
-                    match binder with
-                    | LetBinder (l,(t,_tacopt)) ->
-                        let uu____13348 = desugar_term_aq env1 t2  in
-                        (match uu____13348 with
-                         | (body1,aq) ->
-                             let fv =
-                               let uu____13362 =
-                                 FStar_Syntax_Util.incr_delta_qualifier t11
-                                  in
-                               FStar_Syntax_Syntax.lid_as_fv l uu____13362
-                                 FStar_Pervasives_Native.None
-                                in
-                             let uu____13363 =
-                               FStar_All.pipe_left mk1
-                                 (FStar_Syntax_Syntax.Tm_let
-                                    ((false,
-                                       [mk_lb
-                                          (attrs, (FStar_Util.Inr fv), t,
-                                            t11,
-                                            (t11.FStar_Syntax_Syntax.pos))]),
-                                      body1))
-                                in
-                             (uu____13363, aq))
-                    | LocalBinder (x,uu____13396) ->
-                        let uu____13397 = desugar_term_aq env1 t2  in
-                        (match uu____13397 with
-                         | (body1,aq) ->
-                             let body2 =
-                               match pat1 with
-                               | [] -> body1
-                               | ({
-                                    FStar_Syntax_Syntax.v =
-                                      FStar_Syntax_Syntax.Pat_wild
-                                      uu____13411;
-                                    FStar_Syntax_Syntax.p = uu____13412;_},uu____13413)::[]
-                                   -> body1
-                               | uu____13426 ->
-                                   let uu____13429 =
-                                     let uu____13436 =
-                                       let uu____13437 =
-                                         let uu____13460 =
-                                           FStar_Syntax_Syntax.bv_to_name x
-                                            in
-                                         let uu____13463 =
-                                           desugar_disjunctive_pattern pat1
-                                             FStar_Pervasives_Native.None
-                                             body1
-                                            in
-                                         (uu____13460, uu____13463)  in
-                                       FStar_Syntax_Syntax.Tm_match
-                                         uu____13437
-                                        in
-                                     FStar_Syntax_Syntax.mk uu____13436  in
-                                   uu____13429 FStar_Pervasives_Native.None
-                                     top.FStar_Parser_AST.range
-                                in
-                             let uu____13500 =
-                               let uu____13503 =
-                                 let uu____13504 =
-                                   let uu____13518 =
-                                     let uu____13521 =
-                                       let uu____13522 =
-                                         FStar_Syntax_Syntax.mk_binder x  in
-                                       [uu____13522]  in
-                                     FStar_Syntax_Subst.close uu____13521
-                                       body2
-                                      in
-                                   ((false,
-                                      [mk_lb
-                                         (attrs, (FStar_Util.Inl x),
-                                           (x.FStar_Syntax_Syntax.sort), t11,
-                                           (t11.FStar_Syntax_Syntax.pos))]),
-                                     uu____13518)
-                                    in
-                                 FStar_Syntax_Syntax.Tm_let uu____13504  in
-                               FStar_All.pipe_left mk1 uu____13503  in
-                             (uu____13500, aq))
-                     in
-                  (match uu____13322 with | (tm,aq) -> (tm, aq))
+              let uu____13492 = desugar_term_aq env t1  in
+              match uu____13492 with
+              | (t11,aq0) ->
+                  let uu____13513 =
+                    desugar_binding_pat_maybe_top top_level env pat  in
+                  (match uu____13513 with
+                   | (env1,binder,pat1) ->
+                       let uu____13543 =
+                         match binder with
+                         | LetBinder (l,(t,_tacopt)) ->
+                             let uu____13585 = desugar_term_aq env1 t2  in
+                             (match uu____13585 with
+                              | (body1,aq) ->
+                                  let fv =
+                                    let uu____13607 =
+                                      FStar_Syntax_Util.incr_delta_qualifier
+                                        t11
+                                       in
+                                    FStar_Syntax_Syntax.lid_as_fv l
+                                      uu____13607
+                                      FStar_Pervasives_Native.None
+                                     in
+                                  let uu____13608 =
+                                    FStar_All.pipe_left mk1
+                                      (FStar_Syntax_Syntax.Tm_let
+                                         ((false,
+                                            [mk_lb
+                                               (attrs, (FStar_Util.Inr fv),
+                                                 t, t11,
+                                                 (t11.FStar_Syntax_Syntax.pos))]),
+                                           body1))
+                                     in
+                                  (uu____13608, aq))
+                         | LocalBinder (x,uu____13649) ->
+                             let uu____13650 = desugar_term_aq env1 t2  in
+                             (match uu____13650 with
+                              | (body1,aq) ->
+                                  let body2 =
+                                    match pat1 with
+                                    | [] -> body1
+                                    | ({
+                                         FStar_Syntax_Syntax.v =
+                                           FStar_Syntax_Syntax.Pat_wild
+                                           uu____13672;
+                                         FStar_Syntax_Syntax.p = uu____13673;_},uu____13674)::[]
+                                        -> body1
+                                    | uu____13687 ->
+                                        let uu____13690 =
+                                          let uu____13697 =
+                                            let uu____13698 =
+                                              let uu____13721 =
+                                                FStar_Syntax_Syntax.bv_to_name
+                                                  x
+                                                 in
+                                              let uu____13724 =
+                                                desugar_disjunctive_pattern
+                                                  pat1
+                                                  FStar_Pervasives_Native.None
+                                                  body1
+                                                 in
+                                              (uu____13721, uu____13724)  in
+                                            FStar_Syntax_Syntax.Tm_match
+                                              uu____13698
+                                             in
+                                          FStar_Syntax_Syntax.mk uu____13697
+                                           in
+                                        uu____13690
+                                          FStar_Pervasives_Native.None
+                                          top.FStar_Parser_AST.range
+                                     in
+                                  let uu____13761 =
+                                    let uu____13764 =
+                                      let uu____13765 =
+                                        let uu____13779 =
+                                          let uu____13782 =
+                                            let uu____13783 =
+                                              FStar_Syntax_Syntax.mk_binder x
+                                               in
+                                            [uu____13783]  in
+                                          FStar_Syntax_Subst.close
+                                            uu____13782 body2
+                                           in
+                                        ((false,
+                                           [mk_lb
+                                              (attrs, (FStar_Util.Inl x),
+                                                (x.FStar_Syntax_Syntax.sort),
+                                                t11,
+                                                (t11.FStar_Syntax_Syntax.pos))]),
+                                          uu____13779)
+                                         in
+                                      FStar_Syntax_Syntax.Tm_let uu____13765
+                                       in
+                                    FStar_All.pipe_left mk1 uu____13764  in
+                                  (uu____13761, aq))
+                          in
+                       (match uu____13543 with
+                        | (tm,aq1) -> (tm, (FStar_List.append aq0 aq1))))
                in
-            let uu____13584 = FStar_List.hd lbs  in
-            (match uu____13584 with
+            let uu____13891 = FStar_List.hd lbs  in
+            (match uu____13891 with
              | (attrs,(head_pat,defn)) ->
-                 let uu____13628 = is_rec || (is_app_pattern head_pat)  in
-                 if uu____13628
+                 let uu____13935 = is_rec || (is_app_pattern head_pat)  in
+                 if uu____13935
                  then ds_let_rec_or_app ()
                  else ds_non_rec attrs head_pat defn body)
         | FStar_Parser_AST.If (t1,t2,t3) ->
@@ -3669,53 +3691,53 @@ and (desugar_term_maybe_top :
                 FStar_Syntax_Syntax.tun
                in
             let t_bool1 =
-              let uu____13644 =
-                let uu____13645 =
+              let uu____13951 =
+                let uu____13952 =
                   FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.bool_lid
                     FStar_Syntax_Syntax.delta_constant
                     FStar_Pervasives_Native.None
                    in
-                FStar_Syntax_Syntax.Tm_fvar uu____13645  in
-              mk1 uu____13644  in
-            let uu____13646 = desugar_term_aq env t1  in
-            (match uu____13646 with
+                FStar_Syntax_Syntax.Tm_fvar uu____13952  in
+              mk1 uu____13951  in
+            let uu____13953 = desugar_term_aq env t1  in
+            (match uu____13953 with
              | (t1',aq1) ->
-                 let uu____13657 = desugar_term_aq env t2  in
-                 (match uu____13657 with
+                 let uu____13964 = desugar_term_aq env t2  in
+                 (match uu____13964 with
                   | (t2',aq2) ->
-                      let uu____13668 = desugar_term_aq env t3  in
-                      (match uu____13668 with
+                      let uu____13975 = desugar_term_aq env t3  in
+                      (match uu____13975 with
                        | (t3',aq3) ->
-                           let uu____13679 =
-                             let uu____13680 =
-                               let uu____13681 =
-                                 let uu____13704 =
-                                   let uu____13721 =
-                                     let uu____13736 =
+                           let uu____13986 =
+                             let uu____13987 =
+                               let uu____13988 =
+                                 let uu____14011 =
+                                   let uu____14028 =
+                                     let uu____14043 =
                                        FStar_Syntax_Syntax.withinfo
                                          (FStar_Syntax_Syntax.Pat_constant
                                             (FStar_Const.Const_bool true))
                                          t1.FStar_Parser_AST.range
                                         in
-                                     (uu____13736,
+                                     (uu____14043,
                                        FStar_Pervasives_Native.None, t2')
                                       in
-                                   let uu____13750 =
-                                     let uu____13767 =
-                                       let uu____13782 =
+                                   let uu____14057 =
+                                     let uu____14074 =
+                                       let uu____14089 =
                                          FStar_Syntax_Syntax.withinfo
                                            (FStar_Syntax_Syntax.Pat_wild x)
                                            t1.FStar_Parser_AST.range
                                           in
-                                       (uu____13782,
+                                       (uu____14089,
                                          FStar_Pervasives_Native.None, t3')
                                         in
-                                     [uu____13767]  in
-                                   uu____13721 :: uu____13750  in
-                                 (t1', uu____13704)  in
-                               FStar_Syntax_Syntax.Tm_match uu____13681  in
-                             mk1 uu____13680  in
-                           (uu____13679, (join_aqs [aq1; aq2; aq3])))))
+                                     [uu____14074]  in
+                                   uu____14028 :: uu____14057  in
+                                 (t1', uu____14011)  in
+                               FStar_Syntax_Syntax.Tm_match uu____13988  in
+                             mk1 uu____13987  in
+                           (uu____13986, (join_aqs [aq1; aq2; aq3])))))
         | FStar_Parser_AST.TryWith (e,branches) ->
             let r = top.FStar_Parser_AST.range  in
             let handler = FStar_Parser_AST.mk_function branches r r  in
@@ -3743,75 +3765,75 @@ and (desugar_term_maybe_top :
                in
             desugar_term_aq env a2
         | FStar_Parser_AST.Match (e,branches) ->
-            let desugar_branch uu____13978 =
-              match uu____13978 with
+            let desugar_branch uu____14285 =
+              match uu____14285 with
               | (pat,wopt,b) ->
-                  let uu____14000 = desugar_match_pat env pat  in
-                  (match uu____14000 with
+                  let uu____14307 = desugar_match_pat env pat  in
+                  (match uu____14307 with
                    | (env1,pat1) ->
                        let wopt1 =
                          match wopt with
                          | FStar_Pervasives_Native.None  ->
                              FStar_Pervasives_Native.None
                          | FStar_Pervasives_Native.Some e1 ->
-                             let uu____14031 = desugar_term env1 e1  in
-                             FStar_Pervasives_Native.Some uu____14031
+                             let uu____14338 = desugar_term env1 e1  in
+                             FStar_Pervasives_Native.Some uu____14338
                           in
-                       let uu____14036 = desugar_term_aq env1 b  in
-                       (match uu____14036 with
+                       let uu____14343 = desugar_term_aq env1 b  in
+                       (match uu____14343 with
                         | (b1,aq) ->
-                            let uu____14049 =
+                            let uu____14356 =
                               desugar_disjunctive_pattern pat1 wopt1 b1  in
-                            (uu____14049, aq)))
+                            (uu____14356, aq)))
                in
-            let uu____14054 = desugar_term_aq env e  in
-            (match uu____14054 with
+            let uu____14361 = desugar_term_aq env e  in
+            (match uu____14361 with
              | (e1,aq) ->
-                 let uu____14065 =
-                   let uu____14096 =
-                     let uu____14129 = FStar_List.map desugar_branch branches
+                 let uu____14372 =
+                   let uu____14403 =
+                     let uu____14436 = FStar_List.map desugar_branch branches
                         in
-                     FStar_All.pipe_right uu____14129 FStar_List.unzip  in
-                   FStar_All.pipe_right uu____14096
-                     (fun uu____14347  ->
-                        match uu____14347 with
+                     FStar_All.pipe_right uu____14436 FStar_List.unzip  in
+                   FStar_All.pipe_right uu____14403
+                     (fun uu____14654  ->
+                        match uu____14654 with
                         | (x,y) -> ((FStar_List.flatten x), y))
                     in
-                 (match uu____14065 with
+                 (match uu____14372 with
                   | (brs,aqs) ->
-                      let uu____14566 =
+                      let uu____14873 =
                         FStar_All.pipe_left mk1
                           (FStar_Syntax_Syntax.Tm_match (e1, brs))
                          in
-                      (uu____14566, (join_aqs (aq :: aqs)))))
+                      (uu____14873, (join_aqs (aq :: aqs)))))
         | FStar_Parser_AST.Ascribed (e,t,tac_opt) ->
-            let uu____14600 =
-              let uu____14621 = is_comp_type env t  in
-              if uu____14621
+            let uu____14907 =
+              let uu____14928 = is_comp_type env t  in
+              if uu____14928
               then
                 let comp = desugar_comp t.FStar_Parser_AST.range true env t
                    in
                 ((FStar_Util.Inr comp), [])
               else
-                (let uu____14676 = desugar_term_aq env t  in
-                 match uu____14676 with
+                (let uu____14983 = desugar_term_aq env t  in
+                 match uu____14983 with
                  | (tm,aq) -> ((FStar_Util.Inl tm), aq))
                in
-            (match uu____14600 with
+            (match uu____14907 with
              | (annot,aq0) ->
                  let tac_opt1 = FStar_Util.map_opt tac_opt (desugar_term env)
                     in
-                 let uu____14768 = desugar_term_aq env e  in
-                 (match uu____14768 with
+                 let uu____15075 = desugar_term_aq env e  in
+                 (match uu____15075 with
                   | (e1,aq) ->
-                      let uu____14779 =
+                      let uu____15086 =
                         FStar_All.pipe_left mk1
                           (FStar_Syntax_Syntax.Tm_ascribed
                              (e1, (annot, tac_opt1),
                                FStar_Pervasives_Native.None))
                          in
-                      (uu____14779, (FStar_List.append aq0 aq))))
-        | FStar_Parser_AST.Record (uu____14818,[]) ->
+                      (uu____15086, (FStar_List.append aq0 aq))))
+        | FStar_Parser_AST.Record (uu____15125,[]) ->
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_UnexpectedEmptyRecord,
                 "Unexpected empty record") top.FStar_Parser_AST.range
@@ -3819,37 +3841,37 @@ and (desugar_term_maybe_top :
             let record = check_fields env fields top.FStar_Parser_AST.range
                in
             let user_ns =
-              let uu____14861 = FStar_List.hd fields  in
-              match uu____14861 with | (f,uu____14873) -> f.FStar_Ident.ns
+              let uu____15168 = FStar_List.hd fields  in
+              match uu____15168 with | (f,uu____15180) -> f.FStar_Ident.ns
                in
             let get_field xopt f =
               let found =
                 FStar_All.pipe_right fields
                   (FStar_Util.find_opt
-                     (fun uu____14919  ->
-                        match uu____14919 with
-                        | (g,uu____14926) ->
+                     (fun uu____15226  ->
+                        match uu____15226 with
+                        | (g,uu____15233) ->
                             f.FStar_Ident.idText =
                               (g.FStar_Ident.ident).FStar_Ident.idText))
                  in
               let fn = FStar_Ident.lid_of_ids (FStar_List.append user_ns [f])
                  in
               match found with
-              | FStar_Pervasives_Native.Some (uu____14933,e) -> (fn, e)
+              | FStar_Pervasives_Native.Some (uu____15240,e) -> (fn, e)
               | FStar_Pervasives_Native.None  ->
                   (match xopt with
                    | FStar_Pervasives_Native.None  ->
-                       let uu____14947 =
-                         let uu____14953 =
+                       let uu____15254 =
+                         let uu____15260 =
                            FStar_Util.format2
                              "Field %s of record type %s is missing"
                              f.FStar_Ident.idText
                              (record.FStar_Syntax_DsEnv.typename).FStar_Ident.str
                             in
                          (FStar_Errors.Fatal_MissingFieldInRecord,
-                           uu____14953)
+                           uu____15260)
                           in
-                       FStar_Errors.raise_error uu____14947
+                       FStar_Errors.raise_error uu____15254
                          top.FStar_Parser_AST.range
                    | FStar_Pervasives_Native.Some x ->
                        (fn,
@@ -3865,47 +3887,47 @@ and (desugar_term_maybe_top :
             let recterm =
               match eopt with
               | FStar_Pervasives_Native.None  ->
-                  let uu____14964 =
-                    let uu____14975 =
+                  let uu____15271 =
+                    let uu____15282 =
                       FStar_All.pipe_right record.FStar_Syntax_DsEnv.fields
                         (FStar_List.map
-                           (fun uu____15006  ->
-                              match uu____15006 with
-                              | (f,uu____15016) ->
-                                  let uu____15017 =
-                                    let uu____15018 =
+                           (fun uu____15313  ->
+                              match uu____15313 with
+                              | (f,uu____15323) ->
+                                  let uu____15324 =
+                                    let uu____15325 =
                                       get_field FStar_Pervasives_Native.None
                                         f
                                        in
                                     FStar_All.pipe_left
-                                      FStar_Pervasives_Native.snd uu____15018
+                                      FStar_Pervasives_Native.snd uu____15325
                                      in
-                                  (uu____15017, FStar_Parser_AST.Nothing)))
+                                  (uu____15324, FStar_Parser_AST.Nothing)))
                        in
-                    (user_constrname, uu____14975)  in
-                  FStar_Parser_AST.Construct uu____14964
+                    (user_constrname, uu____15282)  in
+                  FStar_Parser_AST.Construct uu____15271
               | FStar_Pervasives_Native.Some e ->
                   let x = FStar_Ident.gen e.FStar_Parser_AST.range  in
                   let xterm =
-                    let uu____15036 =
-                      let uu____15037 = FStar_Ident.lid_of_ids [x]  in
-                      FStar_Parser_AST.Var uu____15037  in
-                    FStar_Parser_AST.mk_term uu____15036
+                    let uu____15343 =
+                      let uu____15344 = FStar_Ident.lid_of_ids [x]  in
+                      FStar_Parser_AST.Var uu____15344  in
+                    FStar_Parser_AST.mk_term uu____15343
                       x.FStar_Ident.idRange FStar_Parser_AST.Expr
                      in
                   let record1 =
-                    let uu____15039 =
-                      let uu____15052 =
+                    let uu____15346 =
+                      let uu____15359 =
                         FStar_All.pipe_right record.FStar_Syntax_DsEnv.fields
                           (FStar_List.map
-                             (fun uu____15082  ->
-                                match uu____15082 with
-                                | (f,uu____15092) ->
+                             (fun uu____15389  ->
+                                match uu____15389 with
+                                | (f,uu____15399) ->
                                     get_field
                                       (FStar_Pervasives_Native.Some xterm) f))
                          in
-                      (FStar_Pervasives_Native.None, uu____15052)  in
-                    FStar_Parser_AST.Record uu____15039  in
+                      (FStar_Pervasives_Native.None, uu____15359)  in
+                    FStar_Parser_AST.Record uu____15346  in
                   FStar_Parser_AST.Let
                     (FStar_Parser_AST.NoLetQualifier,
                       [(FStar_Pervasives_Native.None,
@@ -3921,60 +3943,60 @@ and (desugar_term_maybe_top :
               FStar_Parser_AST.mk_term recterm top.FStar_Parser_AST.range
                 top.FStar_Parser_AST.level
                in
-            let uu____15152 = desugar_term_aq env recterm1  in
-            (match uu____15152 with
+            let uu____15459 = desugar_term_aq env recterm1  in
+            (match uu____15459 with
              | (e,s) ->
                  (match e.FStar_Syntax_Syntax.n with
                   | FStar_Syntax_Syntax.Tm_app
                       ({
                          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
                            fv;
-                         FStar_Syntax_Syntax.pos = uu____15168;
-                         FStar_Syntax_Syntax.vars = uu____15169;_},args)
+                         FStar_Syntax_Syntax.pos = uu____15475;
+                         FStar_Syntax_Syntax.vars = uu____15476;_},args)
                       ->
-                      let uu____15195 =
-                        let uu____15196 =
-                          let uu____15197 =
-                            let uu____15214 =
-                              let uu____15217 =
+                      let uu____15502 =
+                        let uu____15503 =
+                          let uu____15504 =
+                            let uu____15521 =
+                              let uu____15524 =
                                 FStar_Ident.set_lid_range
                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                   e.FStar_Syntax_Syntax.pos
                                  in
-                              let uu____15218 =
-                                let uu____15221 =
-                                  let uu____15222 =
-                                    let uu____15229 =
+                              let uu____15525 =
+                                let uu____15528 =
+                                  let uu____15529 =
+                                    let uu____15536 =
                                       FStar_All.pipe_right
                                         record.FStar_Syntax_DsEnv.fields
                                         (FStar_List.map
                                            FStar_Pervasives_Native.fst)
                                        in
                                     ((record.FStar_Syntax_DsEnv.typename),
-                                      uu____15229)
+                                      uu____15536)
                                      in
-                                  FStar_Syntax_Syntax.Record_ctor uu____15222
+                                  FStar_Syntax_Syntax.Record_ctor uu____15529
                                    in
-                                FStar_Pervasives_Native.Some uu____15221  in
-                              FStar_Syntax_Syntax.fvar uu____15217
+                                FStar_Pervasives_Native.Some uu____15528  in
+                              FStar_Syntax_Syntax.fvar uu____15524
                                 FStar_Syntax_Syntax.delta_constant
-                                uu____15218
+                                uu____15525
                                in
-                            (uu____15214, args)  in
-                          FStar_Syntax_Syntax.Tm_app uu____15197  in
-                        FStar_All.pipe_left mk1 uu____15196  in
-                      (uu____15195, s)
-                  | uu____15258 -> (e, s)))
+                            (uu____15521, args)  in
+                          FStar_Syntax_Syntax.Tm_app uu____15504  in
+                        FStar_All.pipe_left mk1 uu____15503  in
+                      (uu____15502, s)
+                  | uu____15565 -> (e, s)))
         | FStar_Parser_AST.Project (e,f) ->
             (FStar_Syntax_DsEnv.fail_if_qualified_by_curmodule env f;
-             (let uu____15262 =
+             (let uu____15569 =
                 FStar_Syntax_DsEnv.fail_or env
                   (FStar_Syntax_DsEnv.try_lookup_dc_by_field_name env) f
                  in
-              match uu____15262 with
+              match uu____15569 with
               | (constrname,is_rec) ->
-                  let uu____15281 = desugar_term_aq env e  in
-                  (match uu____15281 with
+                  let uu____15588 = desugar_term_aq env e  in
+                  (match uu____15588 with
                    | (e1,s) ->
                        let projname =
                          FStar_Syntax_Util.mk_field_projector_name_from_ident
@@ -3987,65 +4009,65 @@ and (desugar_term_maybe_top :
                              (FStar_Syntax_Syntax.Record_projector
                                 (constrname, (f.FStar_Ident.ident)))
                          else FStar_Pervasives_Native.None  in
-                       let uu____15301 =
-                         let uu____15302 =
-                           let uu____15303 =
-                             let uu____15320 =
-                               let uu____15323 =
-                                 let uu____15324 = FStar_Ident.range_of_lid f
+                       let uu____15608 =
+                         let uu____15609 =
+                           let uu____15610 =
+                             let uu____15627 =
+                               let uu____15630 =
+                                 let uu____15631 = FStar_Ident.range_of_lid f
                                     in
                                  FStar_Ident.set_lid_range projname
-                                   uu____15324
+                                   uu____15631
                                   in
-                               FStar_Syntax_Syntax.fvar uu____15323
+                               FStar_Syntax_Syntax.fvar uu____15630
                                  (FStar_Syntax_Syntax.Delta_equational_at_level
                                     Prims.int_one) qual
                                 in
-                             let uu____15326 =
-                               let uu____15337 =
+                             let uu____15633 =
+                               let uu____15644 =
                                  FStar_Syntax_Syntax.as_arg e1  in
-                               [uu____15337]  in
-                             (uu____15320, uu____15326)  in
-                           FStar_Syntax_Syntax.Tm_app uu____15303  in
-                         FStar_All.pipe_left mk1 uu____15302  in
-                       (uu____15301, s))))
-        | FStar_Parser_AST.NamedTyp (uu____15374,e) -> desugar_term_aq env e
+                               [uu____15644]  in
+                             (uu____15627, uu____15633)  in
+                           FStar_Syntax_Syntax.Tm_app uu____15610  in
+                         FStar_All.pipe_left mk1 uu____15609  in
+                       (uu____15608, s))))
+        | FStar_Parser_AST.NamedTyp (uu____15681,e) -> desugar_term_aq env e
         | FStar_Parser_AST.Paren e -> failwith "impossible"
         | FStar_Parser_AST.VQuote e ->
             let tm = desugar_term env e  in
-            let uu____15384 =
-              let uu____15385 = FStar_Syntax_Subst.compress tm  in
-              uu____15385.FStar_Syntax_Syntax.n  in
-            (match uu____15384 with
+            let uu____15691 =
+              let uu____15692 = FStar_Syntax_Subst.compress tm  in
+              uu____15692.FStar_Syntax_Syntax.n  in
+            (match uu____15691 with
              | FStar_Syntax_Syntax.Tm_fvar fv ->
-                 let uu____15393 =
-                   let uu___2088_15394 =
-                     let uu____15395 =
-                       let uu____15397 = FStar_Syntax_Syntax.lid_of_fv fv  in
-                       FStar_Ident.string_of_lid uu____15397  in
-                     FStar_Syntax_Util.exp_string uu____15395  in
+                 let uu____15700 =
+                   let uu___2094_15701 =
+                     let uu____15702 =
+                       let uu____15704 = FStar_Syntax_Syntax.lid_of_fv fv  in
+                       FStar_Ident.string_of_lid uu____15704  in
+                     FStar_Syntax_Util.exp_string uu____15702  in
                    {
                      FStar_Syntax_Syntax.n =
-                       (uu___2088_15394.FStar_Syntax_Syntax.n);
+                       (uu___2094_15701.FStar_Syntax_Syntax.n);
                      FStar_Syntax_Syntax.pos = (e.FStar_Parser_AST.range);
                      FStar_Syntax_Syntax.vars =
-                       (uu___2088_15394.FStar_Syntax_Syntax.vars)
+                       (uu___2094_15701.FStar_Syntax_Syntax.vars)
                    }  in
-                 (uu____15393, noaqs)
-             | uu____15398 ->
-                 let uu____15399 =
-                   let uu____15405 =
-                     let uu____15407 = FStar_Syntax_Print.term_to_string tm
+                 (uu____15700, noaqs)
+             | uu____15705 ->
+                 let uu____15706 =
+                   let uu____15712 =
+                     let uu____15714 = FStar_Syntax_Print.term_to_string tm
                         in
                      Prims.op_Hat "VQuote, expected an fvar, got: "
-                       uu____15407
+                       uu____15714
                       in
-                   (FStar_Errors.Fatal_UnexpectedTermVQuote, uu____15405)  in
-                 FStar_Errors.raise_error uu____15399
+                   (FStar_Errors.Fatal_UnexpectedTermVQuote, uu____15712)  in
+                 FStar_Errors.raise_error uu____15706
                    top.FStar_Parser_AST.range)
         | FStar_Parser_AST.Quote (e,FStar_Parser_AST.Static ) ->
-            let uu____15416 = desugar_term_aq env e  in
-            (match uu____15416 with
+            let uu____15723 = desugar_term_aq env e  in
+            (match uu____15723 with
              | (tm,vts) ->
                  let qi =
                    {
@@ -4053,38 +4075,38 @@ and (desugar_term_maybe_top :
                        FStar_Syntax_Syntax.Quote_static;
                      FStar_Syntax_Syntax.antiquotes = vts
                    }  in
-                 let uu____15428 =
+                 let uu____15735 =
                    FStar_All.pipe_left mk1
                      (FStar_Syntax_Syntax.Tm_quoted (tm, qi))
                     in
-                 (uu____15428, noaqs))
+                 (uu____15735, noaqs))
         | FStar_Parser_AST.Antiquote e ->
             let bv =
               FStar_Syntax_Syntax.new_bv
                 (FStar_Pervasives_Native.Some (e.FStar_Parser_AST.range))
                 FStar_Syntax_Syntax.tun
                in
-            let uu____15433 = FStar_Syntax_Syntax.bv_to_name bv  in
-            let uu____15434 =
-              let uu____15435 =
-                let uu____15442 = desugar_term env e  in (bv, uu____15442)
+            let uu____15740 = FStar_Syntax_Syntax.bv_to_name bv  in
+            let uu____15741 =
+              let uu____15742 =
+                let uu____15749 = desugar_term env e  in (bv, uu____15749)
                  in
-              [uu____15435]  in
-            (uu____15433, uu____15434)
+              [uu____15742]  in
+            (uu____15740, uu____15741)
         | FStar_Parser_AST.Quote (e,FStar_Parser_AST.Dynamic ) ->
             let qi =
               {
                 FStar_Syntax_Syntax.qkind = FStar_Syntax_Syntax.Quote_dynamic;
                 FStar_Syntax_Syntax.antiquotes = []
               }  in
-            let uu____15467 =
-              let uu____15468 =
-                let uu____15469 =
-                  let uu____15476 = desugar_term env e  in (uu____15476, qi)
+            let uu____15774 =
+              let uu____15775 =
+                let uu____15776 =
+                  let uu____15783 = desugar_term env e  in (uu____15783, qi)
                    in
-                FStar_Syntax_Syntax.Tm_quoted uu____15469  in
-              FStar_All.pipe_left mk1 uu____15468  in
-            (uu____15467, noaqs)
+                FStar_Syntax_Syntax.Tm_quoted uu____15776  in
+              FStar_All.pipe_left mk1 uu____15775  in
+            (uu____15774, noaqs)
         | FStar_Parser_AST.CalcProof (rel,init_expr,steps) ->
             let eta_and_annot rel1 =
               let x = FStar_Ident.gen rel1.FStar_Parser_AST.range  in
@@ -4105,35 +4127,35 @@ and (desugar_term_maybe_top :
                   (FStar_Parser_AST.PatVar (y, FStar_Pervasives_Native.None))
                   rel1.FStar_Parser_AST.range]
                  in
-              let uu____15505 =
-                let uu____15506 =
-                  let uu____15513 =
-                    let uu____15514 =
-                      let uu____15515 =
-                        let uu____15524 =
+              let uu____15812 =
+                let uu____15813 =
+                  let uu____15820 =
+                    let uu____15821 =
+                      let uu____15822 =
+                        let uu____15831 =
                           FStar_Parser_AST.mkApp rel1
                             [(xt, FStar_Parser_AST.Nothing);
                             (yt, FStar_Parser_AST.Nothing)]
                             rel1.FStar_Parser_AST.range
                            in
-                        let uu____15537 =
-                          let uu____15538 =
-                            let uu____15539 = FStar_Ident.lid_of_str "Type0"
+                        let uu____15844 =
+                          let uu____15845 =
+                            let uu____15846 = FStar_Ident.lid_of_str "Type0"
                                in
-                            FStar_Parser_AST.Name uu____15539  in
-                          FStar_Parser_AST.mk_term uu____15538
+                            FStar_Parser_AST.Name uu____15846  in
+                          FStar_Parser_AST.mk_term uu____15845
                             rel1.FStar_Parser_AST.range FStar_Parser_AST.Expr
                            in
-                        (uu____15524, uu____15537,
+                        (uu____15831, uu____15844,
                           FStar_Pervasives_Native.None)
                          in
-                      FStar_Parser_AST.Ascribed uu____15515  in
-                    FStar_Parser_AST.mk_term uu____15514
+                      FStar_Parser_AST.Ascribed uu____15822  in
+                    FStar_Parser_AST.mk_term uu____15821
                       rel1.FStar_Parser_AST.range FStar_Parser_AST.Expr
                      in
-                  (pats, uu____15513)  in
-                FStar_Parser_AST.Abs uu____15506  in
-              FStar_Parser_AST.mk_term uu____15505
+                  (pats, uu____15820)  in
+                FStar_Parser_AST.Abs uu____15813  in
+              FStar_Parser_AST.mk_term uu____15812
                 rel1.FStar_Parser_AST.range FStar_Parser_AST.Expr
                in
             let rel1 = eta_and_annot rel  in
@@ -4147,11 +4169,11 @@ and (desugar_term_maybe_top :
                 FStar_Range.dummyRange FStar_Parser_AST.Expr
                in
             let last_expr =
-              let uu____15554 = FStar_List.last steps  in
-              match uu____15554 with
+              let uu____15861 = FStar_List.last steps  in
+              match uu____15861 with
               | FStar_Pervasives_Native.Some (FStar_Parser_AST.CalcStep
-                  (uu____15557,uu____15558,last_expr)) -> last_expr
-              | uu____15560 -> failwith "impossible: no last_expr on calc"
+                  (uu____15864,uu____15865,last_expr)) -> last_expr
+              | uu____15867 -> failwith "impossible: no last_expr on calc"
                in
             let step r =
               FStar_Parser_AST.mk_term
@@ -4170,90 +4192,90 @@ and (desugar_term_maybe_top :
                 [(init_expr, FStar_Parser_AST.Nothing)]
                 FStar_Range.dummyRange
                in
-            let uu____15588 =
+            let uu____15895 =
               FStar_List.fold_left
-                (fun uu____15605  ->
-                   fun uu____15606  ->
-                     match (uu____15605, uu____15606) with
+                (fun uu____15912  ->
+                   fun uu____15913  ->
+                     match (uu____15912, uu____15913) with
                      | ((e1,prev),FStar_Parser_AST.CalcStep
                         (rel2,just,next_expr)) ->
                          let pf =
-                           let uu____15629 =
-                             let uu____15636 =
-                               let uu____15643 =
-                                 let uu____15650 =
-                                   let uu____15657 =
-                                     let uu____15662 = eta_and_annot rel2  in
-                                     (uu____15662, FStar_Parser_AST.Nothing)
+                           let uu____15936 =
+                             let uu____15943 =
+                               let uu____15950 =
+                                 let uu____15957 =
+                                   let uu____15964 =
+                                     let uu____15969 = eta_and_annot rel2  in
+                                     (uu____15969, FStar_Parser_AST.Nothing)
                                       in
-                                   let uu____15663 =
-                                     let uu____15670 =
-                                       let uu____15677 =
-                                         let uu____15682 =
+                                   let uu____15970 =
+                                     let uu____15977 =
+                                       let uu____15984 =
+                                         let uu____15989 =
                                            FStar_Parser_AST.thunk e1  in
-                                         (uu____15682,
+                                         (uu____15989,
                                            FStar_Parser_AST.Nothing)
                                           in
-                                       let uu____15683 =
-                                         let uu____15690 =
-                                           let uu____15695 =
+                                       let uu____15990 =
+                                         let uu____15997 =
+                                           let uu____16002 =
                                              FStar_Parser_AST.thunk just  in
-                                           (uu____15695,
+                                           (uu____16002,
                                              FStar_Parser_AST.Nothing)
                                             in
-                                         [uu____15690]  in
-                                       uu____15677 :: uu____15683  in
+                                         [uu____15997]  in
+                                       uu____15984 :: uu____15990  in
                                      (next_expr, FStar_Parser_AST.Nothing) ::
-                                       uu____15670
+                                       uu____15977
                                       in
-                                   uu____15657 :: uu____15663  in
-                                 (prev, FStar_Parser_AST.Hash) :: uu____15650
+                                   uu____15964 :: uu____15970  in
+                                 (prev, FStar_Parser_AST.Hash) :: uu____15957
                                   in
                                (init_expr, FStar_Parser_AST.Hash) ::
-                                 uu____15643
+                                 uu____15950
                                 in
                              ((wild rel2.FStar_Parser_AST.range),
-                               FStar_Parser_AST.Hash) :: uu____15636
+                               FStar_Parser_AST.Hash) :: uu____15943
                               in
                            FStar_Parser_AST.mkApp
-                             (step rel2.FStar_Parser_AST.range) uu____15629
+                             (step rel2.FStar_Parser_AST.range) uu____15936
                              FStar_Range.dummyRange
                             in
                          (pf, next_expr)) (e, init_expr) steps
                in
-            (match uu____15588 with
-             | (e1,uu____15733) ->
+            (match uu____15895 with
+             | (e1,uu____16040) ->
                  let e2 =
-                   let uu____15735 =
-                     let uu____15742 =
-                       let uu____15749 =
-                         let uu____15756 =
-                           let uu____15761 = FStar_Parser_AST.thunk e1  in
-                           (uu____15761, FStar_Parser_AST.Nothing)  in
-                         [uu____15756]  in
-                       (last_expr, FStar_Parser_AST.Hash) :: uu____15749  in
-                     (init_expr, FStar_Parser_AST.Hash) :: uu____15742  in
-                   FStar_Parser_AST.mkApp finish1 uu____15735
+                   let uu____16042 =
+                     let uu____16049 =
+                       let uu____16056 =
+                         let uu____16063 =
+                           let uu____16068 = FStar_Parser_AST.thunk e1  in
+                           (uu____16068, FStar_Parser_AST.Nothing)  in
+                         [uu____16063]  in
+                       (last_expr, FStar_Parser_AST.Hash) :: uu____16056  in
+                     (init_expr, FStar_Parser_AST.Hash) :: uu____16049  in
+                   FStar_Parser_AST.mkApp finish1 uu____16042
                      FStar_Range.dummyRange
                     in
                  desugar_term_maybe_top top_level env e2)
-        | uu____15778 when
+        | uu____16085 when
             top.FStar_Parser_AST.level = FStar_Parser_AST.Formula ->
-            let uu____15779 = desugar_formula env top  in
-            (uu____15779, noaqs)
-        | uu____15780 ->
-            let uu____15781 =
-              let uu____15787 =
-                let uu____15789 = FStar_Parser_AST.term_to_string top  in
-                Prims.op_Hat "Unexpected term: " uu____15789  in
-              (FStar_Errors.Fatal_UnexpectedTerm, uu____15787)  in
-            FStar_Errors.raise_error uu____15781 top.FStar_Parser_AST.range
+            let uu____16086 = desugar_formula env top  in
+            (uu____16086, noaqs)
+        | uu____16087 ->
+            let uu____16088 =
+              let uu____16094 =
+                let uu____16096 = FStar_Parser_AST.term_to_string top  in
+                Prims.op_Hat "Unexpected term: " uu____16096  in
+              (FStar_Errors.Fatal_UnexpectedTerm, uu____16094)  in
+            FStar_Errors.raise_error uu____16088 top.FStar_Parser_AST.range
 
 and (not_ascribed : FStar_Parser_AST.term -> Prims.bool) =
   fun t  ->
     match t.FStar_Parser_AST.tm with
-    | FStar_Parser_AST.Ascribed uu____15799 -> false
-    | uu____15809 -> true
+    | FStar_Parser_AST.Ascribed uu____16106 -> false
+    | uu____16116 -> true
 
 and (desugar_args :
   FStar_Syntax_DsEnv.env ->
@@ -4265,11 +4287,11 @@ and (desugar_args :
     fun args  ->
       FStar_All.pipe_right args
         (FStar_List.map
-           (fun uu____15847  ->
-              match uu____15847 with
+           (fun uu____16154  ->
+              match uu____16154 with
               | (a,imp) ->
-                  let uu____15860 = desugar_term env a  in
-                  arg_withimp_e imp uu____15860))
+                  let uu____16167 = desugar_term env a  in
+                  arg_withimp_e imp uu____16167))
 
 and (desugar_comp :
   FStar_Range.range ->
@@ -4283,54 +4305,54 @@ and (desugar_comp :
       fun env  ->
         fun t  ->
           let fail1 err = FStar_Errors.raise_error err r  in
-          let is_requires uu____15897 =
-            match uu____15897 with
-            | (t1,uu____15904) ->
-                let uu____15905 =
-                  let uu____15906 = unparen t1  in
-                  uu____15906.FStar_Parser_AST.tm  in
-                (match uu____15905 with
-                 | FStar_Parser_AST.Requires uu____15908 -> true
-                 | uu____15917 -> false)
+          let is_requires uu____16204 =
+            match uu____16204 with
+            | (t1,uu____16211) ->
+                let uu____16212 =
+                  let uu____16213 = unparen t1  in
+                  uu____16213.FStar_Parser_AST.tm  in
+                (match uu____16212 with
+                 | FStar_Parser_AST.Requires uu____16215 -> true
+                 | uu____16224 -> false)
              in
-          let is_ensures uu____15929 =
-            match uu____15929 with
-            | (t1,uu____15936) ->
-                let uu____15937 =
-                  let uu____15938 = unparen t1  in
-                  uu____15938.FStar_Parser_AST.tm  in
-                (match uu____15937 with
-                 | FStar_Parser_AST.Ensures uu____15940 -> true
-                 | uu____15949 -> false)
+          let is_ensures uu____16236 =
+            match uu____16236 with
+            | (t1,uu____16243) ->
+                let uu____16244 =
+                  let uu____16245 = unparen t1  in
+                  uu____16245.FStar_Parser_AST.tm  in
+                (match uu____16244 with
+                 | FStar_Parser_AST.Ensures uu____16247 -> true
+                 | uu____16256 -> false)
              in
-          let is_app head1 uu____15967 =
-            match uu____15967 with
-            | (t1,uu____15975) ->
-                let uu____15976 =
-                  let uu____15977 = unparen t1  in
-                  uu____15977.FStar_Parser_AST.tm  in
-                (match uu____15976 with
+          let is_app head1 uu____16274 =
+            match uu____16274 with
+            | (t1,uu____16282) ->
+                let uu____16283 =
+                  let uu____16284 = unparen t1  in
+                  uu____16284.FStar_Parser_AST.tm  in
+                (match uu____16283 with
                  | FStar_Parser_AST.App
                      ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var d;
-                        FStar_Parser_AST.range = uu____15980;
-                        FStar_Parser_AST.level = uu____15981;_},uu____15982,uu____15983)
+                        FStar_Parser_AST.range = uu____16287;
+                        FStar_Parser_AST.level = uu____16288;_},uu____16289,uu____16290)
                      -> (d.FStar_Ident.ident).FStar_Ident.idText = head1
-                 | uu____15985 -> false)
+                 | uu____16292 -> false)
              in
-          let is_smt_pat uu____15997 =
-            match uu____15997 with
-            | (t1,uu____16004) ->
-                let uu____16005 =
-                  let uu____16006 = unparen t1  in
-                  uu____16006.FStar_Parser_AST.tm  in
-                (match uu____16005 with
+          let is_smt_pat uu____16304 =
+            match uu____16304 with
+            | (t1,uu____16311) ->
+                let uu____16312 =
+                  let uu____16313 = unparen t1  in
+                  uu____16313.FStar_Parser_AST.tm  in
+                (match uu____16312 with
                  | FStar_Parser_AST.Construct
                      (cons1,({
                                FStar_Parser_AST.tm =
                                  FStar_Parser_AST.Construct
-                                 (smtpat,uu____16010);
-                               FStar_Parser_AST.range = uu____16011;
-                               FStar_Parser_AST.level = uu____16012;_},uu____16013)::uu____16014::[])
+                                 (smtpat,uu____16317);
+                               FStar_Parser_AST.range = uu____16318;
+                               FStar_Parser_AST.level = uu____16319;_},uu____16320)::uu____16321::[])
                      ->
                      (FStar_Ident.lid_equals cons1
                         FStar_Parser_Const.cons_lid)
@@ -4342,8 +4364,8 @@ and (desugar_comp :
                      (cons1,({
                                FStar_Parser_AST.tm = FStar_Parser_AST.Var
                                  smtpat;
-                               FStar_Parser_AST.range = uu____16063;
-                               FStar_Parser_AST.level = uu____16064;_},uu____16065)::uu____16066::[])
+                               FStar_Parser_AST.range = uu____16370;
+                               FStar_Parser_AST.level = uu____16371;_},uu____16372)::uu____16373::[])
                      ->
                      (FStar_Ident.lid_equals cons1
                         FStar_Parser_Const.cons_lid)
@@ -4351,12 +4373,12 @@ and (desugar_comp :
                        (FStar_Util.for_some
                           (fun s  -> smtpat.FStar_Ident.str = s)
                           ["smt_pat"; "smt_pat_or"])
-                 | uu____16099 -> false)
+                 | uu____16406 -> false)
              in
           let is_decreases = is_app "decreases"  in
           let pre_process_comp_typ t1 =
-            let uu____16134 = head_and_args t1  in
-            match uu____16134 with
+            let uu____16441 = head_and_args t1  in
+            match uu____16441 with
             | (head1,args) ->
                 (match head1.FStar_Parser_AST.tm with
                  | FStar_Parser_AST.Name lemma when
@@ -4390,13 +4412,13 @@ and (desugar_comp :
                            FStar_Parser_AST.Type_level),
                          FStar_Parser_AST.Nothing)
                         in
-                     let thunk_ens uu____16227 =
-                       match uu____16227 with
+                     let thunk_ens uu____16534 =
+                       match uu____16534 with
                        | (e,i) ->
-                           let uu____16238 = FStar_Parser_AST.thunk e  in
-                           (uu____16238, i)
+                           let uu____16545 = FStar_Parser_AST.thunk e  in
+                           (uu____16545, i)
                         in
-                     let fail_lemma uu____16250 =
+                     let fail_lemma uu____16557 =
                        let expected_one_of =
                          ["Lemma post";
                          "Lemma (ensures post)";
@@ -4424,85 +4446,85 @@ and (desugar_comp :
                        | smtpat::[] when is_smt_pat smtpat -> fail_lemma ()
                        | dec::[] when is_decreases dec -> fail_lemma ()
                        | ens::[] ->
-                           let uu____16356 =
-                             let uu____16363 =
-                               let uu____16370 = thunk_ens ens  in
-                               [uu____16370; nil_pat]  in
-                             req_true :: uu____16363  in
-                           unit_tm :: uu____16356
+                           let uu____16663 =
+                             let uu____16670 =
+                               let uu____16677 = thunk_ens ens  in
+                               [uu____16677; nil_pat]  in
+                             req_true :: uu____16670  in
+                           unit_tm :: uu____16663
                        | req::ens::[] when
                            (is_requires req) && (is_ensures ens) ->
-                           let uu____16417 =
-                             let uu____16424 =
-                               let uu____16431 = thunk_ens ens  in
-                               [uu____16431; nil_pat]  in
-                             req :: uu____16424  in
-                           unit_tm :: uu____16417
+                           let uu____16724 =
+                             let uu____16731 =
+                               let uu____16738 = thunk_ens ens  in
+                               [uu____16738; nil_pat]  in
+                             req :: uu____16731  in
+                           unit_tm :: uu____16724
                        | ens::smtpat::[] when
-                           (((let uu____16480 = is_requires ens  in
-                              Prims.op_Negation uu____16480) &&
-                               (let uu____16483 = is_smt_pat ens  in
-                                Prims.op_Negation uu____16483))
+                           (((let uu____16787 = is_requires ens  in
+                              Prims.op_Negation uu____16787) &&
+                               (let uu____16790 = is_smt_pat ens  in
+                                Prims.op_Negation uu____16790))
                               &&
-                              (let uu____16486 = is_decreases ens  in
-                               Prims.op_Negation uu____16486))
+                              (let uu____16793 = is_decreases ens  in
+                               Prims.op_Negation uu____16793))
                              && (is_smt_pat smtpat)
                            ->
-                           let uu____16488 =
-                             let uu____16495 =
-                               let uu____16502 = thunk_ens ens  in
-                               [uu____16502; smtpat]  in
-                             req_true :: uu____16495  in
-                           unit_tm :: uu____16488
+                           let uu____16795 =
+                             let uu____16802 =
+                               let uu____16809 = thunk_ens ens  in
+                               [uu____16809; smtpat]  in
+                             req_true :: uu____16802  in
+                           unit_tm :: uu____16795
                        | ens::dec::[] when
                            (is_ensures ens) && (is_decreases dec) ->
-                           let uu____16549 =
-                             let uu____16556 =
-                               let uu____16563 = thunk_ens ens  in
-                               [uu____16563; nil_pat; dec]  in
-                             req_true :: uu____16556  in
-                           unit_tm :: uu____16549
+                           let uu____16856 =
+                             let uu____16863 =
+                               let uu____16870 = thunk_ens ens  in
+                               [uu____16870; nil_pat; dec]  in
+                             req_true :: uu____16863  in
+                           unit_tm :: uu____16856
                        | ens::dec::smtpat::[] when
                            ((is_ensures ens) && (is_decreases dec)) &&
                              (is_smt_pat smtpat)
                            ->
-                           let uu____16623 =
-                             let uu____16630 =
-                               let uu____16637 = thunk_ens ens  in
-                               [uu____16637; smtpat; dec]  in
-                             req_true :: uu____16630  in
-                           unit_tm :: uu____16623
+                           let uu____16930 =
+                             let uu____16937 =
+                               let uu____16944 = thunk_ens ens  in
+                               [uu____16944; smtpat; dec]  in
+                             req_true :: uu____16937  in
+                           unit_tm :: uu____16930
                        | req::ens::dec::[] when
                            ((is_requires req) && (is_ensures ens)) &&
                              (is_decreases dec)
                            ->
-                           let uu____16697 =
-                             let uu____16704 =
-                               let uu____16711 = thunk_ens ens  in
-                               [uu____16711; nil_pat; dec]  in
-                             req :: uu____16704  in
-                           unit_tm :: uu____16697
+                           let uu____17004 =
+                             let uu____17011 =
+                               let uu____17018 = thunk_ens ens  in
+                               [uu____17018; nil_pat; dec]  in
+                             req :: uu____17011  in
+                           unit_tm :: uu____17004
                        | req::ens::smtpat::[] when
                            ((is_requires req) && (is_ensures ens)) &&
                              (is_smt_pat smtpat)
                            ->
-                           let uu____16771 =
-                             let uu____16778 =
-                               let uu____16785 = thunk_ens ens  in
-                               [uu____16785; smtpat]  in
-                             req :: uu____16778  in
-                           unit_tm :: uu____16771
+                           let uu____17078 =
+                             let uu____17085 =
+                               let uu____17092 = thunk_ens ens  in
+                               [uu____17092; smtpat]  in
+                             req :: uu____17085  in
+                           unit_tm :: uu____17078
                        | req::ens::dec::smtpat::[] when
                            (((is_requires req) && (is_ensures ens)) &&
                               (is_smt_pat smtpat))
                              && (is_decreases dec)
                            ->
-                           let uu____16850 =
-                             let uu____16857 =
-                               let uu____16864 = thunk_ens ens  in
-                               [uu____16864; dec; smtpat]  in
-                             req :: uu____16857  in
-                           unit_tm :: uu____16850
+                           let uu____17157 =
+                             let uu____17164 =
+                               let uu____17171 = thunk_ens ens  in
+                               [uu____17171; dec; smtpat]  in
+                             req :: uu____17164  in
+                           unit_tm :: uu____17157
                        | _other -> fail_lemma ()  in
                      let head_and_attributes =
                        FStar_Syntax_DsEnv.fail_or env
@@ -4512,65 +4534,65 @@ and (desugar_comp :
                      (head_and_attributes, args1)
                  | FStar_Parser_AST.Name l when
                      FStar_Syntax_DsEnv.is_effect_name env l ->
-                     let uu____16926 =
+                     let uu____17233 =
                        FStar_Syntax_DsEnv.fail_or env
                          (FStar_Syntax_DsEnv.try_lookup_effect_name_and_attributes
                             env) l
                         in
-                     (uu____16926, args)
+                     (uu____17233, args)
                  | FStar_Parser_AST.Name l when
-                     (let uu____16954 = FStar_Syntax_DsEnv.current_module env
+                     (let uu____17261 = FStar_Syntax_DsEnv.current_module env
                          in
-                      FStar_Ident.lid_equals uu____16954
+                      FStar_Ident.lid_equals uu____17261
                         FStar_Parser_Const.prims_lid)
                        && ((l.FStar_Ident.ident).FStar_Ident.idText = "Tot")
                      ->
-                     let uu____16957 =
-                       let uu____16964 =
+                     let uu____17264 =
+                       let uu____17271 =
                          FStar_Ident.set_lid_range
                            FStar_Parser_Const.effect_Tot_lid
                            head1.FStar_Parser_AST.range
                           in
-                       (uu____16964, [])  in
-                     (uu____16957, args)
+                       (uu____17271, [])  in
+                     (uu____17264, args)
                  | FStar_Parser_AST.Name l when
-                     (let uu____16982 = FStar_Syntax_DsEnv.current_module env
+                     (let uu____17289 = FStar_Syntax_DsEnv.current_module env
                          in
-                      FStar_Ident.lid_equals uu____16982
+                      FStar_Ident.lid_equals uu____17289
                         FStar_Parser_Const.prims_lid)
                        && ((l.FStar_Ident.ident).FStar_Ident.idText = "GTot")
                      ->
-                     let uu____16985 =
-                       let uu____16992 =
+                     let uu____17292 =
+                       let uu____17299 =
                          FStar_Ident.set_lid_range
                            FStar_Parser_Const.effect_GTot_lid
                            head1.FStar_Parser_AST.range
                           in
-                       (uu____16992, [])  in
-                     (uu____16985, args)
+                       (uu____17299, [])  in
+                     (uu____17292, args)
                  | FStar_Parser_AST.Name l when
                      (((l.FStar_Ident.ident).FStar_Ident.idText = "Type") ||
                         ((l.FStar_Ident.ident).FStar_Ident.idText = "Type0"))
                        ||
                        ((l.FStar_Ident.ident).FStar_Ident.idText = "Effect")
                      ->
-                     let uu____17014 =
-                       let uu____17021 =
+                     let uu____17321 =
+                       let uu____17328 =
                          FStar_Ident.set_lid_range
                            FStar_Parser_Const.effect_Tot_lid
                            head1.FStar_Parser_AST.range
                           in
-                       (uu____17021, [])  in
-                     (uu____17014, [(t1, FStar_Parser_AST.Nothing)])
-                 | uu____17044 when allow_type_promotion ->
+                       (uu____17328, [])  in
+                     (uu____17321, [(t1, FStar_Parser_AST.Nothing)])
+                 | uu____17351 when allow_type_promotion ->
                      let default_effect =
-                       let uu____17046 = FStar_Options.ml_ish ()  in
-                       if uu____17046
+                       let uu____17353 = FStar_Options.ml_ish ()  in
+                       if uu____17353
                        then FStar_Parser_Const.effect_ML_lid
                        else
-                         ((let uu____17052 =
+                         ((let uu____17359 =
                              FStar_Options.warn_default_effects ()  in
-                           if uu____17052
+                           if uu____17359
                            then
                              FStar_Errors.log_issue
                                head1.FStar_Parser_AST.range
@@ -4579,152 +4601,152 @@ and (desugar_comp :
                            else ());
                           FStar_Parser_Const.effect_Tot_lid)
                         in
-                     let uu____17059 =
-                       let uu____17066 =
+                     let uu____17366 =
+                       let uu____17373 =
                          FStar_Ident.set_lid_range default_effect
                            head1.FStar_Parser_AST.range
                           in
-                       (uu____17066, [])  in
-                     (uu____17059, [(t1, FStar_Parser_AST.Nothing)])
-                 | uu____17089 ->
+                       (uu____17373, [])  in
+                     (uu____17366, [(t1, FStar_Parser_AST.Nothing)])
+                 | uu____17396 ->
                      FStar_Errors.raise_error
                        (FStar_Errors.Fatal_EffectNotFound,
                          "Expected an effect constructor")
                        t1.FStar_Parser_AST.range)
              in
-          let uu____17108 = pre_process_comp_typ t  in
-          match uu____17108 with
+          let uu____17415 = pre_process_comp_typ t  in
+          match uu____17415 with
           | ((eff,cattributes),args) ->
               (if (FStar_List.length args) = Prims.int_zero
                then
-                 (let uu____17160 =
-                    let uu____17166 =
-                      let uu____17168 = FStar_Syntax_Print.lid_to_string eff
+                 (let uu____17467 =
+                    let uu____17473 =
+                      let uu____17475 = FStar_Syntax_Print.lid_to_string eff
                          in
                       FStar_Util.format1 "Not enough args to effect %s"
-                        uu____17168
+                        uu____17475
                        in
-                    (FStar_Errors.Fatal_NotEnoughArgsToEffect, uu____17166)
+                    (FStar_Errors.Fatal_NotEnoughArgsToEffect, uu____17473)
                      in
-                  fail1 uu____17160)
+                  fail1 uu____17467)
                else ();
-               (let is_universe uu____17184 =
-                  match uu____17184 with
-                  | (uu____17190,imp) -> imp = FStar_Parser_AST.UnivApp  in
-                let uu____17192 = FStar_Util.take is_universe args  in
-                match uu____17192 with
+               (let is_universe uu____17491 =
+                  match uu____17491 with
+                  | (uu____17497,imp) -> imp = FStar_Parser_AST.UnivApp  in
+                let uu____17499 = FStar_Util.take is_universe args  in
+                match uu____17499 with
                 | (universes,args1) ->
                     let universes1 =
                       FStar_List.map
-                        (fun uu____17251  ->
-                           match uu____17251 with
+                        (fun uu____17558  ->
+                           match uu____17558 with
                            | (u,imp) -> desugar_universe u) universes
                        in
-                    let uu____17258 =
-                      let uu____17273 = FStar_List.hd args1  in
-                      let uu____17282 = FStar_List.tl args1  in
-                      (uu____17273, uu____17282)  in
-                    (match uu____17258 with
+                    let uu____17565 =
+                      let uu____17580 = FStar_List.hd args1  in
+                      let uu____17589 = FStar_List.tl args1  in
+                      (uu____17580, uu____17589)  in
+                    (match uu____17565 with
                      | (result_arg,rest) ->
                          let result_typ =
                            desugar_typ env
                              (FStar_Pervasives_Native.fst result_arg)
                             in
                          let rest1 = desugar_args env rest  in
-                         let uu____17337 =
-                           let is_decrease uu____17376 =
-                             match uu____17376 with
-                             | (t1,uu____17387) ->
+                         let uu____17644 =
+                           let is_decrease uu____17683 =
+                             match uu____17683 with
+                             | (t1,uu____17694) ->
                                  (match t1.FStar_Syntax_Syntax.n with
                                   | FStar_Syntax_Syntax.Tm_app
                                       ({
                                          FStar_Syntax_Syntax.n =
                                            FStar_Syntax_Syntax.Tm_fvar fv;
                                          FStar_Syntax_Syntax.pos =
-                                           uu____17398;
+                                           uu____17705;
                                          FStar_Syntax_Syntax.vars =
-                                           uu____17399;_},uu____17400::[])
+                                           uu____17706;_},uu____17707::[])
                                       ->
                                       FStar_Syntax_Syntax.fv_eq_lid fv
                                         FStar_Parser_Const.decreases_lid
-                                  | uu____17439 -> false)
+                                  | uu____17746 -> false)
                               in
                            FStar_All.pipe_right rest1
                              (FStar_List.partition is_decrease)
                             in
-                         (match uu____17337 with
+                         (match uu____17644 with
                           | (dec,rest2) ->
                               let decreases_clause =
                                 FStar_All.pipe_right dec
                                   (FStar_List.map
-                                     (fun uu____17556  ->
-                                        match uu____17556 with
-                                        | (t1,uu____17566) ->
+                                     (fun uu____17863  ->
+                                        match uu____17863 with
+                                        | (t1,uu____17873) ->
                                             (match t1.FStar_Syntax_Syntax.n
                                              with
                                              | FStar_Syntax_Syntax.Tm_app
-                                                 (uu____17575,(arg,uu____17577)::[])
+                                                 (uu____17882,(arg,uu____17884)::[])
                                                  ->
                                                  FStar_Syntax_Syntax.DECREASES
                                                    arg
-                                             | uu____17616 ->
+                                             | uu____17923 ->
                                                  failwith "impos")))
                                  in
                               let no_additional_args =
                                 let is_empty l =
                                   match l with
                                   | [] -> true
-                                  | uu____17637 -> false  in
+                                  | uu____17944 -> false  in
                                 (((is_empty decreases_clause) &&
                                     (is_empty rest2))
                                    && (is_empty cattributes))
                                   && (is_empty universes1)
                                  in
-                              let uu____17649 =
+                              let uu____17956 =
                                 no_additional_args &&
                                   (FStar_Ident.lid_equals eff
                                      FStar_Parser_Const.effect_Tot_lid)
                                  in
-                              if uu____17649
+                              if uu____17956
                               then FStar_Syntax_Syntax.mk_Total result_typ
                               else
-                                (let uu____17656 =
+                                (let uu____17963 =
                                    no_additional_args &&
                                      (FStar_Ident.lid_equals eff
                                         FStar_Parser_Const.effect_GTot_lid)
                                     in
-                                 if uu____17656
+                                 if uu____17963
                                  then
                                    FStar_Syntax_Syntax.mk_GTotal result_typ
                                  else
                                    (let flags =
-                                      let uu____17666 =
+                                      let uu____17973 =
                                         FStar_Ident.lid_equals eff
                                           FStar_Parser_Const.effect_Lemma_lid
                                          in
-                                      if uu____17666
+                                      if uu____17973
                                       then [FStar_Syntax_Syntax.LEMMA]
                                       else
-                                        (let uu____17673 =
+                                        (let uu____17980 =
                                            FStar_Ident.lid_equals eff
                                              FStar_Parser_Const.effect_Tot_lid
                                             in
-                                         if uu____17673
+                                         if uu____17980
                                          then [FStar_Syntax_Syntax.TOTAL]
                                          else
-                                           (let uu____17680 =
+                                           (let uu____17987 =
                                               FStar_Ident.lid_equals eff
                                                 FStar_Parser_Const.effect_ML_lid
                                                in
-                                            if uu____17680
+                                            if uu____17987
                                             then
                                               [FStar_Syntax_Syntax.MLEFFECT]
                                             else
-                                              (let uu____17687 =
+                                              (let uu____17994 =
                                                  FStar_Ident.lid_equals eff
                                                    FStar_Parser_Const.effect_GTot_lid
                                                   in
-                                               if uu____17687
+                                               if uu____17994
                                                then
                                                  [FStar_Syntax_Syntax.SOMETRIVIAL]
                                                else [])))
@@ -4732,11 +4754,11 @@ and (desugar_comp :
                                     let flags1 =
                                       FStar_List.append flags cattributes  in
                                     let rest3 =
-                                      let uu____17708 =
+                                      let uu____18015 =
                                         FStar_Ident.lid_equals eff
                                           FStar_Parser_Const.effect_Lemma_lid
                                          in
-                                      if uu____17708
+                                      if uu____18015
                                       then
                                         match rest2 with
                                         | req::ens::(pat,aq)::[] ->
@@ -4755,13 +4777,13 @@ and (desugar_comp :
                                                       [FStar_Syntax_Syntax.U_zero]
                                                      in
                                                   let pattern =
-                                                    let uu____17799 =
+                                                    let uu____18106 =
                                                       FStar_Ident.set_lid_range
                                                         FStar_Parser_Const.pattern_lid
                                                         pat.FStar_Syntax_Syntax.pos
                                                        in
                                                     FStar_Syntax_Syntax.fvar
-                                                      uu____17799
+                                                      uu____18106
                                                       FStar_Syntax_Syntax.delta_constant
                                                       FStar_Pervasives_Native.None
                                                      in
@@ -4772,11 +4794,11 @@ and (desugar_comp :
                                                           FStar_Syntax_Syntax.imp_tag))]
                                                     FStar_Pervasives_Native.None
                                                     pat.FStar_Syntax_Syntax.pos
-                                              | uu____17820 -> pat  in
-                                            let uu____17821 =
-                                              let uu____17832 =
-                                                let uu____17843 =
-                                                  let uu____17852 =
+                                              | uu____18127 -> pat  in
+                                            let uu____18128 =
+                                              let uu____18139 =
+                                                let uu____18150 =
+                                                  let uu____18159 =
                                                     FStar_Syntax_Syntax.mk
                                                       (FStar_Syntax_Syntax.Tm_meta
                                                          (pat1,
@@ -4785,11 +4807,11 @@ and (desugar_comp :
                                                       FStar_Pervasives_Native.None
                                                       pat1.FStar_Syntax_Syntax.pos
                                                      in
-                                                  (uu____17852, aq)  in
-                                                [uu____17843]  in
-                                              ens :: uu____17832  in
-                                            req :: uu____17821
-                                        | uu____17893 -> rest2
+                                                  (uu____18159, aq)  in
+                                                [uu____18150]  in
+                                              ens :: uu____18139  in
+                                            req :: uu____18128
+                                        | uu____18200 -> rest2
                                       else rest2  in
                                     FStar_Syntax_Syntax.mk_Comp
                                       {
@@ -4817,56 +4839,56 @@ and (desugar_formula :
         | "==>" -> FStar_Pervasives_Native.Some FStar_Parser_Const.imp_lid
         | "<==>" -> FStar_Pervasives_Native.Some FStar_Parser_Const.iff_lid
         | "~" -> FStar_Pervasives_Native.Some FStar_Parser_Const.not_lid
-        | uu____17925 -> FStar_Pervasives_Native.None  in
+        | uu____18232 -> FStar_Pervasives_Native.None  in
       let mk1 t =
         FStar_Syntax_Syntax.mk t FStar_Pervasives_Native.None
           f.FStar_Parser_AST.range
          in
       let setpos t =
-        let uu___2395_17947 = t  in
+        let uu___2401_18254 = t  in
         {
-          FStar_Syntax_Syntax.n = (uu___2395_17947.FStar_Syntax_Syntax.n);
+          FStar_Syntax_Syntax.n = (uu___2401_18254.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = (f.FStar_Parser_AST.range);
           FStar_Syntax_Syntax.vars =
-            (uu___2395_17947.FStar_Syntax_Syntax.vars)
+            (uu___2401_18254.FStar_Syntax_Syntax.vars)
         }  in
       let desugar_quant q b pats body =
         let tk =
           desugar_binder env
-            (let uu___2402_18001 = b  in
+            (let uu___2408_18308 = b  in
              {
-               FStar_Parser_AST.b = (uu___2402_18001.FStar_Parser_AST.b);
+               FStar_Parser_AST.b = (uu___2408_18308.FStar_Parser_AST.b);
                FStar_Parser_AST.brange =
-                 (uu___2402_18001.FStar_Parser_AST.brange);
+                 (uu___2408_18308.FStar_Parser_AST.brange);
                FStar_Parser_AST.blevel = FStar_Parser_AST.Formula;
                FStar_Parser_AST.aqual =
-                 (uu___2402_18001.FStar_Parser_AST.aqual)
+                 (uu___2408_18308.FStar_Parser_AST.aqual)
              })
            in
-        let with_pats env1 uu____18030 body1 =
-          match uu____18030 with
+        let with_pats env1 uu____18337 body1 =
+          match uu____18337 with
           | (names1,pats1) ->
               (match (names1, pats1) with
                | ([],[]) -> body1
-               | ([],uu____18076::uu____18077) ->
+               | ([],uu____18383::uu____18384) ->
                    failwith
                      "Impossible: Annotated pattern without binders in scope"
-               | uu____18095 ->
+               | uu____18402 ->
                    let names2 =
                      FStar_All.pipe_right names1
                        (FStar_List.map
                           (fun i  ->
-                             let uu___2421_18122 =
+                             let uu___2427_18429 =
                                FStar_Syntax_DsEnv.fail_or2
                                  (FStar_Syntax_DsEnv.try_lookup_id env1) i
                                 in
                              {
                                FStar_Syntax_Syntax.n =
-                                 (uu___2421_18122.FStar_Syntax_Syntax.n);
+                                 (uu___2427_18429.FStar_Syntax_Syntax.n);
                                FStar_Syntax_Syntax.pos =
                                  (i.FStar_Ident.idRange);
                                FStar_Syntax_Syntax.vars =
-                                 (uu___2421_18122.FStar_Syntax_Syntax.vars)
+                                 (uu___2427_18429.FStar_Syntax_Syntax.vars)
                              }))
                       in
                    let pats2 =
@@ -4876,12 +4898,12 @@ and (desugar_formula :
                              FStar_All.pipe_right es
                                (FStar_List.map
                                   (fun e  ->
-                                     let uu____18185 = desugar_term env1 e
+                                     let uu____18492 = desugar_term env1 e
                                         in
                                      FStar_All.pipe_left
                                        (arg_withimp_t
                                           FStar_Parser_AST.Nothing)
-                                       uu____18185))))
+                                       uu____18492))))
                       in
                    mk1
                      (FStar_Syntax_Syntax.Tm_meta
@@ -4890,65 +4912,65 @@ and (desugar_formula :
            in
         match tk with
         | (FStar_Pervasives_Native.Some a,k) ->
-            let uu____18216 = FStar_Syntax_DsEnv.push_bv env a  in
-            (match uu____18216 with
+            let uu____18523 = FStar_Syntax_DsEnv.push_bv env a  in
+            (match uu____18523 with
              | (env1,a1) ->
                  let a2 =
-                   let uu___2434_18226 = a1  in
+                   let uu___2440_18533 = a1  in
                    {
                      FStar_Syntax_Syntax.ppname =
-                       (uu___2434_18226.FStar_Syntax_Syntax.ppname);
+                       (uu___2440_18533.FStar_Syntax_Syntax.ppname);
                      FStar_Syntax_Syntax.index =
-                       (uu___2434_18226.FStar_Syntax_Syntax.index);
+                       (uu___2440_18533.FStar_Syntax_Syntax.index);
                      FStar_Syntax_Syntax.sort = k
                    }  in
                  let body1 = desugar_formula env1 body  in
                  let body2 = with_pats env1 pats body1  in
                  let body3 =
-                   let uu____18232 =
-                     let uu____18235 =
-                       let uu____18236 = FStar_Syntax_Syntax.mk_binder a2  in
-                       [uu____18236]  in
-                     no_annot_abs uu____18235 body2  in
-                   FStar_All.pipe_left setpos uu____18232  in
-                 let uu____18257 =
-                   let uu____18258 =
-                     let uu____18275 =
-                       let uu____18278 =
+                   let uu____18539 =
+                     let uu____18542 =
+                       let uu____18543 = FStar_Syntax_Syntax.mk_binder a2  in
+                       [uu____18543]  in
+                     no_annot_abs uu____18542 body2  in
+                   FStar_All.pipe_left setpos uu____18539  in
+                 let uu____18564 =
+                   let uu____18565 =
+                     let uu____18582 =
+                       let uu____18585 =
                          FStar_Ident.set_lid_range q
                            b.FStar_Parser_AST.brange
                           in
-                       FStar_Syntax_Syntax.fvar uu____18278
+                       FStar_Syntax_Syntax.fvar uu____18585
                          (FStar_Syntax_Syntax.Delta_constant_at_level
                             Prims.int_one) FStar_Pervasives_Native.None
                         in
-                     let uu____18280 =
-                       let uu____18291 = FStar_Syntax_Syntax.as_arg body3  in
-                       [uu____18291]  in
-                     (uu____18275, uu____18280)  in
-                   FStar_Syntax_Syntax.Tm_app uu____18258  in
-                 FStar_All.pipe_left mk1 uu____18257)
-        | uu____18330 -> failwith "impossible"  in
+                     let uu____18587 =
+                       let uu____18598 = FStar_Syntax_Syntax.as_arg body3  in
+                       [uu____18598]  in
+                     (uu____18582, uu____18587)  in
+                   FStar_Syntax_Syntax.Tm_app uu____18565  in
+                 FStar_All.pipe_left mk1 uu____18564)
+        | uu____18637 -> failwith "impossible"  in
       let push_quant q binders pats body =
         match binders with
         | b::b'::_rest ->
             let rest = b' :: _rest  in
             let body1 =
-              let uu____18395 = q (rest, pats, body)  in
-              let uu____18398 =
+              let uu____18702 = q (rest, pats, body)  in
+              let uu____18705 =
                 FStar_Range.union_ranges b'.FStar_Parser_AST.brange
                   body.FStar_Parser_AST.range
                  in
-              FStar_Parser_AST.mk_term uu____18395 uu____18398
+              FStar_Parser_AST.mk_term uu____18702 uu____18705
                 FStar_Parser_AST.Formula
                in
-            let uu____18399 = q ([b], ([], []), body1)  in
-            FStar_Parser_AST.mk_term uu____18399 f.FStar_Parser_AST.range
+            let uu____18706 = q ([b], ([], []), body1)  in
+            FStar_Parser_AST.mk_term uu____18706 f.FStar_Parser_AST.range
               FStar_Parser_AST.Formula
-        | uu____18410 -> failwith "impossible"  in
-      let uu____18414 =
-        let uu____18415 = unparen f  in uu____18415.FStar_Parser_AST.tm  in
-      match uu____18414 with
+        | uu____18717 -> failwith "impossible"  in
+      let uu____18721 =
+        let uu____18722 = unparen f  in uu____18722.FStar_Parser_AST.tm  in
+      match uu____18721 with
       | FStar_Parser_AST.Labeled (f1,l,p) ->
           let f2 = desugar_formula env f1  in
           FStar_All.pipe_left mk1
@@ -4956,30 +4978,30 @@ and (desugar_formula :
                (f2,
                  (FStar_Syntax_Syntax.Meta_labeled
                     (l, (f2.FStar_Syntax_Syntax.pos), p))))
-      | FStar_Parser_AST.QForall ([],uu____18428,uu____18429) ->
+      | FStar_Parser_AST.QForall ([],uu____18735,uu____18736) ->
           failwith "Impossible: Quantifier without binders"
-      | FStar_Parser_AST.QExists ([],uu____18453,uu____18454) ->
+      | FStar_Parser_AST.QExists ([],uu____18760,uu____18761) ->
           failwith "Impossible: Quantifier without binders"
       | FStar_Parser_AST.QForall (_1::_2::_3,pats,body) ->
           let binders = _1 :: _2 :: _3  in
-          let uu____18510 =
+          let uu____18817 =
             push_quant (fun x  -> FStar_Parser_AST.QForall x) binders pats
               body
              in
-          desugar_formula env uu____18510
+          desugar_formula env uu____18817
       | FStar_Parser_AST.QExists (_1::_2::_3,pats,body) ->
           let binders = _1 :: _2 :: _3  in
-          let uu____18554 =
+          let uu____18861 =
             push_quant (fun x  -> FStar_Parser_AST.QExists x) binders pats
               body
              in
-          desugar_formula env uu____18554
+          desugar_formula env uu____18861
       | FStar_Parser_AST.QForall (b::[],pats,body) ->
           desugar_quant FStar_Parser_Const.forall_lid b pats body
       | FStar_Parser_AST.QExists (b::[],pats,body) ->
           desugar_quant FStar_Parser_Const.exists_lid b pats body
       | FStar_Parser_AST.Paren f1 -> failwith "impossible"
-      | uu____18618 -> desugar_term env f
+      | uu____18925 -> desugar_term env f
 
 and (typars_of_binders :
   FStar_Syntax_DsEnv.env ->
@@ -4989,55 +5011,55 @@ and (typars_of_binders :
   =
   fun env  ->
     fun bs  ->
-      let uu____18623 =
+      let uu____18930 =
         FStar_List.fold_left
-          (fun uu____18656  ->
+          (fun uu____18963  ->
              fun b  ->
-               match uu____18656 with
+               match uu____18963 with
                | (env1,out) ->
                    let tk =
                      desugar_binder env1
-                       (let uu___2513_18700 = b  in
+                       (let uu___2519_19007 = b  in
                         {
                           FStar_Parser_AST.b =
-                            (uu___2513_18700.FStar_Parser_AST.b);
+                            (uu___2519_19007.FStar_Parser_AST.b);
                           FStar_Parser_AST.brange =
-                            (uu___2513_18700.FStar_Parser_AST.brange);
+                            (uu___2519_19007.FStar_Parser_AST.brange);
                           FStar_Parser_AST.blevel = FStar_Parser_AST.Formula;
                           FStar_Parser_AST.aqual =
-                            (uu___2513_18700.FStar_Parser_AST.aqual)
+                            (uu___2519_19007.FStar_Parser_AST.aqual)
                         })
                       in
                    (match tk with
                     | (FStar_Pervasives_Native.Some a,k) ->
-                        let uu____18715 = FStar_Syntax_DsEnv.push_bv env1 a
+                        let uu____19022 = FStar_Syntax_DsEnv.push_bv env1 a
                            in
-                        (match uu____18715 with
+                        (match uu____19022 with
                          | (env2,a1) ->
                              let a2 =
-                               let uu___2523_18733 = a1  in
+                               let uu___2529_19040 = a1  in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___2523_18733.FStar_Syntax_Syntax.ppname);
+                                   (uu___2529_19040.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___2523_18733.FStar_Syntax_Syntax.index);
+                                   (uu___2529_19040.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = k
                                }  in
-                             let uu____18734 =
-                               let uu____18741 =
-                                 let uu____18746 =
+                             let uu____19041 =
+                               let uu____19048 =
+                                 let uu____19053 =
                                    trans_aqual env2 b.FStar_Parser_AST.aqual
                                     in
-                                 (a2, uu____18746)  in
-                               uu____18741 :: out  in
-                             (env2, uu____18734))
-                    | uu____18757 ->
+                                 (a2, uu____19053)  in
+                               uu____19048 :: out  in
+                             (env2, uu____19041))
+                    | uu____19064 ->
                         FStar_Errors.raise_error
                           (FStar_Errors.Fatal_UnexpectedBinder,
                             "Unexpected binder") b.FStar_Parser_AST.brange))
           (env, []) bs
          in
-      match uu____18623 with | (env1,tpars) -> (env1, (FStar_List.rev tpars))
+      match uu____18930 with | (env1,tpars) -> (env1, (FStar_List.rev tpars))
 
 and (desugar_binder :
   FStar_Syntax_DsEnv.env ->
@@ -5049,21 +5071,21 @@ and (desugar_binder :
     fun b  ->
       match b.FStar_Parser_AST.b with
       | FStar_Parser_AST.TAnnotated (x,t) ->
-          let uu____18830 = desugar_typ env t  in
-          ((FStar_Pervasives_Native.Some x), uu____18830)
+          let uu____19137 = desugar_typ env t  in
+          ((FStar_Pervasives_Native.Some x), uu____19137)
       | FStar_Parser_AST.Annotated (x,t) ->
-          let uu____18835 = desugar_typ env t  in
-          ((FStar_Pervasives_Native.Some x), uu____18835)
+          let uu____19142 = desugar_typ env t  in
+          ((FStar_Pervasives_Native.Some x), uu____19142)
       | FStar_Parser_AST.TVariable x ->
-          let uu____18839 =
+          let uu____19146 =
             FStar_Syntax_Syntax.mk
               (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_unknown)
               FStar_Pervasives_Native.None x.FStar_Ident.idRange
              in
-          ((FStar_Pervasives_Native.Some x), uu____18839)
+          ((FStar_Pervasives_Native.Some x), uu____19146)
       | FStar_Parser_AST.NoName t ->
-          let uu____18843 = desugar_typ env t  in
-          (FStar_Pervasives_Native.None, uu____18843)
+          let uu____19150 = desugar_typ env t  in
+          (FStar_Pervasives_Native.None, uu____19150)
       | FStar_Parser_AST.Variable x ->
           ((FStar_Pervasives_Native.Some x), FStar_Syntax_Syntax.tun)
 
@@ -5077,27 +5099,27 @@ and (as_binder :
   =
   fun env  ->
     fun imp  ->
-      fun uu___12_18851  ->
-        match uu___12_18851 with
+      fun uu___12_19158  ->
+        match uu___12_19158 with
         | (FStar_Pervasives_Native.None ,k) ->
-            let uu____18873 = FStar_Syntax_Syntax.null_binder k  in
-            (uu____18873, env)
+            let uu____19180 = FStar_Syntax_Syntax.null_binder k  in
+            (uu____19180, env)
         | (FStar_Pervasives_Native.Some a,k) ->
-            let uu____18890 = FStar_Syntax_DsEnv.push_bv env a  in
-            (match uu____18890 with
+            let uu____19197 = FStar_Syntax_DsEnv.push_bv env a  in
+            (match uu____19197 with
              | (env1,a1) ->
-                 let uu____18907 =
-                   let uu____18914 = trans_aqual env1 imp  in
-                   ((let uu___2557_18920 = a1  in
+                 let uu____19214 =
+                   let uu____19221 = trans_aqual env1 imp  in
+                   ((let uu___2563_19227 = a1  in
                      {
                        FStar_Syntax_Syntax.ppname =
-                         (uu___2557_18920.FStar_Syntax_Syntax.ppname);
+                         (uu___2563_19227.FStar_Syntax_Syntax.ppname);
                        FStar_Syntax_Syntax.index =
-                         (uu___2557_18920.FStar_Syntax_Syntax.index);
+                         (uu___2563_19227.FStar_Syntax_Syntax.index);
                        FStar_Syntax_Syntax.sort = k
-                     }), uu____18914)
+                     }), uu____19221)
                     in
-                 (uu____18907, env1))
+                 (uu____19214, env1))
 
 and (trans_aqual :
   FStar_Syntax_DsEnv.env ->
@@ -5105,17 +5127,17 @@ and (trans_aqual :
       FStar_Syntax_Syntax.aqual)
   =
   fun env  ->
-    fun uu___13_18928  ->
-      match uu___13_18928 with
+    fun uu___13_19235  ->
+      match uu___13_19235 with
       | FStar_Pervasives_Native.Some (FStar_Parser_AST.Implicit ) ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.imp_tag
       | FStar_Pervasives_Native.Some (FStar_Parser_AST.Equality ) ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Equality
       | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta t) ->
-          let uu____18932 =
-            let uu____18933 = desugar_term env t  in
-            FStar_Syntax_Syntax.Meta uu____18933  in
-          FStar_Pervasives_Native.Some uu____18932
+          let uu____19239 =
+            let uu____19240 = desugar_term env t  in
+            FStar_Syntax_Syntax.Meta uu____19240  in
+          FStar_Pervasives_Native.Some uu____19239
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
 
 let (binder_ident :
@@ -5123,21 +5145,21 @@ let (binder_ident :
   =
   fun b  ->
     match b.FStar_Parser_AST.b with
-    | FStar_Parser_AST.TAnnotated (x,uu____18949) ->
+    | FStar_Parser_AST.TAnnotated (x,uu____19256) ->
         FStar_Pervasives_Native.Some x
-    | FStar_Parser_AST.Annotated (x,uu____18951) ->
+    | FStar_Parser_AST.Annotated (x,uu____19258) ->
         FStar_Pervasives_Native.Some x
     | FStar_Parser_AST.TVariable x -> FStar_Pervasives_Native.Some x
     | FStar_Parser_AST.Variable x -> FStar_Pervasives_Native.Some x
-    | FStar_Parser_AST.NoName uu____18954 -> FStar_Pervasives_Native.None
+    | FStar_Parser_AST.NoName uu____19261 -> FStar_Pervasives_Native.None
   
 let (binder_idents :
   FStar_Parser_AST.binder Prims.list -> FStar_Ident.ident Prims.list) =
   fun bs  ->
     FStar_List.collect
       (fun b  ->
-         let uu____18972 = binder_ident b  in
-         FStar_Common.list_of_option uu____18972) bs
+         let uu____19279 = binder_ident b  in
+         FStar_Common.list_of_option uu____19279) bs
   
 let (mk_data_discriminators :
   FStar_Syntax_Syntax.qualifier Prims.list ->
@@ -5150,28 +5172,28 @@ let (mk_data_discriminators :
         let quals1 =
           FStar_All.pipe_right quals
             (FStar_List.filter
-               (fun uu___14_19009  ->
-                  match uu___14_19009 with
+               (fun uu___14_19316  ->
+                  match uu___14_19316 with
                   | FStar_Syntax_Syntax.NoExtract  -> true
                   | FStar_Syntax_Syntax.Abstract  -> true
                   | FStar_Syntax_Syntax.Private  -> true
-                  | uu____19014 -> false))
+                  | uu____19321 -> false))
            in
         let quals2 q =
-          let uu____19028 =
-            (let uu____19032 = FStar_Syntax_DsEnv.iface env  in
-             Prims.op_Negation uu____19032) ||
+          let uu____19335 =
+            (let uu____19339 = FStar_Syntax_DsEnv.iface env  in
+             Prims.op_Negation uu____19339) ||
               (FStar_Syntax_DsEnv.admitted_iface env)
              in
-          if uu____19028
+          if uu____19335
           then FStar_List.append (FStar_Syntax_Syntax.Assumption :: q) quals1
           else FStar_List.append q quals1  in
         FStar_All.pipe_right datas
           (FStar_List.map
              (fun d  ->
                 let disc_name = FStar_Syntax_Util.mk_discriminator d  in
-                let uu____19049 = FStar_Ident.range_of_lid disc_name  in
-                let uu____19050 =
+                let uu____19356 = FStar_Ident.range_of_lid disc_name  in
+                let uu____19357 =
                   quals2
                     [FStar_Syntax_Syntax.OnlyName;
                     FStar_Syntax_Syntax.Discriminator d]
@@ -5180,8 +5202,8 @@ let (mk_data_discriminators :
                   FStar_Syntax_Syntax.sigel =
                     (FStar_Syntax_Syntax.Sig_declare_typ
                        (disc_name, [], FStar_Syntax_Syntax.tun));
-                  FStar_Syntax_Syntax.sigrng = uu____19049;
-                  FStar_Syntax_Syntax.sigquals = uu____19050;
+                  FStar_Syntax_Syntax.sigrng = uu____19356;
+                  FStar_Syntax_Syntax.sigquals = uu____19357;
                   FStar_Syntax_Syntax.sigmeta =
                     FStar_Syntax_Syntax.default_sigmeta;
                   FStar_Syntax_Syntax.sigattrs = []
@@ -5201,37 +5223,37 @@ let (mk_indexed_projector_names :
         fun lid  ->
           fun fields  ->
             let p = FStar_Ident.range_of_lid lid  in
-            let uu____19090 =
+            let uu____19397 =
               FStar_All.pipe_right fields
                 (FStar_List.mapi
                    (fun i  ->
-                      fun uu____19128  ->
-                        match uu____19128 with
-                        | (x,uu____19139) ->
-                            let uu____19144 =
+                      fun uu____19435  ->
+                        match uu____19435 with
+                        | (x,uu____19446) ->
+                            let uu____19451 =
                               FStar_Syntax_Util.mk_field_projector_name lid x
                                 i
                                in
-                            (match uu____19144 with
-                             | (field_name,uu____19152) ->
+                            (match uu____19451 with
+                             | (field_name,uu____19459) ->
                                  let only_decl =
-                                   ((let uu____19157 =
+                                   ((let uu____19464 =
                                        FStar_Syntax_DsEnv.current_module env
                                         in
                                      FStar_Ident.lid_equals
                                        FStar_Parser_Const.prims_lid
-                                       uu____19157)
+                                       uu____19464)
                                       ||
                                       (fvq <> FStar_Syntax_Syntax.Data_ctor))
                                      ||
-                                     (let uu____19159 =
-                                        let uu____19161 =
+                                     (let uu____19466 =
+                                        let uu____19468 =
                                           FStar_Syntax_DsEnv.current_module
                                             env
                                            in
-                                        uu____19161.FStar_Ident.str  in
+                                        uu____19468.FStar_Ident.str  in
                                       FStar_Options.dont_gen_projectors
-                                        uu____19159)
+                                        uu____19466)
                                     in
                                  let no_decl =
                                    FStar_Syntax_Syntax.is_type
@@ -5240,30 +5262,30 @@ let (mk_indexed_projector_names :
                                  let quals q =
                                    if only_decl
                                    then
-                                     let uu____19179 =
+                                     let uu____19486 =
                                        FStar_List.filter
-                                         (fun uu___15_19183  ->
-                                            match uu___15_19183 with
+                                         (fun uu___15_19490  ->
+                                            match uu___15_19490 with
                                             | FStar_Syntax_Syntax.Abstract 
                                                 -> false
-                                            | uu____19186 -> true) q
+                                            | uu____19493 -> true) q
                                         in
                                      FStar_Syntax_Syntax.Assumption ::
-                                       uu____19179
+                                       uu____19486
                                    else q  in
                                  let quals1 =
                                    let iquals1 =
                                      FStar_All.pipe_right iquals
                                        (FStar_List.filter
-                                          (fun uu___16_19201  ->
-                                             match uu___16_19201 with
+                                          (fun uu___16_19508  ->
+                                             match uu___16_19508 with
                                              | FStar_Syntax_Syntax.NoExtract 
                                                  -> true
                                              | FStar_Syntax_Syntax.Abstract 
                                                  -> true
                                              | FStar_Syntax_Syntax.Private 
                                                  -> true
-                                             | uu____19206 -> false))
+                                             | uu____19513 -> false))
                                       in
                                    quals (FStar_Syntax_Syntax.OnlyName ::
                                      (FStar_Syntax_Syntax.Projector
@@ -5271,14 +5293,14 @@ let (mk_indexed_projector_names :
                                      :: iquals1)
                                     in
                                  let decl =
-                                   let uu____19209 =
+                                   let uu____19516 =
                                      FStar_Ident.range_of_lid field_name  in
                                    {
                                      FStar_Syntax_Syntax.sigel =
                                        (FStar_Syntax_Syntax.Sig_declare_typ
                                           (field_name, [],
                                             FStar_Syntax_Syntax.tun));
-                                     FStar_Syntax_Syntax.sigrng = uu____19209;
+                                     FStar_Syntax_Syntax.sigrng = uu____19516;
                                      FStar_Syntax_Syntax.sigquals = quals1;
                                      FStar_Syntax_Syntax.sigmeta =
                                        FStar_Syntax_Syntax.default_sigmeta;
@@ -5288,12 +5310,12 @@ let (mk_indexed_projector_names :
                                  then [decl]
                                  else
                                    (let dd =
-                                      let uu____19216 =
+                                      let uu____19523 =
                                         FStar_All.pipe_right quals1
                                           (FStar_List.contains
                                              FStar_Syntax_Syntax.Abstract)
                                          in
-                                      if uu____19216
+                                      if uu____19523
                                       then
                                         FStar_Syntax_Syntax.Delta_abstract
                                           (FStar_Syntax_Syntax.Delta_equational_at_level
@@ -5303,16 +5325,16 @@ let (mk_indexed_projector_names :
                                           Prims.int_one
                                        in
                                     let lb =
-                                      let uu____19227 =
-                                        let uu____19232 =
+                                      let uu____19534 =
+                                        let uu____19539 =
                                           FStar_Syntax_Syntax.lid_as_fv
                                             field_name dd
                                             FStar_Pervasives_Native.None
                                            in
-                                        FStar_Util.Inr uu____19232  in
+                                        FStar_Util.Inr uu____19539  in
                                       {
                                         FStar_Syntax_Syntax.lbname =
-                                          uu____19227;
+                                          uu____19534;
                                         FStar_Syntax_Syntax.lbunivs = [];
                                         FStar_Syntax_Syntax.lbtyp =
                                           FStar_Syntax_Syntax.tun;
@@ -5325,28 +5347,28 @@ let (mk_indexed_projector_names :
                                           FStar_Range.dummyRange
                                       }  in
                                     let impl =
-                                      let uu____19236 =
-                                        let uu____19237 =
-                                          let uu____19244 =
-                                            let uu____19247 =
-                                              let uu____19248 =
+                                      let uu____19543 =
+                                        let uu____19544 =
+                                          let uu____19551 =
+                                            let uu____19554 =
+                                              let uu____19555 =
                                                 FStar_All.pipe_right
                                                   lb.FStar_Syntax_Syntax.lbname
                                                   FStar_Util.right
                                                  in
                                               FStar_All.pipe_right
-                                                uu____19248
+                                                uu____19555
                                                 (fun fv  ->
                                                    (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
                                                in
-                                            [uu____19247]  in
-                                          ((false, [lb]), uu____19244)  in
+                                            [uu____19554]  in
+                                          ((false, [lb]), uu____19551)  in
                                         FStar_Syntax_Syntax.Sig_let
-                                          uu____19237
+                                          uu____19544
                                          in
                                       {
                                         FStar_Syntax_Syntax.sigel =
-                                          uu____19236;
+                                          uu____19543;
                                         FStar_Syntax_Syntax.sigrng = p;
                                         FStar_Syntax_Syntax.sigquals = quals1;
                                         FStar_Syntax_Syntax.sigmeta =
@@ -5355,7 +5377,7 @@ let (mk_indexed_projector_names :
                                       }  in
                                     if no_decl then [impl] else [decl; impl]))))
                in
-            FStar_All.pipe_right uu____19090 FStar_List.flatten
+            FStar_All.pipe_right uu____19397 FStar_List.flatten
   
 let (mk_data_projector_names :
   FStar_Syntax_Syntax.qualifier Prims.list ->
@@ -5367,29 +5389,29 @@ let (mk_data_projector_names :
       fun se  ->
         match se.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_datacon
-            (lid,uu____19297,t,uu____19299,n1,uu____19301) when
-            let uu____19308 =
+            (lid,uu____19604,t,uu____19606,n1,uu____19608) when
+            let uu____19615 =
               FStar_Ident.lid_equals lid FStar_Parser_Const.lexcons_lid  in
-            Prims.op_Negation uu____19308 ->
-            let uu____19310 = FStar_Syntax_Util.arrow_formals t  in
-            (match uu____19310 with
-             | (formals,uu____19328) ->
+            Prims.op_Negation uu____19615 ->
+            let uu____19617 = FStar_Syntax_Util.arrow_formals t  in
+            (match uu____19617 with
+             | (formals,uu____19635) ->
                  (match formals with
                   | [] -> []
-                  | uu____19357 ->
-                      let filter_records uu___17_19373 =
-                        match uu___17_19373 with
+                  | uu____19664 ->
+                      let filter_records uu___17_19680 =
+                        match uu___17_19680 with
                         | FStar_Syntax_Syntax.RecordConstructor
-                            (uu____19376,fns) ->
+                            (uu____19683,fns) ->
                             FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Record_ctor (lid, fns))
-                        | uu____19388 -> FStar_Pervasives_Native.None  in
+                        | uu____19695 -> FStar_Pervasives_Native.None  in
                       let fv_qual =
-                        let uu____19390 =
+                        let uu____19697 =
                           FStar_Util.find_map se.FStar_Syntax_Syntax.sigquals
                             filter_records
                            in
-                        match uu____19390 with
+                        match uu____19697 with
                         | FStar_Pervasives_Native.None  ->
                             FStar_Syntax_Syntax.Data_ctor
                         | FStar_Pervasives_Native.Some q -> q  in
@@ -5403,12 +5425,12 @@ let (mk_data_projector_names :
                                   FStar_Syntax_Syntax.Private iquals))
                         then FStar_Syntax_Syntax.Private :: iquals
                         else iquals  in
-                      let uu____19402 = FStar_Util.first_N n1 formals  in
-                      (match uu____19402 with
-                       | (uu____19431,rest) ->
+                      let uu____19709 = FStar_Util.first_N n1 formals  in
+                      (match uu____19709 with
+                       | (uu____19738,rest) ->
                            mk_indexed_projector_names iquals1 fv_qual env lid
                              rest)))
-        | uu____19465 -> []
+        | uu____19772 -> []
   
 let (mk_typ_abbrev :
   FStar_Ident.lident ->
@@ -5430,40 +5452,40 @@ let (mk_typ_abbrev :
               fun quals  ->
                 fun rng  ->
                   let dd =
-                    let uu____19544 =
+                    let uu____19851 =
                       FStar_All.pipe_right quals
                         (FStar_List.contains FStar_Syntax_Syntax.Abstract)
                        in
-                    if uu____19544
+                    if uu____19851
                     then
-                      let uu____19550 =
+                      let uu____19857 =
                         FStar_Syntax_Util.incr_delta_qualifier t  in
-                      FStar_Syntax_Syntax.Delta_abstract uu____19550
+                      FStar_Syntax_Syntax.Delta_abstract uu____19857
                     else FStar_Syntax_Util.incr_delta_qualifier t  in
                   let lb =
-                    let uu____19554 =
-                      let uu____19559 =
+                    let uu____19861 =
+                      let uu____19866 =
                         FStar_Syntax_Syntax.lid_as_fv lid dd
                           FStar_Pervasives_Native.None
                          in
-                      FStar_Util.Inr uu____19559  in
-                    let uu____19560 =
+                      FStar_Util.Inr uu____19866  in
+                    let uu____19867 =
                       if FStar_Util.is_some kopt
                       then
-                        let uu____19566 =
-                          let uu____19569 =
+                        let uu____19873 =
+                          let uu____19876 =
                             FStar_All.pipe_right kopt FStar_Util.must  in
-                          FStar_Syntax_Syntax.mk_Total uu____19569  in
-                        FStar_Syntax_Util.arrow typars uu____19566
+                          FStar_Syntax_Syntax.mk_Total uu____19876  in
+                        FStar_Syntax_Util.arrow typars uu____19873
                       else FStar_Syntax_Syntax.tun  in
-                    let uu____19574 = no_annot_abs typars t  in
+                    let uu____19881 = no_annot_abs typars t  in
                     {
-                      FStar_Syntax_Syntax.lbname = uu____19554;
+                      FStar_Syntax_Syntax.lbname = uu____19861;
                       FStar_Syntax_Syntax.lbunivs = uvs;
-                      FStar_Syntax_Syntax.lbtyp = uu____19560;
+                      FStar_Syntax_Syntax.lbtyp = uu____19867;
                       FStar_Syntax_Syntax.lbeff =
                         FStar_Parser_Const.effect_Tot_lid;
-                      FStar_Syntax_Syntax.lbdef = uu____19574;
+                      FStar_Syntax_Syntax.lbdef = uu____19881;
                       FStar_Syntax_Syntax.lbattrs = [];
                       FStar_Syntax_Syntax.lbpos = rng
                     }  in
@@ -5489,32 +5511,32 @@ let rec (desugar_tycon :
       fun quals  ->
         fun tcs  ->
           let rng = d.FStar_Parser_AST.drange  in
-          let tycon_id uu___18_19628 =
-            match uu___18_19628 with
-            | FStar_Parser_AST.TyconAbstract (id1,uu____19630,uu____19631) ->
+          let tycon_id uu___18_19935 =
+            match uu___18_19935 with
+            | FStar_Parser_AST.TyconAbstract (id1,uu____19937,uu____19938) ->
                 id1
             | FStar_Parser_AST.TyconAbbrev
-                (id1,uu____19641,uu____19642,uu____19643) -> id1
+                (id1,uu____19948,uu____19949,uu____19950) -> id1
             | FStar_Parser_AST.TyconRecord
-                (id1,uu____19653,uu____19654,uu____19655) -> id1
+                (id1,uu____19960,uu____19961,uu____19962) -> id1
             | FStar_Parser_AST.TyconVariant
-                (id1,uu____19685,uu____19686,uu____19687) -> id1
+                (id1,uu____19992,uu____19993,uu____19994) -> id1
              in
           let binder_to_term b =
             match b.FStar_Parser_AST.b with
-            | FStar_Parser_AST.Annotated (x,uu____19733) ->
-                let uu____19734 =
-                  let uu____19735 = FStar_Ident.lid_of_ids [x]  in
-                  FStar_Parser_AST.Var uu____19735  in
-                FStar_Parser_AST.mk_term uu____19734 x.FStar_Ident.idRange
+            | FStar_Parser_AST.Annotated (x,uu____20040) ->
+                let uu____20041 =
+                  let uu____20042 = FStar_Ident.lid_of_ids [x]  in
+                  FStar_Parser_AST.Var uu____20042  in
+                FStar_Parser_AST.mk_term uu____20041 x.FStar_Ident.idRange
                   FStar_Parser_AST.Expr
             | FStar_Parser_AST.Variable x ->
-                let uu____19737 =
-                  let uu____19738 = FStar_Ident.lid_of_ids [x]  in
-                  FStar_Parser_AST.Var uu____19738  in
-                FStar_Parser_AST.mk_term uu____19737 x.FStar_Ident.idRange
+                let uu____20044 =
+                  let uu____20045 = FStar_Ident.lid_of_ids [x]  in
+                  FStar_Parser_AST.Var uu____20045  in
+                FStar_Parser_AST.mk_term uu____20044 x.FStar_Ident.idRange
                   FStar_Parser_AST.Expr
-            | FStar_Parser_AST.TAnnotated (a,uu____19740) ->
+            | FStar_Parser_AST.TAnnotated (a,uu____20047) ->
                 FStar_Parser_AST.mk_term (FStar_Parser_AST.Tvar a)
                   a.FStar_Ident.idRange FStar_Parser_AST.Type_level
             | FStar_Parser_AST.TVariable a ->
@@ -5536,21 +5558,21 @@ let rec (desugar_tycon :
               match b.FStar_Parser_AST.aqual with
               | FStar_Pervasives_Native.Some (FStar_Parser_AST.Implicit ) ->
                   FStar_Parser_AST.Hash
-              | uu____19771 -> FStar_Parser_AST.Nothing  in
+              | uu____20078 -> FStar_Parser_AST.Nothing  in
             FStar_List.fold_left
               (fun out  ->
                  fun b  ->
-                   let uu____19779 =
-                     let uu____19780 =
-                       let uu____19787 = binder_to_term b  in
-                       (out, uu____19787, (imp_of_aqual b))  in
-                     FStar_Parser_AST.App uu____19780  in
-                   FStar_Parser_AST.mk_term uu____19779
+                   let uu____20086 =
+                     let uu____20087 =
+                       let uu____20094 = binder_to_term b  in
+                       (out, uu____20094, (imp_of_aqual b))  in
+                     FStar_Parser_AST.App uu____20087  in
+                   FStar_Parser_AST.mk_term uu____20086
                      out.FStar_Parser_AST.range out.FStar_Parser_AST.level) t
               binders
              in
-          let tycon_record_as_variant uu___19_19799 =
-            match uu___19_19799 with
+          let tycon_record_as_variant uu___19_20106 =
+            match uu___19_20106 with
             | FStar_Parser_AST.TyconRecord (id1,parms,kopt,fields) ->
                 let constrName =
                   FStar_Ident.mk_ident
@@ -5559,23 +5581,23 @@ let rec (desugar_tycon :
                    in
                 let mfields =
                   FStar_List.map
-                    (fun uu____19856  ->
-                       match uu____19856 with
-                       | (x,t,uu____19867) ->
+                    (fun uu____20163  ->
+                       match uu____20163 with
+                       | (x,t,uu____20174) ->
                            FStar_Parser_AST.mk_binder
                              (FStar_Parser_AST.Annotated (x, t))
                              x.FStar_Ident.idRange FStar_Parser_AST.Expr
                              FStar_Pervasives_Native.None) fields
                    in
                 let result =
-                  let uu____19873 =
-                    let uu____19874 =
-                      let uu____19875 = FStar_Ident.lid_of_ids [id1]  in
-                      FStar_Parser_AST.Var uu____19875  in
-                    FStar_Parser_AST.mk_term uu____19874
+                  let uu____20180 =
+                    let uu____20181 =
+                      let uu____20182 = FStar_Ident.lid_of_ids [id1]  in
+                      FStar_Parser_AST.Var uu____20182  in
+                    FStar_Parser_AST.mk_term uu____20181
                       id1.FStar_Ident.idRange FStar_Parser_AST.Type_level
                      in
-                  apply_binders uu____19873 parms  in
+                  apply_binders uu____20180 parms  in
                 let constrTyp =
                   FStar_Parser_AST.mk_term
                     (FStar_Parser_AST.Product
@@ -5583,51 +5605,51 @@ let rec (desugar_tycon :
                     id1.FStar_Ident.idRange FStar_Parser_AST.Type_level
                    in
                 let names1 =
-                  let uu____19882 = binder_idents parms  in id1 ::
-                    uu____19882
+                  let uu____20189 = binder_idents parms  in id1 ::
+                    uu____20189
                    in
                 (FStar_List.iter
-                   (fun uu____19900  ->
-                      match uu____19900 with
-                      | (f,uu____19910,uu____19911) ->
-                          let uu____19916 =
+                   (fun uu____20207  ->
+                      match uu____20207 with
+                      | (f,uu____20217,uu____20218) ->
+                          let uu____20223 =
                             FStar_Util.for_some
                               (fun i  -> FStar_Ident.ident_equals f i) names1
                              in
-                          if uu____19916
+                          if uu____20223
                           then
-                            let uu____19921 =
-                              let uu____19927 =
-                                let uu____19929 =
+                            let uu____20228 =
+                              let uu____20234 =
+                                let uu____20236 =
                                   FStar_Ident.string_of_ident f  in
                                 FStar_Util.format1
                                   "Field %s shadows the record's name or a parameter of it, please rename it"
-                                  uu____19929
+                                  uu____20236
                                  in
-                              (FStar_Errors.Error_FieldShadow, uu____19927)
+                              (FStar_Errors.Error_FieldShadow, uu____20234)
                                in
-                            FStar_Errors.raise_error uu____19921
+                            FStar_Errors.raise_error uu____20228
                               f.FStar_Ident.idRange
                           else ()) fields;
-                 (let uu____19935 =
+                 (let uu____20242 =
                     FStar_All.pipe_right fields
                       (FStar_List.map
-                         (fun uu____19962  ->
-                            match uu____19962 with
-                            | (x,uu____19972,uu____19973) -> x))
+                         (fun uu____20269  ->
+                            match uu____20269 with
+                            | (x,uu____20279,uu____20280) -> x))
                      in
                   ((FStar_Parser_AST.TyconVariant
                       (id1, parms, kopt,
                         [(constrName,
                            (FStar_Pervasives_Native.Some constrTyp),
                            FStar_Pervasives_Native.None, false)])),
-                    uu____19935)))
-            | uu____20031 -> failwith "impossible"  in
-          let desugar_abstract_tc quals1 _env mutuals uu___20_20071 =
-            match uu___20_20071 with
+                    uu____20242)))
+            | uu____20338 -> failwith "impossible"  in
+          let desugar_abstract_tc quals1 _env mutuals uu___20_20378 =
+            match uu___20_20378 with
             | FStar_Parser_AST.TyconAbstract (id1,binders,kopt) ->
-                let uu____20095 = typars_of_binders _env binders  in
-                (match uu____20095 with
+                let uu____20402 = typars_of_binders _env binders  in
+                (match uu____20402 with
                  | (_env',typars) ->
                      let k =
                        match kopt with
@@ -5637,15 +5659,15 @@ let rec (desugar_tycon :
                            desugar_term _env' k
                         in
                      let tconstr =
-                       let uu____20131 =
-                         let uu____20132 =
-                           let uu____20133 = FStar_Ident.lid_of_ids [id1]  in
-                           FStar_Parser_AST.Var uu____20133  in
-                         FStar_Parser_AST.mk_term uu____20132
+                       let uu____20438 =
+                         let uu____20439 =
+                           let uu____20440 = FStar_Ident.lid_of_ids [id1]  in
+                           FStar_Parser_AST.Var uu____20440  in
+                         FStar_Parser_AST.mk_term uu____20439
                            id1.FStar_Ident.idRange
                            FStar_Parser_AST.Type_level
                           in
-                       apply_binders uu____20131 binders  in
+                       apply_binders uu____20438 binders  in
                      let qlid = FStar_Syntax_DsEnv.qualify _env id1  in
                      let typars1 = FStar_Syntax_Subst.close_binders typars
                         in
@@ -5670,40 +5692,40 @@ let rec (desugar_tycon :
                          id1 FStar_Syntax_Syntax.delta_constant
                         in
                      (_env1, _env2, se, tconstr))
-            | uu____20144 -> failwith "Unexpected tycon"  in
+            | uu____20451 -> failwith "Unexpected tycon"  in
           let push_tparams env1 bs =
-            let uu____20187 =
+            let uu____20494 =
               FStar_List.fold_left
-                (fun uu____20221  ->
-                   fun uu____20222  ->
-                     match (uu____20221, uu____20222) with
+                (fun uu____20528  ->
+                   fun uu____20529  ->
+                     match (uu____20528, uu____20529) with
                      | ((env2,tps),(x,imp)) ->
-                         let uu____20291 =
+                         let uu____20598 =
                            FStar_Syntax_DsEnv.push_bv env2
                              x.FStar_Syntax_Syntax.ppname
                             in
-                         (match uu____20291 with
+                         (match uu____20598 with
                           | (env3,y) -> (env3, ((y, imp) :: tps))))
                 (env1, []) bs
                in
-            match uu____20187 with
+            match uu____20494 with
             | (env2,bs1) -> (env2, (FStar_List.rev bs1))  in
           match tcs with
           | (FStar_Parser_AST.TyconAbstract (id1,bs,kopt))::[] ->
               let kopt1 =
                 match kopt with
                 | FStar_Pervasives_Native.None  ->
-                    let uu____20382 = tm_type_z id1.FStar_Ident.idRange  in
-                    FStar_Pervasives_Native.Some uu____20382
-                | uu____20383 -> kopt  in
+                    let uu____20689 = tm_type_z id1.FStar_Ident.idRange  in
+                    FStar_Pervasives_Native.Some uu____20689
+                | uu____20690 -> kopt  in
               let tc = FStar_Parser_AST.TyconAbstract (id1, bs, kopt1)  in
-              let uu____20391 = desugar_abstract_tc quals env [] tc  in
-              (match uu____20391 with
-               | (uu____20404,uu____20405,se,uu____20407) ->
+              let uu____20698 = desugar_abstract_tc quals env [] tc  in
+              (match uu____20698 with
+               | (uu____20711,uu____20712,se,uu____20714) ->
                    let se1 =
                      match se.FStar_Syntax_Syntax.sigel with
                      | FStar_Syntax_Syntax.Sig_inductive_typ
-                         (l,uu____20410,typars,k,[],[]) ->
+                         (l,uu____20717,typars,k,[],[]) ->
                          let quals1 = se.FStar_Syntax_Syntax.sigquals  in
                          let quals2 =
                            if
@@ -5711,25 +5733,25 @@ let rec (desugar_tycon :
                                FStar_Syntax_Syntax.Assumption quals1
                            then quals1
                            else
-                             ((let uu____20429 =
-                                 let uu____20431 = FStar_Options.ml_ish ()
+                             ((let uu____20736 =
+                                 let uu____20738 = FStar_Options.ml_ish ()
                                     in
-                                 Prims.op_Negation uu____20431  in
-                               if uu____20429
+                                 Prims.op_Negation uu____20738  in
+                               if uu____20736
                                then
-                                 let uu____20434 =
-                                   let uu____20440 =
-                                     let uu____20442 =
+                                 let uu____20741 =
+                                   let uu____20747 =
+                                     let uu____20749 =
                                        FStar_Syntax_Print.lid_to_string l  in
                                      FStar_Util.format1
                                        "Adding an implicit 'assume new' qualifier on %s"
-                                       uu____20442
+                                       uu____20749
                                       in
                                    (FStar_Errors.Warning_AddImplicitAssumeNewQualifier,
-                                     uu____20440)
+                                     uu____20747)
                                     in
                                  FStar_Errors.log_issue
-                                   se.FStar_Syntax_Syntax.sigrng uu____20434
+                                   se.FStar_Syntax_Syntax.sigrng uu____20741
                                else ());
                               FStar_Syntax_Syntax.Assumption
                               ::
@@ -5740,74 +5762,74 @@ let rec (desugar_tycon :
                          let t =
                            match typars with
                            | [] -> k
-                           | uu____20455 ->
-                               let uu____20456 =
-                                 let uu____20463 =
-                                   let uu____20464 =
-                                     let uu____20479 =
+                           | uu____20762 ->
+                               let uu____20763 =
+                                 let uu____20770 =
+                                   let uu____20771 =
+                                     let uu____20786 =
                                        FStar_Syntax_Syntax.mk_Total k  in
-                                     (typars, uu____20479)  in
-                                   FStar_Syntax_Syntax.Tm_arrow uu____20464
+                                     (typars, uu____20786)  in
+                                   FStar_Syntax_Syntax.Tm_arrow uu____20771
                                     in
-                                 FStar_Syntax_Syntax.mk uu____20463  in
-                               uu____20456 FStar_Pervasives_Native.None
+                                 FStar_Syntax_Syntax.mk uu____20770  in
+                               uu____20763 FStar_Pervasives_Native.None
                                  se.FStar_Syntax_Syntax.sigrng
                             in
-                         let uu___2832_20492 = se  in
+                         let uu___2838_20799 = se  in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (FStar_Syntax_Syntax.Sig_declare_typ (l, [], t));
                            FStar_Syntax_Syntax.sigrng =
-                             (uu___2832_20492.FStar_Syntax_Syntax.sigrng);
+                             (uu___2838_20799.FStar_Syntax_Syntax.sigrng);
                            FStar_Syntax_Syntax.sigquals = quals2;
                            FStar_Syntax_Syntax.sigmeta =
-                             (uu___2832_20492.FStar_Syntax_Syntax.sigmeta);
+                             (uu___2838_20799.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs =
-                             (uu___2832_20492.FStar_Syntax_Syntax.sigattrs)
+                             (uu___2838_20799.FStar_Syntax_Syntax.sigattrs)
                          }
-                     | uu____20493 -> failwith "Impossible"  in
+                     | uu____20800 -> failwith "Impossible"  in
                    let env1 = FStar_Syntax_DsEnv.push_sigelt env se1  in
                    let env2 =
-                     let uu____20497 = FStar_Syntax_DsEnv.qualify env1 id1
+                     let uu____20804 = FStar_Syntax_DsEnv.qualify env1 id1
                         in
-                     FStar_Syntax_DsEnv.push_doc env1 uu____20497
+                     FStar_Syntax_DsEnv.push_doc env1 uu____20804
                        d.FStar_Parser_AST.doc
                       in
                    (env2, [se1]))
           | (FStar_Parser_AST.TyconAbbrev (id1,binders,kopt,t))::[] ->
-              let uu____20510 = typars_of_binders env binders  in
-              (match uu____20510 with
+              let uu____20817 = typars_of_binders env binders  in
+              (match uu____20817 with
                | (env',typars) ->
                    let kopt1 =
                      match kopt with
                      | FStar_Pervasives_Native.None  ->
-                         let uu____20544 =
+                         let uu____20851 =
                            FStar_Util.for_some
-                             (fun uu___21_20547  ->
-                                match uu___21_20547 with
+                             (fun uu___21_20854  ->
+                                match uu___21_20854 with
                                 | FStar_Syntax_Syntax.Effect  -> true
-                                | uu____20550 -> false) quals
+                                | uu____20857 -> false) quals
                             in
-                         if uu____20544
+                         if uu____20851
                          then
                            FStar_Pervasives_Native.Some
                              FStar_Syntax_Syntax.teff
                          else FStar_Pervasives_Native.None
                      | FStar_Pervasives_Native.Some k ->
-                         let uu____20558 = desugar_term env' k  in
-                         FStar_Pervasives_Native.Some uu____20558
+                         let uu____20865 = desugar_term env' k  in
+                         FStar_Pervasives_Native.Some uu____20865
                       in
                    let t0 = t  in
                    let quals1 =
-                     let uu____20563 =
+                     let uu____20870 =
                        FStar_All.pipe_right quals
                          (FStar_Util.for_some
-                            (fun uu___22_20569  ->
-                               match uu___22_20569 with
+                            (fun uu___22_20876  ->
+                               match uu___22_20876 with
                                | FStar_Syntax_Syntax.Logic  -> true
-                               | uu____20572 -> false))
+                               | uu____20879 -> false))
                         in
-                     if uu____20563
+                     if uu____20870
                      then quals
                      else
                        if
@@ -5817,40 +5839,40 @@ let rec (desugar_tycon :
                       in
                    let qlid = FStar_Syntax_DsEnv.qualify env id1  in
                    let se =
-                     let uu____20586 =
+                     let uu____20893 =
                        FStar_All.pipe_right quals1
                          (FStar_List.contains FStar_Syntax_Syntax.Effect)
                         in
-                     if uu____20586
+                     if uu____20893
                      then
-                       let uu____20592 =
-                         let uu____20599 =
-                           let uu____20600 = unparen t  in
-                           uu____20600.FStar_Parser_AST.tm  in
-                         match uu____20599 with
+                       let uu____20899 =
+                         let uu____20906 =
+                           let uu____20907 = unparen t  in
+                           uu____20907.FStar_Parser_AST.tm  in
+                         match uu____20906 with
                          | FStar_Parser_AST.Construct (head1,args) ->
-                             let uu____20621 =
+                             let uu____20928 =
                                match FStar_List.rev args with
-                               | (last_arg,uu____20651)::args_rev ->
-                                   let uu____20663 =
-                                     let uu____20664 = unparen last_arg  in
-                                     uu____20664.FStar_Parser_AST.tm  in
-                                   (match uu____20663 with
+                               | (last_arg,uu____20958)::args_rev ->
+                                   let uu____20970 =
+                                     let uu____20971 = unparen last_arg  in
+                                     uu____20971.FStar_Parser_AST.tm  in
+                                   (match uu____20970 with
                                     | FStar_Parser_AST.Attributes ts ->
                                         (ts, (FStar_List.rev args_rev))
-                                    | uu____20692 -> ([], args))
-                               | uu____20701 -> ([], args)  in
-                             (match uu____20621 with
+                                    | uu____20999 -> ([], args))
+                               | uu____21008 -> ([], args)  in
+                             (match uu____20928 with
                               | (cattributes,args1) ->
-                                  let uu____20740 =
+                                  let uu____21047 =
                                     desugar_attributes env cattributes  in
                                   ((FStar_Parser_AST.mk_term
                                       (FStar_Parser_AST.Construct
                                          (head1, args1))
                                       t.FStar_Parser_AST.range
-                                      t.FStar_Parser_AST.level), uu____20740))
-                         | uu____20751 -> (t, [])  in
-                       match uu____20592 with
+                                      t.FStar_Parser_AST.level), uu____21047))
+                         | uu____21058 -> (t, [])  in
+                       match uu____20899 with
                        | (t1,cattributes) ->
                            let c =
                              desugar_comp t1.FStar_Parser_AST.range false
@@ -5863,10 +5885,10 @@ let rec (desugar_tycon :
                            let quals2 =
                              FStar_All.pipe_right quals1
                                (FStar_List.filter
-                                  (fun uu___23_20774  ->
-                                     match uu___23_20774 with
+                                  (fun uu___23_21081  ->
+                                     match uu___23_21081 with
                                      | FStar_Syntax_Syntax.Effect  -> false
-                                     | uu____20777 -> true))
+                                     | uu____21084 -> true))
                               in
                            {
                              FStar_Syntax_Syntax.sigel =
@@ -5891,23 +5913,23 @@ let rec (desugar_tycon :
                        d.FStar_Parser_AST.doc
                       in
                    (env2, [se]))
-          | (FStar_Parser_AST.TyconRecord uu____20786)::[] ->
+          | (FStar_Parser_AST.TyconRecord uu____21093)::[] ->
               let trec = FStar_List.hd tcs  in
-              let uu____20810 = tycon_record_as_variant trec  in
-              (match uu____20810 with
+              let uu____21117 = tycon_record_as_variant trec  in
+              (match uu____21117 with
                | (t,fs) ->
-                   let uu____20827 =
-                     let uu____20830 =
-                       let uu____20831 =
-                         let uu____20840 =
-                           let uu____20843 =
+                   let uu____21134 =
+                     let uu____21137 =
+                       let uu____21138 =
+                         let uu____21147 =
+                           let uu____21150 =
                              FStar_Syntax_DsEnv.current_module env  in
-                           FStar_Ident.ids_of_lid uu____20843  in
-                         (uu____20840, fs)  in
-                       FStar_Syntax_Syntax.RecordType uu____20831  in
-                     uu____20830 :: quals  in
-                   desugar_tycon env d uu____20827 [t])
-          | uu____20848::uu____20849 ->
+                           FStar_Ident.ids_of_lid uu____21150  in
+                         (uu____21147, fs)  in
+                       FStar_Syntax_Syntax.RecordType uu____21138  in
+                     uu____21137 :: quals  in
+                   desugar_tycon env d uu____21134 [t])
+          | uu____21155::uu____21156 ->
               let env0 = env  in
               let mutuals =
                 FStar_List.map
@@ -5916,89 +5938,89 @@ let rec (desugar_tycon :
                        (tycon_id x)) tcs
                  in
               let rec collect_tcs quals1 et tc =
-                let uu____21019 = et  in
-                match uu____21019 with
+                let uu____21326 = et  in
+                match uu____21326 with
                 | (env1,tcs1) ->
                     (match tc with
-                     | FStar_Parser_AST.TyconRecord uu____21249 ->
+                     | FStar_Parser_AST.TyconRecord uu____21556 ->
                          let trec = tc  in
-                         let uu____21273 = tycon_record_as_variant trec  in
-                         (match uu____21273 with
+                         let uu____21580 = tycon_record_as_variant trec  in
+                         (match uu____21580 with
                           | (t,fs) ->
-                              let uu____21333 =
-                                let uu____21336 =
-                                  let uu____21337 =
-                                    let uu____21346 =
-                                      let uu____21349 =
+                              let uu____21640 =
+                                let uu____21643 =
+                                  let uu____21644 =
+                                    let uu____21653 =
+                                      let uu____21656 =
                                         FStar_Syntax_DsEnv.current_module
                                           env1
                                          in
-                                      FStar_Ident.ids_of_lid uu____21349  in
-                                    (uu____21346, fs)  in
-                                  FStar_Syntax_Syntax.RecordType uu____21337
+                                      FStar_Ident.ids_of_lid uu____21656  in
+                                    (uu____21653, fs)  in
+                                  FStar_Syntax_Syntax.RecordType uu____21644
                                    in
-                                uu____21336 :: quals1  in
-                              collect_tcs uu____21333 (env1, tcs1) t)
+                                uu____21643 :: quals1  in
+                              collect_tcs uu____21640 (env1, tcs1) t)
                      | FStar_Parser_AST.TyconVariant
                          (id1,binders,kopt,constructors) ->
-                         let uu____21439 =
+                         let uu____21746 =
                            desugar_abstract_tc quals1 env1 mutuals
                              (FStar_Parser_AST.TyconAbstract
                                 (id1, binders, kopt))
                             in
-                         (match uu____21439 with
-                          | (env2,uu____21500,se,tconstr) ->
+                         (match uu____21746 with
+                          | (env2,uu____21807,se,tconstr) ->
                               (env2,
                                 ((FStar_Util.Inl
                                     (se, constructors, tconstr, quals1)) ::
                                 tcs1)))
                      | FStar_Parser_AST.TyconAbbrev (id1,binders,kopt,t) ->
-                         let uu____21653 =
+                         let uu____21960 =
                            desugar_abstract_tc quals1 env1 mutuals
                              (FStar_Parser_AST.TyconAbstract
                                 (id1, binders, kopt))
                             in
-                         (match uu____21653 with
-                          | (env2,uu____21714,se,tconstr) ->
+                         (match uu____21960 with
+                          | (env2,uu____22021,se,tconstr) ->
                               (env2,
                                 ((FStar_Util.Inr (se, binders, t, quals1)) ::
                                 tcs1)))
-                     | uu____21842 ->
+                     | uu____22149 ->
                          FStar_Errors.raise_error
                            (FStar_Errors.Fatal_NonInductiveInMutuallyDefinedType,
                              "Mutually defined type contains a non-inductive element")
                            rng)
                  in
-              let uu____21892 =
+              let uu____22199 =
                 FStar_List.fold_left (collect_tcs quals) (env, []) tcs  in
-              (match uu____21892 with
+              (match uu____22199 with
                | (env1,tcs1) ->
                    let tcs2 = FStar_List.rev tcs1  in
                    let docs_tps_sigelts =
                      FStar_All.pipe_right tcs2
                        (FStar_List.collect
-                          (fun uu___25_22407  ->
-                             match uu___25_22407 with
+                          (fun uu___25_22714  ->
+                             match uu___25_22714 with
                              | FStar_Util.Inr
                                  ({
                                     FStar_Syntax_Syntax.sigel =
                                       FStar_Syntax_Syntax.Sig_inductive_typ
-                                      (id1,uvs,tpars,k,uu____22473,uu____22474);
-                                    FStar_Syntax_Syntax.sigrng = uu____22475;
+                                      (id1,uvs,tpars,k,uu____22780,uu____22781);
+                                    FStar_Syntax_Syntax.sigrng = uu____22782;
                                     FStar_Syntax_Syntax.sigquals =
-                                      uu____22476;
-                                    FStar_Syntax_Syntax.sigmeta = uu____22477;
+                                      uu____22783;
+                                    FStar_Syntax_Syntax.sigmeta = uu____22784;
                                     FStar_Syntax_Syntax.sigattrs =
-                                      uu____22478;_},binders,t,quals1)
+                                      uu____22785;_},binders,t,quals1)
                                  ->
                                  let t1 =
-                                   let uu____22542 =
+                                   let uu____22849 =
                                      typars_of_binders env1 binders  in
-                                   match uu____22542 with
+                                   match uu____22849 with
                                    | (env2,tpars1) ->
-                                       let uu____22569 =
+                                       let uu____22876 =
                                          push_tparams env2 tpars1  in
-                                       (match uu____22569 with
+                                       (match uu____22876 with
                                         | (env_tps,tpars2) ->
                                             let t1 = desugar_typ env_tps t
                                                in
@@ -6009,27 +6031,27 @@ let rec (desugar_tycon :
                                             FStar_Syntax_Subst.close tpars3
                                               t1)
                                     in
-                                 let uu____22598 =
-                                   let uu____22617 =
+                                 let uu____22905 =
+                                   let uu____22924 =
                                      mk_typ_abbrev id1 uvs tpars
                                        (FStar_Pervasives_Native.Some k) t1
                                        [id1] quals1 rng
                                       in
                                    ((id1, (d.FStar_Parser_AST.doc)), [],
-                                     uu____22617)
+                                     uu____22924)
                                     in
-                                 [uu____22598]
+                                 [uu____22905]
                              | FStar_Util.Inl
                                  ({
                                     FStar_Syntax_Syntax.sigel =
                                       FStar_Syntax_Syntax.Sig_inductive_typ
-                                      (tname,univs1,tpars,k,mutuals1,uu____22677);
-                                    FStar_Syntax_Syntax.sigrng = uu____22678;
+                                      (tname,univs1,tpars,k,mutuals1,uu____22984);
+                                    FStar_Syntax_Syntax.sigrng = uu____22985;
                                     FStar_Syntax_Syntax.sigquals =
                                       tname_quals;
-                                    FStar_Syntax_Syntax.sigmeta = uu____22680;
+                                    FStar_Syntax_Syntax.sigmeta = uu____22987;
                                     FStar_Syntax_Syntax.sigattrs =
-                                      uu____22681;_},constrs,tconstr,quals1)
+                                      uu____22988;_},constrs,tconstr,quals1)
                                  ->
                                  let mk_tot t =
                                    let tot1 =
@@ -6046,27 +6068,27 @@ let rec (desugar_tycon :
                                      t.FStar_Parser_AST.level
                                     in
                                  let tycon = (tname, tpars, k)  in
-                                 let uu____22782 = push_tparams env1 tpars
+                                 let uu____23089 = push_tparams env1 tpars
                                     in
-                                 (match uu____22782 with
+                                 (match uu____23089 with
                                   | (env_tps,tps) ->
                                       let data_tpars =
                                         FStar_List.map
-                                          (fun uu____22849  ->
-                                             match uu____22849 with
-                                             | (x,uu____22861) ->
+                                          (fun uu____23156  ->
+                                             match uu____23156 with
+                                             | (x,uu____23168) ->
                                                  (x,
                                                    (FStar_Pervasives_Native.Some
                                                       (FStar_Syntax_Syntax.Implicit
                                                          true)))) tps
                                          in
                                       let tot_tconstr = mk_tot tconstr  in
-                                      let uu____22866 =
-                                        let uu____22893 =
+                                      let uu____23173 =
+                                        let uu____23200 =
                                           FStar_All.pipe_right constrs
                                             (FStar_List.map
-                                               (fun uu____23003  ->
-                                                  match uu____23003 with
+                                               (fun uu____23310  ->
+                                                  match uu____23310 with
                                                   | (id1,topt,doc1,of_notation)
                                                       ->
                                                       let t =
@@ -6099,10 +6121,10 @@ let rec (desugar_tycon :
                                                                t -> t)
                                                          in
                                                       let t1 =
-                                                        let uu____23063 =
+                                                        let uu____23370 =
                                                           close env_tps t  in
                                                         desugar_term env_tps
-                                                          uu____23063
+                                                          uu____23370
                                                          in
                                                       let name =
                                                         FStar_Syntax_DsEnv.qualify
@@ -6113,54 +6135,54 @@ let rec (desugar_tycon :
                                                           tname_quals
                                                           (FStar_List.collect
                                                              (fun
-                                                                uu___24_23074
+                                                                uu___24_23381
                                                                  ->
-                                                                match uu___24_23074
+                                                                match uu___24_23381
                                                                 with
                                                                 | FStar_Syntax_Syntax.RecordType
                                                                     fns ->
                                                                     [
                                                                     FStar_Syntax_Syntax.RecordConstructor
                                                                     fns]
-                                                                | uu____23086
+                                                                | uu____23393
                                                                     -> []))
                                                          in
                                                       let ntps =
                                                         FStar_List.length
                                                           data_tpars
                                                          in
-                                                      let uu____23094 =
-                                                        let uu____23113 =
-                                                          let uu____23114 =
-                                                            let uu____23115 =
-                                                              let uu____23131
+                                                      let uu____23401 =
+                                                        let uu____23420 =
+                                                          let uu____23421 =
+                                                            let uu____23422 =
+                                                              let uu____23438
                                                                 =
-                                                                let uu____23132
+                                                                let uu____23439
                                                                   =
-                                                                  let uu____23135
+                                                                  let uu____23442
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     t1
                                                                     FStar_Syntax_Util.name_function_binders
                                                                      in
                                                                   FStar_Syntax_Syntax.mk_Total
-                                                                    uu____23135
+                                                                    uu____23442
                                                                    in
                                                                 FStar_Syntax_Util.arrow
                                                                   data_tpars
-                                                                  uu____23132
+                                                                  uu____23439
                                                                  in
                                                               (name, univs1,
-                                                                uu____23131,
+                                                                uu____23438,
                                                                 tname, ntps,
                                                                 mutuals1)
                                                                in
                                                             FStar_Syntax_Syntax.Sig_datacon
-                                                              uu____23115
+                                                              uu____23422
                                                              in
                                                           {
                                                             FStar_Syntax_Syntax.sigel
-                                                              = uu____23114;
+                                                              = uu____23421;
                                                             FStar_Syntax_Syntax.sigrng
                                                               = rng;
                                                             FStar_Syntax_Syntax.sigquals
@@ -6172,14 +6194,14 @@ let rec (desugar_tycon :
                                                               = []
                                                           }  in
                                                         ((name, doc1), tps,
-                                                          uu____23113)
+                                                          uu____23420)
                                                          in
-                                                      (name, uu____23094)))
+                                                      (name, uu____23401)))
                                            in
                                         FStar_All.pipe_left FStar_List.split
-                                          uu____22893
+                                          uu____23200
                                          in
-                                      (match uu____22866 with
+                                      (match uu____23173 with
                                        | (constrNames,constrs1) ->
                                            ((tname, (d.FStar_Parser_AST.doc)),
                                              [],
@@ -6198,31 +6220,31 @@ let rec (desugar_tycon :
                                                  []
                                              })
                                            :: constrs1))
-                             | uu____23347 -> failwith "impossible"))
+                             | uu____23654 -> failwith "impossible"))
                       in
                    let name_docs =
                      FStar_All.pipe_right docs_tps_sigelts
                        (FStar_List.map
-                          (fun uu____23475  ->
-                             match uu____23475 with
-                             | (name_doc,uu____23501,uu____23502) -> name_doc))
+                          (fun uu____23782  ->
+                             match uu____23782 with
+                             | (name_doc,uu____23808,uu____23809) -> name_doc))
                       in
                    let sigelts =
                      FStar_All.pipe_right docs_tps_sigelts
                        (FStar_List.map
-                          (fun uu____23574  ->
-                             match uu____23574 with
-                             | (uu____23593,uu____23594,se) -> se))
+                          (fun uu____23881  ->
+                             match uu____23881 with
+                             | (uu____23900,uu____23901,se) -> se))
                       in
-                   let uu____23620 =
-                     let uu____23627 =
+                   let uu____23927 =
+                     let uu____23934 =
                        FStar_List.collect FStar_Syntax_Util.lids_of_sigelt
                          sigelts
                         in
                      FStar_Syntax_MutRecTy.disentangle_abbrevs_from_bundle
-                       sigelts quals uu____23627 rng
+                       sigelts quals uu____23934 rng
                       in
-                   (match uu____23620 with
+                   (match uu____23927 with
                     | (bundle,abbrevs) ->
                         let env2 = FStar_Syntax_DsEnv.push_sigelt env0 bundle
                            in
@@ -6233,9 +6255,9 @@ let rec (desugar_tycon :
                         let data_ops =
                           FStar_All.pipe_right docs_tps_sigelts
                             (FStar_List.collect
-                               (fun uu____23689  ->
-                                  match uu____23689 with
-                                  | (uu____23710,tps,se) ->
+                               (fun uu____23996  ->
+                                  match uu____23996 with
+                                  | (uu____24017,tps,se) ->
                                       mk_data_projector_names quals env3 se))
                            in
                         let discs =
@@ -6244,7 +6266,7 @@ let rec (desugar_tycon :
                                (fun se  ->
                                   match se.FStar_Syntax_Syntax.sigel with
                                   | FStar_Syntax_Syntax.Sig_inductive_typ
-                                      (tname,uu____23758,tps,k,uu____23761,constrs)
+                                      (tname,uu____24065,tps,k,uu____24068,constrs)
                                       ->
                                       let quals1 =
                                         se.FStar_Syntax_Syntax.sigquals  in
@@ -6261,13 +6283,13 @@ let rec (desugar_tycon :
                                         then FStar_Syntax_Syntax.Private ::
                                           quals1
                                         else quals1  in
-                                      let uu____23782 =
+                                      let uu____24089 =
                                         FStar_All.pipe_right constrs
                                           (FStar_List.filter
                                              (fun data_lid  ->
                                                 let data_quals =
                                                   let data_se =
-                                                    let uu____23797 =
+                                                    let uu____24104 =
                                                       FStar_All.pipe_right
                                                         sigelts
                                                         (FStar_List.find
@@ -6275,38 +6297,38 @@ let rec (desugar_tycon :
                                                               match se1.FStar_Syntax_Syntax.sigel
                                                               with
                                                               | FStar_Syntax_Syntax.Sig_datacon
-                                                                  (name,uu____23814,uu____23815,uu____23816,uu____23817,uu____23818)
+                                                                  (name,uu____24121,uu____24122,uu____24123,uu____24124,uu____24125)
                                                                   ->
                                                                   FStar_Ident.lid_equals
                                                                     name
                                                                     data_lid
-                                                              | uu____23825
+                                                              | uu____24132
                                                                   -> false))
                                                        in
                                                     FStar_All.pipe_right
-                                                      uu____23797
+                                                      uu____24104
                                                       FStar_Util.must
                                                      in
                                                   data_se.FStar_Syntax_Syntax.sigquals
                                                    in
-                                                let uu____23829 =
+                                                let uu____24136 =
                                                   FStar_All.pipe_right
                                                     data_quals
                                                     (FStar_List.existsb
-                                                       (fun uu___26_23836  ->
-                                                          match uu___26_23836
+                                                       (fun uu___26_24143  ->
+                                                          match uu___26_24143
                                                           with
                                                           | FStar_Syntax_Syntax.RecordConstructor
-                                                              uu____23838 ->
+                                                              uu____24145 ->
                                                               true
-                                                          | uu____23848 ->
+                                                          | uu____24155 ->
                                                               false))
                                                    in
-                                                Prims.op_Negation uu____23829))
+                                                Prims.op_Negation uu____24136))
                                          in
                                       mk_data_discriminators quals2 env3
-                                        uu____23782
-                                  | uu____23850 -> []))
+                                        uu____24089
+                                  | uu____24157 -> []))
                            in
                         let ops = FStar_List.append discs data_ops  in
                         let env4 =
@@ -6316,8 +6338,8 @@ let rec (desugar_tycon :
                         let env5 =
                           FStar_List.fold_left
                             (fun acc  ->
-                               fun uu____23867  ->
-                                 match uu____23867 with
+                               fun uu____24174  ->
+                                 match uu____24174 with
                                  | (lid,doc1) ->
                                      FStar_Syntax_DsEnv.push_doc env4 lid
                                        doc1) env4 name_docs
@@ -6336,28 +6358,28 @@ let (desugar_binders :
   =
   fun env  ->
     fun binders  ->
-      let uu____23912 =
+      let uu____24219 =
         FStar_List.fold_left
-          (fun uu____23947  ->
+          (fun uu____24254  ->
              fun b  ->
-               match uu____23947 with
+               match uu____24254 with
                | (env1,binders1) ->
-                   let uu____23991 = desugar_binder env1 b  in
-                   (match uu____23991 with
+                   let uu____24298 = desugar_binder env1 b  in
+                   (match uu____24298 with
                     | (FStar_Pervasives_Native.Some a,k) ->
-                        let uu____24014 =
+                        let uu____24321 =
                           as_binder env1 b.FStar_Parser_AST.aqual
                             ((FStar_Pervasives_Native.Some a), k)
                            in
-                        (match uu____24014 with
+                        (match uu____24321 with
                          | (binder,env2) -> (env2, (binder :: binders1)))
-                    | uu____24067 ->
+                    | uu____24374 ->
                         FStar_Errors.raise_error
                           (FStar_Errors.Fatal_MissingNameInBinder,
                             "Missing name in binder")
                           b.FStar_Parser_AST.brange)) (env, []) binders
          in
-      match uu____23912 with
+      match uu____24219 with
       | (env1,binders1) -> (env1, (FStar_List.rev binders1))
   
 let (push_reflect_effect :
@@ -6369,23 +6391,23 @@ let (push_reflect_effect :
     fun quals  ->
       fun effect_name  ->
         fun range  ->
-          let uu____24171 =
+          let uu____24478 =
             FStar_All.pipe_right quals
               (FStar_Util.for_some
-                 (fun uu___27_24178  ->
-                    match uu___27_24178 with
-                    | FStar_Syntax_Syntax.Reflectable uu____24180 -> true
-                    | uu____24182 -> false))
+                 (fun uu___27_24485  ->
+                    match uu___27_24485 with
+                    | FStar_Syntax_Syntax.Reflectable uu____24487 -> true
+                    | uu____24489 -> false))
              in
-          if uu____24171
+          if uu____24478
           then
             let monad_env =
               FStar_Syntax_DsEnv.enter_monad_scope env
                 effect_name.FStar_Ident.ident
                in
             let reflect_lid =
-              let uu____24187 = FStar_Ident.id_of_text "reflect"  in
-              FStar_All.pipe_right uu____24187
+              let uu____24494 = FStar_Ident.id_of_text "reflect"  in
+              FStar_All.pipe_right uu____24494
                 (FStar_Syntax_DsEnv.qualify monad_env)
                in
             let quals1 =
@@ -6414,52 +6436,52 @@ let (parse_attr_with_list :
   fun warn  ->
     fun at1  ->
       fun head1  ->
-        let warn1 uu____24238 =
+        let warn1 uu____24545 =
           if warn
           then
-            let uu____24240 =
-              let uu____24246 =
-                let uu____24248 = FStar_Ident.string_of_lid head1  in
+            let uu____24547 =
+              let uu____24553 =
+                let uu____24555 = FStar_Ident.string_of_lid head1  in
                 FStar_Util.format1
                   "Found ill-applied '%s', argument should be a non-empty list of integer literals"
-                  uu____24248
+                  uu____24555
                  in
-              (FStar_Errors.Warning_UnappliedFail, uu____24246)  in
-            FStar_Errors.log_issue at1.FStar_Syntax_Syntax.pos uu____24240
+              (FStar_Errors.Warning_UnappliedFail, uu____24553)  in
+            FStar_Errors.log_issue at1.FStar_Syntax_Syntax.pos uu____24547
           else ()  in
-        let uu____24254 = FStar_Syntax_Util.head_and_args at1  in
-        match uu____24254 with
+        let uu____24561 = FStar_Syntax_Util.head_and_args at1  in
+        match uu____24561 with
         | (hd1,args) ->
-            let uu____24307 =
-              let uu____24308 = FStar_Syntax_Subst.compress hd1  in
-              uu____24308.FStar_Syntax_Syntax.n  in
-            (match uu____24307 with
+            let uu____24614 =
+              let uu____24615 = FStar_Syntax_Subst.compress hd1  in
+              uu____24615.FStar_Syntax_Syntax.n  in
+            (match uu____24614 with
              | FStar_Syntax_Syntax.Tm_fvar fv when
                  FStar_Syntax_Syntax.fv_eq_lid fv head1 ->
                  (match args with
                   | [] -> ((FStar_Pervasives_Native.Some []), true)
-                  | (a1,uu____24352)::[] ->
-                      let uu____24377 =
-                        let uu____24382 =
-                          let uu____24391 =
+                  | (a1,uu____24659)::[] ->
+                      let uu____24684 =
+                        let uu____24689 =
+                          let uu____24698 =
                             FStar_Syntax_Embeddings.e_list
                               FStar_Syntax_Embeddings.e_int
                              in
-                          FStar_Syntax_Embeddings.unembed uu____24391 a1  in
-                        uu____24382 true FStar_Syntax_Embeddings.id_norm_cb
+                          FStar_Syntax_Embeddings.unembed uu____24698 a1  in
+                        uu____24689 true FStar_Syntax_Embeddings.id_norm_cb
                          in
-                      (match uu____24377 with
+                      (match uu____24684 with
                        | FStar_Pervasives_Native.Some es ->
-                           let uu____24414 =
-                             let uu____24420 =
+                           let uu____24721 =
+                             let uu____24727 =
                                FStar_List.map FStar_BigInt.to_int_fs es  in
-                             FStar_Pervasives_Native.Some uu____24420  in
-                           (uu____24414, true)
-                       | uu____24435 ->
+                             FStar_Pervasives_Native.Some uu____24727  in
+                           (uu____24721, true)
+                       | uu____24742 ->
                            (warn1 (); (FStar_Pervasives_Native.None, true)))
-                  | uu____24451 ->
+                  | uu____24758 ->
                       (warn1 (); (FStar_Pervasives_Native.None, true)))
-             | uu____24473 -> (FStar_Pervasives_Native.None, false))
+             | uu____24780 -> (FStar_Pervasives_Native.None, false))
   
 let (get_fail_attr :
   Prims.bool ->
@@ -6474,17 +6496,17 @@ let (get_fail_attr :
         | FStar_Pervasives_Native.Some l ->
             FStar_Pervasives_Native.Some (l, b)
          in
-      let uu____24590 =
+      let uu____24897 =
         parse_attr_with_list warn at1 FStar_Parser_Const.fail_attr  in
-      match uu____24590 with
+      match uu____24897 with
       | (res,matched) ->
           if matched
           then rebind res false
           else
-            (let uu____24639 =
+            (let uu____24946 =
                parse_attr_with_list warn at1 FStar_Parser_Const.fail_lax_attr
                 in
-             match uu____24639 with | (res1,uu____24661) -> rebind res1 true)
+             match uu____24946 with | (res1,uu____24968) -> rebind res1 true)
   
 let rec (desugar_effect :
   FStar_Syntax_DsEnv.env ->
@@ -6509,18 +6531,18 @@ let rec (desugar_effect :
                   let env0 = env  in
                   let monad_env =
                     FStar_Syntax_DsEnv.enter_monad_scope env eff_name  in
-                  let uu____24826 = desugar_binders monad_env eff_binders  in
-                  match uu____24826 with
+                  let uu____25133 = desugar_binders monad_env eff_binders  in
+                  match uu____25133 with
                   | (env1,binders) ->
                       let eff_t = desugar_term env1 eff_typ  in
                       let for_free =
-                        let uu____24866 =
-                          let uu____24868 =
-                            let uu____24877 =
+                        let uu____25173 =
+                          let uu____25175 =
+                            let uu____25184 =
                               FStar_Syntax_Util.arrow_formals eff_t  in
-                            FStar_Pervasives_Native.fst uu____24877  in
-                          FStar_List.length uu____24868  in
-                        uu____24866 = Prims.int_one  in
+                            FStar_Pervasives_Native.fst uu____25184  in
+                          FStar_List.length uu____25175  in
+                        uu____25173 = Prims.int_one  in
                       let mandatory_members =
                         let rr_members = ["repr"; "return"; "bind"]  in
                         if for_free
@@ -6538,40 +6560,40 @@ let rec (desugar_effect :
                       let name_of_eff_decl decl =
                         match decl.FStar_Parser_AST.d with
                         | FStar_Parser_AST.Tycon
-                            (uu____24955,uu____24956,(FStar_Parser_AST.TyconAbbrev
-                                                      (name,uu____24958,uu____24959,uu____24960),uu____24961)::[])
+                            (uu____25262,uu____25263,(FStar_Parser_AST.TyconAbbrev
+                                                      (name,uu____25265,uu____25266,uu____25267),uu____25268)::[])
                             -> FStar_Ident.text_of_id name
-                        | uu____24998 ->
+                        | uu____25305 ->
                             failwith "Malformed effect member declaration."
                          in
-                      let uu____25001 =
+                      let uu____25308 =
                         FStar_List.partition
                           (fun decl  ->
-                             let uu____25013 = name_of_eff_decl decl  in
-                             FStar_List.mem uu____25013 mandatory_members)
+                             let uu____25320 = name_of_eff_decl decl  in
+                             FStar_List.mem uu____25320 mandatory_members)
                           eff_decls
                          in
-                      (match uu____25001 with
+                      (match uu____25308 with
                        | (mandatory_members_decls,actions) ->
-                           let uu____25032 =
+                           let uu____25339 =
                              FStar_All.pipe_right mandatory_members_decls
                                (FStar_List.fold_left
-                                  (fun uu____25061  ->
+                                  (fun uu____25368  ->
                                      fun decl  ->
-                                       match uu____25061 with
+                                       match uu____25368 with
                                        | (env2,out) ->
-                                           let uu____25081 =
+                                           let uu____25388 =
                                              desugar_decl env2 decl  in
-                                           (match uu____25081 with
+                                           (match uu____25388 with
                                             | (env3,ses) ->
-                                                let uu____25094 =
-                                                  let uu____25097 =
+                                                let uu____25401 =
+                                                  let uu____25404 =
                                                     FStar_List.hd ses  in
-                                                  uu____25097 :: out  in
-                                                (env3, uu____25094)))
+                                                  uu____25404 :: out  in
+                                                (env3, uu____25401)))
                                   (env1, []))
                               in
-                           (match uu____25032 with
+                           (match uu____25339 with
                             | (env2,decls) ->
                                 let binders1 =
                                   FStar_Syntax_Subst.close_binders binders
@@ -6582,37 +6604,37 @@ let rec (desugar_effect :
                                        (fun d1  ->
                                           match d1.FStar_Parser_AST.d with
                                           | FStar_Parser_AST.Tycon
-                                              (uu____25166,uu____25167,
+                                              (uu____25473,uu____25474,
                                                (FStar_Parser_AST.TyconAbbrev
-                                                (name,action_params,uu____25170,
+                                                (name,action_params,uu____25477,
                                                  {
                                                    FStar_Parser_AST.tm =
                                                      FStar_Parser_AST.Construct
-                                                     (uu____25171,(def,uu____25173)::
-                                                      (cps_type,uu____25175)::[]);
+                                                     (uu____25478,(def,uu____25480)::
+                                                      (cps_type,uu____25482)::[]);
                                                    FStar_Parser_AST.range =
-                                                     uu____25176;
+                                                     uu____25483;
                                                    FStar_Parser_AST.level =
-                                                     uu____25177;_}),doc1)::[])
+                                                     uu____25484;_}),doc1)::[])
                                               when Prims.op_Negation for_free
                                               ->
-                                              let uu____25233 =
+                                              let uu____25540 =
                                                 desugar_binders env2
                                                   action_params
                                                  in
-                                              (match uu____25233 with
+                                              (match uu____25540 with
                                                | (env3,action_params1) ->
                                                    let action_params2 =
                                                      FStar_Syntax_Subst.close_binders
                                                        action_params1
                                                       in
-                                                   let uu____25271 =
-                                                     let uu____25272 =
+                                                   let uu____25578 =
+                                                     let uu____25579 =
                                                        FStar_Syntax_DsEnv.qualify
                                                          env3 name
                                                         in
-                                                     let uu____25273 =
-                                                       let uu____25274 =
+                                                     let uu____25580 =
+                                                       let uu____25581 =
                                                          desugar_term env3
                                                            def
                                                           in
@@ -6620,10 +6642,10 @@ let rec (desugar_effect :
                                                          (FStar_List.append
                                                             binders1
                                                             action_params2)
-                                                         uu____25274
+                                                         uu____25581
                                                         in
-                                                     let uu____25281 =
-                                                       let uu____25282 =
+                                                     let uu____25588 =
+                                                       let uu____25589 =
                                                          desugar_typ env3
                                                            cps_type
                                                           in
@@ -6631,11 +6653,11 @@ let rec (desugar_effect :
                                                          (FStar_List.append
                                                             binders1
                                                             action_params2)
-                                                         uu____25282
+                                                         uu____25589
                                                         in
                                                      {
                                                        FStar_Syntax_Syntax.action_name
-                                                         = uu____25272;
+                                                         = uu____25579;
                                                        FStar_Syntax_Syntax.action_unqualified_name
                                                          = name;
                                                        FStar_Syntax_Syntax.action_univs
@@ -6643,33 +6665,33 @@ let rec (desugar_effect :
                                                        FStar_Syntax_Syntax.action_params
                                                          = action_params2;
                                                        FStar_Syntax_Syntax.action_defn
-                                                         = uu____25273;
+                                                         = uu____25580;
                                                        FStar_Syntax_Syntax.action_typ
-                                                         = uu____25281
+                                                         = uu____25588
                                                      }  in
-                                                   (uu____25271, doc1))
+                                                   (uu____25578, doc1))
                                           | FStar_Parser_AST.Tycon
-                                              (uu____25291,uu____25292,
+                                              (uu____25598,uu____25599,
                                                (FStar_Parser_AST.TyconAbbrev
-                                                (name,action_params,uu____25295,defn),doc1)::[])
+                                                (name,action_params,uu____25602,defn),doc1)::[])
                                               when for_free ->
-                                              let uu____25334 =
+                                              let uu____25641 =
                                                 desugar_binders env2
                                                   action_params
                                                  in
-                                              (match uu____25334 with
+                                              (match uu____25641 with
                                                | (env3,action_params1) ->
                                                    let action_params2 =
                                                      FStar_Syntax_Subst.close_binders
                                                        action_params1
                                                       in
-                                                   let uu____25372 =
-                                                     let uu____25373 =
+                                                   let uu____25679 =
+                                                     let uu____25680 =
                                                        FStar_Syntax_DsEnv.qualify
                                                          env3 name
                                                         in
-                                                     let uu____25374 =
-                                                       let uu____25375 =
+                                                     let uu____25681 =
+                                                       let uu____25682 =
                                                          desugar_term env3
                                                            defn
                                                           in
@@ -6677,11 +6699,11 @@ let rec (desugar_effect :
                                                          (FStar_List.append
                                                             binders1
                                                             action_params2)
-                                                         uu____25375
+                                                         uu____25682
                                                         in
                                                      {
                                                        FStar_Syntax_Syntax.action_name
-                                                         = uu____25373;
+                                                         = uu____25680;
                                                        FStar_Syntax_Syntax.action_unqualified_name
                                                          = name;
                                                        FStar_Syntax_Syntax.action_univs
@@ -6689,13 +6711,13 @@ let rec (desugar_effect :
                                                        FStar_Syntax_Syntax.action_params
                                                          = action_params2;
                                                        FStar_Syntax_Syntax.action_defn
-                                                         = uu____25374;
+                                                         = uu____25681;
                                                        FStar_Syntax_Syntax.action_typ
                                                          =
                                                          FStar_Syntax_Syntax.tun
                                                      }  in
-                                                   (uu____25372, doc1))
-                                          | uu____25384 ->
+                                                   (uu____25679, doc1))
+                                          | uu____25691 ->
                                               FStar_Errors.raise_error
                                                 (FStar_Errors.Fatal_MalformedActionDeclaration,
                                                   "Malformed action declaration; if this is an \"effect for free\", just provide the direct-style declaration. If this is not an \"effect for free\", please provide a pair of the definition and its cps-type with arrows inserted in the right place (see examples).")
@@ -6709,24 +6731,24 @@ let rec (desugar_effect :
                                   FStar_Syntax_Subst.close binders1 eff_t  in
                                 let lookup1 s =
                                   let l =
-                                    let uu____25420 =
+                                    let uu____25727 =
                                       FStar_Ident.mk_ident
                                         (s, (d.FStar_Parser_AST.drange))
                                        in
                                     FStar_Syntax_DsEnv.qualify env2
-                                      uu____25420
+                                      uu____25727
                                      in
-                                  let uu____25422 =
-                                    let uu____25423 =
+                                  let uu____25729 =
+                                    let uu____25730 =
                                       FStar_Syntax_DsEnv.fail_or env2
                                         (FStar_Syntax_DsEnv.try_lookup_definition
                                            env2) l
                                        in
                                     FStar_All.pipe_left
                                       (FStar_Syntax_Subst.close binders1)
-                                      uu____25423
+                                      uu____25730
                                      in
-                                  ([], uu____25422)  in
+                                  ([], uu____25729)  in
                                 let mname =
                                   FStar_Syntax_DsEnv.qualify env0 eff_name
                                    in
@@ -6740,20 +6762,20 @@ let rec (desugar_effect :
                                   if for_free
                                   then
                                     let dummy_tscheme =
-                                      let uu____25441 =
+                                      let uu____25748 =
                                         FStar_Syntax_Syntax.mk
                                           FStar_Syntax_Syntax.Tm_unknown
                                           FStar_Pervasives_Native.None
                                           FStar_Range.dummyRange
                                          in
-                                      ([], uu____25441)  in
-                                    let uu____25448 =
-                                      let uu____25449 =
-                                        let uu____25450 = lookup1 "repr"  in
-                                        let uu____25452 = lookup1 "return"
+                                      ([], uu____25748)  in
+                                    let uu____25755 =
+                                      let uu____25756 =
+                                        let uu____25757 = lookup1 "repr"  in
+                                        let uu____25759 = lookup1 "return"
                                            in
-                                        let uu____25454 = lookup1 "bind"  in
-                                        let uu____25456 =
+                                        let uu____25761 = lookup1 "bind"  in
+                                        let uu____25763 =
                                           FStar_List.map (desugar_term env2)
                                             attrs
                                            in
@@ -6781,21 +6803,21 @@ let rec (desugar_effect :
                                           FStar_Syntax_Syntax.trivial =
                                             dummy_tscheme;
                                           FStar_Syntax_Syntax.repr =
-                                            uu____25450;
+                                            uu____25757;
                                           FStar_Syntax_Syntax.return_repr =
-                                            uu____25452;
+                                            uu____25759;
                                           FStar_Syntax_Syntax.bind_repr =
-                                            uu____25454;
+                                            uu____25761;
                                           FStar_Syntax_Syntax.actions =
                                             actions1;
                                           FStar_Syntax_Syntax.eff_attrs =
-                                            uu____25456
+                                            uu____25763
                                         }  in
                                       FStar_Syntax_Syntax.Sig_new_effect_for_free
-                                        uu____25449
+                                        uu____25756
                                        in
                                     {
-                                      FStar_Syntax_Syntax.sigel = uu____25448;
+                                      FStar_Syntax_Syntax.sigel = uu____25755;
                                       FStar_Syntax_Syntax.sigrng =
                                         (d.FStar_Parser_AST.drange);
                                       FStar_Syntax_Syntax.sigquals =
@@ -6807,47 +6829,47 @@ let rec (desugar_effect :
                                   else
                                     (let rr =
                                        FStar_Util.for_some
-                                         (fun uu___28_25468  ->
-                                            match uu___28_25468 with
+                                         (fun uu___28_25775  ->
+                                            match uu___28_25775 with
                                             | FStar_Syntax_Syntax.Reifiable 
                                                 -> true
                                             | FStar_Syntax_Syntax.Reflectable
-                                                uu____25471 -> true
-                                            | uu____25473 -> false)
+                                                uu____25778 -> true
+                                            | uu____25780 -> false)
                                          qualifiers
                                         in
                                      let un_ts =
                                        ([], FStar_Syntax_Syntax.tun)  in
-                                     let uu____25488 =
-                                       let uu____25489 =
-                                         let uu____25490 =
+                                     let uu____25795 =
+                                       let uu____25796 =
+                                         let uu____25797 =
                                            lookup1 "return_wp"  in
-                                         let uu____25492 = lookup1 "bind_wp"
+                                         let uu____25799 = lookup1 "bind_wp"
                                             in
-                                         let uu____25494 =
+                                         let uu____25801 =
                                            lookup1 "if_then_else"  in
-                                         let uu____25496 = lookup1 "ite_wp"
+                                         let uu____25803 = lookup1 "ite_wp"
                                             in
-                                         let uu____25498 = lookup1 "stronger"
+                                         let uu____25805 = lookup1 "stronger"
                                             in
-                                         let uu____25500 = lookup1 "close_wp"
+                                         let uu____25807 = lookup1 "close_wp"
                                             in
-                                         let uu____25502 = lookup1 "trivial"
+                                         let uu____25809 = lookup1 "trivial"
                                             in
-                                         let uu____25504 =
+                                         let uu____25811 =
                                            if rr
                                            then lookup1 "repr"
                                            else ([], FStar_Syntax_Syntax.tun)
                                             in
-                                         let uu____25513 =
+                                         let uu____25820 =
                                            if rr
                                            then lookup1 "return"
                                            else un_ts  in
-                                         let uu____25518 =
+                                         let uu____25825 =
                                            if rr
                                            then lookup1 "bind"
                                            else un_ts  in
-                                         let uu____25523 =
+                                         let uu____25830 =
                                            FStar_List.map (desugar_term env2)
                                              attrs
                                             in
@@ -6861,36 +6883,36 @@ let rec (desugar_effect :
                                            FStar_Syntax_Syntax.signature =
                                              ([], eff_t1);
                                            FStar_Syntax_Syntax.ret_wp =
-                                             uu____25490;
+                                             uu____25797;
                                            FStar_Syntax_Syntax.bind_wp =
-                                             uu____25492;
+                                             uu____25799;
                                            FStar_Syntax_Syntax.if_then_else =
-                                             uu____25494;
+                                             uu____25801;
                                            FStar_Syntax_Syntax.ite_wp =
-                                             uu____25496;
+                                             uu____25803;
                                            FStar_Syntax_Syntax.stronger =
-                                             uu____25498;
+                                             uu____25805;
                                            FStar_Syntax_Syntax.close_wp =
-                                             uu____25500;
+                                             uu____25807;
                                            FStar_Syntax_Syntax.trivial =
-                                             uu____25502;
+                                             uu____25809;
                                            FStar_Syntax_Syntax.repr =
-                                             uu____25504;
+                                             uu____25811;
                                            FStar_Syntax_Syntax.return_repr =
-                                             uu____25513;
+                                             uu____25820;
                                            FStar_Syntax_Syntax.bind_repr =
-                                             uu____25518;
+                                             uu____25825;
                                            FStar_Syntax_Syntax.actions =
                                              actions1;
                                            FStar_Syntax_Syntax.eff_attrs =
-                                             uu____25523
+                                             uu____25830
                                          }  in
                                        FStar_Syntax_Syntax.Sig_new_effect
-                                         uu____25489
+                                         uu____25796
                                         in
                                      {
                                        FStar_Syntax_Syntax.sigel =
-                                         uu____25488;
+                                         uu____25795;
                                        FStar_Syntax_Syntax.sigrng =
                                          (d.FStar_Parser_AST.drange);
                                        FStar_Syntax_Syntax.sigquals =
@@ -6910,17 +6932,17 @@ let rec (desugar_effect :
                                   FStar_All.pipe_right actions_docs
                                     (FStar_List.fold_left
                                        (fun env5  ->
-                                          fun uu____25553  ->
-                                            match uu____25553 with
+                                          fun uu____25860  ->
+                                            match uu____25860 with
                                             | (a,doc1) ->
                                                 let env6 =
-                                                  let uu____25567 =
+                                                  let uu____25874 =
                                                     FStar_Syntax_Util.action_as_lb
                                                       mname a
                                                       (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
                                                      in
                                                   FStar_Syntax_DsEnv.push_sigelt
-                                                    env5 uu____25567
+                                                    env5 uu____25874
                                                    in
                                                 FStar_Syntax_DsEnv.push_doc
                                                   env6
@@ -6960,30 +6982,30 @@ and (desugar_redefine_effect :
                 let env0 = env  in
                 let env1 = FStar_Syntax_DsEnv.enter_monad_scope env eff_name
                    in
-                let uu____25591 = desugar_binders env1 eff_binders  in
-                match uu____25591 with
+                let uu____25898 = desugar_binders env1 eff_binders  in
+                match uu____25898 with
                 | (env2,binders) ->
-                    let uu____25628 =
-                      let uu____25639 = head_and_args defn  in
-                      match uu____25639 with
+                    let uu____25935 =
+                      let uu____25946 = head_and_args defn  in
+                      match uu____25946 with
                       | (head1,args) ->
                           let lid =
                             match head1.FStar_Parser_AST.tm with
                             | FStar_Parser_AST.Name l -> l
-                            | uu____25676 ->
-                                let uu____25677 =
-                                  let uu____25683 =
-                                    let uu____25685 =
-                                      let uu____25687 =
+                            | uu____25983 ->
+                                let uu____25984 =
+                                  let uu____25990 =
+                                    let uu____25992 =
+                                      let uu____25994 =
                                         FStar_Parser_AST.term_to_string head1
                                          in
-                                      Prims.op_Hat uu____25687 " not found"
+                                      Prims.op_Hat uu____25994 " not found"
                                        in
-                                    Prims.op_Hat "Effect " uu____25685  in
+                                    Prims.op_Hat "Effect " uu____25992  in
                                   (FStar_Errors.Fatal_EffectNotFound,
-                                    uu____25683)
+                                    uu____25990)
                                    in
-                                FStar_Errors.raise_error uu____25677
+                                FStar_Errors.raise_error uu____25984
                                   d.FStar_Parser_AST.drange
                              in
                           let ed =
@@ -6991,25 +7013,25 @@ and (desugar_redefine_effect :
                               (FStar_Syntax_DsEnv.try_lookup_effect_defn env2)
                               lid
                              in
-                          let uu____25693 =
+                          let uu____26000 =
                             match FStar_List.rev args with
-                            | (last_arg,uu____25723)::args_rev ->
-                                let uu____25735 =
-                                  let uu____25736 = unparen last_arg  in
-                                  uu____25736.FStar_Parser_AST.tm  in
-                                (match uu____25735 with
+                            | (last_arg,uu____26030)::args_rev ->
+                                let uu____26042 =
+                                  let uu____26043 = unparen last_arg  in
+                                  uu____26043.FStar_Parser_AST.tm  in
+                                (match uu____26042 with
                                  | FStar_Parser_AST.Attributes ts ->
                                      (ts, (FStar_List.rev args_rev))
-                                 | uu____25764 -> ([], args))
-                            | uu____25773 -> ([], args)  in
-                          (match uu____25693 with
+                                 | uu____26071 -> ([], args))
+                            | uu____26080 -> ([], args)  in
+                          (match uu____26000 with
                            | (cattributes,args1) ->
-                               let uu____25816 = desugar_args env2 args1  in
-                               let uu____25817 =
+                               let uu____26123 = desugar_args env2 args1  in
+                               let uu____26124 =
                                  desugar_attributes env2 cattributes  in
-                               (lid, ed, uu____25816, uu____25817))
+                               (lid, ed, uu____26123, uu____26124))
                        in
-                    (match uu____25628 with
+                    (match uu____25935 with
                      | (ed_lid,ed,args,cattributes) ->
                          let binders1 =
                            FStar_Syntax_Subst.close_binders binders  in
@@ -7023,95 +7045,95 @@ and (desugar_redefine_effect :
                                 "Unexpected number of arguments to effect constructor")
                               defn.FStar_Parser_AST.range
                           else ();
-                          (let uu____25857 =
+                          (let uu____26164 =
                              FStar_Syntax_Subst.open_term'
                                ed.FStar_Syntax_Syntax.binders
                                FStar_Syntax_Syntax.t_unit
                               in
-                           match uu____25857 with
-                           | (ed_binders,uu____25871,ed_binders_opening) ->
-                               let sub' shift_n uu____25890 =
-                                 match uu____25890 with
+                           match uu____26164 with
+                           | (ed_binders,uu____26178,ed_binders_opening) ->
+                               let sub' shift_n uu____26197 =
+                                 match uu____26197 with
                                  | (us,x) ->
                                      let x1 =
-                                       let uu____25905 =
+                                       let uu____26212 =
                                          FStar_Syntax_Subst.shift_subst
                                            (shift_n + (FStar_List.length us))
                                            ed_binders_opening
                                           in
-                                       FStar_Syntax_Subst.subst uu____25905 x
+                                       FStar_Syntax_Subst.subst uu____26212 x
                                         in
                                      let s =
                                        FStar_Syntax_Util.subst_of_list
                                          ed_binders args
                                         in
-                                     let uu____25909 =
-                                       let uu____25910 =
+                                     let uu____26216 =
+                                       let uu____26217 =
                                          FStar_Syntax_Subst.subst s x1  in
-                                       (us, uu____25910)  in
+                                       (us, uu____26217)  in
                                      FStar_Syntax_Subst.close_tscheme
-                                       binders1 uu____25909
+                                       binders1 uu____26216
                                   in
                                let sub1 = sub' Prims.int_zero  in
                                let mname =
                                  FStar_Syntax_DsEnv.qualify env0 eff_name  in
                                let ed1 =
-                                 let uu____25931 =
+                                 let uu____26238 =
                                    sub1 ed.FStar_Syntax_Syntax.signature  in
-                                 let uu____25932 =
+                                 let uu____26239 =
                                    sub1 ed.FStar_Syntax_Syntax.ret_wp  in
-                                 let uu____25933 =
+                                 let uu____26240 =
                                    sub1 ed.FStar_Syntax_Syntax.bind_wp  in
-                                 let uu____25934 =
+                                 let uu____26241 =
                                    sub1 ed.FStar_Syntax_Syntax.if_then_else
                                     in
-                                 let uu____25935 =
+                                 let uu____26242 =
                                    sub1 ed.FStar_Syntax_Syntax.ite_wp  in
-                                 let uu____25936 =
+                                 let uu____26243 =
                                    sub1 ed.FStar_Syntax_Syntax.stronger  in
-                                 let uu____25937 =
+                                 let uu____26244 =
                                    sub1 ed.FStar_Syntax_Syntax.close_wp  in
-                                 let uu____25938 =
+                                 let uu____26245 =
                                    sub1 ed.FStar_Syntax_Syntax.trivial  in
-                                 let uu____25939 =
+                                 let uu____26246 =
                                    sub1 ed.FStar_Syntax_Syntax.repr  in
-                                 let uu____25940 =
+                                 let uu____26247 =
                                    sub1 ed.FStar_Syntax_Syntax.return_repr
                                     in
-                                 let uu____25941 =
+                                 let uu____26248 =
                                    sub1 ed.FStar_Syntax_Syntax.bind_repr  in
-                                 let uu____25942 =
+                                 let uu____26249 =
                                    FStar_List.map
                                      (fun action  ->
                                         let nparam =
                                           FStar_List.length
                                             action.FStar_Syntax_Syntax.action_params
                                            in
-                                        let uu____25958 =
+                                        let uu____26265 =
                                           FStar_Syntax_DsEnv.qualify env2
                                             action.FStar_Syntax_Syntax.action_unqualified_name
                                            in
-                                        let uu____25959 =
-                                          let uu____25960 =
+                                        let uu____26266 =
+                                          let uu____26267 =
                                             sub' nparam
                                               ([],
                                                 (action.FStar_Syntax_Syntax.action_defn))
                                              in
                                           FStar_Pervasives_Native.snd
-                                            uu____25960
+                                            uu____26267
                                            in
-                                        let uu____25975 =
-                                          let uu____25976 =
+                                        let uu____26282 =
+                                          let uu____26283 =
                                             sub' nparam
                                               ([],
                                                 (action.FStar_Syntax_Syntax.action_typ))
                                              in
                                           FStar_Pervasives_Native.snd
-                                            uu____25976
+                                            uu____26283
                                            in
                                         {
                                           FStar_Syntax_Syntax.action_name =
-                                            uu____25958;
+                                            uu____26265;
                                           FStar_Syntax_Syntax.action_unqualified_name
                                             =
                                             (action.FStar_Syntax_Syntax.action_unqualified_name);
@@ -7120,9 +7142,9 @@ and (desugar_redefine_effect :
                                           FStar_Syntax_Syntax.action_params =
                                             (action.FStar_Syntax_Syntax.action_params);
                                           FStar_Syntax_Syntax.action_defn =
-                                            uu____25959;
+                                            uu____26266;
                                           FStar_Syntax_Syntax.action_typ =
-                                            uu____25975
+                                            uu____26282
                                         }) ed.FStar_Syntax_Syntax.actions
                                     in
                                  {
@@ -7133,48 +7155,48 @@ and (desugar_redefine_effect :
                                      (ed.FStar_Syntax_Syntax.univs);
                                    FStar_Syntax_Syntax.binders = binders1;
                                    FStar_Syntax_Syntax.signature =
-                                     uu____25931;
-                                   FStar_Syntax_Syntax.ret_wp = uu____25932;
-                                   FStar_Syntax_Syntax.bind_wp = uu____25933;
+                                     uu____26238;
+                                   FStar_Syntax_Syntax.ret_wp = uu____26239;
+                                   FStar_Syntax_Syntax.bind_wp = uu____26240;
                                    FStar_Syntax_Syntax.if_then_else =
-                                     uu____25934;
-                                   FStar_Syntax_Syntax.ite_wp = uu____25935;
-                                   FStar_Syntax_Syntax.stronger = uu____25936;
-                                   FStar_Syntax_Syntax.close_wp = uu____25937;
-                                   FStar_Syntax_Syntax.trivial = uu____25938;
-                                   FStar_Syntax_Syntax.repr = uu____25939;
+                                     uu____26241;
+                                   FStar_Syntax_Syntax.ite_wp = uu____26242;
+                                   FStar_Syntax_Syntax.stronger = uu____26243;
+                                   FStar_Syntax_Syntax.close_wp = uu____26244;
+                                   FStar_Syntax_Syntax.trivial = uu____26245;
+                                   FStar_Syntax_Syntax.repr = uu____26246;
                                    FStar_Syntax_Syntax.return_repr =
-                                     uu____25940;
+                                     uu____26247;
                                    FStar_Syntax_Syntax.bind_repr =
-                                     uu____25941;
-                                   FStar_Syntax_Syntax.actions = uu____25942;
+                                     uu____26248;
+                                   FStar_Syntax_Syntax.actions = uu____26249;
                                    FStar_Syntax_Syntax.eff_attrs =
                                      (ed.FStar_Syntax_Syntax.eff_attrs)
                                  }  in
                                let se =
                                  let for_free =
-                                   let uu____25994 =
-                                     let uu____25996 =
-                                       let uu____26005 =
-                                         let uu____26020 =
+                                   let uu____26301 =
+                                     let uu____26303 =
+                                       let uu____26312 =
+                                         let uu____26327 =
                                            FStar_All.pipe_right
                                              ed1.FStar_Syntax_Syntax.signature
                                              FStar_Pervasives_Native.snd
                                             in
-                                         FStar_All.pipe_right uu____26020
+                                         FStar_All.pipe_right uu____26327
                                            FStar_Syntax_Util.arrow_formals
                                           in
                                        FStar_Pervasives_Native.fst
-                                         uu____26005
+                                         uu____26312
                                         in
-                                     FStar_List.length uu____25996  in
-                                   uu____25994 = Prims.int_one  in
-                                 let uu____26065 =
-                                   let uu____26068 =
+                                     FStar_List.length uu____26303  in
+                                   uu____26301 = Prims.int_one  in
+                                 let uu____26372 =
+                                   let uu____26375 =
                                      trans_qual1
                                        (FStar_Pervasives_Native.Some mname)
                                       in
-                                   FStar_List.map uu____26068 quals  in
+                                   FStar_List.map uu____26375 quals  in
                                  {
                                    FStar_Syntax_Syntax.sigel =
                                      (if for_free
@@ -7186,7 +7208,7 @@ and (desugar_redefine_effect :
                                           ed1);
                                    FStar_Syntax_Syntax.sigrng =
                                      (d.FStar_Parser_AST.drange);
-                                   FStar_Syntax_Syntax.sigquals = uu____26065;
+                                   FStar_Syntax_Syntax.sigquals = uu____26372;
                                    FStar_Syntax_Syntax.sigmeta =
                                      FStar_Syntax_Syntax.default_sigmeta;
                                    FStar_Syntax_Syntax.sigattrs = []
@@ -7210,30 +7232,30 @@ and (desugar_redefine_effect :
                                                a.FStar_Syntax_Syntax.action_name
                                               in
                                            let env6 =
-                                             let uu____26092 =
+                                             let uu____26399 =
                                                FStar_Syntax_Util.action_as_lb
                                                  mname a
                                                  (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
                                                 in
                                              FStar_Syntax_DsEnv.push_sigelt
-                                               env5 uu____26092
+                                               env5 uu____26399
                                               in
                                            FStar_Syntax_DsEnv.push_doc env6
                                              a.FStar_Syntax_Syntax.action_name
                                              doc1) env4)
                                   in
                                let env6 =
-                                 let uu____26094 =
+                                 let uu____26401 =
                                    FStar_All.pipe_right quals
                                      (FStar_List.contains
                                         FStar_Parser_AST.Reflectable)
                                     in
-                                 if uu____26094
+                                 if uu____26401
                                  then
                                    let reflect_lid =
-                                     let uu____26101 =
+                                     let uu____26408 =
                                        FStar_Ident.id_of_text "reflect"  in
-                                     FStar_All.pipe_right uu____26101
+                                     FStar_All.pipe_right uu____26408
                                        (FStar_Syntax_DsEnv.qualify monad_env)
                                       in
                                    let quals1 =
@@ -7267,11 +7289,11 @@ and (mk_comment_attr :
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax Prims.list)
   =
   fun d  ->
-    let uu____26113 =
+    let uu____26420 =
       match d.FStar_Parser_AST.doc with
       | FStar_Pervasives_Native.None  -> ("", [])
       | FStar_Pervasives_Native.Some fsdoc -> fsdoc  in
-    match uu____26113 with
+    match uu____26420 with
     | (text,kv) ->
         let summary =
           match FStar_List.assoc "summary" kv with
@@ -7281,19 +7303,19 @@ and (mk_comment_attr :
            in
         let pp =
           match FStar_List.assoc "type" kv with
-          | FStar_Pervasives_Native.Some uu____26200 ->
-              let uu____26203 =
-                let uu____26205 =
+          | FStar_Pervasives_Native.Some uu____26507 ->
+              let uu____26510 =
+                let uu____26512 =
                   FStar_Parser_ToDocument.signature_to_document d  in
                 FStar_Pprint.pretty_string 0.95 (Prims.of_int (80))
-                  uu____26205
+                  uu____26512
                  in
-              Prims.op_Hat "\n  " uu____26203
-          | uu____26208 -> ""  in
+              Prims.op_Hat "\n  " uu____26510
+          | uu____26515 -> ""  in
         let other =
           FStar_List.filter_map
-            (fun uu____26227  ->
-               match uu____26227 with
+            (fun uu____26534  ->
+               match uu____26534 with
                | (k,v1) ->
                    if (k <> "summary") && (k <> "type")
                    then
@@ -7309,21 +7331,21 @@ and (mk_comment_attr :
           Prims.op_Hat summary (Prims.op_Hat pp (Prims.op_Hat other1 text))
            in
         let fv =
-          let uu____26272 = FStar_Ident.lid_of_str "FStar.Pervasives.Comment"
+          let uu____26579 = FStar_Ident.lid_of_str "FStar.Pervasives.Comment"
              in
-          FStar_Syntax_Syntax.fvar uu____26272
+          FStar_Syntax_Syntax.fvar uu____26579
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
            in
         if str = ""
         then []
         else
-          (let uu____26285 =
+          (let uu____26592 =
              let arg = FStar_Syntax_Util.exp_string str  in
-             let uu____26289 =
-               let uu____26300 = FStar_Syntax_Syntax.as_arg arg  in
-               [uu____26300]  in
-             FStar_Syntax_Util.mk_app fv uu____26289  in
-           [uu____26285])
+             let uu____26596 =
+               let uu____26607 = FStar_Syntax_Syntax.as_arg arg  in
+               [uu____26607]  in
+             FStar_Syntax_Util.mk_app fv uu____26596  in
+           [uu____26592])
 
 and (desugar_decl_aux :
   FStar_Syntax_DsEnv.env ->
@@ -7332,8 +7354,8 @@ and (desugar_decl_aux :
   fun env  ->
     fun d  ->
       let env0 = env  in
-      let uu____26336 = desugar_decl_noattrs env d  in
-      match uu____26336 with
+      let uu____26643 = desugar_decl_noattrs env d  in
+      match uu____26643 with
       | (env1,sigelts) ->
           let attrs = d.FStar_Parser_AST.attrs  in
           let attrs1 = FStar_List.map (desugar_term env1) attrs  in
@@ -7342,83 +7364,83 @@ and (desugar_decl_aux :
             | {
                 FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
                   (lbs,names1);
-                FStar_Syntax_Syntax.sigrng = uu____26366;
-                FStar_Syntax_Syntax.sigquals = uu____26367;
-                FStar_Syntax_Syntax.sigmeta = uu____26368;
-                FStar_Syntax_Syntax.sigattrs = uu____26369;_}::[] ->
-                let uu____26378 =
+                FStar_Syntax_Syntax.sigrng = uu____26673;
+                FStar_Syntax_Syntax.sigquals = uu____26674;
+                FStar_Syntax_Syntax.sigmeta = uu____26675;
+                FStar_Syntax_Syntax.sigattrs = uu____26676;_}::[] ->
+                let uu____26685 =
                   FStar_All.pipe_right names1
                     (FStar_List.collect
                        (fun nm  ->
-                          let uu____26388 =
+                          let uu____26695 =
                             FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                               env0 nm
                              in
-                          FStar_Pervasives_Native.snd uu____26388))
+                          FStar_Pervasives_Native.snd uu____26695))
                    in
-                FStar_All.pipe_right uu____26378
+                FStar_All.pipe_right uu____26685
                   (FStar_List.filter
                      (fun t  ->
-                        let uu____26410 = get_fail_attr false t  in
-                        FStar_Option.isNone uu____26410))
-            | uu____26430 -> []  in
+                        let uu____26717 = get_fail_attr false t  in
+                        FStar_Option.isNone uu____26717))
+            | uu____26737 -> []  in
           let attrs2 =
-            let uu____26438 = mk_comment_attr d  in
-            FStar_List.append uu____26438
+            let uu____26745 = mk_comment_attr d  in
+            FStar_List.append uu____26745
               (FStar_List.append attrs1 val_attrs)
              in
-          let uu____26447 =
+          let uu____26754 =
             FStar_List.mapi
               (fun i  ->
                  fun sigelt  ->
                    if i = Prims.int_zero
                    then
-                     let uu___3413_26457 = sigelt  in
+                     let uu___3419_26764 = sigelt  in
                      {
                        FStar_Syntax_Syntax.sigel =
-                         (uu___3413_26457.FStar_Syntax_Syntax.sigel);
+                         (uu___3419_26764.FStar_Syntax_Syntax.sigel);
                        FStar_Syntax_Syntax.sigrng =
-                         (uu___3413_26457.FStar_Syntax_Syntax.sigrng);
+                         (uu___3419_26764.FStar_Syntax_Syntax.sigrng);
                        FStar_Syntax_Syntax.sigquals =
-                         (uu___3413_26457.FStar_Syntax_Syntax.sigquals);
+                         (uu___3419_26764.FStar_Syntax_Syntax.sigquals);
                        FStar_Syntax_Syntax.sigmeta =
-                         (uu___3413_26457.FStar_Syntax_Syntax.sigmeta);
+                         (uu___3419_26764.FStar_Syntax_Syntax.sigmeta);
                        FStar_Syntax_Syntax.sigattrs = attrs2
                      }
                    else
-                     (let uu___3415_26460 = sigelt  in
-                      let uu____26461 =
+                     (let uu___3421_26767 = sigelt  in
+                      let uu____26768 =
                         FStar_List.filter
                           (fun at1  ->
-                             let uu____26467 = get_fail_attr false at1  in
-                             FStar_Option.isNone uu____26467) attrs2
+                             let uu____26774 = get_fail_attr false at1  in
+                             FStar_Option.isNone uu____26774) attrs2
                          in
                       {
                         FStar_Syntax_Syntax.sigel =
-                          (uu___3415_26460.FStar_Syntax_Syntax.sigel);
+                          (uu___3421_26767.FStar_Syntax_Syntax.sigel);
                         FStar_Syntax_Syntax.sigrng =
-                          (uu___3415_26460.FStar_Syntax_Syntax.sigrng);
+                          (uu___3421_26767.FStar_Syntax_Syntax.sigrng);
                         FStar_Syntax_Syntax.sigquals =
-                          (uu___3415_26460.FStar_Syntax_Syntax.sigquals);
+                          (uu___3421_26767.FStar_Syntax_Syntax.sigquals);
                         FStar_Syntax_Syntax.sigmeta =
-                          (uu___3415_26460.FStar_Syntax_Syntax.sigmeta);
-                        FStar_Syntax_Syntax.sigattrs = uu____26461
+                          (uu___3421_26767.FStar_Syntax_Syntax.sigmeta);
+                        FStar_Syntax_Syntax.sigattrs = uu____26768
                       })) sigelts
              in
-          (env1, uu____26447)
+          (env1, uu____26754)
 
 and (desugar_decl :
   env_t -> FStar_Parser_AST.decl -> (env_t * FStar_Syntax_Syntax.sigelts)) =
   fun env  ->
     fun d  ->
-      let uu____26493 = desugar_decl_aux env d  in
-      match uu____26493 with
+      let uu____26800 = desugar_decl_aux env d  in
+      match uu____26800 with
       | (env1,ses) ->
-          let uu____26504 =
+          let uu____26811 =
             FStar_All.pipe_right ses
               (FStar_List.map generalize_annotated_univs)
              in
-          (env1, uu____26504)
+          (env1, uu____26811)
 
 and (desugar_decl_noattrs :
   FStar_Syntax_DsEnv.env ->
@@ -7442,54 +7464,54 @@ and (desugar_decl_noattrs :
                 FStar_Syntax_Syntax.sigattrs = []
               }  in
             (env, [se])))
-      | FStar_Parser_AST.Fsdoc uu____26532 -> (env, [])
+      | FStar_Parser_AST.Fsdoc uu____26839 -> (env, [])
       | FStar_Parser_AST.TopLevelModule id1 -> (env, [])
       | FStar_Parser_AST.Open lid ->
           let env1 = FStar_Syntax_DsEnv.push_namespace env lid  in (env1, [])
       | FStar_Parser_AST.Friend lid ->
-          let uu____26537 = FStar_Syntax_DsEnv.iface env  in
-          if uu____26537
+          let uu____26844 = FStar_Syntax_DsEnv.iface env  in
+          if uu____26844
           then
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_FriendInterface,
                 "'friend' declarations are not allowed in interfaces")
               d.FStar_Parser_AST.drange
           else
-            (let uu____26552 =
-               let uu____26554 =
-                 let uu____26556 = FStar_Syntax_DsEnv.dep_graph env  in
-                 let uu____26557 = FStar_Syntax_DsEnv.current_module env  in
-                 FStar_Parser_Dep.module_has_interface uu____26556
-                   uu____26557
+            (let uu____26859 =
+               let uu____26861 =
+                 let uu____26863 = FStar_Syntax_DsEnv.dep_graph env  in
+                 let uu____26864 = FStar_Syntax_DsEnv.current_module env  in
+                 FStar_Parser_Dep.module_has_interface uu____26863
+                   uu____26864
                   in
-               Prims.op_Negation uu____26554  in
-             if uu____26552
+               Prims.op_Negation uu____26861  in
+             if uu____26859
              then
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_FriendInterface,
                    "'friend' declarations are not allowed in modules that lack interfaces")
                  d.FStar_Parser_AST.drange
              else
-               (let uu____26571 =
-                  let uu____26573 =
-                    let uu____26575 = FStar_Syntax_DsEnv.dep_graph env  in
-                    FStar_Parser_Dep.module_has_interface uu____26575 lid  in
-                  Prims.op_Negation uu____26573  in
-                if uu____26571
+               (let uu____26878 =
+                  let uu____26880 =
+                    let uu____26882 = FStar_Syntax_DsEnv.dep_graph env  in
+                    FStar_Parser_Dep.module_has_interface uu____26882 lid  in
+                  Prims.op_Negation uu____26880  in
+                if uu____26878
                 then
                   FStar_Errors.raise_error
                     (FStar_Errors.Fatal_FriendInterface,
                       "'friend' declarations cannot refer to modules that lack interfaces")
                     d.FStar_Parser_AST.drange
                 else
-                  (let uu____26589 =
-                     let uu____26591 =
-                       let uu____26593 = FStar_Syntax_DsEnv.dep_graph env  in
-                       FStar_Parser_Dep.deps_has_implementation uu____26593
+                  (let uu____26896 =
+                     let uu____26898 =
+                       let uu____26900 = FStar_Syntax_DsEnv.dep_graph env  in
+                       FStar_Parser_Dep.deps_has_implementation uu____26900
                          lid
                         in
-                     Prims.op_Negation uu____26591  in
-                   if uu____26589
+                     Prims.op_Negation uu____26898  in
+                   if uu____26896
                    then
                      FStar_Errors.raise_error
                        (FStar_Errors.Fatal_FriendInterface,
@@ -7499,8 +7521,8 @@ and (desugar_decl_noattrs :
       | FStar_Parser_AST.Include lid ->
           let env1 = FStar_Syntax_DsEnv.push_include env lid  in (env1, [])
       | FStar_Parser_AST.ModuleAbbrev (x,l) ->
-          let uu____26611 = FStar_Syntax_DsEnv.push_module_abbrev env x l  in
-          (uu____26611, [])
+          let uu____26918 = FStar_Syntax_DsEnv.push_module_abbrev env x l  in
+          (uu____26918, [])
       | FStar_Parser_AST.Tycon (is_effect,typeclass,tcs) ->
           let quals = d.FStar_Parser_AST.quals  in
           let quals1 =
@@ -7511,9 +7533,9 @@ and (desugar_decl_noattrs :
             if typeclass
             then
               match tcs with
-              | (FStar_Parser_AST.TyconRecord uu____26652,uu____26653)::[] ->
+              | (FStar_Parser_AST.TyconRecord uu____26959,uu____26960)::[] ->
                   FStar_Parser_AST.Noeq :: quals1
-              | uu____26692 ->
+              | uu____26999 ->
                   FStar_Errors.raise_error
                     (FStar_Errors.Error_BadClassDecl,
                       "Ill-formed `class` declaration: definition must be a record type")
@@ -7521,74 +7543,74 @@ and (desugar_decl_noattrs :
             else quals1  in
           let tcs1 =
             FStar_List.map
-              (fun uu____26719  ->
-                 match uu____26719 with | (x,uu____26727) -> x) tcs
+              (fun uu____27026  ->
+                 match uu____27026 with | (x,uu____27034) -> x) tcs
              in
-          let uu____26732 =
-            let uu____26737 =
+          let uu____27039 =
+            let uu____27044 =
               FStar_List.map (trans_qual1 FStar_Pervasives_Native.None)
                 quals2
                in
-            desugar_tycon env d uu____26737 tcs1  in
-          (match uu____26732 with
+            desugar_tycon env d uu____27044 tcs1  in
+          (match uu____27039 with
            | (env1,ses) ->
                let mkclass lid =
-                 let uu____26754 =
-                   let uu____26755 =
-                     let uu____26762 =
+                 let uu____27061 =
+                   let uu____27062 =
+                     let uu____27069 =
                        FStar_Syntax_Syntax.new_bv
                          FStar_Pervasives_Native.None FStar_Syntax_Syntax.tun
                         in
-                     FStar_Syntax_Syntax.mk_binder uu____26762  in
-                   [uu____26755]  in
-                 let uu____26775 =
-                   let uu____26778 =
+                     FStar_Syntax_Syntax.mk_binder uu____27069  in
+                   [uu____27062]  in
+                 let uu____27082 =
+                   let uu____27085 =
                      FStar_Syntax_Syntax.tabbrev
                        FStar_Parser_Const.mk_class_lid
                       in
-                   let uu____26781 =
-                     let uu____26792 =
-                       let uu____26801 =
-                         let uu____26802 = FStar_Ident.string_of_lid lid  in
-                         FStar_Syntax_Util.exp_string uu____26802  in
-                       FStar_Syntax_Syntax.as_arg uu____26801  in
-                     [uu____26792]  in
-                   FStar_Syntax_Util.mk_app uu____26778 uu____26781  in
-                 FStar_Syntax_Util.abs uu____26754 uu____26775
+                   let uu____27088 =
+                     let uu____27099 =
+                       let uu____27108 =
+                         let uu____27109 = FStar_Ident.string_of_lid lid  in
+                         FStar_Syntax_Util.exp_string uu____27109  in
+                       FStar_Syntax_Syntax.as_arg uu____27108  in
+                     [uu____27099]  in
+                   FStar_Syntax_Util.mk_app uu____27085 uu____27088  in
+                 FStar_Syntax_Util.abs uu____27061 uu____27082
                    FStar_Pervasives_Native.None
                   in
                let get_meths se =
                  let rec get_fname quals3 =
                    match quals3 with
                    | (FStar_Syntax_Syntax.Projector
-                       (uu____26842,id1))::uu____26844 ->
+                       (uu____27149,id1))::uu____27151 ->
                        FStar_Pervasives_Native.Some id1
-                   | uu____26847::quals4 -> get_fname quals4
+                   | uu____27154::quals4 -> get_fname quals4
                    | [] -> FStar_Pervasives_Native.None  in
-                 let uu____26851 = get_fname se.FStar_Syntax_Syntax.sigquals
+                 let uu____27158 = get_fname se.FStar_Syntax_Syntax.sigquals
                     in
-                 match uu____26851 with
+                 match uu____27158 with
                  | FStar_Pervasives_Native.None  -> []
                  | FStar_Pervasives_Native.Some id1 ->
-                     let uu____26857 = FStar_Syntax_DsEnv.qualify env1 id1
+                     let uu____27164 = FStar_Syntax_DsEnv.qualify env1 id1
                         in
-                     [uu____26857]
+                     [uu____27164]
                   in
                let rec splice_decl meths se =
                  match se.FStar_Syntax_Syntax.sigel with
-                 | FStar_Syntax_Syntax.Sig_bundle (ses1,uu____26878) ->
+                 | FStar_Syntax_Syntax.Sig_bundle (ses1,uu____27185) ->
                      FStar_List.concatMap (splice_decl meths) ses1
                  | FStar_Syntax_Syntax.Sig_inductive_typ
-                     (lid,uu____26888,uu____26889,uu____26890,uu____26891,uu____26892)
+                     (lid,uu____27195,uu____27196,uu____27197,uu____27198,uu____27199)
                      ->
-                     let uu____26901 =
-                       let uu____26902 =
-                         let uu____26903 =
-                           let uu____26910 = mkclass lid  in
-                           (meths, uu____26910)  in
-                         FStar_Syntax_Syntax.Sig_splice uu____26903  in
+                     let uu____27208 =
+                       let uu____27209 =
+                         let uu____27210 =
+                           let uu____27217 = mkclass lid  in
+                           (meths, uu____27217)  in
+                         FStar_Syntax_Syntax.Sig_splice uu____27210  in
                        {
-                         FStar_Syntax_Syntax.sigel = uu____26902;
+                         FStar_Syntax_Syntax.sigel = uu____27209;
                          FStar_Syntax_Syntax.sigrng =
                            (d.FStar_Parser_AST.drange);
                          FStar_Syntax_Syntax.sigquals = [];
@@ -7596,8 +7618,8 @@ and (desugar_decl_noattrs :
                            FStar_Syntax_Syntax.default_sigmeta;
                          FStar_Syntax_Syntax.sigattrs = []
                        }  in
-                     [uu____26901]
-                 | uu____26913 -> []  in
+                     [uu____27208]
+                 | uu____27220 -> []  in
                let extra =
                  if typeclass
                  then
@@ -7615,34 +7637,34 @@ and (desugar_decl_noattrs :
             (isrec = FStar_Parser_AST.NoLetQualifier) &&
               (match lets with
                | ({
-                    FStar_Parser_AST.pat = FStar_Parser_AST.PatOp uu____26947;
-                    FStar_Parser_AST.prange = uu____26948;_},uu____26949)::[]
+                    FStar_Parser_AST.pat = FStar_Parser_AST.PatOp uu____27254;
+                    FStar_Parser_AST.prange = uu____27255;_},uu____27256)::[]
                    -> false
                | ({
                     FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                      uu____26959;
-                    FStar_Parser_AST.prange = uu____26960;_},uu____26961)::[]
+                      uu____27266;
+                    FStar_Parser_AST.prange = uu____27267;_},uu____27268)::[]
                    -> false
                | ({
                     FStar_Parser_AST.pat = FStar_Parser_AST.PatAscribed
                       ({
                          FStar_Parser_AST.pat = FStar_Parser_AST.PatOp
-                           uu____26977;
-                         FStar_Parser_AST.prange = uu____26978;_},uu____26979);
-                    FStar_Parser_AST.prange = uu____26980;_},uu____26981)::[]
+                           uu____27284;
+                         FStar_Parser_AST.prange = uu____27285;_},uu____27286);
+                    FStar_Parser_AST.prange = uu____27287;_},uu____27288)::[]
                    -> false
                | ({
                     FStar_Parser_AST.pat = FStar_Parser_AST.PatAscribed
                       ({
                          FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                           uu____27003;
-                         FStar_Parser_AST.prange = uu____27004;_},uu____27005);
-                    FStar_Parser_AST.prange = uu____27006;_},uu____27007)::[]
+                           uu____27310;
+                         FStar_Parser_AST.prange = uu____27311;_},uu____27312);
+                    FStar_Parser_AST.prange = uu____27313;_},uu____27314)::[]
                    -> false
-               | (p,uu____27036)::[] ->
-                   let uu____27045 = is_app_pattern p  in
-                   Prims.op_Negation uu____27045
-               | uu____27047 -> false)
+               | (p,uu____27343)::[] ->
+                   let uu____27352 = is_app_pattern p  in
+                   Prims.op_Negation uu____27352
+               | uu____27354 -> false)
              in
           if Prims.op_Negation expand_toplevel_pattern
           then
@@ -7659,19 +7681,19 @@ and (desugar_decl_noattrs :
                         d.FStar_Parser_AST.drange FStar_Parser_AST.Expr)))
                 d.FStar_Parser_AST.drange FStar_Parser_AST.Expr
                in
-            let uu____27122 = desugar_term_maybe_top true env as_inner_let
+            let uu____27429 = desugar_term_maybe_top true env as_inner_let
                in
-            (match uu____27122 with
+            (match uu____27429 with
              | (ds_lets,aq) ->
                  (check_no_aq aq;
-                  (let uu____27135 =
-                     let uu____27136 =
+                  (let uu____27442 =
+                     let uu____27443 =
                        FStar_All.pipe_left FStar_Syntax_Subst.compress
                          ds_lets
                         in
-                     uu____27136.FStar_Syntax_Syntax.n  in
-                   match uu____27135 with
-                   | FStar_Syntax_Syntax.Tm_let (lbs,uu____27146) ->
+                     uu____27443.FStar_Syntax_Syntax.n  in
+                   match uu____27442 with
+                   | FStar_Syntax_Syntax.Tm_let (lbs,uu____27453) ->
                        let fvs =
                          FStar_All.pipe_right
                            (FStar_Pervasives_Native.snd lbs)
@@ -7684,42 +7706,42 @@ and (desugar_decl_noattrs :
                          FStar_All.pipe_right fvs
                            (FStar_List.collect
                               (fun fv  ->
-                                 let uu____27187 =
+                                 let uu____27494 =
                                    FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                                      env
                                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                     in
-                                 FStar_Pervasives_Native.fst uu____27187))
+                                 FStar_Pervasives_Native.fst uu____27494))
                           in
                        let quals1 =
                          match quals with
-                         | uu____27205::uu____27206 ->
+                         | uu____27512::uu____27513 ->
                              FStar_List.map
                                (trans_qual1 FStar_Pervasives_Native.None)
                                quals
-                         | uu____27209 -> val_quals  in
+                         | uu____27516 -> val_quals  in
                        let quals2 =
-                         let uu____27213 =
+                         let uu____27520 =
                            FStar_All.pipe_right lets1
                              (FStar_Util.for_some
-                                (fun uu____27246  ->
-                                   match uu____27246 with
-                                   | (uu____27260,(uu____27261,t)) ->
+                                (fun uu____27553  ->
+                                   match uu____27553 with
+                                   | (uu____27567,(uu____27568,t)) ->
                                        t.FStar_Parser_AST.level =
                                          FStar_Parser_AST.Formula))
                             in
-                         if uu____27213
+                         if uu____27520
                          then FStar_Syntax_Syntax.Logic :: quals1
                          else quals1  in
                        let lbs1 =
-                         let uu____27281 =
+                         let uu____27588 =
                            FStar_All.pipe_right quals2
                              (FStar_List.contains
                                 FStar_Syntax_Syntax.Abstract)
                             in
-                         if uu____27281
+                         if uu____27588
                          then
-                           let uu____27287 =
+                           let uu____27594 =
                              FStar_All.pipe_right
                                (FStar_Pervasives_Native.snd lbs)
                                (FStar_List.map
@@ -7728,35 +7750,35 @@ and (desugar_decl_noattrs :
                                        FStar_Util.right
                                          lb.FStar_Syntax_Syntax.lbname
                                         in
-                                     let uu___3593_27302 = lb  in
+                                     let uu___3599_27609 = lb  in
                                      {
                                        FStar_Syntax_Syntax.lbname =
                                          (FStar_Util.Inr
-                                            (let uu___3595_27304 = fv  in
+                                            (let uu___3601_27611 = fv  in
                                              {
                                                FStar_Syntax_Syntax.fv_name =
-                                                 (uu___3595_27304.FStar_Syntax_Syntax.fv_name);
+                                                 (uu___3601_27611.FStar_Syntax_Syntax.fv_name);
                                                FStar_Syntax_Syntax.fv_delta =
                                                  (FStar_Syntax_Syntax.Delta_abstract
                                                     (fv.FStar_Syntax_Syntax.fv_delta));
                                                FStar_Syntax_Syntax.fv_qual =
-                                                 (uu___3595_27304.FStar_Syntax_Syntax.fv_qual)
+                                                 (uu___3601_27611.FStar_Syntax_Syntax.fv_qual)
                                              }));
                                        FStar_Syntax_Syntax.lbunivs =
-                                         (uu___3593_27302.FStar_Syntax_Syntax.lbunivs);
+                                         (uu___3599_27609.FStar_Syntax_Syntax.lbunivs);
                                        FStar_Syntax_Syntax.lbtyp =
-                                         (uu___3593_27302.FStar_Syntax_Syntax.lbtyp);
+                                         (uu___3599_27609.FStar_Syntax_Syntax.lbtyp);
                                        FStar_Syntax_Syntax.lbeff =
-                                         (uu___3593_27302.FStar_Syntax_Syntax.lbeff);
+                                         (uu___3599_27609.FStar_Syntax_Syntax.lbeff);
                                        FStar_Syntax_Syntax.lbdef =
-                                         (uu___3593_27302.FStar_Syntax_Syntax.lbdef);
+                                         (uu___3599_27609.FStar_Syntax_Syntax.lbdef);
                                        FStar_Syntax_Syntax.lbattrs =
-                                         (uu___3593_27302.FStar_Syntax_Syntax.lbattrs);
+                                         (uu___3599_27609.FStar_Syntax_Syntax.lbattrs);
                                        FStar_Syntax_Syntax.lbpos =
-                                         (uu___3593_27302.FStar_Syntax_Syntax.lbpos)
+                                         (uu___3599_27609.FStar_Syntax_Syntax.lbpos)
                                      }))
                               in
-                           ((FStar_Pervasives_Native.fst lbs), uu____27287)
+                           ((FStar_Pervasives_Native.fst lbs), uu____27594)
                          else lbs  in
                        let names1 =
                          FStar_All.pipe_right fvs
@@ -7788,17 +7810,17 @@ and (desugar_decl_noattrs :
                                   d.FStar_Parser_AST.doc) env1 names1
                           in
                        (env2, [s])
-                   | uu____27334 ->
+                   | uu____27641 ->
                        failwith "Desugaring a let did not produce a let")))
           else
-            (let uu____27342 =
+            (let uu____27649 =
                match lets with
                | (pat,body)::[] -> (pat, body)
-               | uu____27361 ->
+               | uu____27668 ->
                    failwith
                      "expand_toplevel_pattern should only allow single definition lets"
                 in
-             match uu____27342 with
+             match uu____27649 with
              | (pat,body) ->
                  let fresh_toplevel_name =
                    FStar_Ident.gen FStar_Range.dummyRange  in
@@ -7811,40 +7833,40 @@ and (desugar_decl_noattrs :
                       in
                    match pat.FStar_Parser_AST.pat with
                    | FStar_Parser_AST.PatAscribed (pat1,ty) ->
-                       let uu___3621_27398 = pat1  in
+                       let uu___3627_27705 = pat1  in
                        {
                          FStar_Parser_AST.pat =
                            (FStar_Parser_AST.PatAscribed (var_pat, ty));
                          FStar_Parser_AST.prange =
-                           (uu___3621_27398.FStar_Parser_AST.prange)
+                           (uu___3627_27705.FStar_Parser_AST.prange)
                        }
-                   | uu____27405 -> var_pat  in
+                   | uu____27712 -> var_pat  in
                  let main_let =
                    desugar_decl env
-                     (let uu___3625_27412 = d  in
+                     (let uu___3631_27719 = d  in
                       {
                         FStar_Parser_AST.d =
                           (FStar_Parser_AST.TopLevelLet
                              (isrec, [(fresh_pat, body)]));
                         FStar_Parser_AST.drange =
-                          (uu___3625_27412.FStar_Parser_AST.drange);
+                          (uu___3631_27719.FStar_Parser_AST.drange);
                         FStar_Parser_AST.doc =
-                          (uu___3625_27412.FStar_Parser_AST.doc);
+                          (uu___3631_27719.FStar_Parser_AST.doc);
                         FStar_Parser_AST.quals = (FStar_Parser_AST.Private ::
                           (d.FStar_Parser_AST.quals));
                         FStar_Parser_AST.attrs =
-                          (uu___3625_27412.FStar_Parser_AST.attrs)
+                          (uu___3631_27719.FStar_Parser_AST.attrs)
                       })
                     in
-                 let build_projection uu____27448 id1 =
-                   match uu____27448 with
+                 let build_projection uu____27755 id1 =
+                   match uu____27755 with
                    | (env1,ses) ->
                        let main =
-                         let uu____27469 =
-                           let uu____27470 =
+                         let uu____27776 =
+                           let uu____27777 =
                              FStar_Ident.lid_of_ids [fresh_toplevel_name]  in
-                           FStar_Parser_AST.Var uu____27470  in
-                         FStar_Parser_AST.mk_term uu____27469
+                           FStar_Parser_AST.Var uu____27777  in
+                         FStar_Parser_AST.mk_term uu____27776
                            FStar_Range.dummyRange FStar_Parser_AST.Expr
                           in
                        let lid = FStar_Ident.lid_of_ids [id1]  in
@@ -7872,13 +7894,13 @@ and (desugar_decl_noattrs :
                               (FStar_Parser_AST.NoLetQualifier,
                                 [(bv_pat, body1)])) FStar_Range.dummyRange []
                           in
-                       let uu____27520 = desugar_decl env1 id_decl  in
-                       (match uu____27520 with
+                       let uu____27827 = desugar_decl env1 id_decl  in
+                       (match uu____27827 with
                         | (env2,ses') -> (env2, (FStar_List.append ses ses')))
                     in
                  let bvs =
-                   let uu____27538 = gather_pattern_bound_vars true pat  in
-                   FStar_All.pipe_right uu____27538 FStar_Util.set_elements
+                   let uu____27845 = gather_pattern_bound_vars true pat  in
+                   FStar_All.pipe_right uu____27845 FStar_Util.set_elements
                     in
                  FStar_List.fold_left build_projection main_let bvs)
       | FStar_Parser_AST.Main t ->
@@ -7912,21 +7934,21 @@ and (desugar_decl_noattrs :
       | FStar_Parser_AST.Val (id1,t) ->
           let quals = d.FStar_Parser_AST.quals  in
           let t1 =
-            let uu____27562 = close_fun env t  in
-            desugar_term env uu____27562  in
+            let uu____27869 = close_fun env t  in
+            desugar_term env uu____27869  in
           let quals1 =
-            let uu____27566 =
+            let uu____27873 =
               (FStar_Syntax_DsEnv.iface env) &&
                 (FStar_Syntax_DsEnv.admitted_iface env)
                in
-            if uu____27566
+            if uu____27873
             then FStar_Parser_AST.Assumption :: quals
             else quals  in
           let lid = FStar_Syntax_DsEnv.qualify env id1  in
           let attrs =
             FStar_List.map (desugar_term env) d.FStar_Parser_AST.attrs  in
           let se =
-            let uu____27578 =
+            let uu____27885 =
               FStar_List.map (trans_qual1 FStar_Pervasives_Native.None)
                 quals1
                in
@@ -7934,7 +7956,7 @@ and (desugar_decl_noattrs :
               FStar_Syntax_Syntax.sigel =
                 (FStar_Syntax_Syntax.Sig_declare_typ (lid, [], t1));
               FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
-              FStar_Syntax_Syntax.sigquals = uu____27578;
+              FStar_Syntax_Syntax.sigquals = uu____27885;
               FStar_Syntax_Syntax.sigmeta =
                 FStar_Syntax_Syntax.default_sigmeta;
               FStar_Syntax_Syntax.sigattrs = attrs
@@ -7952,19 +7974,19 @@ and (desugar_decl_noattrs :
                   FStar_Parser_Const.exn_lid
             | FStar_Pervasives_Native.Some term ->
                 let t = desugar_term env term  in
-                let uu____27592 =
-                  let uu____27601 = FStar_Syntax_Syntax.null_binder t  in
-                  [uu____27601]  in
-                let uu____27620 =
-                  let uu____27623 =
+                let uu____27899 =
+                  let uu____27908 = FStar_Syntax_Syntax.null_binder t  in
+                  [uu____27908]  in
+                let uu____27927 =
+                  let uu____27930 =
                     FStar_Syntax_DsEnv.fail_or env
                       (FStar_Syntax_DsEnv.try_lookup_lid env)
                       FStar_Parser_Const.exn_lid
                      in
                   FStar_All.pipe_left FStar_Syntax_Syntax.mk_Total
-                    uu____27623
+                    uu____27930
                    in
-                FStar_Syntax_Util.arrow uu____27592 uu____27620
+                FStar_Syntax_Util.arrow uu____27899 uu____27927
              in
           let l = FStar_Syntax_DsEnv.qualify env id1  in
           let qual = [FStar_Syntax_Syntax.ExceptionConstructor]  in
@@ -8013,53 +8035,53 @@ and (desugar_decl_noattrs :
             attrs
       | FStar_Parser_AST.SubEffect l ->
           let lookup1 l1 =
-            let uu____27678 =
+            let uu____27985 =
               FStar_Syntax_DsEnv.try_lookup_effect_name env l1  in
-            match uu____27678 with
+            match uu____27985 with
             | FStar_Pervasives_Native.None  ->
-                let uu____27681 =
-                  let uu____27687 =
-                    let uu____27689 =
-                      let uu____27691 = FStar_Syntax_Print.lid_to_string l1
+                let uu____27988 =
+                  let uu____27994 =
+                    let uu____27996 =
+                      let uu____27998 = FStar_Syntax_Print.lid_to_string l1
                          in
-                      Prims.op_Hat uu____27691 " not found"  in
-                    Prims.op_Hat "Effect name " uu____27689  in
-                  (FStar_Errors.Fatal_EffectNotFound, uu____27687)  in
-                FStar_Errors.raise_error uu____27681
+                      Prims.op_Hat uu____27998 " not found"  in
+                    Prims.op_Hat "Effect name " uu____27996  in
+                  (FStar_Errors.Fatal_EffectNotFound, uu____27994)  in
+                FStar_Errors.raise_error uu____27988
                   d.FStar_Parser_AST.drange
             | FStar_Pervasives_Native.Some l2 -> l2  in
           let src = lookup1 l.FStar_Parser_AST.msource  in
           let dst = lookup1 l.FStar_Parser_AST.mdest  in
-          let uu____27699 =
+          let uu____28006 =
             match l.FStar_Parser_AST.lift_op with
             | FStar_Parser_AST.NonReifiableLift t ->
-                let uu____27717 =
-                  let uu____27720 =
-                    let uu____27721 = desugar_term env t  in
-                    ([], uu____27721)  in
-                  FStar_Pervasives_Native.Some uu____27720  in
-                (uu____27717, FStar_Pervasives_Native.None)
+                let uu____28024 =
+                  let uu____28027 =
+                    let uu____28028 = desugar_term env t  in
+                    ([], uu____28028)  in
+                  FStar_Pervasives_Native.Some uu____28027  in
+                (uu____28024, FStar_Pervasives_Native.None)
             | FStar_Parser_AST.ReifiableLift (wp,t) ->
-                let uu____27734 =
-                  let uu____27737 =
-                    let uu____27738 = desugar_term env wp  in
-                    ([], uu____27738)  in
-                  FStar_Pervasives_Native.Some uu____27737  in
-                let uu____27745 =
-                  let uu____27748 =
-                    let uu____27749 = desugar_term env t  in
-                    ([], uu____27749)  in
-                  FStar_Pervasives_Native.Some uu____27748  in
-                (uu____27734, uu____27745)
+                let uu____28041 =
+                  let uu____28044 =
+                    let uu____28045 = desugar_term env wp  in
+                    ([], uu____28045)  in
+                  FStar_Pervasives_Native.Some uu____28044  in
+                let uu____28052 =
+                  let uu____28055 =
+                    let uu____28056 = desugar_term env t  in
+                    ([], uu____28056)  in
+                  FStar_Pervasives_Native.Some uu____28055  in
+                (uu____28041, uu____28052)
             | FStar_Parser_AST.LiftForFree t ->
-                let uu____27761 =
-                  let uu____27764 =
-                    let uu____27765 = desugar_term env t  in
-                    ([], uu____27765)  in
-                  FStar_Pervasives_Native.Some uu____27764  in
-                (FStar_Pervasives_Native.None, uu____27761)
+                let uu____28068 =
+                  let uu____28071 =
+                    let uu____28072 = desugar_term env t  in
+                    ([], uu____28072)  in
+                  FStar_Pervasives_Native.Some uu____28071  in
+                (FStar_Pervasives_Native.None, uu____28068)
              in
-          (match uu____27699 with
+          (match uu____28006 with
            | (lift_wp,lift) ->
                let se =
                  {
@@ -8081,14 +8103,14 @@ and (desugar_decl_noattrs :
       | FStar_Parser_AST.Splice (ids,t) ->
           let t1 = desugar_term env t  in
           let se =
-            let uu____27799 =
-              let uu____27800 =
-                let uu____27807 =
+            let uu____28106 =
+              let uu____28107 =
+                let uu____28114 =
                   FStar_List.map (FStar_Syntax_DsEnv.qualify env) ids  in
-                (uu____27807, t1)  in
-              FStar_Syntax_Syntax.Sig_splice uu____27800  in
+                (uu____28114, t1)  in
+              FStar_Syntax_Syntax.Sig_splice uu____28107  in
             {
-              FStar_Syntax_Syntax.sigel = uu____27799;
+              FStar_Syntax_Syntax.sigel = uu____28106;
               FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
               FStar_Syntax_Syntax.sigquals = [];
               FStar_Syntax_Syntax.sigmeta =
@@ -8104,18 +8126,18 @@ let (desugar_decls :
   =
   fun env  ->
     fun decls  ->
-      let uu____27834 =
+      let uu____28141 =
         FStar_List.fold_left
-          (fun uu____27854  ->
+          (fun uu____28161  ->
              fun d  ->
-               match uu____27854 with
+               match uu____28161 with
                | (env1,sigelts) ->
-                   let uu____27874 = desugar_decl env1 d  in
-                   (match uu____27874 with
+                   let uu____28181 = desugar_decl env1 d  in
+                   (match uu____28181 with
                     | (env2,se) -> (env2, (FStar_List.append sigelts se))))
           (env, []) decls
          in
-      match uu____27834 with | (env1,sigelts) -> (env1, sigelts)
+      match uu____28141 with | (env1,sigelts) -> (env1, sigelts)
   
 let (open_prims_all :
   (FStar_Parser_AST.decoration Prims.list -> FStar_Parser_AST.decl)
@@ -8138,41 +8160,41 @@ let (desugar_modul_common :
       fun m  ->
         let env1 =
           match (curmod, m) with
-          | (FStar_Pervasives_Native.None ,uu____27965) -> env
+          | (FStar_Pervasives_Native.None ,uu____28272) -> env
           | (FStar_Pervasives_Native.Some
              { FStar_Syntax_Syntax.name = prev_lid;
-               FStar_Syntax_Syntax.declarations = uu____27969;
-               FStar_Syntax_Syntax.exports = uu____27970;
-               FStar_Syntax_Syntax.is_interface = uu____27971;_},FStar_Parser_AST.Module
-             (current_lid,uu____27973)) when
+               FStar_Syntax_Syntax.declarations = uu____28276;
+               FStar_Syntax_Syntax.exports = uu____28277;
+               FStar_Syntax_Syntax.is_interface = uu____28278;_},FStar_Parser_AST.Module
+             (current_lid,uu____28280)) when
               (FStar_Ident.lid_equals prev_lid current_lid) &&
                 (FStar_Options.interactive ())
               -> env
-          | (FStar_Pervasives_Native.Some prev_mod,uu____27982) ->
-              let uu____27985 =
+          | (FStar_Pervasives_Native.Some prev_mod,uu____28289) ->
+              let uu____28292 =
                 FStar_Syntax_DsEnv.finish_module_or_interface env prev_mod
                  in
-              FStar_Pervasives_Native.fst uu____27985
+              FStar_Pervasives_Native.fst uu____28292
            in
-        let uu____27990 =
+        let uu____28297 =
           match m with
           | FStar_Parser_AST.Interface (mname,decls,admitted) ->
-              let uu____28032 =
+              let uu____28339 =
                 FStar_Syntax_DsEnv.prepare_module_or_interface true admitted
                   env1 mname FStar_Syntax_DsEnv.default_mii
                  in
-              (uu____28032, mname, decls, true)
+              (uu____28339, mname, decls, true)
           | FStar_Parser_AST.Module (mname,decls) ->
-              let uu____28054 =
+              let uu____28361 =
                 FStar_Syntax_DsEnv.prepare_module_or_interface false false
                   env1 mname FStar_Syntax_DsEnv.default_mii
                  in
-              (uu____28054, mname, decls, false)
+              (uu____28361, mname, decls, false)
            in
-        match uu____27990 with
+        match uu____28297 with
         | ((env2,pop_when_done),mname,decls,intf) ->
-            let uu____28096 = desugar_decls env2 decls  in
-            (match uu____28096 with
+            let uu____28403 = desugar_decls env2 decls  in
+            (match uu____28403 with
              | (env3,sigelts) ->
                  let modul =
                    {
@@ -8198,23 +8220,23 @@ let (desugar_partial_modul :
     fun env  ->
       fun m  ->
         let m1 =
-          let uu____28164 =
+          let uu____28471 =
             (FStar_Options.interactive ()) &&
-              (let uu____28167 =
-                 let uu____28169 =
-                   let uu____28171 = FStar_Options.file_list ()  in
-                   FStar_List.hd uu____28171  in
-                 FStar_Util.get_file_extension uu____28169  in
-               FStar_List.mem uu____28167 ["fsti"; "fsi"])
+              (let uu____28474 =
+                 let uu____28476 =
+                   let uu____28478 = FStar_Options.file_list ()  in
+                   FStar_List.hd uu____28478  in
+                 FStar_Util.get_file_extension uu____28476  in
+               FStar_List.mem uu____28474 ["fsti"; "fsi"])
              in
-          if uu____28164 then as_interface m else m  in
-        let uu____28185 = desugar_modul_common curmod env m1  in
-        match uu____28185 with
+          if uu____28471 then as_interface m else m  in
+        let uu____28492 = desugar_modul_common curmod env m1  in
+        match uu____28492 with
         | (env1,modul,pop_when_done) ->
             if pop_when_done
             then
-              let uu____28207 = FStar_Syntax_DsEnv.pop ()  in
-              (uu____28207, modul)
+              let uu____28514 = FStar_Syntax_DsEnv.pop ()  in
+              (uu____28514, modul)
             else (env1, modul)
   
 let (desugar_modul :
@@ -8223,32 +8245,32 @@ let (desugar_modul :
   =
   fun env  ->
     fun m  ->
-      let uu____28229 =
+      let uu____28536 =
         desugar_modul_common FStar_Pervasives_Native.None env m  in
-      match uu____28229 with
+      match uu____28536 with
       | (env1,modul,pop_when_done) ->
-          let uu____28246 =
+          let uu____28553 =
             FStar_Syntax_DsEnv.finish_module_or_interface env1 modul  in
-          (match uu____28246 with
+          (match uu____28553 with
            | (env2,modul1) ->
-               ((let uu____28258 =
+               ((let uu____28565 =
                    FStar_Options.dump_module
                      (modul1.FStar_Syntax_Syntax.name).FStar_Ident.str
                     in
-                 if uu____28258
+                 if uu____28565
                  then
-                   let uu____28261 =
+                   let uu____28568 =
                      FStar_Syntax_Print.modul_to_string modul1  in
                    FStar_Util.print1 "Module after desugaring:\n%s\n"
-                     uu____28261
+                     uu____28568
                  else ());
-                (let uu____28266 =
+                (let uu____28573 =
                    if pop_when_done
                    then
                      FStar_Syntax_DsEnv.export_interface
                        modul1.FStar_Syntax_Syntax.name env2
                    else env2  in
-                 (uu____28266, modul1))))
+                 (uu____28573, modul1))))
   
 let with_options : 'a . (unit -> 'a) -> 'a =
   fun f  ->
@@ -8266,9 +8288,9 @@ let (ast_modul_to_modul :
   fun modul  ->
     fun env  ->
       with_options
-        (fun uu____28316  ->
-           let uu____28317 = desugar_modul env modul  in
-           match uu____28317 with | (e,m) -> (m, e))
+        (fun uu____28623  ->
+           let uu____28624 = desugar_modul env modul  in
+           match uu____28624 with | (e,m) -> (m, e))
   
 let (decls_to_sigelts :
   FStar_Parser_AST.decl Prims.list ->
@@ -8277,9 +8299,9 @@ let (decls_to_sigelts :
   fun decls  ->
     fun env  ->
       with_options
-        (fun uu____28355  ->
-           let uu____28356 = desugar_decls env decls  in
-           match uu____28356 with | (env1,sigelts) -> (sigelts, env1))
+        (fun uu____28662  ->
+           let uu____28663 = desugar_decls env decls  in
+           match uu____28663 with | (env1,sigelts) -> (sigelts, env1))
   
 let (partial_ast_modul_to_modul :
   FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option ->
@@ -8290,9 +8312,9 @@ let (partial_ast_modul_to_modul :
     fun a_modul  ->
       fun env  ->
         with_options
-          (fun uu____28407  ->
-             let uu____28408 = desugar_partial_modul modul env a_modul  in
-             match uu____28408 with | (env1,modul1) -> (modul1, env1))
+          (fun uu____28714  ->
+             let uu____28715 = desugar_partial_modul modul env a_modul  in
+             match uu____28715 with | (env1,modul1) -> (modul1, env1))
   
 let (add_modul_to_env :
   FStar_Syntax_Syntax.modul ->
@@ -8308,51 +8330,51 @@ let (add_modul_to_env :
             let erase_binders bs =
               match bs with
               | [] -> []
-              | uu____28503 ->
+              | uu____28810 ->
                   let t =
-                    let uu____28513 =
+                    let uu____28820 =
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_abs
                            (bs, FStar_Syntax_Syntax.t_unit,
                              FStar_Pervasives_Native.None))
                         FStar_Pervasives_Native.None FStar_Range.dummyRange
                        in
-                    erase_univs uu____28513  in
-                  let uu____28526 =
-                    let uu____28527 = FStar_Syntax_Subst.compress t  in
-                    uu____28527.FStar_Syntax_Syntax.n  in
-                  (match uu____28526 with
-                   | FStar_Syntax_Syntax.Tm_abs (bs1,uu____28539,uu____28540)
+                    erase_univs uu____28820  in
+                  let uu____28833 =
+                    let uu____28834 = FStar_Syntax_Subst.compress t  in
+                    uu____28834.FStar_Syntax_Syntax.n  in
+                  (match uu____28833 with
+                   | FStar_Syntax_Syntax.Tm_abs (bs1,uu____28846,uu____28847)
                        -> bs1
-                   | uu____28565 -> failwith "Impossible")
+                   | uu____28872 -> failwith "Impossible")
                in
-            let uu____28575 =
-              let uu____28582 = erase_binders ed.FStar_Syntax_Syntax.binders
+            let uu____28882 =
+              let uu____28889 = erase_binders ed.FStar_Syntax_Syntax.binders
                  in
-              FStar_Syntax_Subst.open_term' uu____28582
+              FStar_Syntax_Subst.open_term' uu____28889
                 FStar_Syntax_Syntax.t_unit
                in
-            match uu____28575 with
-            | (binders,uu____28584,binders_opening) ->
+            match uu____28882 with
+            | (binders,uu____28891,binders_opening) ->
                 let erase_term t =
-                  let uu____28592 =
-                    let uu____28593 =
+                  let uu____28899 =
+                    let uu____28900 =
                       FStar_Syntax_Subst.subst binders_opening t  in
-                    erase_univs uu____28593  in
-                  FStar_Syntax_Subst.close binders uu____28592  in
-                let erase_tscheme uu____28611 =
-                  match uu____28611 with
+                    erase_univs uu____28900  in
+                  FStar_Syntax_Subst.close binders uu____28899  in
+                let erase_tscheme uu____28918 =
+                  match uu____28918 with
                   | (us,t) ->
                       let t1 =
-                        let uu____28631 =
+                        let uu____28938 =
                           FStar_Syntax_Subst.shift_subst
                             (FStar_List.length us) binders_opening
                            in
-                        FStar_Syntax_Subst.subst uu____28631 t  in
-                      let uu____28634 =
-                        let uu____28635 = erase_univs t1  in
-                        FStar_Syntax_Subst.close binders uu____28635  in
-                      ([], uu____28634)
+                        FStar_Syntax_Subst.subst uu____28938 t  in
+                      let uu____28941 =
+                        let uu____28942 = erase_univs t1  in
+                        FStar_Syntax_Subst.close binders uu____28942  in
+                      ([], uu____28941)
                    in
                 let erase_action action =
                   let opening =
@@ -8364,13 +8386,13 @@ let (add_modul_to_env :
                   let erased_action_params =
                     match action.FStar_Syntax_Syntax.action_params with
                     | [] -> []
-                    | uu____28658 ->
+                    | uu____28965 ->
                         let bs =
-                          let uu____28668 =
+                          let uu____28975 =
                             FStar_Syntax_Subst.subst_binders opening
                               action.FStar_Syntax_Syntax.action_params
                              in
-                          FStar_All.pipe_left erase_binders uu____28668  in
+                          FStar_All.pipe_left erase_binders uu____28975  in
                         let t =
                           FStar_Syntax_Syntax.mk
                             (FStar_Syntax_Syntax.Tm_abs
@@ -8379,153 +8401,153 @@ let (add_modul_to_env :
                             FStar_Pervasives_Native.None
                             FStar_Range.dummyRange
                            in
-                        let uu____28708 =
-                          let uu____28709 =
-                            let uu____28712 =
+                        let uu____29015 =
+                          let uu____29016 =
+                            let uu____29019 =
                               FStar_Syntax_Subst.close binders t  in
-                            FStar_Syntax_Subst.compress uu____28712  in
-                          uu____28709.FStar_Syntax_Syntax.n  in
-                        (match uu____28708 with
+                            FStar_Syntax_Subst.compress uu____29019  in
+                          uu____29016.FStar_Syntax_Syntax.n  in
+                        (match uu____29015 with
                          | FStar_Syntax_Syntax.Tm_abs
-                             (bs1,uu____28714,uu____28715) -> bs1
-                         | uu____28740 -> failwith "Impossible")
+                             (bs1,uu____29021,uu____29022) -> bs1
+                         | uu____29047 -> failwith "Impossible")
                      in
                   let erase_term1 t =
-                    let uu____28748 =
-                      let uu____28749 = FStar_Syntax_Subst.subst opening t
+                    let uu____29055 =
+                      let uu____29056 = FStar_Syntax_Subst.subst opening t
                          in
-                      erase_univs uu____28749  in
-                    FStar_Syntax_Subst.close binders uu____28748  in
-                  let uu___3883_28750 = action  in
-                  let uu____28751 =
+                      erase_univs uu____29056  in
+                    FStar_Syntax_Subst.close binders uu____29055  in
+                  let uu___3889_29057 = action  in
+                  let uu____29058 =
                     erase_term1 action.FStar_Syntax_Syntax.action_defn  in
-                  let uu____28752 =
+                  let uu____29059 =
                     erase_term1 action.FStar_Syntax_Syntax.action_typ  in
                   {
                     FStar_Syntax_Syntax.action_name =
-                      (uu___3883_28750.FStar_Syntax_Syntax.action_name);
+                      (uu___3889_29057.FStar_Syntax_Syntax.action_name);
                     FStar_Syntax_Syntax.action_unqualified_name =
-                      (uu___3883_28750.FStar_Syntax_Syntax.action_unqualified_name);
+                      (uu___3889_29057.FStar_Syntax_Syntax.action_unqualified_name);
                     FStar_Syntax_Syntax.action_univs = [];
                     FStar_Syntax_Syntax.action_params = erased_action_params;
-                    FStar_Syntax_Syntax.action_defn = uu____28751;
-                    FStar_Syntax_Syntax.action_typ = uu____28752
+                    FStar_Syntax_Syntax.action_defn = uu____29058;
+                    FStar_Syntax_Syntax.action_typ = uu____29059
                   }  in
-                let uu___3885_28753 = ed  in
-                let uu____28754 = FStar_Syntax_Subst.close_binders binders
+                let uu___3891_29060 = ed  in
+                let uu____29061 = FStar_Syntax_Subst.close_binders binders
                    in
-                let uu____28755 =
+                let uu____29062 =
                   erase_tscheme ed.FStar_Syntax_Syntax.signature  in
-                let uu____28756 = erase_tscheme ed.FStar_Syntax_Syntax.ret_wp
+                let uu____29063 = erase_tscheme ed.FStar_Syntax_Syntax.ret_wp
                    in
-                let uu____28757 =
+                let uu____29064 =
                   erase_tscheme ed.FStar_Syntax_Syntax.bind_wp  in
-                let uu____28758 =
+                let uu____29065 =
                   erase_tscheme ed.FStar_Syntax_Syntax.if_then_else  in
-                let uu____28759 = erase_tscheme ed.FStar_Syntax_Syntax.ite_wp
+                let uu____29066 = erase_tscheme ed.FStar_Syntax_Syntax.ite_wp
                    in
-                let uu____28760 =
+                let uu____29067 =
                   erase_tscheme ed.FStar_Syntax_Syntax.stronger  in
-                let uu____28761 =
+                let uu____29068 =
                   erase_tscheme ed.FStar_Syntax_Syntax.close_wp  in
-                let uu____28762 =
+                let uu____29069 =
                   erase_tscheme ed.FStar_Syntax_Syntax.trivial  in
-                let uu____28763 = erase_tscheme ed.FStar_Syntax_Syntax.repr
+                let uu____29070 = erase_tscheme ed.FStar_Syntax_Syntax.repr
                    in
-                let uu____28764 =
+                let uu____29071 =
                   erase_tscheme ed.FStar_Syntax_Syntax.return_repr  in
-                let uu____28765 =
+                let uu____29072 =
                   erase_tscheme ed.FStar_Syntax_Syntax.bind_repr  in
-                let uu____28766 =
+                let uu____29073 =
                   FStar_List.map erase_action ed.FStar_Syntax_Syntax.actions
                    in
                 {
                   FStar_Syntax_Syntax.cattributes =
-                    (uu___3885_28753.FStar_Syntax_Syntax.cattributes);
+                    (uu___3891_29060.FStar_Syntax_Syntax.cattributes);
                   FStar_Syntax_Syntax.mname =
-                    (uu___3885_28753.FStar_Syntax_Syntax.mname);
+                    (uu___3891_29060.FStar_Syntax_Syntax.mname);
                   FStar_Syntax_Syntax.univs = [];
-                  FStar_Syntax_Syntax.binders = uu____28754;
-                  FStar_Syntax_Syntax.signature = uu____28755;
-                  FStar_Syntax_Syntax.ret_wp = uu____28756;
-                  FStar_Syntax_Syntax.bind_wp = uu____28757;
-                  FStar_Syntax_Syntax.if_then_else = uu____28758;
-                  FStar_Syntax_Syntax.ite_wp = uu____28759;
-                  FStar_Syntax_Syntax.stronger = uu____28760;
-                  FStar_Syntax_Syntax.close_wp = uu____28761;
-                  FStar_Syntax_Syntax.trivial = uu____28762;
-                  FStar_Syntax_Syntax.repr = uu____28763;
-                  FStar_Syntax_Syntax.return_repr = uu____28764;
-                  FStar_Syntax_Syntax.bind_repr = uu____28765;
-                  FStar_Syntax_Syntax.actions = uu____28766;
+                  FStar_Syntax_Syntax.binders = uu____29061;
+                  FStar_Syntax_Syntax.signature = uu____29062;
+                  FStar_Syntax_Syntax.ret_wp = uu____29063;
+                  FStar_Syntax_Syntax.bind_wp = uu____29064;
+                  FStar_Syntax_Syntax.if_then_else = uu____29065;
+                  FStar_Syntax_Syntax.ite_wp = uu____29066;
+                  FStar_Syntax_Syntax.stronger = uu____29067;
+                  FStar_Syntax_Syntax.close_wp = uu____29068;
+                  FStar_Syntax_Syntax.trivial = uu____29069;
+                  FStar_Syntax_Syntax.repr = uu____29070;
+                  FStar_Syntax_Syntax.return_repr = uu____29071;
+                  FStar_Syntax_Syntax.bind_repr = uu____29072;
+                  FStar_Syntax_Syntax.actions = uu____29073;
                   FStar_Syntax_Syntax.eff_attrs =
-                    (uu___3885_28753.FStar_Syntax_Syntax.eff_attrs)
+                    (uu___3891_29060.FStar_Syntax_Syntax.eff_attrs)
                 }
              in
           let push_sigelt1 env se =
             match se.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_new_effect ed ->
                 let se' =
-                  let uu___3892_28782 = se  in
-                  let uu____28783 =
-                    let uu____28784 = erase_univs_ed ed  in
-                    FStar_Syntax_Syntax.Sig_new_effect uu____28784  in
+                  let uu___3898_29089 = se  in
+                  let uu____29090 =
+                    let uu____29091 = erase_univs_ed ed  in
+                    FStar_Syntax_Syntax.Sig_new_effect uu____29091  in
                   {
-                    FStar_Syntax_Syntax.sigel = uu____28783;
+                    FStar_Syntax_Syntax.sigel = uu____29090;
                     FStar_Syntax_Syntax.sigrng =
-                      (uu___3892_28782.FStar_Syntax_Syntax.sigrng);
+                      (uu___3898_29089.FStar_Syntax_Syntax.sigrng);
                     FStar_Syntax_Syntax.sigquals =
-                      (uu___3892_28782.FStar_Syntax_Syntax.sigquals);
+                      (uu___3898_29089.FStar_Syntax_Syntax.sigquals);
                     FStar_Syntax_Syntax.sigmeta =
-                      (uu___3892_28782.FStar_Syntax_Syntax.sigmeta);
+                      (uu___3898_29089.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
-                      (uu___3892_28782.FStar_Syntax_Syntax.sigattrs)
+                      (uu___3898_29089.FStar_Syntax_Syntax.sigattrs)
                   }  in
                 let env1 = FStar_Syntax_DsEnv.push_sigelt env se'  in
                 push_reflect_effect env1 se.FStar_Syntax_Syntax.sigquals
                   ed.FStar_Syntax_Syntax.mname se.FStar_Syntax_Syntax.sigrng
             | FStar_Syntax_Syntax.Sig_new_effect_for_free ed ->
                 let se' =
-                  let uu___3898_28788 = se  in
-                  let uu____28789 =
-                    let uu____28790 = erase_univs_ed ed  in
-                    FStar_Syntax_Syntax.Sig_new_effect_for_free uu____28790
+                  let uu___3904_29095 = se  in
+                  let uu____29096 =
+                    let uu____29097 = erase_univs_ed ed  in
+                    FStar_Syntax_Syntax.Sig_new_effect_for_free uu____29097
                      in
                   {
-                    FStar_Syntax_Syntax.sigel = uu____28789;
+                    FStar_Syntax_Syntax.sigel = uu____29096;
                     FStar_Syntax_Syntax.sigrng =
-                      (uu___3898_28788.FStar_Syntax_Syntax.sigrng);
+                      (uu___3904_29095.FStar_Syntax_Syntax.sigrng);
                     FStar_Syntax_Syntax.sigquals =
-                      (uu___3898_28788.FStar_Syntax_Syntax.sigquals);
+                      (uu___3904_29095.FStar_Syntax_Syntax.sigquals);
                     FStar_Syntax_Syntax.sigmeta =
-                      (uu___3898_28788.FStar_Syntax_Syntax.sigmeta);
+                      (uu___3904_29095.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
-                      (uu___3898_28788.FStar_Syntax_Syntax.sigattrs)
+                      (uu___3904_29095.FStar_Syntax_Syntax.sigattrs)
                   }  in
                 let env1 = FStar_Syntax_DsEnv.push_sigelt env se'  in
                 push_reflect_effect env1 se.FStar_Syntax_Syntax.sigquals
                   ed.FStar_Syntax_Syntax.mname se.FStar_Syntax_Syntax.sigrng
-            | uu____28792 -> FStar_Syntax_DsEnv.push_sigelt env se  in
-          let uu____28793 =
+            | uu____29099 -> FStar_Syntax_DsEnv.push_sigelt env se  in
+          let uu____29100 =
             FStar_Syntax_DsEnv.prepare_module_or_interface false false en
               m.FStar_Syntax_Syntax.name mii
              in
-          match uu____28793 with
+          match uu____29100 with
           | (en1,pop_when_done) ->
               let en2 =
-                let uu____28810 =
+                let uu____29117 =
                   FStar_Syntax_DsEnv.set_current_module en1
                     m.FStar_Syntax_Syntax.name
                    in
-                FStar_List.fold_left push_sigelt1 uu____28810
+                FStar_List.fold_left push_sigelt1 uu____29117
                   m.FStar_Syntax_Syntax.exports
                  in
               let env = FStar_Syntax_DsEnv.finish en2 m  in
-              let uu____28812 =
+              let uu____29119 =
                 if pop_when_done
                 then
                   FStar_Syntax_DsEnv.export_interface
                     m.FStar_Syntax_Syntax.name env
                 else env  in
-              ((), uu____28812)
+              ((), uu____29119)
   

--- a/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
+++ b/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
@@ -1053,7 +1053,9 @@ let (generalize_annotated_univs :
                             FStar_Syntax_Syntax.sigmeta =
                               (uu___596_3006.FStar_Syntax_Syntax.sigmeta);
                             FStar_Syntax_Syntax.sigattrs =
-                              (uu___596_3006.FStar_Syntax_Syntax.sigattrs)
+                              (uu___596_3006.FStar_Syntax_Syntax.sigattrs);
+                            FStar_Syntax_Syntax.sigopts =
+                              (uu___596_3006.FStar_Syntax_Syntax.sigopts)
                           }
                       | FStar_Syntax_Syntax.Sig_datacon
                           (lid,uu____3041,t,tlid,n1,lids1) ->
@@ -1073,7 +1075,9 @@ let (generalize_annotated_univs :
                             FStar_Syntax_Syntax.sigmeta =
                               (uu___606_3052.FStar_Syntax_Syntax.sigmeta);
                             FStar_Syntax_Syntax.sigattrs =
-                              (uu___606_3052.FStar_Syntax_Syntax.sigattrs)
+                              (uu___606_3052.FStar_Syntax_Syntax.sigattrs);
+                            FStar_Syntax_Syntax.sigopts =
+                              (uu___606_3052.FStar_Syntax_Syntax.sigopts)
                           }
                       | uu____3074 ->
                           failwith
@@ -1090,7 +1094,9 @@ let (generalize_annotated_univs :
           FStar_Syntax_Syntax.sigmeta =
             (uu___585_2964.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs =
-            (uu___585_2964.FStar_Syntax_Syntax.sigattrs)
+            (uu___585_2964.FStar_Syntax_Syntax.sigattrs);
+          FStar_Syntax_Syntax.sigopts =
+            (uu___585_2964.FStar_Syntax_Syntax.sigopts)
         }
     | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____3081,t) ->
         let uvs =
@@ -1111,7 +1117,9 @@ let (generalize_annotated_univs :
           FStar_Syntax_Syntax.sigmeta =
             (uu___615_3089.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs =
-            (uu___615_3089.FStar_Syntax_Syntax.sigattrs)
+            (uu___615_3089.FStar_Syntax_Syntax.sigattrs);
+          FStar_Syntax_Syntax.sigopts =
+            (uu___615_3089.FStar_Syntax_Syntax.sigopts)
         }
     | FStar_Syntax_Syntax.Sig_let ((b,lbs),lids) ->
         let lb_univnames lb =
@@ -1193,7 +1201,9 @@ let (generalize_annotated_univs :
           FStar_Syntax_Syntax.sigmeta =
             (uu___670_3396.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs =
-            (uu___670_3396.FStar_Syntax_Syntax.sigattrs)
+            (uu___670_3396.FStar_Syntax_Syntax.sigattrs);
+          FStar_Syntax_Syntax.sigopts =
+            (uu___670_3396.FStar_Syntax_Syntax.sigopts)
         }
     | FStar_Syntax_Syntax.Sig_assume (lid,uu____3431,fml) ->
         let uvs =
@@ -1214,7 +1224,9 @@ let (generalize_annotated_univs :
           FStar_Syntax_Syntax.sigmeta =
             (uu___681_3439.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs =
-            (uu___681_3439.FStar_Syntax_Syntax.sigattrs)
+            (uu___681_3439.FStar_Syntax_Syntax.sigattrs);
+          FStar_Syntax_Syntax.sigopts =
+            (uu___681_3439.FStar_Syntax_Syntax.sigopts)
         }
     | FStar_Syntax_Syntax.Sig_effect_abbrev (lid,uu____3450,bs,c,flags) ->
         let uvs =
@@ -1240,7 +1252,9 @@ let (generalize_annotated_univs :
           FStar_Syntax_Syntax.sigmeta =
             (uu___692_3473.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs =
-            (uu___692_3473.FStar_Syntax_Syntax.sigattrs)
+            (uu___692_3473.FStar_Syntax_Syntax.sigattrs);
+          FStar_Syntax_Syntax.sigopts =
+            (uu___692_3473.FStar_Syntax_Syntax.sigopts)
         }
     | uu____3492 -> s
   
@@ -5206,7 +5220,8 @@ let (mk_data_discriminators :
                   FStar_Syntax_Syntax.sigquals = uu____19357;
                   FStar_Syntax_Syntax.sigmeta =
                     FStar_Syntax_Syntax.default_sigmeta;
-                  FStar_Syntax_Syntax.sigattrs = []
+                  FStar_Syntax_Syntax.sigattrs = [];
+                  FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                 }))
   
 let (mk_indexed_projector_names :
@@ -5304,7 +5319,9 @@ let (mk_indexed_projector_names :
                                      FStar_Syntax_Syntax.sigquals = quals1;
                                      FStar_Syntax_Syntax.sigmeta =
                                        FStar_Syntax_Syntax.default_sigmeta;
-                                     FStar_Syntax_Syntax.sigattrs = []
+                                     FStar_Syntax_Syntax.sigattrs = [];
+                                     FStar_Syntax_Syntax.sigopts =
+                                       FStar_Pervasives_Native.None
                                    }  in
                                  if only_decl
                                  then [decl]
@@ -5373,7 +5390,9 @@ let (mk_indexed_projector_names :
                                         FStar_Syntax_Syntax.sigquals = quals1;
                                         FStar_Syntax_Syntax.sigmeta =
                                           FStar_Syntax_Syntax.default_sigmeta;
-                                        FStar_Syntax_Syntax.sigattrs = []
+                                        FStar_Syntax_Syntax.sigattrs = [];
+                                        FStar_Syntax_Syntax.sigopts =
+                                          FStar_Pervasives_Native.None
                                       }  in
                                     if no_decl then [impl] else [decl; impl]))))
                in
@@ -5496,7 +5515,9 @@ let (mk_typ_abbrev :
                     FStar_Syntax_Syntax.sigquals = quals;
                     FStar_Syntax_Syntax.sigmeta =
                       FStar_Syntax_Syntax.default_sigmeta;
-                    FStar_Syntax_Syntax.sigattrs = []
+                    FStar_Syntax_Syntax.sigattrs = [];
+                    FStar_Syntax_Syntax.sigopts =
+                      FStar_Pervasives_Native.None
                   }
   
 let rec (desugar_tycon :
@@ -5681,7 +5702,9 @@ let rec (desugar_tycon :
                          FStar_Syntax_Syntax.sigquals = quals1;
                          FStar_Syntax_Syntax.sigmeta =
                            FStar_Syntax_Syntax.default_sigmeta;
-                         FStar_Syntax_Syntax.sigattrs = []
+                         FStar_Syntax_Syntax.sigattrs = [];
+                         FStar_Syntax_Syntax.sigopts =
+                           FStar_Pervasives_Native.None
                        }  in
                      let _env1 =
                        FStar_Syntax_DsEnv.push_top_level_rec_binding _env id1
@@ -5785,7 +5808,9 @@ let rec (desugar_tycon :
                            FStar_Syntax_Syntax.sigmeta =
                              (uu___2838_20799.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs =
-                             (uu___2838_20799.FStar_Syntax_Syntax.sigattrs)
+                             (uu___2838_20799.FStar_Syntax_Syntax.sigattrs);
+                           FStar_Syntax_Syntax.sigopts =
+                             (uu___2838_20799.FStar_Syntax_Syntax.sigopts)
                          }
                      | uu____20800 -> failwith "Impossible"  in
                    let env1 = FStar_Syntax_DsEnv.push_sigelt env se1  in
@@ -5900,7 +5925,9 @@ let rec (desugar_tycon :
                              FStar_Syntax_Syntax.sigquals = quals2;
                              FStar_Syntax_Syntax.sigmeta =
                                FStar_Syntax_Syntax.default_sigmeta;
-                             FStar_Syntax_Syntax.sigattrs = []
+                             FStar_Syntax_Syntax.sigattrs = [];
+                             FStar_Syntax_Syntax.sigopts =
+                               FStar_Pervasives_Native.None
                            }
                      else
                        (let t1 = desugar_typ env' t  in
@@ -5999,28 +6026,29 @@ let rec (desugar_tycon :
                    let docs_tps_sigelts =
                      FStar_All.pipe_right tcs2
                        (FStar_List.collect
-                          (fun uu___25_22714  ->
-                             match uu___25_22714 with
+                          (fun uu___25_22715  ->
+                             match uu___25_22715 with
                              | FStar_Util.Inr
                                  ({
                                     FStar_Syntax_Syntax.sigel =
                                       FStar_Syntax_Syntax.Sig_inductive_typ
-                                      (id1,uvs,tpars,k,uu____22780,uu____22781);
-                                    FStar_Syntax_Syntax.sigrng = uu____22782;
+                                      (id1,uvs,tpars,k,uu____22781,uu____22782);
+                                    FStar_Syntax_Syntax.sigrng = uu____22783;
                                     FStar_Syntax_Syntax.sigquals =
-                                      uu____22783;
-                                    FStar_Syntax_Syntax.sigmeta = uu____22784;
+                                      uu____22784;
+                                    FStar_Syntax_Syntax.sigmeta = uu____22785;
                                     FStar_Syntax_Syntax.sigattrs =
-                                      uu____22785;_},binders,t,quals1)
+                                      uu____22786;
+                                    FStar_Syntax_Syntax.sigopts = uu____22787;_},binders,t,quals1)
                                  ->
                                  let t1 =
-                                   let uu____22849 =
+                                   let uu____22853 =
                                      typars_of_binders env1 binders  in
-                                   match uu____22849 with
+                                   match uu____22853 with
                                    | (env2,tpars1) ->
-                                       let uu____22876 =
+                                       let uu____22880 =
                                          push_tparams env2 tpars1  in
-                                       (match uu____22876 with
+                                       (match uu____22880 with
                                         | (env_tps,tpars2) ->
                                             let t1 = desugar_typ env_tps t
                                                in
@@ -6031,27 +6059,28 @@ let rec (desugar_tycon :
                                             FStar_Syntax_Subst.close tpars3
                                               t1)
                                     in
-                                 let uu____22905 =
-                                   let uu____22924 =
+                                 let uu____22909 =
+                                   let uu____22928 =
                                      mk_typ_abbrev id1 uvs tpars
                                        (FStar_Pervasives_Native.Some k) t1
                                        [id1] quals1 rng
                                       in
                                    ((id1, (d.FStar_Parser_AST.doc)), [],
-                                     uu____22924)
+                                     uu____22928)
                                     in
-                                 [uu____22905]
+                                 [uu____22909]
                              | FStar_Util.Inl
                                  ({
                                     FStar_Syntax_Syntax.sigel =
                                       FStar_Syntax_Syntax.Sig_inductive_typ
-                                      (tname,univs1,tpars,k,mutuals1,uu____22984);
-                                    FStar_Syntax_Syntax.sigrng = uu____22985;
+                                      (tname,univs1,tpars,k,mutuals1,uu____22988);
+                                    FStar_Syntax_Syntax.sigrng = uu____22989;
                                     FStar_Syntax_Syntax.sigquals =
                                       tname_quals;
-                                    FStar_Syntax_Syntax.sigmeta = uu____22987;
+                                    FStar_Syntax_Syntax.sigmeta = uu____22991;
                                     FStar_Syntax_Syntax.sigattrs =
-                                      uu____22988;_},constrs,tconstr,quals1)
+                                      uu____22992;
+                                    FStar_Syntax_Syntax.sigopts = uu____22993;_},constrs,tconstr,quals1)
                                  ->
                                  let mk_tot t =
                                    let tot1 =
@@ -6068,27 +6097,27 @@ let rec (desugar_tycon :
                                      t.FStar_Parser_AST.level
                                     in
                                  let tycon = (tname, tpars, k)  in
-                                 let uu____23089 = push_tparams env1 tpars
+                                 let uu____23096 = push_tparams env1 tpars
                                     in
-                                 (match uu____23089 with
+                                 (match uu____23096 with
                                   | (env_tps,tps) ->
                                       let data_tpars =
                                         FStar_List.map
-                                          (fun uu____23156  ->
-                                             match uu____23156 with
-                                             | (x,uu____23168) ->
+                                          (fun uu____23163  ->
+                                             match uu____23163 with
+                                             | (x,uu____23175) ->
                                                  (x,
                                                    (FStar_Pervasives_Native.Some
                                                       (FStar_Syntax_Syntax.Implicit
                                                          true)))) tps
                                          in
                                       let tot_tconstr = mk_tot tconstr  in
-                                      let uu____23173 =
-                                        let uu____23200 =
+                                      let uu____23180 =
+                                        let uu____23207 =
                                           FStar_All.pipe_right constrs
                                             (FStar_List.map
-                                               (fun uu____23310  ->
-                                                  match uu____23310 with
+                                               (fun uu____23317  ->
+                                                  match uu____23317 with
                                                   | (id1,topt,doc1,of_notation)
                                                       ->
                                                       let t =
@@ -6121,10 +6150,10 @@ let rec (desugar_tycon :
                                                                t -> t)
                                                          in
                                                       let t1 =
-                                                        let uu____23370 =
+                                                        let uu____23377 =
                                                           close env_tps t  in
                                                         desugar_term env_tps
-                                                          uu____23370
+                                                          uu____23377
                                                          in
                                                       let name =
                                                         FStar_Syntax_DsEnv.qualify
@@ -6135,54 +6164,54 @@ let rec (desugar_tycon :
                                                           tname_quals
                                                           (FStar_List.collect
                                                              (fun
-                                                                uu___24_23381
+                                                                uu___24_23388
                                                                  ->
-                                                                match uu___24_23381
+                                                                match uu___24_23388
                                                                 with
                                                                 | FStar_Syntax_Syntax.RecordType
                                                                     fns ->
                                                                     [
                                                                     FStar_Syntax_Syntax.RecordConstructor
                                                                     fns]
-                                                                | uu____23393
+                                                                | uu____23400
                                                                     -> []))
                                                          in
                                                       let ntps =
                                                         FStar_List.length
                                                           data_tpars
                                                          in
-                                                      let uu____23401 =
-                                                        let uu____23420 =
-                                                          let uu____23421 =
-                                                            let uu____23422 =
-                                                              let uu____23438
+                                                      let uu____23408 =
+                                                        let uu____23427 =
+                                                          let uu____23428 =
+                                                            let uu____23429 =
+                                                              let uu____23445
                                                                 =
-                                                                let uu____23439
+                                                                let uu____23446
                                                                   =
-                                                                  let uu____23442
+                                                                  let uu____23449
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     t1
                                                                     FStar_Syntax_Util.name_function_binders
                                                                      in
                                                                   FStar_Syntax_Syntax.mk_Total
-                                                                    uu____23442
+                                                                    uu____23449
                                                                    in
                                                                 FStar_Syntax_Util.arrow
                                                                   data_tpars
-                                                                  uu____23439
+                                                                  uu____23446
                                                                  in
                                                               (name, univs1,
-                                                                uu____23438,
+                                                                uu____23445,
                                                                 tname, ntps,
                                                                 mutuals1)
                                                                in
                                                             FStar_Syntax_Syntax.Sig_datacon
-                                                              uu____23422
+                                                              uu____23429
                                                              in
                                                           {
                                                             FStar_Syntax_Syntax.sigel
-                                                              = uu____23421;
+                                                              = uu____23428;
                                                             FStar_Syntax_Syntax.sigrng
                                                               = rng;
                                                             FStar_Syntax_Syntax.sigquals
@@ -6191,17 +6220,20 @@ let rec (desugar_tycon :
                                                               =
                                                               FStar_Syntax_Syntax.default_sigmeta;
                                                             FStar_Syntax_Syntax.sigattrs
-                                                              = []
+                                                              = [];
+                                                            FStar_Syntax_Syntax.sigopts
+                                                              =
+                                                              FStar_Pervasives_Native.None
                                                           }  in
                                                         ((name, doc1), tps,
-                                                          uu____23420)
+                                                          uu____23427)
                                                          in
-                                                      (name, uu____23401)))
+                                                      (name, uu____23408)))
                                            in
                                         FStar_All.pipe_left FStar_List.split
-                                          uu____23200
+                                          uu____23207
                                          in
-                                      (match uu____23173 with
+                                      (match uu____23180 with
                                        | (constrNames,constrs1) ->
                                            ((tname, (d.FStar_Parser_AST.doc)),
                                              [],
@@ -6217,34 +6249,36 @@ let rec (desugar_tycon :
                                                FStar_Syntax_Syntax.sigmeta =
                                                  FStar_Syntax_Syntax.default_sigmeta;
                                                FStar_Syntax_Syntax.sigattrs =
-                                                 []
+                                                 [];
+                                               FStar_Syntax_Syntax.sigopts =
+                                                 FStar_Pervasives_Native.None
                                              })
                                            :: constrs1))
-                             | uu____23654 -> failwith "impossible"))
+                             | uu____23661 -> failwith "impossible"))
                       in
                    let name_docs =
                      FStar_All.pipe_right docs_tps_sigelts
                        (FStar_List.map
-                          (fun uu____23782  ->
-                             match uu____23782 with
-                             | (name_doc,uu____23808,uu____23809) -> name_doc))
+                          (fun uu____23789  ->
+                             match uu____23789 with
+                             | (name_doc,uu____23815,uu____23816) -> name_doc))
                       in
                    let sigelts =
                      FStar_All.pipe_right docs_tps_sigelts
                        (FStar_List.map
-                          (fun uu____23881  ->
-                             match uu____23881 with
-                             | (uu____23900,uu____23901,se) -> se))
+                          (fun uu____23888  ->
+                             match uu____23888 with
+                             | (uu____23907,uu____23908,se) -> se))
                       in
-                   let uu____23927 =
-                     let uu____23934 =
+                   let uu____23934 =
+                     let uu____23941 =
                        FStar_List.collect FStar_Syntax_Util.lids_of_sigelt
                          sigelts
                         in
                      FStar_Syntax_MutRecTy.disentangle_abbrevs_from_bundle
-                       sigelts quals uu____23934 rng
+                       sigelts quals uu____23941 rng
                       in
-                   (match uu____23927 with
+                   (match uu____23934 with
                     | (bundle,abbrevs) ->
                         let env2 = FStar_Syntax_DsEnv.push_sigelt env0 bundle
                            in
@@ -6255,9 +6289,9 @@ let rec (desugar_tycon :
                         let data_ops =
                           FStar_All.pipe_right docs_tps_sigelts
                             (FStar_List.collect
-                               (fun uu____23996  ->
-                                  match uu____23996 with
-                                  | (uu____24017,tps,se) ->
+                               (fun uu____24003  ->
+                                  match uu____24003 with
+                                  | (uu____24024,tps,se) ->
                                       mk_data_projector_names quals env3 se))
                            in
                         let discs =
@@ -6266,7 +6300,7 @@ let rec (desugar_tycon :
                                (fun se  ->
                                   match se.FStar_Syntax_Syntax.sigel with
                                   | FStar_Syntax_Syntax.Sig_inductive_typ
-                                      (tname,uu____24065,tps,k,uu____24068,constrs)
+                                      (tname,uu____24072,tps,k,uu____24075,constrs)
                                       ->
                                       let quals1 =
                                         se.FStar_Syntax_Syntax.sigquals  in
@@ -6283,13 +6317,13 @@ let rec (desugar_tycon :
                                         then FStar_Syntax_Syntax.Private ::
                                           quals1
                                         else quals1  in
-                                      let uu____24089 =
+                                      let uu____24096 =
                                         FStar_All.pipe_right constrs
                                           (FStar_List.filter
                                              (fun data_lid  ->
                                                 let data_quals =
                                                   let data_se =
-                                                    let uu____24104 =
+                                                    let uu____24111 =
                                                       FStar_All.pipe_right
                                                         sigelts
                                                         (FStar_List.find
@@ -6297,38 +6331,38 @@ let rec (desugar_tycon :
                                                               match se1.FStar_Syntax_Syntax.sigel
                                                               with
                                                               | FStar_Syntax_Syntax.Sig_datacon
-                                                                  (name,uu____24121,uu____24122,uu____24123,uu____24124,uu____24125)
+                                                                  (name,uu____24128,uu____24129,uu____24130,uu____24131,uu____24132)
                                                                   ->
                                                                   FStar_Ident.lid_equals
                                                                     name
                                                                     data_lid
-                                                              | uu____24132
+                                                              | uu____24139
                                                                   -> false))
                                                        in
                                                     FStar_All.pipe_right
-                                                      uu____24104
+                                                      uu____24111
                                                       FStar_Util.must
                                                      in
                                                   data_se.FStar_Syntax_Syntax.sigquals
                                                    in
-                                                let uu____24136 =
+                                                let uu____24143 =
                                                   FStar_All.pipe_right
                                                     data_quals
                                                     (FStar_List.existsb
-                                                       (fun uu___26_24143  ->
-                                                          match uu___26_24143
+                                                       (fun uu___26_24150  ->
+                                                          match uu___26_24150
                                                           with
                                                           | FStar_Syntax_Syntax.RecordConstructor
-                                                              uu____24145 ->
+                                                              uu____24152 ->
                                                               true
-                                                          | uu____24155 ->
+                                                          | uu____24162 ->
                                                               false))
                                                    in
-                                                Prims.op_Negation uu____24136))
+                                                Prims.op_Negation uu____24143))
                                          in
                                       mk_data_discriminators quals2 env3
-                                        uu____24089
-                                  | uu____24157 -> []))
+                                        uu____24096
+                                  | uu____24164 -> []))
                            in
                         let ops = FStar_List.append discs data_ops  in
                         let env4 =
@@ -6338,8 +6372,8 @@ let rec (desugar_tycon :
                         let env5 =
                           FStar_List.fold_left
                             (fun acc  ->
-                               fun uu____24174  ->
-                                 match uu____24174 with
+                               fun uu____24181  ->
+                                 match uu____24181 with
                                  | (lid,doc1) ->
                                      FStar_Syntax_DsEnv.push_doc env4 lid
                                        doc1) env4 name_docs
@@ -6358,28 +6392,28 @@ let (desugar_binders :
   =
   fun env  ->
     fun binders  ->
-      let uu____24219 =
+      let uu____24226 =
         FStar_List.fold_left
-          (fun uu____24254  ->
+          (fun uu____24261  ->
              fun b  ->
-               match uu____24254 with
+               match uu____24261 with
                | (env1,binders1) ->
-                   let uu____24298 = desugar_binder env1 b  in
-                   (match uu____24298 with
+                   let uu____24305 = desugar_binder env1 b  in
+                   (match uu____24305 with
                     | (FStar_Pervasives_Native.Some a,k) ->
-                        let uu____24321 =
+                        let uu____24328 =
                           as_binder env1 b.FStar_Parser_AST.aqual
                             ((FStar_Pervasives_Native.Some a), k)
                            in
-                        (match uu____24321 with
+                        (match uu____24328 with
                          | (binder,env2) -> (env2, (binder :: binders1)))
-                    | uu____24374 ->
+                    | uu____24381 ->
                         FStar_Errors.raise_error
                           (FStar_Errors.Fatal_MissingNameInBinder,
                             "Missing name in binder")
                           b.FStar_Parser_AST.brange)) (env, []) binders
          in
-      match uu____24219 with
+      match uu____24226 with
       | (env1,binders1) -> (env1, (FStar_List.rev binders1))
   
 let (push_reflect_effect :
@@ -6391,23 +6425,23 @@ let (push_reflect_effect :
     fun quals  ->
       fun effect_name  ->
         fun range  ->
-          let uu____24478 =
+          let uu____24485 =
             FStar_All.pipe_right quals
               (FStar_Util.for_some
-                 (fun uu___27_24485  ->
-                    match uu___27_24485 with
-                    | FStar_Syntax_Syntax.Reflectable uu____24487 -> true
-                    | uu____24489 -> false))
+                 (fun uu___27_24492  ->
+                    match uu___27_24492 with
+                    | FStar_Syntax_Syntax.Reflectable uu____24494 -> true
+                    | uu____24496 -> false))
              in
-          if uu____24478
+          if uu____24485
           then
             let monad_env =
               FStar_Syntax_DsEnv.enter_monad_scope env
                 effect_name.FStar_Ident.ident
                in
             let reflect_lid =
-              let uu____24494 = FStar_Ident.id_of_text "reflect"  in
-              FStar_All.pipe_right uu____24494
+              let uu____24501 = FStar_Ident.id_of_text "reflect"  in
+              FStar_All.pipe_right uu____24501
                 (FStar_Syntax_DsEnv.qualify monad_env)
                in
             let quals1 =
@@ -6422,7 +6456,8 @@ let (push_reflect_effect :
                 FStar_Syntax_Syntax.sigquals = quals1;
                 FStar_Syntax_Syntax.sigmeta =
                   FStar_Syntax_Syntax.default_sigmeta;
-                FStar_Syntax_Syntax.sigattrs = []
+                FStar_Syntax_Syntax.sigattrs = [];
+                FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
               }  in
             FStar_Syntax_DsEnv.push_sigelt env refl_decl
           else env
@@ -6436,52 +6471,52 @@ let (parse_attr_with_list :
   fun warn  ->
     fun at1  ->
       fun head1  ->
-        let warn1 uu____24545 =
+        let warn1 uu____24552 =
           if warn
           then
-            let uu____24547 =
-              let uu____24553 =
-                let uu____24555 = FStar_Ident.string_of_lid head1  in
+            let uu____24554 =
+              let uu____24560 =
+                let uu____24562 = FStar_Ident.string_of_lid head1  in
                 FStar_Util.format1
                   "Found ill-applied '%s', argument should be a non-empty list of integer literals"
-                  uu____24555
+                  uu____24562
                  in
-              (FStar_Errors.Warning_UnappliedFail, uu____24553)  in
-            FStar_Errors.log_issue at1.FStar_Syntax_Syntax.pos uu____24547
+              (FStar_Errors.Warning_UnappliedFail, uu____24560)  in
+            FStar_Errors.log_issue at1.FStar_Syntax_Syntax.pos uu____24554
           else ()  in
-        let uu____24561 = FStar_Syntax_Util.head_and_args at1  in
-        match uu____24561 with
+        let uu____24568 = FStar_Syntax_Util.head_and_args at1  in
+        match uu____24568 with
         | (hd1,args) ->
-            let uu____24614 =
-              let uu____24615 = FStar_Syntax_Subst.compress hd1  in
-              uu____24615.FStar_Syntax_Syntax.n  in
-            (match uu____24614 with
+            let uu____24621 =
+              let uu____24622 = FStar_Syntax_Subst.compress hd1  in
+              uu____24622.FStar_Syntax_Syntax.n  in
+            (match uu____24621 with
              | FStar_Syntax_Syntax.Tm_fvar fv when
                  FStar_Syntax_Syntax.fv_eq_lid fv head1 ->
                  (match args with
                   | [] -> ((FStar_Pervasives_Native.Some []), true)
-                  | (a1,uu____24659)::[] ->
-                      let uu____24684 =
-                        let uu____24689 =
-                          let uu____24698 =
+                  | (a1,uu____24666)::[] ->
+                      let uu____24691 =
+                        let uu____24696 =
+                          let uu____24705 =
                             FStar_Syntax_Embeddings.e_list
                               FStar_Syntax_Embeddings.e_int
                              in
-                          FStar_Syntax_Embeddings.unembed uu____24698 a1  in
-                        uu____24689 true FStar_Syntax_Embeddings.id_norm_cb
+                          FStar_Syntax_Embeddings.unembed uu____24705 a1  in
+                        uu____24696 true FStar_Syntax_Embeddings.id_norm_cb
                          in
-                      (match uu____24684 with
+                      (match uu____24691 with
                        | FStar_Pervasives_Native.Some es ->
-                           let uu____24721 =
-                             let uu____24727 =
+                           let uu____24728 =
+                             let uu____24734 =
                                FStar_List.map FStar_BigInt.to_int_fs es  in
-                             FStar_Pervasives_Native.Some uu____24727  in
-                           (uu____24721, true)
-                       | uu____24742 ->
+                             FStar_Pervasives_Native.Some uu____24734  in
+                           (uu____24728, true)
+                       | uu____24749 ->
                            (warn1 (); (FStar_Pervasives_Native.None, true)))
-                  | uu____24758 ->
+                  | uu____24765 ->
                       (warn1 (); (FStar_Pervasives_Native.None, true)))
-             | uu____24780 -> (FStar_Pervasives_Native.None, false))
+             | uu____24787 -> (FStar_Pervasives_Native.None, false))
   
 let (get_fail_attr :
   Prims.bool ->
@@ -6496,17 +6531,17 @@ let (get_fail_attr :
         | FStar_Pervasives_Native.Some l ->
             FStar_Pervasives_Native.Some (l, b)
          in
-      let uu____24897 =
+      let uu____24904 =
         parse_attr_with_list warn at1 FStar_Parser_Const.fail_attr  in
-      match uu____24897 with
+      match uu____24904 with
       | (res,matched) ->
           if matched
           then rebind res false
           else
-            (let uu____24946 =
+            (let uu____24953 =
                parse_attr_with_list warn at1 FStar_Parser_Const.fail_lax_attr
                 in
-             match uu____24946 with | (res1,uu____24968) -> rebind res1 true)
+             match uu____24953 with | (res1,uu____24975) -> rebind res1 true)
   
 let rec (desugar_effect :
   FStar_Syntax_DsEnv.env ->
@@ -6531,18 +6566,18 @@ let rec (desugar_effect :
                   let env0 = env  in
                   let monad_env =
                     FStar_Syntax_DsEnv.enter_monad_scope env eff_name  in
-                  let uu____25133 = desugar_binders monad_env eff_binders  in
-                  match uu____25133 with
+                  let uu____25140 = desugar_binders monad_env eff_binders  in
+                  match uu____25140 with
                   | (env1,binders) ->
                       let eff_t = desugar_term env1 eff_typ  in
                       let for_free =
-                        let uu____25173 =
-                          let uu____25175 =
-                            let uu____25184 =
+                        let uu____25180 =
+                          let uu____25182 =
+                            let uu____25191 =
                               FStar_Syntax_Util.arrow_formals eff_t  in
-                            FStar_Pervasives_Native.fst uu____25184  in
-                          FStar_List.length uu____25175  in
-                        uu____25173 = Prims.int_one  in
+                            FStar_Pervasives_Native.fst uu____25191  in
+                          FStar_List.length uu____25182  in
+                        uu____25180 = Prims.int_one  in
                       let mandatory_members =
                         let rr_members = ["repr"; "return"; "bind"]  in
                         if for_free
@@ -6560,40 +6595,40 @@ let rec (desugar_effect :
                       let name_of_eff_decl decl =
                         match decl.FStar_Parser_AST.d with
                         | FStar_Parser_AST.Tycon
-                            (uu____25262,uu____25263,(FStar_Parser_AST.TyconAbbrev
-                                                      (name,uu____25265,uu____25266,uu____25267),uu____25268)::[])
+                            (uu____25269,uu____25270,(FStar_Parser_AST.TyconAbbrev
+                                                      (name,uu____25272,uu____25273,uu____25274),uu____25275)::[])
                             -> FStar_Ident.text_of_id name
-                        | uu____25305 ->
+                        | uu____25312 ->
                             failwith "Malformed effect member declaration."
                          in
-                      let uu____25308 =
+                      let uu____25315 =
                         FStar_List.partition
                           (fun decl  ->
-                             let uu____25320 = name_of_eff_decl decl  in
-                             FStar_List.mem uu____25320 mandatory_members)
+                             let uu____25327 = name_of_eff_decl decl  in
+                             FStar_List.mem uu____25327 mandatory_members)
                           eff_decls
                          in
-                      (match uu____25308 with
+                      (match uu____25315 with
                        | (mandatory_members_decls,actions) ->
-                           let uu____25339 =
+                           let uu____25346 =
                              FStar_All.pipe_right mandatory_members_decls
                                (FStar_List.fold_left
-                                  (fun uu____25368  ->
+                                  (fun uu____25375  ->
                                      fun decl  ->
-                                       match uu____25368 with
+                                       match uu____25375 with
                                        | (env2,out) ->
-                                           let uu____25388 =
+                                           let uu____25395 =
                                              desugar_decl env2 decl  in
-                                           (match uu____25388 with
+                                           (match uu____25395 with
                                             | (env3,ses) ->
-                                                let uu____25401 =
-                                                  let uu____25404 =
+                                                let uu____25408 =
+                                                  let uu____25411 =
                                                     FStar_List.hd ses  in
-                                                  uu____25404 :: out  in
-                                                (env3, uu____25401)))
+                                                  uu____25411 :: out  in
+                                                (env3, uu____25408)))
                                   (env1, []))
                               in
-                           (match uu____25339 with
+                           (match uu____25346 with
                             | (env2,decls) ->
                                 let binders1 =
                                   FStar_Syntax_Subst.close_binders binders
@@ -6604,37 +6639,37 @@ let rec (desugar_effect :
                                        (fun d1  ->
                                           match d1.FStar_Parser_AST.d with
                                           | FStar_Parser_AST.Tycon
-                                              (uu____25473,uu____25474,
+                                              (uu____25480,uu____25481,
                                                (FStar_Parser_AST.TyconAbbrev
-                                                (name,action_params,uu____25477,
+                                                (name,action_params,uu____25484,
                                                  {
                                                    FStar_Parser_AST.tm =
                                                      FStar_Parser_AST.Construct
-                                                     (uu____25478,(def,uu____25480)::
-                                                      (cps_type,uu____25482)::[]);
+                                                     (uu____25485,(def,uu____25487)::
+                                                      (cps_type,uu____25489)::[]);
                                                    FStar_Parser_AST.range =
-                                                     uu____25483;
+                                                     uu____25490;
                                                    FStar_Parser_AST.level =
-                                                     uu____25484;_}),doc1)::[])
+                                                     uu____25491;_}),doc1)::[])
                                               when Prims.op_Negation for_free
                                               ->
-                                              let uu____25540 =
+                                              let uu____25547 =
                                                 desugar_binders env2
                                                   action_params
                                                  in
-                                              (match uu____25540 with
+                                              (match uu____25547 with
                                                | (env3,action_params1) ->
                                                    let action_params2 =
                                                      FStar_Syntax_Subst.close_binders
                                                        action_params1
                                                       in
-                                                   let uu____25578 =
-                                                     let uu____25579 =
+                                                   let uu____25585 =
+                                                     let uu____25586 =
                                                        FStar_Syntax_DsEnv.qualify
                                                          env3 name
                                                         in
-                                                     let uu____25580 =
-                                                       let uu____25581 =
+                                                     let uu____25587 =
+                                                       let uu____25588 =
                                                          desugar_term env3
                                                            def
                                                           in
@@ -6642,10 +6677,10 @@ let rec (desugar_effect :
                                                          (FStar_List.append
                                                             binders1
                                                             action_params2)
-                                                         uu____25581
+                                                         uu____25588
                                                         in
-                                                     let uu____25588 =
-                                                       let uu____25589 =
+                                                     let uu____25595 =
+                                                       let uu____25596 =
                                                          desugar_typ env3
                                                            cps_type
                                                           in
@@ -6653,11 +6688,11 @@ let rec (desugar_effect :
                                                          (FStar_List.append
                                                             binders1
                                                             action_params2)
-                                                         uu____25589
+                                                         uu____25596
                                                         in
                                                      {
                                                        FStar_Syntax_Syntax.action_name
-                                                         = uu____25579;
+                                                         = uu____25586;
                                                        FStar_Syntax_Syntax.action_unqualified_name
                                                          = name;
                                                        FStar_Syntax_Syntax.action_univs
@@ -6665,33 +6700,33 @@ let rec (desugar_effect :
                                                        FStar_Syntax_Syntax.action_params
                                                          = action_params2;
                                                        FStar_Syntax_Syntax.action_defn
-                                                         = uu____25580;
+                                                         = uu____25587;
                                                        FStar_Syntax_Syntax.action_typ
-                                                         = uu____25588
+                                                         = uu____25595
                                                      }  in
-                                                   (uu____25578, doc1))
+                                                   (uu____25585, doc1))
                                           | FStar_Parser_AST.Tycon
-                                              (uu____25598,uu____25599,
+                                              (uu____25605,uu____25606,
                                                (FStar_Parser_AST.TyconAbbrev
-                                                (name,action_params,uu____25602,defn),doc1)::[])
+                                                (name,action_params,uu____25609,defn),doc1)::[])
                                               when for_free ->
-                                              let uu____25641 =
+                                              let uu____25648 =
                                                 desugar_binders env2
                                                   action_params
                                                  in
-                                              (match uu____25641 with
+                                              (match uu____25648 with
                                                | (env3,action_params1) ->
                                                    let action_params2 =
                                                      FStar_Syntax_Subst.close_binders
                                                        action_params1
                                                       in
-                                                   let uu____25679 =
-                                                     let uu____25680 =
+                                                   let uu____25686 =
+                                                     let uu____25687 =
                                                        FStar_Syntax_DsEnv.qualify
                                                          env3 name
                                                         in
-                                                     let uu____25681 =
-                                                       let uu____25682 =
+                                                     let uu____25688 =
+                                                       let uu____25689 =
                                                          desugar_term env3
                                                            defn
                                                           in
@@ -6699,11 +6734,11 @@ let rec (desugar_effect :
                                                          (FStar_List.append
                                                             binders1
                                                             action_params2)
-                                                         uu____25682
+                                                         uu____25689
                                                         in
                                                      {
                                                        FStar_Syntax_Syntax.action_name
-                                                         = uu____25680;
+                                                         = uu____25687;
                                                        FStar_Syntax_Syntax.action_unqualified_name
                                                          = name;
                                                        FStar_Syntax_Syntax.action_univs
@@ -6711,13 +6746,13 @@ let rec (desugar_effect :
                                                        FStar_Syntax_Syntax.action_params
                                                          = action_params2;
                                                        FStar_Syntax_Syntax.action_defn
-                                                         = uu____25681;
+                                                         = uu____25688;
                                                        FStar_Syntax_Syntax.action_typ
                                                          =
                                                          FStar_Syntax_Syntax.tun
                                                      }  in
-                                                   (uu____25679, doc1))
-                                          | uu____25691 ->
+                                                   (uu____25686, doc1))
+                                          | uu____25698 ->
                                               FStar_Errors.raise_error
                                                 (FStar_Errors.Fatal_MalformedActionDeclaration,
                                                   "Malformed action declaration; if this is an \"effect for free\", just provide the direct-style declaration. If this is not an \"effect for free\", please provide a pair of the definition and its cps-type with arrows inserted in the right place (see examples).")
@@ -6731,24 +6766,24 @@ let rec (desugar_effect :
                                   FStar_Syntax_Subst.close binders1 eff_t  in
                                 let lookup1 s =
                                   let l =
-                                    let uu____25727 =
+                                    let uu____25734 =
                                       FStar_Ident.mk_ident
                                         (s, (d.FStar_Parser_AST.drange))
                                        in
                                     FStar_Syntax_DsEnv.qualify env2
-                                      uu____25727
+                                      uu____25734
                                      in
-                                  let uu____25729 =
-                                    let uu____25730 =
+                                  let uu____25736 =
+                                    let uu____25737 =
                                       FStar_Syntax_DsEnv.fail_or env2
                                         (FStar_Syntax_DsEnv.try_lookup_definition
                                            env2) l
                                        in
                                     FStar_All.pipe_left
                                       (FStar_Syntax_Subst.close binders1)
-                                      uu____25730
+                                      uu____25737
                                      in
-                                  ([], uu____25729)  in
+                                  ([], uu____25736)  in
                                 let mname =
                                   FStar_Syntax_DsEnv.qualify env0 eff_name
                                    in
@@ -6762,20 +6797,20 @@ let rec (desugar_effect :
                                   if for_free
                                   then
                                     let dummy_tscheme =
-                                      let uu____25748 =
+                                      let uu____25755 =
                                         FStar_Syntax_Syntax.mk
                                           FStar_Syntax_Syntax.Tm_unknown
                                           FStar_Pervasives_Native.None
                                           FStar_Range.dummyRange
                                          in
-                                      ([], uu____25748)  in
-                                    let uu____25755 =
-                                      let uu____25756 =
-                                        let uu____25757 = lookup1 "repr"  in
-                                        let uu____25759 = lookup1 "return"
+                                      ([], uu____25755)  in
+                                    let uu____25762 =
+                                      let uu____25763 =
+                                        let uu____25764 = lookup1 "repr"  in
+                                        let uu____25766 = lookup1 "return"
                                            in
-                                        let uu____25761 = lookup1 "bind"  in
-                                        let uu____25763 =
+                                        let uu____25768 = lookup1 "bind"  in
+                                        let uu____25770 =
                                           FStar_List.map (desugar_term env2)
                                             attrs
                                            in
@@ -6803,73 +6838,75 @@ let rec (desugar_effect :
                                           FStar_Syntax_Syntax.trivial =
                                             dummy_tscheme;
                                           FStar_Syntax_Syntax.repr =
-                                            uu____25757;
+                                            uu____25764;
                                           FStar_Syntax_Syntax.return_repr =
-                                            uu____25759;
+                                            uu____25766;
                                           FStar_Syntax_Syntax.bind_repr =
-                                            uu____25761;
+                                            uu____25768;
                                           FStar_Syntax_Syntax.actions =
                                             actions1;
                                           FStar_Syntax_Syntax.eff_attrs =
-                                            uu____25763
+                                            uu____25770
                                         }  in
                                       FStar_Syntax_Syntax.Sig_new_effect_for_free
-                                        uu____25756
+                                        uu____25763
                                        in
                                     {
-                                      FStar_Syntax_Syntax.sigel = uu____25755;
+                                      FStar_Syntax_Syntax.sigel = uu____25762;
                                       FStar_Syntax_Syntax.sigrng =
                                         (d.FStar_Parser_AST.drange);
                                       FStar_Syntax_Syntax.sigquals =
                                         qualifiers;
                                       FStar_Syntax_Syntax.sigmeta =
                                         FStar_Syntax_Syntax.default_sigmeta;
-                                      FStar_Syntax_Syntax.sigattrs = []
+                                      FStar_Syntax_Syntax.sigattrs = [];
+                                      FStar_Syntax_Syntax.sigopts =
+                                        FStar_Pervasives_Native.None
                                     }
                                   else
                                     (let rr =
                                        FStar_Util.for_some
-                                         (fun uu___28_25775  ->
-                                            match uu___28_25775 with
+                                         (fun uu___28_25782  ->
+                                            match uu___28_25782 with
                                             | FStar_Syntax_Syntax.Reifiable 
                                                 -> true
                                             | FStar_Syntax_Syntax.Reflectable
-                                                uu____25778 -> true
-                                            | uu____25780 -> false)
+                                                uu____25785 -> true
+                                            | uu____25787 -> false)
                                          qualifiers
                                         in
                                      let un_ts =
                                        ([], FStar_Syntax_Syntax.tun)  in
-                                     let uu____25795 =
-                                       let uu____25796 =
-                                         let uu____25797 =
+                                     let uu____25802 =
+                                       let uu____25803 =
+                                         let uu____25804 =
                                            lookup1 "return_wp"  in
-                                         let uu____25799 = lookup1 "bind_wp"
+                                         let uu____25806 = lookup1 "bind_wp"
                                             in
-                                         let uu____25801 =
+                                         let uu____25808 =
                                            lookup1 "if_then_else"  in
-                                         let uu____25803 = lookup1 "ite_wp"
+                                         let uu____25810 = lookup1 "ite_wp"
                                             in
-                                         let uu____25805 = lookup1 "stronger"
+                                         let uu____25812 = lookup1 "stronger"
                                             in
-                                         let uu____25807 = lookup1 "close_wp"
+                                         let uu____25814 = lookup1 "close_wp"
                                             in
-                                         let uu____25809 = lookup1 "trivial"
+                                         let uu____25816 = lookup1 "trivial"
                                             in
-                                         let uu____25811 =
+                                         let uu____25818 =
                                            if rr
                                            then lookup1 "repr"
                                            else ([], FStar_Syntax_Syntax.tun)
                                             in
-                                         let uu____25820 =
+                                         let uu____25827 =
                                            if rr
                                            then lookup1 "return"
                                            else un_ts  in
-                                         let uu____25825 =
+                                         let uu____25832 =
                                            if rr
                                            then lookup1 "bind"
                                            else un_ts  in
-                                         let uu____25830 =
+                                         let uu____25837 =
                                            FStar_List.map (desugar_term env2)
                                              attrs
                                             in
@@ -6883,43 +6920,45 @@ let rec (desugar_effect :
                                            FStar_Syntax_Syntax.signature =
                                              ([], eff_t1);
                                            FStar_Syntax_Syntax.ret_wp =
-                                             uu____25797;
+                                             uu____25804;
                                            FStar_Syntax_Syntax.bind_wp =
-                                             uu____25799;
+                                             uu____25806;
                                            FStar_Syntax_Syntax.if_then_else =
-                                             uu____25801;
+                                             uu____25808;
                                            FStar_Syntax_Syntax.ite_wp =
-                                             uu____25803;
+                                             uu____25810;
                                            FStar_Syntax_Syntax.stronger =
-                                             uu____25805;
+                                             uu____25812;
                                            FStar_Syntax_Syntax.close_wp =
-                                             uu____25807;
+                                             uu____25814;
                                            FStar_Syntax_Syntax.trivial =
-                                             uu____25809;
+                                             uu____25816;
                                            FStar_Syntax_Syntax.repr =
-                                             uu____25811;
+                                             uu____25818;
                                            FStar_Syntax_Syntax.return_repr =
-                                             uu____25820;
+                                             uu____25827;
                                            FStar_Syntax_Syntax.bind_repr =
-                                             uu____25825;
+                                             uu____25832;
                                            FStar_Syntax_Syntax.actions =
                                              actions1;
                                            FStar_Syntax_Syntax.eff_attrs =
-                                             uu____25830
+                                             uu____25837
                                          }  in
                                        FStar_Syntax_Syntax.Sig_new_effect
-                                         uu____25796
+                                         uu____25803
                                         in
                                      {
                                        FStar_Syntax_Syntax.sigel =
-                                         uu____25795;
+                                         uu____25802;
                                        FStar_Syntax_Syntax.sigrng =
                                          (d.FStar_Parser_AST.drange);
                                        FStar_Syntax_Syntax.sigquals =
                                          qualifiers;
                                        FStar_Syntax_Syntax.sigmeta =
                                          FStar_Syntax_Syntax.default_sigmeta;
-                                       FStar_Syntax_Syntax.sigattrs = []
+                                       FStar_Syntax_Syntax.sigattrs = [];
+                                       FStar_Syntax_Syntax.sigopts =
+                                         FStar_Pervasives_Native.None
                                      })
                                    in
                                 let env3 =
@@ -6932,17 +6971,17 @@ let rec (desugar_effect :
                                   FStar_All.pipe_right actions_docs
                                     (FStar_List.fold_left
                                        (fun env5  ->
-                                          fun uu____25860  ->
-                                            match uu____25860 with
+                                          fun uu____25867  ->
+                                            match uu____25867 with
                                             | (a,doc1) ->
                                                 let env6 =
-                                                  let uu____25874 =
+                                                  let uu____25881 =
                                                     FStar_Syntax_Util.action_as_lb
                                                       mname a
                                                       (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
                                                      in
                                                   FStar_Syntax_DsEnv.push_sigelt
-                                                    env5 uu____25874
+                                                    env5 uu____25881
                                                    in
                                                 FStar_Syntax_DsEnv.push_doc
                                                   env6
@@ -6982,30 +7021,30 @@ and (desugar_redefine_effect :
                 let env0 = env  in
                 let env1 = FStar_Syntax_DsEnv.enter_monad_scope env eff_name
                    in
-                let uu____25898 = desugar_binders env1 eff_binders  in
-                match uu____25898 with
+                let uu____25905 = desugar_binders env1 eff_binders  in
+                match uu____25905 with
                 | (env2,binders) ->
-                    let uu____25935 =
-                      let uu____25946 = head_and_args defn  in
-                      match uu____25946 with
+                    let uu____25942 =
+                      let uu____25953 = head_and_args defn  in
+                      match uu____25953 with
                       | (head1,args) ->
                           let lid =
                             match head1.FStar_Parser_AST.tm with
                             | FStar_Parser_AST.Name l -> l
-                            | uu____25983 ->
-                                let uu____25984 =
-                                  let uu____25990 =
-                                    let uu____25992 =
-                                      let uu____25994 =
+                            | uu____25990 ->
+                                let uu____25991 =
+                                  let uu____25997 =
+                                    let uu____25999 =
+                                      let uu____26001 =
                                         FStar_Parser_AST.term_to_string head1
                                          in
-                                      Prims.op_Hat uu____25994 " not found"
+                                      Prims.op_Hat uu____26001 " not found"
                                        in
-                                    Prims.op_Hat "Effect " uu____25992  in
+                                    Prims.op_Hat "Effect " uu____25999  in
                                   (FStar_Errors.Fatal_EffectNotFound,
-                                    uu____25990)
+                                    uu____25997)
                                    in
-                                FStar_Errors.raise_error uu____25984
+                                FStar_Errors.raise_error uu____25991
                                   d.FStar_Parser_AST.drange
                              in
                           let ed =
@@ -7013,25 +7052,25 @@ and (desugar_redefine_effect :
                               (FStar_Syntax_DsEnv.try_lookup_effect_defn env2)
                               lid
                              in
-                          let uu____26000 =
+                          let uu____26007 =
                             match FStar_List.rev args with
-                            | (last_arg,uu____26030)::args_rev ->
-                                let uu____26042 =
-                                  let uu____26043 = unparen last_arg  in
-                                  uu____26043.FStar_Parser_AST.tm  in
-                                (match uu____26042 with
+                            | (last_arg,uu____26037)::args_rev ->
+                                let uu____26049 =
+                                  let uu____26050 = unparen last_arg  in
+                                  uu____26050.FStar_Parser_AST.tm  in
+                                (match uu____26049 with
                                  | FStar_Parser_AST.Attributes ts ->
                                      (ts, (FStar_List.rev args_rev))
-                                 | uu____26071 -> ([], args))
-                            | uu____26080 -> ([], args)  in
-                          (match uu____26000 with
+                                 | uu____26078 -> ([], args))
+                            | uu____26087 -> ([], args)  in
+                          (match uu____26007 with
                            | (cattributes,args1) ->
-                               let uu____26123 = desugar_args env2 args1  in
-                               let uu____26124 =
+                               let uu____26130 = desugar_args env2 args1  in
+                               let uu____26131 =
                                  desugar_attributes env2 cattributes  in
-                               (lid, ed, uu____26123, uu____26124))
+                               (lid, ed, uu____26130, uu____26131))
                        in
-                    (match uu____25935 with
+                    (match uu____25942 with
                      | (ed_lid,ed,args,cattributes) ->
                          let binders1 =
                            FStar_Syntax_Subst.close_binders binders  in
@@ -7045,95 +7084,95 @@ and (desugar_redefine_effect :
                                 "Unexpected number of arguments to effect constructor")
                               defn.FStar_Parser_AST.range
                           else ();
-                          (let uu____26164 =
+                          (let uu____26171 =
                              FStar_Syntax_Subst.open_term'
                                ed.FStar_Syntax_Syntax.binders
                                FStar_Syntax_Syntax.t_unit
                               in
-                           match uu____26164 with
-                           | (ed_binders,uu____26178,ed_binders_opening) ->
-                               let sub' shift_n uu____26197 =
-                                 match uu____26197 with
+                           match uu____26171 with
+                           | (ed_binders,uu____26185,ed_binders_opening) ->
+                               let sub' shift_n uu____26204 =
+                                 match uu____26204 with
                                  | (us,x) ->
                                      let x1 =
-                                       let uu____26212 =
+                                       let uu____26219 =
                                          FStar_Syntax_Subst.shift_subst
                                            (shift_n + (FStar_List.length us))
                                            ed_binders_opening
                                           in
-                                       FStar_Syntax_Subst.subst uu____26212 x
+                                       FStar_Syntax_Subst.subst uu____26219 x
                                         in
                                      let s =
                                        FStar_Syntax_Util.subst_of_list
                                          ed_binders args
                                         in
-                                     let uu____26216 =
-                                       let uu____26217 =
+                                     let uu____26223 =
+                                       let uu____26224 =
                                          FStar_Syntax_Subst.subst s x1  in
-                                       (us, uu____26217)  in
+                                       (us, uu____26224)  in
                                      FStar_Syntax_Subst.close_tscheme
-                                       binders1 uu____26216
+                                       binders1 uu____26223
                                   in
                                let sub1 = sub' Prims.int_zero  in
                                let mname =
                                  FStar_Syntax_DsEnv.qualify env0 eff_name  in
                                let ed1 =
-                                 let uu____26238 =
+                                 let uu____26245 =
                                    sub1 ed.FStar_Syntax_Syntax.signature  in
-                                 let uu____26239 =
+                                 let uu____26246 =
                                    sub1 ed.FStar_Syntax_Syntax.ret_wp  in
-                                 let uu____26240 =
+                                 let uu____26247 =
                                    sub1 ed.FStar_Syntax_Syntax.bind_wp  in
-                                 let uu____26241 =
+                                 let uu____26248 =
                                    sub1 ed.FStar_Syntax_Syntax.if_then_else
                                     in
-                                 let uu____26242 =
+                                 let uu____26249 =
                                    sub1 ed.FStar_Syntax_Syntax.ite_wp  in
-                                 let uu____26243 =
+                                 let uu____26250 =
                                    sub1 ed.FStar_Syntax_Syntax.stronger  in
-                                 let uu____26244 =
+                                 let uu____26251 =
                                    sub1 ed.FStar_Syntax_Syntax.close_wp  in
-                                 let uu____26245 =
+                                 let uu____26252 =
                                    sub1 ed.FStar_Syntax_Syntax.trivial  in
-                                 let uu____26246 =
+                                 let uu____26253 =
                                    sub1 ed.FStar_Syntax_Syntax.repr  in
-                                 let uu____26247 =
+                                 let uu____26254 =
                                    sub1 ed.FStar_Syntax_Syntax.return_repr
                                     in
-                                 let uu____26248 =
+                                 let uu____26255 =
                                    sub1 ed.FStar_Syntax_Syntax.bind_repr  in
-                                 let uu____26249 =
+                                 let uu____26256 =
                                    FStar_List.map
                                      (fun action  ->
                                         let nparam =
                                           FStar_List.length
                                             action.FStar_Syntax_Syntax.action_params
                                            in
-                                        let uu____26265 =
+                                        let uu____26272 =
                                           FStar_Syntax_DsEnv.qualify env2
                                             action.FStar_Syntax_Syntax.action_unqualified_name
                                            in
-                                        let uu____26266 =
-                                          let uu____26267 =
+                                        let uu____26273 =
+                                          let uu____26274 =
                                             sub' nparam
                                               ([],
                                                 (action.FStar_Syntax_Syntax.action_defn))
                                              in
                                           FStar_Pervasives_Native.snd
-                                            uu____26267
+                                            uu____26274
                                            in
-                                        let uu____26282 =
-                                          let uu____26283 =
+                                        let uu____26289 =
+                                          let uu____26290 =
                                             sub' nparam
                                               ([],
                                                 (action.FStar_Syntax_Syntax.action_typ))
                                              in
                                           FStar_Pervasives_Native.snd
-                                            uu____26283
+                                            uu____26290
                                            in
                                         {
                                           FStar_Syntax_Syntax.action_name =
-                                            uu____26265;
+                                            uu____26272;
                                           FStar_Syntax_Syntax.action_unqualified_name
                                             =
                                             (action.FStar_Syntax_Syntax.action_unqualified_name);
@@ -7142,9 +7181,9 @@ and (desugar_redefine_effect :
                                           FStar_Syntax_Syntax.action_params =
                                             (action.FStar_Syntax_Syntax.action_params);
                                           FStar_Syntax_Syntax.action_defn =
-                                            uu____26266;
+                                            uu____26273;
                                           FStar_Syntax_Syntax.action_typ =
-                                            uu____26282
+                                            uu____26289
                                         }) ed.FStar_Syntax_Syntax.actions
                                     in
                                  {
@@ -7155,48 +7194,48 @@ and (desugar_redefine_effect :
                                      (ed.FStar_Syntax_Syntax.univs);
                                    FStar_Syntax_Syntax.binders = binders1;
                                    FStar_Syntax_Syntax.signature =
-                                     uu____26238;
-                                   FStar_Syntax_Syntax.ret_wp = uu____26239;
-                                   FStar_Syntax_Syntax.bind_wp = uu____26240;
+                                     uu____26245;
+                                   FStar_Syntax_Syntax.ret_wp = uu____26246;
+                                   FStar_Syntax_Syntax.bind_wp = uu____26247;
                                    FStar_Syntax_Syntax.if_then_else =
-                                     uu____26241;
-                                   FStar_Syntax_Syntax.ite_wp = uu____26242;
-                                   FStar_Syntax_Syntax.stronger = uu____26243;
-                                   FStar_Syntax_Syntax.close_wp = uu____26244;
-                                   FStar_Syntax_Syntax.trivial = uu____26245;
-                                   FStar_Syntax_Syntax.repr = uu____26246;
-                                   FStar_Syntax_Syntax.return_repr =
-                                     uu____26247;
-                                   FStar_Syntax_Syntax.bind_repr =
                                      uu____26248;
-                                   FStar_Syntax_Syntax.actions = uu____26249;
+                                   FStar_Syntax_Syntax.ite_wp = uu____26249;
+                                   FStar_Syntax_Syntax.stronger = uu____26250;
+                                   FStar_Syntax_Syntax.close_wp = uu____26251;
+                                   FStar_Syntax_Syntax.trivial = uu____26252;
+                                   FStar_Syntax_Syntax.repr = uu____26253;
+                                   FStar_Syntax_Syntax.return_repr =
+                                     uu____26254;
+                                   FStar_Syntax_Syntax.bind_repr =
+                                     uu____26255;
+                                   FStar_Syntax_Syntax.actions = uu____26256;
                                    FStar_Syntax_Syntax.eff_attrs =
                                      (ed.FStar_Syntax_Syntax.eff_attrs)
                                  }  in
                                let se =
                                  let for_free =
-                                   let uu____26301 =
-                                     let uu____26303 =
-                                       let uu____26312 =
-                                         let uu____26327 =
+                                   let uu____26308 =
+                                     let uu____26310 =
+                                       let uu____26319 =
+                                         let uu____26334 =
                                            FStar_All.pipe_right
                                              ed1.FStar_Syntax_Syntax.signature
                                              FStar_Pervasives_Native.snd
                                             in
-                                         FStar_All.pipe_right uu____26327
+                                         FStar_All.pipe_right uu____26334
                                            FStar_Syntax_Util.arrow_formals
                                           in
                                        FStar_Pervasives_Native.fst
-                                         uu____26312
+                                         uu____26319
                                         in
-                                     FStar_List.length uu____26303  in
-                                   uu____26301 = Prims.int_one  in
-                                 let uu____26372 =
-                                   let uu____26375 =
+                                     FStar_List.length uu____26310  in
+                                   uu____26308 = Prims.int_one  in
+                                 let uu____26379 =
+                                   let uu____26382 =
                                      trans_qual1
                                        (FStar_Pervasives_Native.Some mname)
                                       in
-                                   FStar_List.map uu____26375 quals  in
+                                   FStar_List.map uu____26382 quals  in
                                  {
                                    FStar_Syntax_Syntax.sigel =
                                      (if for_free
@@ -7208,10 +7247,12 @@ and (desugar_redefine_effect :
                                           ed1);
                                    FStar_Syntax_Syntax.sigrng =
                                      (d.FStar_Parser_AST.drange);
-                                   FStar_Syntax_Syntax.sigquals = uu____26372;
+                                   FStar_Syntax_Syntax.sigquals = uu____26379;
                                    FStar_Syntax_Syntax.sigmeta =
                                      FStar_Syntax_Syntax.default_sigmeta;
-                                   FStar_Syntax_Syntax.sigattrs = []
+                                   FStar_Syntax_Syntax.sigattrs = [];
+                                   FStar_Syntax_Syntax.sigopts =
+                                     FStar_Pervasives_Native.None
                                  }  in
                                let monad_env = env2  in
                                let env3 =
@@ -7232,30 +7273,30 @@ and (desugar_redefine_effect :
                                                a.FStar_Syntax_Syntax.action_name
                                               in
                                            let env6 =
-                                             let uu____26399 =
+                                             let uu____26406 =
                                                FStar_Syntax_Util.action_as_lb
                                                  mname a
                                                  (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
                                                 in
                                              FStar_Syntax_DsEnv.push_sigelt
-                                               env5 uu____26399
+                                               env5 uu____26406
                                               in
                                            FStar_Syntax_DsEnv.push_doc env6
                                              a.FStar_Syntax_Syntax.action_name
                                              doc1) env4)
                                   in
                                let env6 =
-                                 let uu____26401 =
+                                 let uu____26408 =
                                    FStar_All.pipe_right quals
                                      (FStar_List.contains
                                         FStar_Parser_AST.Reflectable)
                                     in
-                                 if uu____26401
+                                 if uu____26408
                                  then
                                    let reflect_lid =
-                                     let uu____26408 =
+                                     let uu____26415 =
                                        FStar_Ident.id_of_text "reflect"  in
-                                     FStar_All.pipe_right uu____26408
+                                     FStar_All.pipe_right uu____26415
                                        (FStar_Syntax_DsEnv.qualify monad_env)
                                       in
                                    let quals1 =
@@ -7273,7 +7314,9 @@ and (desugar_redefine_effect :
                                        FStar_Syntax_Syntax.sigquals = quals1;
                                        FStar_Syntax_Syntax.sigmeta =
                                          FStar_Syntax_Syntax.default_sigmeta;
-                                       FStar_Syntax_Syntax.sigattrs = []
+                                       FStar_Syntax_Syntax.sigattrs = [];
+                                       FStar_Syntax_Syntax.sigopts =
+                                         FStar_Pervasives_Native.None
                                      }  in
                                    FStar_Syntax_DsEnv.push_sigelt env5
                                      refl_decl
@@ -7289,11 +7332,11 @@ and (mk_comment_attr :
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax Prims.list)
   =
   fun d  ->
-    let uu____26420 =
+    let uu____26427 =
       match d.FStar_Parser_AST.doc with
       | FStar_Pervasives_Native.None  -> ("", [])
       | FStar_Pervasives_Native.Some fsdoc -> fsdoc  in
-    match uu____26420 with
+    match uu____26427 with
     | (text,kv) ->
         let summary =
           match FStar_List.assoc "summary" kv with
@@ -7303,19 +7346,19 @@ and (mk_comment_attr :
            in
         let pp =
           match FStar_List.assoc "type" kv with
-          | FStar_Pervasives_Native.Some uu____26507 ->
-              let uu____26510 =
-                let uu____26512 =
+          | FStar_Pervasives_Native.Some uu____26514 ->
+              let uu____26517 =
+                let uu____26519 =
                   FStar_Parser_ToDocument.signature_to_document d  in
                 FStar_Pprint.pretty_string 0.95 (Prims.of_int (80))
-                  uu____26512
+                  uu____26519
                  in
-              Prims.op_Hat "\n  " uu____26510
-          | uu____26515 -> ""  in
+              Prims.op_Hat "\n  " uu____26517
+          | uu____26522 -> ""  in
         let other =
           FStar_List.filter_map
-            (fun uu____26534  ->
-               match uu____26534 with
+            (fun uu____26541  ->
+               match uu____26541 with
                | (k,v1) ->
                    if (k <> "summary") && (k <> "type")
                    then
@@ -7331,21 +7374,21 @@ and (mk_comment_attr :
           Prims.op_Hat summary (Prims.op_Hat pp (Prims.op_Hat other1 text))
            in
         let fv =
-          let uu____26579 = FStar_Ident.lid_of_str "FStar.Pervasives.Comment"
+          let uu____26586 = FStar_Ident.lid_of_str "FStar.Pervasives.Comment"
              in
-          FStar_Syntax_Syntax.fvar uu____26579
+          FStar_Syntax_Syntax.fvar uu____26586
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
            in
         if str = ""
         then []
         else
-          (let uu____26592 =
+          (let uu____26599 =
              let arg = FStar_Syntax_Util.exp_string str  in
-             let uu____26596 =
-               let uu____26607 = FStar_Syntax_Syntax.as_arg arg  in
-               [uu____26607]  in
-             FStar_Syntax_Util.mk_app fv uu____26596  in
-           [uu____26592])
+             let uu____26603 =
+               let uu____26614 = FStar_Syntax_Syntax.as_arg arg  in
+               [uu____26614]  in
+             FStar_Syntax_Util.mk_app fv uu____26603  in
+           [uu____26599])
 
 and (desugar_decl_aux :
   FStar_Syntax_DsEnv.env ->
@@ -7354,8 +7397,8 @@ and (desugar_decl_aux :
   fun env  ->
     fun d  ->
       let env0 = env  in
-      let uu____26643 = desugar_decl_noattrs env d  in
-      match uu____26643 with
+      let uu____26650 = desugar_decl_noattrs env d  in
+      match uu____26650 with
       | (env1,sigelts) ->
           let attrs = d.FStar_Parser_AST.attrs  in
           let attrs1 = FStar_List.map (desugar_term env1) attrs  in
@@ -7364,83 +7407,88 @@ and (desugar_decl_aux :
             | {
                 FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
                   (lbs,names1);
-                FStar_Syntax_Syntax.sigrng = uu____26673;
-                FStar_Syntax_Syntax.sigquals = uu____26674;
-                FStar_Syntax_Syntax.sigmeta = uu____26675;
-                FStar_Syntax_Syntax.sigattrs = uu____26676;_}::[] ->
-                let uu____26685 =
+                FStar_Syntax_Syntax.sigrng = uu____26680;
+                FStar_Syntax_Syntax.sigquals = uu____26681;
+                FStar_Syntax_Syntax.sigmeta = uu____26682;
+                FStar_Syntax_Syntax.sigattrs = uu____26683;
+                FStar_Syntax_Syntax.sigopts = uu____26684;_}::[] ->
+                let uu____26695 =
                   FStar_All.pipe_right names1
                     (FStar_List.collect
                        (fun nm  ->
-                          let uu____26695 =
+                          let uu____26705 =
                             FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                               env0 nm
                              in
-                          FStar_Pervasives_Native.snd uu____26695))
+                          FStar_Pervasives_Native.snd uu____26705))
                    in
-                FStar_All.pipe_right uu____26685
+                FStar_All.pipe_right uu____26695
                   (FStar_List.filter
                      (fun t  ->
-                        let uu____26717 = get_fail_attr false t  in
-                        FStar_Option.isNone uu____26717))
-            | uu____26737 -> []  in
+                        let uu____26727 = get_fail_attr false t  in
+                        FStar_Option.isNone uu____26727))
+            | uu____26747 -> []  in
           let attrs2 =
-            let uu____26745 = mk_comment_attr d  in
-            FStar_List.append uu____26745
+            let uu____26755 = mk_comment_attr d  in
+            FStar_List.append uu____26755
               (FStar_List.append attrs1 val_attrs)
              in
-          let uu____26754 =
+          let uu____26764 =
             FStar_List.mapi
               (fun i  ->
                  fun sigelt  ->
                    if i = Prims.int_zero
                    then
-                     let uu___3419_26764 = sigelt  in
+                     let uu___3422_26774 = sigelt  in
                      {
                        FStar_Syntax_Syntax.sigel =
-                         (uu___3419_26764.FStar_Syntax_Syntax.sigel);
+                         (uu___3422_26774.FStar_Syntax_Syntax.sigel);
                        FStar_Syntax_Syntax.sigrng =
-                         (uu___3419_26764.FStar_Syntax_Syntax.sigrng);
+                         (uu___3422_26774.FStar_Syntax_Syntax.sigrng);
                        FStar_Syntax_Syntax.sigquals =
-                         (uu___3419_26764.FStar_Syntax_Syntax.sigquals);
+                         (uu___3422_26774.FStar_Syntax_Syntax.sigquals);
                        FStar_Syntax_Syntax.sigmeta =
-                         (uu___3419_26764.FStar_Syntax_Syntax.sigmeta);
-                       FStar_Syntax_Syntax.sigattrs = attrs2
+                         (uu___3422_26774.FStar_Syntax_Syntax.sigmeta);
+                       FStar_Syntax_Syntax.sigattrs = attrs2;
+                       FStar_Syntax_Syntax.sigopts =
+                         (uu___3422_26774.FStar_Syntax_Syntax.sigopts)
                      }
                    else
-                     (let uu___3421_26767 = sigelt  in
-                      let uu____26768 =
+                     (let uu___3424_26777 = sigelt  in
+                      let uu____26778 =
                         FStar_List.filter
                           (fun at1  ->
-                             let uu____26774 = get_fail_attr false at1  in
-                             FStar_Option.isNone uu____26774) attrs2
+                             let uu____26784 = get_fail_attr false at1  in
+                             FStar_Option.isNone uu____26784) attrs2
                          in
                       {
                         FStar_Syntax_Syntax.sigel =
-                          (uu___3421_26767.FStar_Syntax_Syntax.sigel);
+                          (uu___3424_26777.FStar_Syntax_Syntax.sigel);
                         FStar_Syntax_Syntax.sigrng =
-                          (uu___3421_26767.FStar_Syntax_Syntax.sigrng);
+                          (uu___3424_26777.FStar_Syntax_Syntax.sigrng);
                         FStar_Syntax_Syntax.sigquals =
-                          (uu___3421_26767.FStar_Syntax_Syntax.sigquals);
+                          (uu___3424_26777.FStar_Syntax_Syntax.sigquals);
                         FStar_Syntax_Syntax.sigmeta =
-                          (uu___3421_26767.FStar_Syntax_Syntax.sigmeta);
-                        FStar_Syntax_Syntax.sigattrs = uu____26768
+                          (uu___3424_26777.FStar_Syntax_Syntax.sigmeta);
+                        FStar_Syntax_Syntax.sigattrs = uu____26778;
+                        FStar_Syntax_Syntax.sigopts =
+                          (uu___3424_26777.FStar_Syntax_Syntax.sigopts)
                       })) sigelts
              in
-          (env1, uu____26754)
+          (env1, uu____26764)
 
 and (desugar_decl :
   env_t -> FStar_Parser_AST.decl -> (env_t * FStar_Syntax_Syntax.sigelts)) =
   fun env  ->
     fun d  ->
-      let uu____26800 = desugar_decl_aux env d  in
-      match uu____26800 with
+      let uu____26810 = desugar_decl_aux env d  in
+      match uu____26810 with
       | (env1,ses) ->
-          let uu____26811 =
+          let uu____26821 =
             FStar_All.pipe_right ses
               (FStar_List.map generalize_annotated_univs)
              in
-          (env1, uu____26811)
+          (env1, uu____26821)
 
 and (desugar_decl_noattrs :
   FStar_Syntax_DsEnv.env ->
@@ -7461,57 +7509,58 @@ and (desugar_decl_noattrs :
                 FStar_Syntax_Syntax.sigquals = [];
                 FStar_Syntax_Syntax.sigmeta =
                   FStar_Syntax_Syntax.default_sigmeta;
-                FStar_Syntax_Syntax.sigattrs = []
+                FStar_Syntax_Syntax.sigattrs = [];
+                FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
               }  in
             (env, [se])))
-      | FStar_Parser_AST.Fsdoc uu____26839 -> (env, [])
+      | FStar_Parser_AST.Fsdoc uu____26849 -> (env, [])
       | FStar_Parser_AST.TopLevelModule id1 -> (env, [])
       | FStar_Parser_AST.Open lid ->
           let env1 = FStar_Syntax_DsEnv.push_namespace env lid  in (env1, [])
       | FStar_Parser_AST.Friend lid ->
-          let uu____26844 = FStar_Syntax_DsEnv.iface env  in
-          if uu____26844
+          let uu____26854 = FStar_Syntax_DsEnv.iface env  in
+          if uu____26854
           then
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_FriendInterface,
                 "'friend' declarations are not allowed in interfaces")
               d.FStar_Parser_AST.drange
           else
-            (let uu____26859 =
-               let uu____26861 =
-                 let uu____26863 = FStar_Syntax_DsEnv.dep_graph env  in
-                 let uu____26864 = FStar_Syntax_DsEnv.current_module env  in
-                 FStar_Parser_Dep.module_has_interface uu____26863
-                   uu____26864
+            (let uu____26869 =
+               let uu____26871 =
+                 let uu____26873 = FStar_Syntax_DsEnv.dep_graph env  in
+                 let uu____26874 = FStar_Syntax_DsEnv.current_module env  in
+                 FStar_Parser_Dep.module_has_interface uu____26873
+                   uu____26874
                   in
-               Prims.op_Negation uu____26861  in
-             if uu____26859
+               Prims.op_Negation uu____26871  in
+             if uu____26869
              then
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_FriendInterface,
                    "'friend' declarations are not allowed in modules that lack interfaces")
                  d.FStar_Parser_AST.drange
              else
-               (let uu____26878 =
-                  let uu____26880 =
-                    let uu____26882 = FStar_Syntax_DsEnv.dep_graph env  in
-                    FStar_Parser_Dep.module_has_interface uu____26882 lid  in
-                  Prims.op_Negation uu____26880  in
-                if uu____26878
+               (let uu____26888 =
+                  let uu____26890 =
+                    let uu____26892 = FStar_Syntax_DsEnv.dep_graph env  in
+                    FStar_Parser_Dep.module_has_interface uu____26892 lid  in
+                  Prims.op_Negation uu____26890  in
+                if uu____26888
                 then
                   FStar_Errors.raise_error
                     (FStar_Errors.Fatal_FriendInterface,
                       "'friend' declarations cannot refer to modules that lack interfaces")
                     d.FStar_Parser_AST.drange
                 else
-                  (let uu____26896 =
-                     let uu____26898 =
-                       let uu____26900 = FStar_Syntax_DsEnv.dep_graph env  in
-                       FStar_Parser_Dep.deps_has_implementation uu____26900
+                  (let uu____26906 =
+                     let uu____26908 =
+                       let uu____26910 = FStar_Syntax_DsEnv.dep_graph env  in
+                       FStar_Parser_Dep.deps_has_implementation uu____26910
                          lid
                         in
-                     Prims.op_Negation uu____26898  in
-                   if uu____26896
+                     Prims.op_Negation uu____26908  in
+                   if uu____26906
                    then
                      FStar_Errors.raise_error
                        (FStar_Errors.Fatal_FriendInterface,
@@ -7521,8 +7570,8 @@ and (desugar_decl_noattrs :
       | FStar_Parser_AST.Include lid ->
           let env1 = FStar_Syntax_DsEnv.push_include env lid  in (env1, [])
       | FStar_Parser_AST.ModuleAbbrev (x,l) ->
-          let uu____26918 = FStar_Syntax_DsEnv.push_module_abbrev env x l  in
-          (uu____26918, [])
+          let uu____26928 = FStar_Syntax_DsEnv.push_module_abbrev env x l  in
+          (uu____26928, [])
       | FStar_Parser_AST.Tycon (is_effect,typeclass,tcs) ->
           let quals = d.FStar_Parser_AST.quals  in
           let quals1 =
@@ -7533,9 +7582,9 @@ and (desugar_decl_noattrs :
             if typeclass
             then
               match tcs with
-              | (FStar_Parser_AST.TyconRecord uu____26959,uu____26960)::[] ->
+              | (FStar_Parser_AST.TyconRecord uu____26969,uu____26970)::[] ->
                   FStar_Parser_AST.Noeq :: quals1
-              | uu____26999 ->
+              | uu____27009 ->
                   FStar_Errors.raise_error
                     (FStar_Errors.Error_BadClassDecl,
                       "Ill-formed `class` declaration: definition must be a record type")
@@ -7543,83 +7592,85 @@ and (desugar_decl_noattrs :
             else quals1  in
           let tcs1 =
             FStar_List.map
-              (fun uu____27026  ->
-                 match uu____27026 with | (x,uu____27034) -> x) tcs
+              (fun uu____27036  ->
+                 match uu____27036 with | (x,uu____27044) -> x) tcs
              in
-          let uu____27039 =
-            let uu____27044 =
+          let uu____27049 =
+            let uu____27054 =
               FStar_List.map (trans_qual1 FStar_Pervasives_Native.None)
                 quals2
                in
-            desugar_tycon env d uu____27044 tcs1  in
-          (match uu____27039 with
+            desugar_tycon env d uu____27054 tcs1  in
+          (match uu____27049 with
            | (env1,ses) ->
                let mkclass lid =
-                 let uu____27061 =
-                   let uu____27062 =
-                     let uu____27069 =
+                 let uu____27071 =
+                   let uu____27072 =
+                     let uu____27079 =
                        FStar_Syntax_Syntax.new_bv
                          FStar_Pervasives_Native.None FStar_Syntax_Syntax.tun
                         in
-                     FStar_Syntax_Syntax.mk_binder uu____27069  in
-                   [uu____27062]  in
-                 let uu____27082 =
-                   let uu____27085 =
+                     FStar_Syntax_Syntax.mk_binder uu____27079  in
+                   [uu____27072]  in
+                 let uu____27092 =
+                   let uu____27095 =
                      FStar_Syntax_Syntax.tabbrev
                        FStar_Parser_Const.mk_class_lid
                       in
-                   let uu____27088 =
-                     let uu____27099 =
-                       let uu____27108 =
-                         let uu____27109 = FStar_Ident.string_of_lid lid  in
-                         FStar_Syntax_Util.exp_string uu____27109  in
-                       FStar_Syntax_Syntax.as_arg uu____27108  in
-                     [uu____27099]  in
-                   FStar_Syntax_Util.mk_app uu____27085 uu____27088  in
-                 FStar_Syntax_Util.abs uu____27061 uu____27082
+                   let uu____27098 =
+                     let uu____27109 =
+                       let uu____27118 =
+                         let uu____27119 = FStar_Ident.string_of_lid lid  in
+                         FStar_Syntax_Util.exp_string uu____27119  in
+                       FStar_Syntax_Syntax.as_arg uu____27118  in
+                     [uu____27109]  in
+                   FStar_Syntax_Util.mk_app uu____27095 uu____27098  in
+                 FStar_Syntax_Util.abs uu____27071 uu____27092
                    FStar_Pervasives_Native.None
                   in
                let get_meths se =
                  let rec get_fname quals3 =
                    match quals3 with
                    | (FStar_Syntax_Syntax.Projector
-                       (uu____27149,id1))::uu____27151 ->
+                       (uu____27159,id1))::uu____27161 ->
                        FStar_Pervasives_Native.Some id1
-                   | uu____27154::quals4 -> get_fname quals4
+                   | uu____27164::quals4 -> get_fname quals4
                    | [] -> FStar_Pervasives_Native.None  in
-                 let uu____27158 = get_fname se.FStar_Syntax_Syntax.sigquals
+                 let uu____27168 = get_fname se.FStar_Syntax_Syntax.sigquals
                     in
-                 match uu____27158 with
+                 match uu____27168 with
                  | FStar_Pervasives_Native.None  -> []
                  | FStar_Pervasives_Native.Some id1 ->
-                     let uu____27164 = FStar_Syntax_DsEnv.qualify env1 id1
+                     let uu____27174 = FStar_Syntax_DsEnv.qualify env1 id1
                         in
-                     [uu____27164]
+                     [uu____27174]
                   in
                let rec splice_decl meths se =
                  match se.FStar_Syntax_Syntax.sigel with
-                 | FStar_Syntax_Syntax.Sig_bundle (ses1,uu____27185) ->
+                 | FStar_Syntax_Syntax.Sig_bundle (ses1,uu____27195) ->
                      FStar_List.concatMap (splice_decl meths) ses1
                  | FStar_Syntax_Syntax.Sig_inductive_typ
-                     (lid,uu____27195,uu____27196,uu____27197,uu____27198,uu____27199)
+                     (lid,uu____27205,uu____27206,uu____27207,uu____27208,uu____27209)
                      ->
-                     let uu____27208 =
-                       let uu____27209 =
-                         let uu____27210 =
-                           let uu____27217 = mkclass lid  in
-                           (meths, uu____27217)  in
-                         FStar_Syntax_Syntax.Sig_splice uu____27210  in
+                     let uu____27218 =
+                       let uu____27219 =
+                         let uu____27220 =
+                           let uu____27227 = mkclass lid  in
+                           (meths, uu____27227)  in
+                         FStar_Syntax_Syntax.Sig_splice uu____27220  in
                        {
-                         FStar_Syntax_Syntax.sigel = uu____27209;
+                         FStar_Syntax_Syntax.sigel = uu____27219;
                          FStar_Syntax_Syntax.sigrng =
                            (d.FStar_Parser_AST.drange);
                          FStar_Syntax_Syntax.sigquals = [];
                          FStar_Syntax_Syntax.sigmeta =
                            FStar_Syntax_Syntax.default_sigmeta;
-                         FStar_Syntax_Syntax.sigattrs = []
+                         FStar_Syntax_Syntax.sigattrs = [];
+                         FStar_Syntax_Syntax.sigopts =
+                           FStar_Pervasives_Native.None
                        }  in
-                     [uu____27208]
-                 | uu____27220 -> []  in
+                     [uu____27218]
+                 | uu____27230 -> []  in
                let extra =
                  if typeclass
                  then
@@ -7637,34 +7688,34 @@ and (desugar_decl_noattrs :
             (isrec = FStar_Parser_AST.NoLetQualifier) &&
               (match lets with
                | ({
-                    FStar_Parser_AST.pat = FStar_Parser_AST.PatOp uu____27254;
-                    FStar_Parser_AST.prange = uu____27255;_},uu____27256)::[]
+                    FStar_Parser_AST.pat = FStar_Parser_AST.PatOp uu____27264;
+                    FStar_Parser_AST.prange = uu____27265;_},uu____27266)::[]
                    -> false
                | ({
                     FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                      uu____27266;
-                    FStar_Parser_AST.prange = uu____27267;_},uu____27268)::[]
+                      uu____27276;
+                    FStar_Parser_AST.prange = uu____27277;_},uu____27278)::[]
                    -> false
                | ({
                     FStar_Parser_AST.pat = FStar_Parser_AST.PatAscribed
                       ({
                          FStar_Parser_AST.pat = FStar_Parser_AST.PatOp
-                           uu____27284;
-                         FStar_Parser_AST.prange = uu____27285;_},uu____27286);
-                    FStar_Parser_AST.prange = uu____27287;_},uu____27288)::[]
+                           uu____27294;
+                         FStar_Parser_AST.prange = uu____27295;_},uu____27296);
+                    FStar_Parser_AST.prange = uu____27297;_},uu____27298)::[]
                    -> false
                | ({
                     FStar_Parser_AST.pat = FStar_Parser_AST.PatAscribed
                       ({
                          FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                           uu____27310;
-                         FStar_Parser_AST.prange = uu____27311;_},uu____27312);
-                    FStar_Parser_AST.prange = uu____27313;_},uu____27314)::[]
+                           uu____27320;
+                         FStar_Parser_AST.prange = uu____27321;_},uu____27322);
+                    FStar_Parser_AST.prange = uu____27323;_},uu____27324)::[]
                    -> false
-               | (p,uu____27343)::[] ->
-                   let uu____27352 = is_app_pattern p  in
-                   Prims.op_Negation uu____27352
-               | uu____27354 -> false)
+               | (p,uu____27353)::[] ->
+                   let uu____27362 = is_app_pattern p  in
+                   Prims.op_Negation uu____27362
+               | uu____27364 -> false)
              in
           if Prims.op_Negation expand_toplevel_pattern
           then
@@ -7681,19 +7732,19 @@ and (desugar_decl_noattrs :
                         d.FStar_Parser_AST.drange FStar_Parser_AST.Expr)))
                 d.FStar_Parser_AST.drange FStar_Parser_AST.Expr
                in
-            let uu____27429 = desugar_term_maybe_top true env as_inner_let
+            let uu____27439 = desugar_term_maybe_top true env as_inner_let
                in
-            (match uu____27429 with
+            (match uu____27439 with
              | (ds_lets,aq) ->
                  (check_no_aq aq;
-                  (let uu____27442 =
-                     let uu____27443 =
+                  (let uu____27452 =
+                     let uu____27453 =
                        FStar_All.pipe_left FStar_Syntax_Subst.compress
                          ds_lets
                         in
-                     uu____27443.FStar_Syntax_Syntax.n  in
-                   match uu____27442 with
-                   | FStar_Syntax_Syntax.Tm_let (lbs,uu____27453) ->
+                     uu____27453.FStar_Syntax_Syntax.n  in
+                   match uu____27452 with
+                   | FStar_Syntax_Syntax.Tm_let (lbs,uu____27463) ->
                        let fvs =
                          FStar_All.pipe_right
                            (FStar_Pervasives_Native.snd lbs)
@@ -7706,42 +7757,42 @@ and (desugar_decl_noattrs :
                          FStar_All.pipe_right fvs
                            (FStar_List.collect
                               (fun fv  ->
-                                 let uu____27494 =
+                                 let uu____27504 =
                                    FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                                      env
                                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                     in
-                                 FStar_Pervasives_Native.fst uu____27494))
+                                 FStar_Pervasives_Native.fst uu____27504))
                           in
                        let quals1 =
                          match quals with
-                         | uu____27512::uu____27513 ->
+                         | uu____27522::uu____27523 ->
                              FStar_List.map
                                (trans_qual1 FStar_Pervasives_Native.None)
                                quals
-                         | uu____27516 -> val_quals  in
+                         | uu____27526 -> val_quals  in
                        let quals2 =
-                         let uu____27520 =
+                         let uu____27530 =
                            FStar_All.pipe_right lets1
                              (FStar_Util.for_some
-                                (fun uu____27553  ->
-                                   match uu____27553 with
-                                   | (uu____27567,(uu____27568,t)) ->
+                                (fun uu____27563  ->
+                                   match uu____27563 with
+                                   | (uu____27577,(uu____27578,t)) ->
                                        t.FStar_Parser_AST.level =
                                          FStar_Parser_AST.Formula))
                             in
-                         if uu____27520
+                         if uu____27530
                          then FStar_Syntax_Syntax.Logic :: quals1
                          else quals1  in
                        let lbs1 =
-                         let uu____27588 =
+                         let uu____27598 =
                            FStar_All.pipe_right quals2
                              (FStar_List.contains
                                 FStar_Syntax_Syntax.Abstract)
                             in
-                         if uu____27588
+                         if uu____27598
                          then
-                           let uu____27594 =
+                           let uu____27604 =
                              FStar_All.pipe_right
                                (FStar_Pervasives_Native.snd lbs)
                                (FStar_List.map
@@ -7750,35 +7801,35 @@ and (desugar_decl_noattrs :
                                        FStar_Util.right
                                          lb.FStar_Syntax_Syntax.lbname
                                         in
-                                     let uu___3599_27609 = lb  in
+                                     let uu___3602_27619 = lb  in
                                      {
                                        FStar_Syntax_Syntax.lbname =
                                          (FStar_Util.Inr
-                                            (let uu___3601_27611 = fv  in
+                                            (let uu___3604_27621 = fv  in
                                              {
                                                FStar_Syntax_Syntax.fv_name =
-                                                 (uu___3601_27611.FStar_Syntax_Syntax.fv_name);
+                                                 (uu___3604_27621.FStar_Syntax_Syntax.fv_name);
                                                FStar_Syntax_Syntax.fv_delta =
                                                  (FStar_Syntax_Syntax.Delta_abstract
                                                     (fv.FStar_Syntax_Syntax.fv_delta));
                                                FStar_Syntax_Syntax.fv_qual =
-                                                 (uu___3601_27611.FStar_Syntax_Syntax.fv_qual)
+                                                 (uu___3604_27621.FStar_Syntax_Syntax.fv_qual)
                                              }));
                                        FStar_Syntax_Syntax.lbunivs =
-                                         (uu___3599_27609.FStar_Syntax_Syntax.lbunivs);
+                                         (uu___3602_27619.FStar_Syntax_Syntax.lbunivs);
                                        FStar_Syntax_Syntax.lbtyp =
-                                         (uu___3599_27609.FStar_Syntax_Syntax.lbtyp);
+                                         (uu___3602_27619.FStar_Syntax_Syntax.lbtyp);
                                        FStar_Syntax_Syntax.lbeff =
-                                         (uu___3599_27609.FStar_Syntax_Syntax.lbeff);
+                                         (uu___3602_27619.FStar_Syntax_Syntax.lbeff);
                                        FStar_Syntax_Syntax.lbdef =
-                                         (uu___3599_27609.FStar_Syntax_Syntax.lbdef);
+                                         (uu___3602_27619.FStar_Syntax_Syntax.lbdef);
                                        FStar_Syntax_Syntax.lbattrs =
-                                         (uu___3599_27609.FStar_Syntax_Syntax.lbattrs);
+                                         (uu___3602_27619.FStar_Syntax_Syntax.lbattrs);
                                        FStar_Syntax_Syntax.lbpos =
-                                         (uu___3599_27609.FStar_Syntax_Syntax.lbpos)
+                                         (uu___3602_27619.FStar_Syntax_Syntax.lbpos)
                                      }))
                               in
-                           ((FStar_Pervasives_Native.fst lbs), uu____27594)
+                           ((FStar_Pervasives_Native.fst lbs), uu____27604)
                          else lbs  in
                        let names1 =
                          FStar_All.pipe_right fvs
@@ -7799,7 +7850,9 @@ and (desugar_decl_noattrs :
                            FStar_Syntax_Syntax.sigquals = quals2;
                            FStar_Syntax_Syntax.sigmeta =
                              FStar_Syntax_Syntax.default_sigmeta;
-                           FStar_Syntax_Syntax.sigattrs = attrs
+                           FStar_Syntax_Syntax.sigattrs = attrs;
+                           FStar_Syntax_Syntax.sigopts =
+                             FStar_Pervasives_Native.None
                          }  in
                        let env1 = FStar_Syntax_DsEnv.push_sigelt env s  in
                        let env2 =
@@ -7810,17 +7863,17 @@ and (desugar_decl_noattrs :
                                   d.FStar_Parser_AST.doc) env1 names1
                           in
                        (env2, [s])
-                   | uu____27641 ->
+                   | uu____27651 ->
                        failwith "Desugaring a let did not produce a let")))
           else
-            (let uu____27649 =
+            (let uu____27659 =
                match lets with
                | (pat,body)::[] -> (pat, body)
-               | uu____27668 ->
+               | uu____27678 ->
                    failwith
                      "expand_toplevel_pattern should only allow single definition lets"
                 in
-             match uu____27649 with
+             match uu____27659 with
              | (pat,body) ->
                  let fresh_toplevel_name =
                    FStar_Ident.gen FStar_Range.dummyRange  in
@@ -7833,40 +7886,40 @@ and (desugar_decl_noattrs :
                       in
                    match pat.FStar_Parser_AST.pat with
                    | FStar_Parser_AST.PatAscribed (pat1,ty) ->
-                       let uu___3627_27705 = pat1  in
+                       let uu___3630_27715 = pat1  in
                        {
                          FStar_Parser_AST.pat =
                            (FStar_Parser_AST.PatAscribed (var_pat, ty));
                          FStar_Parser_AST.prange =
-                           (uu___3627_27705.FStar_Parser_AST.prange)
+                           (uu___3630_27715.FStar_Parser_AST.prange)
                        }
-                   | uu____27712 -> var_pat  in
+                   | uu____27722 -> var_pat  in
                  let main_let =
                    desugar_decl env
-                     (let uu___3631_27719 = d  in
+                     (let uu___3634_27729 = d  in
                       {
                         FStar_Parser_AST.d =
                           (FStar_Parser_AST.TopLevelLet
                              (isrec, [(fresh_pat, body)]));
                         FStar_Parser_AST.drange =
-                          (uu___3631_27719.FStar_Parser_AST.drange);
+                          (uu___3634_27729.FStar_Parser_AST.drange);
                         FStar_Parser_AST.doc =
-                          (uu___3631_27719.FStar_Parser_AST.doc);
+                          (uu___3634_27729.FStar_Parser_AST.doc);
                         FStar_Parser_AST.quals = (FStar_Parser_AST.Private ::
                           (d.FStar_Parser_AST.quals));
                         FStar_Parser_AST.attrs =
-                          (uu___3631_27719.FStar_Parser_AST.attrs)
+                          (uu___3634_27729.FStar_Parser_AST.attrs)
                       })
                     in
-                 let build_projection uu____27755 id1 =
-                   match uu____27755 with
+                 let build_projection uu____27765 id1 =
+                   match uu____27765 with
                    | (env1,ses) ->
                        let main =
-                         let uu____27776 =
-                           let uu____27777 =
+                         let uu____27786 =
+                           let uu____27787 =
                              FStar_Ident.lid_of_ids [fresh_toplevel_name]  in
-                           FStar_Parser_AST.Var uu____27777  in
-                         FStar_Parser_AST.mk_term uu____27776
+                           FStar_Parser_AST.Var uu____27787  in
+                         FStar_Parser_AST.mk_term uu____27786
                            FStar_Range.dummyRange FStar_Parser_AST.Expr
                           in
                        let lid = FStar_Ident.lid_of_ids [id1]  in
@@ -7894,13 +7947,13 @@ and (desugar_decl_noattrs :
                               (FStar_Parser_AST.NoLetQualifier,
                                 [(bv_pat, body1)])) FStar_Range.dummyRange []
                           in
-                       let uu____27827 = desugar_decl env1 id_decl  in
-                       (match uu____27827 with
+                       let uu____27837 = desugar_decl env1 id_decl  in
+                       (match uu____27837 with
                         | (env2,ses') -> (env2, (FStar_List.append ses ses')))
                     in
                  let bvs =
-                   let uu____27845 = gather_pattern_bound_vars true pat  in
-                   FStar_All.pipe_right uu____27845 FStar_Util.set_elements
+                   let uu____27855 = gather_pattern_bound_vars true pat  in
+                   FStar_All.pipe_right uu____27855 FStar_Util.set_elements
                     in
                  FStar_List.fold_left build_projection main_let bvs)
       | FStar_Parser_AST.Main t ->
@@ -7912,7 +7965,8 @@ and (desugar_decl_noattrs :
               FStar_Syntax_Syntax.sigquals = [];
               FStar_Syntax_Syntax.sigmeta =
                 FStar_Syntax_Syntax.default_sigmeta;
-              FStar_Syntax_Syntax.sigattrs = []
+              FStar_Syntax_Syntax.sigattrs = [];
+              FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
             }  in
           (env, [se])
       | FStar_Parser_AST.Assume (id1,t) ->
@@ -7929,26 +7983,27 @@ and (desugar_decl_noattrs :
                  [FStar_Syntax_Syntax.Assumption];
                FStar_Syntax_Syntax.sigmeta =
                  FStar_Syntax_Syntax.default_sigmeta;
-               FStar_Syntax_Syntax.sigattrs = []
+               FStar_Syntax_Syntax.sigattrs = [];
+               FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
              }])
       | FStar_Parser_AST.Val (id1,t) ->
           let quals = d.FStar_Parser_AST.quals  in
           let t1 =
-            let uu____27869 = close_fun env t  in
-            desugar_term env uu____27869  in
+            let uu____27879 = close_fun env t  in
+            desugar_term env uu____27879  in
           let quals1 =
-            let uu____27873 =
+            let uu____27883 =
               (FStar_Syntax_DsEnv.iface env) &&
                 (FStar_Syntax_DsEnv.admitted_iface env)
                in
-            if uu____27873
+            if uu____27883
             then FStar_Parser_AST.Assumption :: quals
             else quals  in
           let lid = FStar_Syntax_DsEnv.qualify env id1  in
           let attrs =
             FStar_List.map (desugar_term env) d.FStar_Parser_AST.attrs  in
           let se =
-            let uu____27885 =
+            let uu____27895 =
               FStar_List.map (trans_qual1 FStar_Pervasives_Native.None)
                 quals1
                in
@@ -7956,10 +8011,11 @@ and (desugar_decl_noattrs :
               FStar_Syntax_Syntax.sigel =
                 (FStar_Syntax_Syntax.Sig_declare_typ (lid, [], t1));
               FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
-              FStar_Syntax_Syntax.sigquals = uu____27885;
+              FStar_Syntax_Syntax.sigquals = uu____27895;
               FStar_Syntax_Syntax.sigmeta =
                 FStar_Syntax_Syntax.default_sigmeta;
-              FStar_Syntax_Syntax.sigattrs = attrs
+              FStar_Syntax_Syntax.sigattrs = attrs;
+              FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
             }  in
           let env1 = FStar_Syntax_DsEnv.push_sigelt env se  in
           let env2 =
@@ -7974,19 +8030,19 @@ and (desugar_decl_noattrs :
                   FStar_Parser_Const.exn_lid
             | FStar_Pervasives_Native.Some term ->
                 let t = desugar_term env term  in
-                let uu____27899 =
-                  let uu____27908 = FStar_Syntax_Syntax.null_binder t  in
-                  [uu____27908]  in
-                let uu____27927 =
-                  let uu____27930 =
+                let uu____27909 =
+                  let uu____27918 = FStar_Syntax_Syntax.null_binder t  in
+                  [uu____27918]  in
+                let uu____27937 =
+                  let uu____27940 =
                     FStar_Syntax_DsEnv.fail_or env
                       (FStar_Syntax_DsEnv.try_lookup_lid env)
                       FStar_Parser_Const.exn_lid
                      in
                   FStar_All.pipe_left FStar_Syntax_Syntax.mk_Total
-                    uu____27930
+                    uu____27940
                    in
-                FStar_Syntax_Util.arrow uu____27899 uu____27927
+                FStar_Syntax_Util.arrow uu____27909 uu____27937
              in
           let l = FStar_Syntax_DsEnv.qualify env id1  in
           let qual = [FStar_Syntax_Syntax.ExceptionConstructor]  in
@@ -8000,7 +8056,8 @@ and (desugar_decl_noattrs :
               FStar_Syntax_Syntax.sigquals = qual;
               FStar_Syntax_Syntax.sigmeta =
                 FStar_Syntax_Syntax.default_sigmeta;
-              FStar_Syntax_Syntax.sigattrs = []
+              FStar_Syntax_Syntax.sigattrs = [];
+              FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
             }  in
           let se' =
             {
@@ -8010,7 +8067,8 @@ and (desugar_decl_noattrs :
               FStar_Syntax_Syntax.sigquals = qual;
               FStar_Syntax_Syntax.sigmeta =
                 FStar_Syntax_Syntax.default_sigmeta;
-              FStar_Syntax_Syntax.sigattrs = []
+              FStar_Syntax_Syntax.sigattrs = [];
+              FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
             }  in
           let env1 = FStar_Syntax_DsEnv.push_sigelt env se'  in
           let env2 =
@@ -8035,53 +8093,53 @@ and (desugar_decl_noattrs :
             attrs
       | FStar_Parser_AST.SubEffect l ->
           let lookup1 l1 =
-            let uu____27985 =
+            let uu____27995 =
               FStar_Syntax_DsEnv.try_lookup_effect_name env l1  in
-            match uu____27985 with
+            match uu____27995 with
             | FStar_Pervasives_Native.None  ->
-                let uu____27988 =
-                  let uu____27994 =
-                    let uu____27996 =
-                      let uu____27998 = FStar_Syntax_Print.lid_to_string l1
+                let uu____27998 =
+                  let uu____28004 =
+                    let uu____28006 =
+                      let uu____28008 = FStar_Syntax_Print.lid_to_string l1
                          in
-                      Prims.op_Hat uu____27998 " not found"  in
-                    Prims.op_Hat "Effect name " uu____27996  in
-                  (FStar_Errors.Fatal_EffectNotFound, uu____27994)  in
-                FStar_Errors.raise_error uu____27988
+                      Prims.op_Hat uu____28008 " not found"  in
+                    Prims.op_Hat "Effect name " uu____28006  in
+                  (FStar_Errors.Fatal_EffectNotFound, uu____28004)  in
+                FStar_Errors.raise_error uu____27998
                   d.FStar_Parser_AST.drange
             | FStar_Pervasives_Native.Some l2 -> l2  in
           let src = lookup1 l.FStar_Parser_AST.msource  in
           let dst = lookup1 l.FStar_Parser_AST.mdest  in
-          let uu____28006 =
+          let uu____28016 =
             match l.FStar_Parser_AST.lift_op with
             | FStar_Parser_AST.NonReifiableLift t ->
-                let uu____28024 =
-                  let uu____28027 =
-                    let uu____28028 = desugar_term env t  in
-                    ([], uu____28028)  in
-                  FStar_Pervasives_Native.Some uu____28027  in
-                (uu____28024, FStar_Pervasives_Native.None)
+                let uu____28034 =
+                  let uu____28037 =
+                    let uu____28038 = desugar_term env t  in
+                    ([], uu____28038)  in
+                  FStar_Pervasives_Native.Some uu____28037  in
+                (uu____28034, FStar_Pervasives_Native.None)
             | FStar_Parser_AST.ReifiableLift (wp,t) ->
-                let uu____28041 =
-                  let uu____28044 =
-                    let uu____28045 = desugar_term env wp  in
-                    ([], uu____28045)  in
-                  FStar_Pervasives_Native.Some uu____28044  in
-                let uu____28052 =
-                  let uu____28055 =
-                    let uu____28056 = desugar_term env t  in
-                    ([], uu____28056)  in
-                  FStar_Pervasives_Native.Some uu____28055  in
-                (uu____28041, uu____28052)
+                let uu____28051 =
+                  let uu____28054 =
+                    let uu____28055 = desugar_term env wp  in
+                    ([], uu____28055)  in
+                  FStar_Pervasives_Native.Some uu____28054  in
+                let uu____28062 =
+                  let uu____28065 =
+                    let uu____28066 = desugar_term env t  in
+                    ([], uu____28066)  in
+                  FStar_Pervasives_Native.Some uu____28065  in
+                (uu____28051, uu____28062)
             | FStar_Parser_AST.LiftForFree t ->
-                let uu____28068 =
-                  let uu____28071 =
-                    let uu____28072 = desugar_term env t  in
-                    ([], uu____28072)  in
-                  FStar_Pervasives_Native.Some uu____28071  in
-                (FStar_Pervasives_Native.None, uu____28068)
+                let uu____28078 =
+                  let uu____28081 =
+                    let uu____28082 = desugar_term env t  in
+                    ([], uu____28082)  in
+                  FStar_Pervasives_Native.Some uu____28081  in
+                (FStar_Pervasives_Native.None, uu____28078)
              in
-          (match uu____28006 with
+          (match uu____28016 with
            | (lift_wp,lift) ->
                let se =
                  {
@@ -8097,25 +8155,27 @@ and (desugar_decl_noattrs :
                    FStar_Syntax_Syntax.sigquals = [];
                    FStar_Syntax_Syntax.sigmeta =
                      FStar_Syntax_Syntax.default_sigmeta;
-                   FStar_Syntax_Syntax.sigattrs = []
+                   FStar_Syntax_Syntax.sigattrs = [];
+                   FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                  }  in
                (env, [se]))
       | FStar_Parser_AST.Splice (ids,t) ->
           let t1 = desugar_term env t  in
           let se =
-            let uu____28106 =
-              let uu____28107 =
-                let uu____28114 =
+            let uu____28116 =
+              let uu____28117 =
+                let uu____28124 =
                   FStar_List.map (FStar_Syntax_DsEnv.qualify env) ids  in
-                (uu____28114, t1)  in
-              FStar_Syntax_Syntax.Sig_splice uu____28107  in
+                (uu____28124, t1)  in
+              FStar_Syntax_Syntax.Sig_splice uu____28117  in
             {
-              FStar_Syntax_Syntax.sigel = uu____28106;
+              FStar_Syntax_Syntax.sigel = uu____28116;
               FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
               FStar_Syntax_Syntax.sigquals = [];
               FStar_Syntax_Syntax.sigmeta =
                 FStar_Syntax_Syntax.default_sigmeta;
-              FStar_Syntax_Syntax.sigattrs = []
+              FStar_Syntax_Syntax.sigattrs = [];
+              FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
             }  in
           let env1 = FStar_Syntax_DsEnv.push_sigelt env se  in (env1, [se])
 
@@ -8126,18 +8186,18 @@ let (desugar_decls :
   =
   fun env  ->
     fun decls  ->
-      let uu____28141 =
+      let uu____28151 =
         FStar_List.fold_left
-          (fun uu____28161  ->
+          (fun uu____28171  ->
              fun d  ->
-               match uu____28161 with
+               match uu____28171 with
                | (env1,sigelts) ->
-                   let uu____28181 = desugar_decl env1 d  in
-                   (match uu____28181 with
+                   let uu____28191 = desugar_decl env1 d  in
+                   (match uu____28191 with
                     | (env2,se) -> (env2, (FStar_List.append sigelts se))))
           (env, []) decls
          in
-      match uu____28141 with | (env1,sigelts) -> (env1, sigelts)
+      match uu____28151 with | (env1,sigelts) -> (env1, sigelts)
   
 let (open_prims_all :
   (FStar_Parser_AST.decoration Prims.list -> FStar_Parser_AST.decl)
@@ -8160,41 +8220,41 @@ let (desugar_modul_common :
       fun m  ->
         let env1 =
           match (curmod, m) with
-          | (FStar_Pervasives_Native.None ,uu____28272) -> env
+          | (FStar_Pervasives_Native.None ,uu____28282) -> env
           | (FStar_Pervasives_Native.Some
              { FStar_Syntax_Syntax.name = prev_lid;
-               FStar_Syntax_Syntax.declarations = uu____28276;
-               FStar_Syntax_Syntax.exports = uu____28277;
-               FStar_Syntax_Syntax.is_interface = uu____28278;_},FStar_Parser_AST.Module
-             (current_lid,uu____28280)) when
+               FStar_Syntax_Syntax.declarations = uu____28286;
+               FStar_Syntax_Syntax.exports = uu____28287;
+               FStar_Syntax_Syntax.is_interface = uu____28288;_},FStar_Parser_AST.Module
+             (current_lid,uu____28290)) when
               (FStar_Ident.lid_equals prev_lid current_lid) &&
                 (FStar_Options.interactive ())
               -> env
-          | (FStar_Pervasives_Native.Some prev_mod,uu____28289) ->
-              let uu____28292 =
+          | (FStar_Pervasives_Native.Some prev_mod,uu____28299) ->
+              let uu____28302 =
                 FStar_Syntax_DsEnv.finish_module_or_interface env prev_mod
                  in
-              FStar_Pervasives_Native.fst uu____28292
+              FStar_Pervasives_Native.fst uu____28302
            in
-        let uu____28297 =
+        let uu____28307 =
           match m with
           | FStar_Parser_AST.Interface (mname,decls,admitted) ->
-              let uu____28339 =
+              let uu____28349 =
                 FStar_Syntax_DsEnv.prepare_module_or_interface true admitted
                   env1 mname FStar_Syntax_DsEnv.default_mii
                  in
-              (uu____28339, mname, decls, true)
+              (uu____28349, mname, decls, true)
           | FStar_Parser_AST.Module (mname,decls) ->
-              let uu____28361 =
+              let uu____28371 =
                 FStar_Syntax_DsEnv.prepare_module_or_interface false false
                   env1 mname FStar_Syntax_DsEnv.default_mii
                  in
-              (uu____28361, mname, decls, false)
+              (uu____28371, mname, decls, false)
            in
-        match uu____28297 with
+        match uu____28307 with
         | ((env2,pop_when_done),mname,decls,intf) ->
-            let uu____28403 = desugar_decls env2 decls  in
-            (match uu____28403 with
+            let uu____28413 = desugar_decls env2 decls  in
+            (match uu____28413 with
              | (env3,sigelts) ->
                  let modul =
                    {
@@ -8220,23 +8280,23 @@ let (desugar_partial_modul :
     fun env  ->
       fun m  ->
         let m1 =
-          let uu____28471 =
+          let uu____28481 =
             (FStar_Options.interactive ()) &&
-              (let uu____28474 =
-                 let uu____28476 =
-                   let uu____28478 = FStar_Options.file_list ()  in
-                   FStar_List.hd uu____28478  in
-                 FStar_Util.get_file_extension uu____28476  in
-               FStar_List.mem uu____28474 ["fsti"; "fsi"])
+              (let uu____28484 =
+                 let uu____28486 =
+                   let uu____28488 = FStar_Options.file_list ()  in
+                   FStar_List.hd uu____28488  in
+                 FStar_Util.get_file_extension uu____28486  in
+               FStar_List.mem uu____28484 ["fsti"; "fsi"])
              in
-          if uu____28471 then as_interface m else m  in
-        let uu____28492 = desugar_modul_common curmod env m1  in
-        match uu____28492 with
+          if uu____28481 then as_interface m else m  in
+        let uu____28502 = desugar_modul_common curmod env m1  in
+        match uu____28502 with
         | (env1,modul,pop_when_done) ->
             if pop_when_done
             then
-              let uu____28514 = FStar_Syntax_DsEnv.pop ()  in
-              (uu____28514, modul)
+              let uu____28524 = FStar_Syntax_DsEnv.pop ()  in
+              (uu____28524, modul)
             else (env1, modul)
   
 let (desugar_modul :
@@ -8245,32 +8305,32 @@ let (desugar_modul :
   =
   fun env  ->
     fun m  ->
-      let uu____28536 =
+      let uu____28546 =
         desugar_modul_common FStar_Pervasives_Native.None env m  in
-      match uu____28536 with
+      match uu____28546 with
       | (env1,modul,pop_when_done) ->
-          let uu____28553 =
+          let uu____28563 =
             FStar_Syntax_DsEnv.finish_module_or_interface env1 modul  in
-          (match uu____28553 with
+          (match uu____28563 with
            | (env2,modul1) ->
-               ((let uu____28565 =
+               ((let uu____28575 =
                    FStar_Options.dump_module
                      (modul1.FStar_Syntax_Syntax.name).FStar_Ident.str
                     in
-                 if uu____28565
+                 if uu____28575
                  then
-                   let uu____28568 =
+                   let uu____28578 =
                      FStar_Syntax_Print.modul_to_string modul1  in
                    FStar_Util.print1 "Module after desugaring:\n%s\n"
-                     uu____28568
+                     uu____28578
                  else ());
-                (let uu____28573 =
+                (let uu____28583 =
                    if pop_when_done
                    then
                      FStar_Syntax_DsEnv.export_interface
                        modul1.FStar_Syntax_Syntax.name env2
                    else env2  in
-                 (uu____28573, modul1))))
+                 (uu____28583, modul1))))
   
 let with_options : 'a . (unit -> 'a) -> 'a =
   fun f  ->
@@ -8288,9 +8348,9 @@ let (ast_modul_to_modul :
   fun modul  ->
     fun env  ->
       with_options
-        (fun uu____28623  ->
-           let uu____28624 = desugar_modul env modul  in
-           match uu____28624 with | (e,m) -> (m, e))
+        (fun uu____28633  ->
+           let uu____28634 = desugar_modul env modul  in
+           match uu____28634 with | (e,m) -> (m, e))
   
 let (decls_to_sigelts :
   FStar_Parser_AST.decl Prims.list ->
@@ -8299,9 +8359,9 @@ let (decls_to_sigelts :
   fun decls  ->
     fun env  ->
       with_options
-        (fun uu____28662  ->
-           let uu____28663 = desugar_decls env decls  in
-           match uu____28663 with | (env1,sigelts) -> (sigelts, env1))
+        (fun uu____28672  ->
+           let uu____28673 = desugar_decls env decls  in
+           match uu____28673 with | (env1,sigelts) -> (sigelts, env1))
   
 let (partial_ast_modul_to_modul :
   FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option ->
@@ -8312,9 +8372,9 @@ let (partial_ast_modul_to_modul :
     fun a_modul  ->
       fun env  ->
         with_options
-          (fun uu____28714  ->
-             let uu____28715 = desugar_partial_modul modul env a_modul  in
-             match uu____28715 with | (env1,modul1) -> (modul1, env1))
+          (fun uu____28724  ->
+             let uu____28725 = desugar_partial_modul modul env a_modul  in
+             match uu____28725 with | (env1,modul1) -> (modul1, env1))
   
 let (add_modul_to_env :
   FStar_Syntax_Syntax.modul ->
@@ -8330,51 +8390,51 @@ let (add_modul_to_env :
             let erase_binders bs =
               match bs with
               | [] -> []
-              | uu____28810 ->
+              | uu____28820 ->
                   let t =
-                    let uu____28820 =
+                    let uu____28830 =
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_abs
                            (bs, FStar_Syntax_Syntax.t_unit,
                              FStar_Pervasives_Native.None))
                         FStar_Pervasives_Native.None FStar_Range.dummyRange
                        in
-                    erase_univs uu____28820  in
-                  let uu____28833 =
-                    let uu____28834 = FStar_Syntax_Subst.compress t  in
-                    uu____28834.FStar_Syntax_Syntax.n  in
-                  (match uu____28833 with
-                   | FStar_Syntax_Syntax.Tm_abs (bs1,uu____28846,uu____28847)
+                    erase_univs uu____28830  in
+                  let uu____28843 =
+                    let uu____28844 = FStar_Syntax_Subst.compress t  in
+                    uu____28844.FStar_Syntax_Syntax.n  in
+                  (match uu____28843 with
+                   | FStar_Syntax_Syntax.Tm_abs (bs1,uu____28856,uu____28857)
                        -> bs1
-                   | uu____28872 -> failwith "Impossible")
+                   | uu____28882 -> failwith "Impossible")
                in
-            let uu____28882 =
-              let uu____28889 = erase_binders ed.FStar_Syntax_Syntax.binders
+            let uu____28892 =
+              let uu____28899 = erase_binders ed.FStar_Syntax_Syntax.binders
                  in
-              FStar_Syntax_Subst.open_term' uu____28889
+              FStar_Syntax_Subst.open_term' uu____28899
                 FStar_Syntax_Syntax.t_unit
                in
-            match uu____28882 with
-            | (binders,uu____28891,binders_opening) ->
+            match uu____28892 with
+            | (binders,uu____28901,binders_opening) ->
                 let erase_term t =
-                  let uu____28899 =
-                    let uu____28900 =
+                  let uu____28909 =
+                    let uu____28910 =
                       FStar_Syntax_Subst.subst binders_opening t  in
-                    erase_univs uu____28900  in
-                  FStar_Syntax_Subst.close binders uu____28899  in
-                let erase_tscheme uu____28918 =
-                  match uu____28918 with
+                    erase_univs uu____28910  in
+                  FStar_Syntax_Subst.close binders uu____28909  in
+                let erase_tscheme uu____28928 =
+                  match uu____28928 with
                   | (us,t) ->
                       let t1 =
-                        let uu____28938 =
+                        let uu____28948 =
                           FStar_Syntax_Subst.shift_subst
                             (FStar_List.length us) binders_opening
                            in
-                        FStar_Syntax_Subst.subst uu____28938 t  in
-                      let uu____28941 =
-                        let uu____28942 = erase_univs t1  in
-                        FStar_Syntax_Subst.close binders uu____28942  in
-                      ([], uu____28941)
+                        FStar_Syntax_Subst.subst uu____28948 t  in
+                      let uu____28951 =
+                        let uu____28952 = erase_univs t1  in
+                        FStar_Syntax_Subst.close binders uu____28952  in
+                      ([], uu____28951)
                    in
                 let erase_action action =
                   let opening =
@@ -8386,13 +8446,13 @@ let (add_modul_to_env :
                   let erased_action_params =
                     match action.FStar_Syntax_Syntax.action_params with
                     | [] -> []
-                    | uu____28965 ->
+                    | uu____28975 ->
                         let bs =
-                          let uu____28975 =
+                          let uu____28985 =
                             FStar_Syntax_Subst.subst_binders opening
                               action.FStar_Syntax_Syntax.action_params
                              in
-                          FStar_All.pipe_left erase_binders uu____28975  in
+                          FStar_All.pipe_left erase_binders uu____28985  in
                         let t =
                           FStar_Syntax_Syntax.mk
                             (FStar_Syntax_Syntax.Tm_abs
@@ -8401,153 +8461,157 @@ let (add_modul_to_env :
                             FStar_Pervasives_Native.None
                             FStar_Range.dummyRange
                            in
-                        let uu____29015 =
-                          let uu____29016 =
-                            let uu____29019 =
+                        let uu____29025 =
+                          let uu____29026 =
+                            let uu____29029 =
                               FStar_Syntax_Subst.close binders t  in
-                            FStar_Syntax_Subst.compress uu____29019  in
-                          uu____29016.FStar_Syntax_Syntax.n  in
-                        (match uu____29015 with
+                            FStar_Syntax_Subst.compress uu____29029  in
+                          uu____29026.FStar_Syntax_Syntax.n  in
+                        (match uu____29025 with
                          | FStar_Syntax_Syntax.Tm_abs
-                             (bs1,uu____29021,uu____29022) -> bs1
-                         | uu____29047 -> failwith "Impossible")
+                             (bs1,uu____29031,uu____29032) -> bs1
+                         | uu____29057 -> failwith "Impossible")
                      in
                   let erase_term1 t =
-                    let uu____29055 =
-                      let uu____29056 = FStar_Syntax_Subst.subst opening t
+                    let uu____29065 =
+                      let uu____29066 = FStar_Syntax_Subst.subst opening t
                          in
-                      erase_univs uu____29056  in
-                    FStar_Syntax_Subst.close binders uu____29055  in
-                  let uu___3889_29057 = action  in
-                  let uu____29058 =
+                      erase_univs uu____29066  in
+                    FStar_Syntax_Subst.close binders uu____29065  in
+                  let uu___3892_29067 = action  in
+                  let uu____29068 =
                     erase_term1 action.FStar_Syntax_Syntax.action_defn  in
-                  let uu____29059 =
+                  let uu____29069 =
                     erase_term1 action.FStar_Syntax_Syntax.action_typ  in
                   {
                     FStar_Syntax_Syntax.action_name =
-                      (uu___3889_29057.FStar_Syntax_Syntax.action_name);
+                      (uu___3892_29067.FStar_Syntax_Syntax.action_name);
                     FStar_Syntax_Syntax.action_unqualified_name =
-                      (uu___3889_29057.FStar_Syntax_Syntax.action_unqualified_name);
+                      (uu___3892_29067.FStar_Syntax_Syntax.action_unqualified_name);
                     FStar_Syntax_Syntax.action_univs = [];
                     FStar_Syntax_Syntax.action_params = erased_action_params;
-                    FStar_Syntax_Syntax.action_defn = uu____29058;
-                    FStar_Syntax_Syntax.action_typ = uu____29059
+                    FStar_Syntax_Syntax.action_defn = uu____29068;
+                    FStar_Syntax_Syntax.action_typ = uu____29069
                   }  in
-                let uu___3891_29060 = ed  in
-                let uu____29061 = FStar_Syntax_Subst.close_binders binders
+                let uu___3894_29070 = ed  in
+                let uu____29071 = FStar_Syntax_Subst.close_binders binders
                    in
-                let uu____29062 =
-                  erase_tscheme ed.FStar_Syntax_Syntax.signature  in
-                let uu____29063 = erase_tscheme ed.FStar_Syntax_Syntax.ret_wp
-                   in
-                let uu____29064 =
-                  erase_tscheme ed.FStar_Syntax_Syntax.bind_wp  in
-                let uu____29065 =
-                  erase_tscheme ed.FStar_Syntax_Syntax.if_then_else  in
-                let uu____29066 = erase_tscheme ed.FStar_Syntax_Syntax.ite_wp
-                   in
-                let uu____29067 =
-                  erase_tscheme ed.FStar_Syntax_Syntax.stronger  in
-                let uu____29068 =
-                  erase_tscheme ed.FStar_Syntax_Syntax.close_wp  in
-                let uu____29069 =
-                  erase_tscheme ed.FStar_Syntax_Syntax.trivial  in
-                let uu____29070 = erase_tscheme ed.FStar_Syntax_Syntax.repr
-                   in
-                let uu____29071 =
-                  erase_tscheme ed.FStar_Syntax_Syntax.return_repr  in
                 let uu____29072 =
+                  erase_tscheme ed.FStar_Syntax_Syntax.signature  in
+                let uu____29073 = erase_tscheme ed.FStar_Syntax_Syntax.ret_wp
+                   in
+                let uu____29074 =
+                  erase_tscheme ed.FStar_Syntax_Syntax.bind_wp  in
+                let uu____29075 =
+                  erase_tscheme ed.FStar_Syntax_Syntax.if_then_else  in
+                let uu____29076 = erase_tscheme ed.FStar_Syntax_Syntax.ite_wp
+                   in
+                let uu____29077 =
+                  erase_tscheme ed.FStar_Syntax_Syntax.stronger  in
+                let uu____29078 =
+                  erase_tscheme ed.FStar_Syntax_Syntax.close_wp  in
+                let uu____29079 =
+                  erase_tscheme ed.FStar_Syntax_Syntax.trivial  in
+                let uu____29080 = erase_tscheme ed.FStar_Syntax_Syntax.repr
+                   in
+                let uu____29081 =
+                  erase_tscheme ed.FStar_Syntax_Syntax.return_repr  in
+                let uu____29082 =
                   erase_tscheme ed.FStar_Syntax_Syntax.bind_repr  in
-                let uu____29073 =
+                let uu____29083 =
                   FStar_List.map erase_action ed.FStar_Syntax_Syntax.actions
                    in
                 {
                   FStar_Syntax_Syntax.cattributes =
-                    (uu___3891_29060.FStar_Syntax_Syntax.cattributes);
+                    (uu___3894_29070.FStar_Syntax_Syntax.cattributes);
                   FStar_Syntax_Syntax.mname =
-                    (uu___3891_29060.FStar_Syntax_Syntax.mname);
+                    (uu___3894_29070.FStar_Syntax_Syntax.mname);
                   FStar_Syntax_Syntax.univs = [];
-                  FStar_Syntax_Syntax.binders = uu____29061;
-                  FStar_Syntax_Syntax.signature = uu____29062;
-                  FStar_Syntax_Syntax.ret_wp = uu____29063;
-                  FStar_Syntax_Syntax.bind_wp = uu____29064;
-                  FStar_Syntax_Syntax.if_then_else = uu____29065;
-                  FStar_Syntax_Syntax.ite_wp = uu____29066;
-                  FStar_Syntax_Syntax.stronger = uu____29067;
-                  FStar_Syntax_Syntax.close_wp = uu____29068;
-                  FStar_Syntax_Syntax.trivial = uu____29069;
-                  FStar_Syntax_Syntax.repr = uu____29070;
-                  FStar_Syntax_Syntax.return_repr = uu____29071;
-                  FStar_Syntax_Syntax.bind_repr = uu____29072;
-                  FStar_Syntax_Syntax.actions = uu____29073;
+                  FStar_Syntax_Syntax.binders = uu____29071;
+                  FStar_Syntax_Syntax.signature = uu____29072;
+                  FStar_Syntax_Syntax.ret_wp = uu____29073;
+                  FStar_Syntax_Syntax.bind_wp = uu____29074;
+                  FStar_Syntax_Syntax.if_then_else = uu____29075;
+                  FStar_Syntax_Syntax.ite_wp = uu____29076;
+                  FStar_Syntax_Syntax.stronger = uu____29077;
+                  FStar_Syntax_Syntax.close_wp = uu____29078;
+                  FStar_Syntax_Syntax.trivial = uu____29079;
+                  FStar_Syntax_Syntax.repr = uu____29080;
+                  FStar_Syntax_Syntax.return_repr = uu____29081;
+                  FStar_Syntax_Syntax.bind_repr = uu____29082;
+                  FStar_Syntax_Syntax.actions = uu____29083;
                   FStar_Syntax_Syntax.eff_attrs =
-                    (uu___3891_29060.FStar_Syntax_Syntax.eff_attrs)
+                    (uu___3894_29070.FStar_Syntax_Syntax.eff_attrs)
                 }
              in
           let push_sigelt1 env se =
             match se.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_new_effect ed ->
                 let se' =
-                  let uu___3898_29089 = se  in
-                  let uu____29090 =
-                    let uu____29091 = erase_univs_ed ed  in
-                    FStar_Syntax_Syntax.Sig_new_effect uu____29091  in
+                  let uu___3901_29099 = se  in
+                  let uu____29100 =
+                    let uu____29101 = erase_univs_ed ed  in
+                    FStar_Syntax_Syntax.Sig_new_effect uu____29101  in
                   {
-                    FStar_Syntax_Syntax.sigel = uu____29090;
+                    FStar_Syntax_Syntax.sigel = uu____29100;
                     FStar_Syntax_Syntax.sigrng =
-                      (uu___3898_29089.FStar_Syntax_Syntax.sigrng);
+                      (uu___3901_29099.FStar_Syntax_Syntax.sigrng);
                     FStar_Syntax_Syntax.sigquals =
-                      (uu___3898_29089.FStar_Syntax_Syntax.sigquals);
+                      (uu___3901_29099.FStar_Syntax_Syntax.sigquals);
                     FStar_Syntax_Syntax.sigmeta =
-                      (uu___3898_29089.FStar_Syntax_Syntax.sigmeta);
+                      (uu___3901_29099.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
-                      (uu___3898_29089.FStar_Syntax_Syntax.sigattrs)
+                      (uu___3901_29099.FStar_Syntax_Syntax.sigattrs);
+                    FStar_Syntax_Syntax.sigopts =
+                      (uu___3901_29099.FStar_Syntax_Syntax.sigopts)
                   }  in
                 let env1 = FStar_Syntax_DsEnv.push_sigelt env se'  in
                 push_reflect_effect env1 se.FStar_Syntax_Syntax.sigquals
                   ed.FStar_Syntax_Syntax.mname se.FStar_Syntax_Syntax.sigrng
             | FStar_Syntax_Syntax.Sig_new_effect_for_free ed ->
                 let se' =
-                  let uu___3904_29095 = se  in
-                  let uu____29096 =
-                    let uu____29097 = erase_univs_ed ed  in
-                    FStar_Syntax_Syntax.Sig_new_effect_for_free uu____29097
+                  let uu___3907_29105 = se  in
+                  let uu____29106 =
+                    let uu____29107 = erase_univs_ed ed  in
+                    FStar_Syntax_Syntax.Sig_new_effect_for_free uu____29107
                      in
                   {
-                    FStar_Syntax_Syntax.sigel = uu____29096;
+                    FStar_Syntax_Syntax.sigel = uu____29106;
                     FStar_Syntax_Syntax.sigrng =
-                      (uu___3904_29095.FStar_Syntax_Syntax.sigrng);
+                      (uu___3907_29105.FStar_Syntax_Syntax.sigrng);
                     FStar_Syntax_Syntax.sigquals =
-                      (uu___3904_29095.FStar_Syntax_Syntax.sigquals);
+                      (uu___3907_29105.FStar_Syntax_Syntax.sigquals);
                     FStar_Syntax_Syntax.sigmeta =
-                      (uu___3904_29095.FStar_Syntax_Syntax.sigmeta);
+                      (uu___3907_29105.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
-                      (uu___3904_29095.FStar_Syntax_Syntax.sigattrs)
+                      (uu___3907_29105.FStar_Syntax_Syntax.sigattrs);
+                    FStar_Syntax_Syntax.sigopts =
+                      (uu___3907_29105.FStar_Syntax_Syntax.sigopts)
                   }  in
                 let env1 = FStar_Syntax_DsEnv.push_sigelt env se'  in
                 push_reflect_effect env1 se.FStar_Syntax_Syntax.sigquals
                   ed.FStar_Syntax_Syntax.mname se.FStar_Syntax_Syntax.sigrng
-            | uu____29099 -> FStar_Syntax_DsEnv.push_sigelt env se  in
-          let uu____29100 =
+            | uu____29109 -> FStar_Syntax_DsEnv.push_sigelt env se  in
+          let uu____29110 =
             FStar_Syntax_DsEnv.prepare_module_or_interface false false en
               m.FStar_Syntax_Syntax.name mii
              in
-          match uu____29100 with
+          match uu____29110 with
           | (en1,pop_when_done) ->
               let en2 =
-                let uu____29117 =
+                let uu____29127 =
                   FStar_Syntax_DsEnv.set_current_module en1
                     m.FStar_Syntax_Syntax.name
                    in
-                FStar_List.fold_left push_sigelt1 uu____29117
+                FStar_List.fold_left push_sigelt1 uu____29127
                   m.FStar_Syntax_Syntax.exports
                  in
               let env = FStar_Syntax_DsEnv.finish en2 m  in
-              let uu____29119 =
+              let uu____29129 =
                 if pop_when_done
                 then
                   FStar_Syntax_DsEnv.export_interface
                     m.FStar_Syntax_Syntax.name env
                 else env  in
-              ((), uu____29119)
+              ((), uu____29129)
   

--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -2358,30 +2358,32 @@ let (lookup_qname : env -> FStar_Ident.lident -> qninfo) =
               FStar_Util.catch_opt uu____15723
                 (fun uu____15969  ->
                    FStar_Util.find_map env.gamma_sig
-                     (fun uu___3_15978  ->
-                        match uu___3_15978 with
-                        | (uu____15981,{
+                     (fun uu___3_15979  ->
+                        match uu___3_15979 with
+                        | (uu____15982,{
                                          FStar_Syntax_Syntax.sigel =
                                            FStar_Syntax_Syntax.Sig_bundle
-                                           (ses,uu____15983);
+                                           (ses,uu____15984);
                                          FStar_Syntax_Syntax.sigrng =
-                                           uu____15984;
-                                         FStar_Syntax_Syntax.sigquals =
                                            uu____15985;
-                                         FStar_Syntax_Syntax.sigmeta =
+                                         FStar_Syntax_Syntax.sigquals =
                                            uu____15986;
+                                         FStar_Syntax_Syntax.sigmeta =
+                                           uu____15987;
                                          FStar_Syntax_Syntax.sigattrs =
-                                           uu____15987;_})
+                                           uu____15988;
+                                         FStar_Syntax_Syntax.sigopts =
+                                           uu____15989;_})
                             ->
                             FStar_Util.find_map ses
                               (fun se  ->
-                                 let uu____16007 =
+                                 let uu____16011 =
                                    FStar_All.pipe_right
                                      (FStar_Syntax_Util.lids_of_sigelt se)
                                      (FStar_Util.for_some
                                         (FStar_Ident.lid_equals lid))
                                     in
-                                 if uu____16007
+                                 if uu____16011
                                  then
                                    cache
                                      ((FStar_Util.Inr
@@ -2392,32 +2394,32 @@ let (lookup_qname : env -> FStar_Ident.lident -> qninfo) =
                             let maybe_cache t =
                               match s.FStar_Syntax_Syntax.sigel with
                               | FStar_Syntax_Syntax.Sig_declare_typ
-                                  uu____16059 ->
+                                  uu____16063 ->
                                   FStar_Pervasives_Native.Some t
-                              | uu____16066 -> cache t  in
-                            let uu____16067 =
+                              | uu____16070 -> cache t  in
+                            let uu____16071 =
                               FStar_List.tryFind (FStar_Ident.lid_equals lid)
                                 lids
                                in
-                            (match uu____16067 with
+                            (match uu____16071 with
                              | FStar_Pervasives_Native.None  ->
                                  FStar_Pervasives_Native.None
                              | FStar_Pervasives_Native.Some l ->
-                                 let uu____16073 =
-                                   let uu____16074 =
+                                 let uu____16077 =
+                                   let uu____16078 =
                                      FStar_Ident.range_of_lid l  in
                                    ((FStar_Util.Inr
                                        (s, FStar_Pervasives_Native.None)),
-                                     uu____16074)
+                                     uu____16078)
                                     in
-                                 maybe_cache uu____16073)))
+                                 maybe_cache uu____16077)))
           | se -> se
         else FStar_Pervasives_Native.None  in
       if FStar_Util.is_some found
       then found
       else
-        (let uu____16145 = find_in_sigtab env lid  in
-         match uu____16145 with
+        (let uu____16149 = find_in_sigtab env lid  in
+         match uu____16149 with
          | FStar_Pervasives_Native.Some se ->
              FStar_Pervasives_Native.Some
                ((FStar_Util.Inr (se, FStar_Pervasives_Native.None)),
@@ -2431,10 +2433,10 @@ let (lookup_sigelt :
   =
   fun env  ->
     fun lid  ->
-      let uu____16226 = lookup_qname env lid  in
-      match uu____16226 with
+      let uu____16230 = lookup_qname env lid  in
+      match uu____16230 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-      | FStar_Pervasives_Native.Some (FStar_Util.Inl uu____16247,rng) ->
+      | FStar_Pervasives_Native.Some (FStar_Util.Inl uu____16251,rng) ->
           FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some (FStar_Util.Inr (se,us),rng) ->
           FStar_Pervasives_Native.Some se
@@ -2443,8 +2445,8 @@ let (lookup_attr :
   env -> Prims.string -> FStar_Syntax_Syntax.sigelt Prims.list) =
   fun env  ->
     fun attr  ->
-      let uu____16361 = FStar_Util.smap_try_find (attrtab env) attr  in
-      match uu____16361 with
+      let uu____16365 = FStar_Util.smap_try_find (attrtab env) attr  in
+      match uu____16365 with
       | FStar_Pervasives_Native.Some ses -> ses
       | FStar_Pervasives_Native.None  -> []
   
@@ -2452,29 +2454,29 @@ let (add_se_to_attrtab : env -> FStar_Syntax_Syntax.sigelt -> unit) =
   fun env  ->
     fun se  ->
       let add_one1 env1 se1 attr =
-        let uu____16406 =
-          let uu____16409 = lookup_attr env1 attr  in se1 :: uu____16409  in
-        FStar_Util.smap_add (attrtab env1) attr uu____16406  in
+        let uu____16410 =
+          let uu____16413 = lookup_attr env1 attr  in se1 :: uu____16413  in
+        FStar_Util.smap_add (attrtab env1) attr uu____16410  in
       FStar_List.iter
         (fun attr  ->
-           let uu____16419 =
-             let uu____16420 = FStar_Syntax_Subst.compress attr  in
-             uu____16420.FStar_Syntax_Syntax.n  in
-           match uu____16419 with
+           let uu____16423 =
+             let uu____16424 = FStar_Syntax_Subst.compress attr  in
+             uu____16424.FStar_Syntax_Syntax.n  in
+           match uu____16423 with
            | FStar_Syntax_Syntax.Tm_fvar fv ->
-               let uu____16424 =
-                 let uu____16426 = FStar_Syntax_Syntax.lid_of_fv fv  in
-                 uu____16426.FStar_Ident.str  in
-               add_one1 env se uu____16424
-           | uu____16427 -> ()) se.FStar_Syntax_Syntax.sigattrs
+               let uu____16428 =
+                 let uu____16430 = FStar_Syntax_Syntax.lid_of_fv fv  in
+                 uu____16430.FStar_Ident.str  in
+               add_one1 env se uu____16428
+           | uu____16431 -> ()) se.FStar_Syntax_Syntax.sigattrs
   
 let rec (add_sigelt : env -> FStar_Syntax_Syntax.sigelt -> unit) =
   fun env  ->
     fun se  ->
       match se.FStar_Syntax_Syntax.sigel with
-      | FStar_Syntax_Syntax.Sig_bundle (ses,uu____16450) ->
+      | FStar_Syntax_Syntax.Sig_bundle (ses,uu____16454) ->
           add_sigelts env ses
-      | uu____16459 ->
+      | uu____16463 ->
           let lids = FStar_Syntax_Util.lids_of_sigelt se  in
           (FStar_List.iter
              (fun l  -> FStar_Util.smap_add (sigtab env) l.FStar_Ident.str se)
@@ -2494,14 +2496,14 @@ let (try_lookup_bv :
   fun env  ->
     fun bv  ->
       FStar_Util.find_map env.gamma
-        (fun uu___4_16497  ->
-           match uu___4_16497 with
+        (fun uu___4_16501  ->
+           match uu___4_16501 with
            | FStar_Syntax_Syntax.Binding_var id1 when
                FStar_Syntax_Syntax.bv_eq id1 bv ->
                FStar_Pervasives_Native.Some
                  ((id1.FStar_Syntax_Syntax.sort),
                    ((id1.FStar_Syntax_Syntax.ppname).FStar_Ident.idRange))
-           | uu____16515 -> FStar_Pervasives_Native.None)
+           | uu____16519 -> FStar_Pervasives_Native.None)
   
 let (lookup_type_of_let :
   FStar_Syntax_Syntax.universes FStar_Pervasives_Native.option ->
@@ -2518,41 +2520,41 @@ let (lookup_type_of_let :
           | FStar_Pervasives_Native.None  -> inst_tscheme ts
           | FStar_Pervasives_Native.Some us -> inst_tscheme_with ts us  in
         match se.FStar_Syntax_Syntax.sigel with
-        | FStar_Syntax_Syntax.Sig_let ((uu____16577,lb::[]),uu____16579) ->
-            let uu____16588 =
-              let uu____16597 =
+        | FStar_Syntax_Syntax.Sig_let ((uu____16581,lb::[]),uu____16583) ->
+            let uu____16592 =
+              let uu____16601 =
                 inst_tscheme1
                   ((lb.FStar_Syntax_Syntax.lbunivs),
                     (lb.FStar_Syntax_Syntax.lbtyp))
                  in
-              let uu____16606 =
+              let uu____16610 =
                 FStar_Syntax_Syntax.range_of_lbname
                   lb.FStar_Syntax_Syntax.lbname
                  in
-              (uu____16597, uu____16606)  in
-            FStar_Pervasives_Native.Some uu____16588
-        | FStar_Syntax_Syntax.Sig_let ((uu____16619,lbs),uu____16621) ->
+              (uu____16601, uu____16610)  in
+            FStar_Pervasives_Native.Some uu____16592
+        | FStar_Syntax_Syntax.Sig_let ((uu____16623,lbs),uu____16625) ->
             FStar_Util.find_map lbs
               (fun lb  ->
                  match lb.FStar_Syntax_Syntax.lbname with
-                 | FStar_Util.Inl uu____16653 -> failwith "impossible"
+                 | FStar_Util.Inl uu____16657 -> failwith "impossible"
                  | FStar_Util.Inr fv ->
-                     let uu____16666 = FStar_Syntax_Syntax.fv_eq_lid fv lid
+                     let uu____16670 = FStar_Syntax_Syntax.fv_eq_lid fv lid
                         in
-                     if uu____16666
+                     if uu____16670
                      then
-                       let uu____16679 =
-                         let uu____16688 =
+                       let uu____16683 =
+                         let uu____16692 =
                            inst_tscheme1
                              ((lb.FStar_Syntax_Syntax.lbunivs),
                                (lb.FStar_Syntax_Syntax.lbtyp))
                             in
-                         let uu____16697 = FStar_Syntax_Syntax.range_of_fv fv
+                         let uu____16701 = FStar_Syntax_Syntax.range_of_fv fv
                             in
-                         (uu____16688, uu____16697)  in
-                       FStar_Pervasives_Native.Some uu____16679
+                         (uu____16692, uu____16701)  in
+                       FStar_Pervasives_Native.Some uu____16683
                      else FStar_Pervasives_Native.None)
-        | uu____16720 -> FStar_Pervasives_Native.None
+        | uu____16724 -> FStar_Pervasives_Native.None
   
 let (effect_signature :
   FStar_Syntax_Syntax.universes FStar_Pervasives_Native.option ->
@@ -2580,54 +2582,54 @@ let (effect_signature :
                          (FStar_Pervasives_Native.fst
                             ne.FStar_Syntax_Syntax.signature))
                   then
-                    let uu____16812 =
-                      let uu____16814 =
-                        let uu____16816 =
-                          let uu____16818 =
-                            let uu____16820 =
+                    let uu____16816 =
+                      let uu____16818 =
+                        let uu____16820 =
+                          let uu____16822 =
+                            let uu____16824 =
                               FStar_Util.string_of_int
                                 (FStar_List.length
                                    (FStar_Pervasives_Native.fst
                                       ne.FStar_Syntax_Syntax.signature))
                                in
-                            let uu____16826 =
-                              let uu____16828 =
+                            let uu____16830 =
+                              let uu____16832 =
                                 FStar_Util.string_of_int
                                   (FStar_List.length us)
                                  in
-                              Prims.op_Hat ", got " uu____16828  in
-                            Prims.op_Hat uu____16820 uu____16826  in
-                          Prims.op_Hat ", expected " uu____16818  in
+                              Prims.op_Hat ", got " uu____16832  in
+                            Prims.op_Hat uu____16824 uu____16830  in
+                          Prims.op_Hat ", expected " uu____16822  in
                         Prims.op_Hat
                           (ne.FStar_Syntax_Syntax.mname).FStar_Ident.str
-                          uu____16816
+                          uu____16820
                          in
                       Prims.op_Hat
                         "effect_signature: incorrect number of universes for the signature of "
-                        uu____16814
+                        uu____16818
                        in
-                    failwith uu____16812
+                    failwith uu____16816
                   else ());
-             (let uu____16835 =
-                let uu____16844 =
+             (let uu____16839 =
+                let uu____16848 =
                   inst_ts us_opt ne.FStar_Syntax_Syntax.signature  in
-                (uu____16844, (se.FStar_Syntax_Syntax.sigrng))  in
-              FStar_Pervasives_Native.Some uu____16835))
+                (uu____16848, (se.FStar_Syntax_Syntax.sigrng))  in
+              FStar_Pervasives_Native.Some uu____16839))
         | FStar_Syntax_Syntax.Sig_effect_abbrev
-            (lid,us,binders,uu____16864,uu____16865) ->
-            let uu____16870 =
-              let uu____16879 =
-                let uu____16884 =
-                  let uu____16885 =
-                    let uu____16888 =
+            (lid,us,binders,uu____16868,uu____16869) ->
+            let uu____16874 =
+              let uu____16883 =
+                let uu____16888 =
+                  let uu____16889 =
+                    let uu____16892 =
                       FStar_Syntax_Syntax.mk_Total FStar_Syntax_Syntax.teff
                        in
-                    FStar_Syntax_Util.arrow binders uu____16888  in
-                  (us, uu____16885)  in
-                inst_ts us_opt uu____16884  in
-              (uu____16879, (se.FStar_Syntax_Syntax.sigrng))  in
-            FStar_Pervasives_Native.Some uu____16870
-        | uu____16907 -> FStar_Pervasives_Native.None
+                    FStar_Syntax_Util.arrow binders uu____16892  in
+                  (us, uu____16889)  in
+                inst_ts us_opt uu____16888  in
+              (uu____16883, (se.FStar_Syntax_Syntax.sigrng))  in
+            FStar_Pervasives_Native.Some uu____16874
+        | uu____16911 -> FStar_Pervasives_Native.None
   
 let (try_lookup_lid_aux :
   FStar_Syntax_Syntax.universes FStar_Pervasives_Native.option ->
@@ -2644,8 +2646,8 @@ let (try_lookup_lid_aux :
           match us_opt with
           | FStar_Pervasives_Native.None  -> inst_tscheme ts
           | FStar_Pervasives_Native.Some us -> inst_tscheme_with ts us  in
-        let mapper uu____16996 =
-          match uu____16996 with
+        let mapper uu____17000 =
+          match uu____17000 with
           | (lr,rng) ->
               (match lr with
                | FStar_Util.Inl t -> FStar_Pervasives_Native.Some (t, rng)
@@ -2653,161 +2655,166 @@ let (try_lookup_lid_aux :
                    ({
                       FStar_Syntax_Syntax.sigel =
                         FStar_Syntax_Syntax.Sig_datacon
-                        (uu____17092,uvs,t,uu____17095,uu____17096,uu____17097);
-                      FStar_Syntax_Syntax.sigrng = uu____17098;
-                      FStar_Syntax_Syntax.sigquals = uu____17099;
-                      FStar_Syntax_Syntax.sigmeta = uu____17100;
-                      FStar_Syntax_Syntax.sigattrs = uu____17101;_},FStar_Pervasives_Native.None
+                        (uu____17096,uvs,t,uu____17099,uu____17100,uu____17101);
+                      FStar_Syntax_Syntax.sigrng = uu____17102;
+                      FStar_Syntax_Syntax.sigquals = uu____17103;
+                      FStar_Syntax_Syntax.sigmeta = uu____17104;
+                      FStar_Syntax_Syntax.sigattrs = uu____17105;
+                      FStar_Syntax_Syntax.sigopts = uu____17106;_},FStar_Pervasives_Native.None
                     )
                    ->
-                   let uu____17124 =
-                     let uu____17133 = inst_tscheme1 (uvs, t)  in
-                     (uu____17133, rng)  in
-                   FStar_Pervasives_Native.Some uu____17124
+                   let uu____17131 =
+                     let uu____17140 = inst_tscheme1 (uvs, t)  in
+                     (uu____17140, rng)  in
+                   FStar_Pervasives_Native.Some uu____17131
                | FStar_Util.Inr
                    ({
                       FStar_Syntax_Syntax.sigel =
                         FStar_Syntax_Syntax.Sig_declare_typ (l,uvs,t);
-                      FStar_Syntax_Syntax.sigrng = uu____17157;
+                      FStar_Syntax_Syntax.sigrng = uu____17164;
                       FStar_Syntax_Syntax.sigquals = qs;
-                      FStar_Syntax_Syntax.sigmeta = uu____17159;
-                      FStar_Syntax_Syntax.sigattrs = uu____17160;_},FStar_Pervasives_Native.None
+                      FStar_Syntax_Syntax.sigmeta = uu____17166;
+                      FStar_Syntax_Syntax.sigattrs = uu____17167;
+                      FStar_Syntax_Syntax.sigopts = uu____17168;_},FStar_Pervasives_Native.None
                     )
                    ->
-                   let uu____17177 =
-                     let uu____17179 = in_cur_mod env l  in uu____17179 = Yes
+                   let uu____17187 =
+                     let uu____17189 = in_cur_mod env l  in uu____17189 = Yes
                       in
-                   if uu____17177
+                   if uu____17187
                    then
-                     let uu____17191 =
+                     let uu____17201 =
                        (FStar_All.pipe_right qs
                           (FStar_List.contains FStar_Syntax_Syntax.Assumption))
                          || env.is_iface
                         in
-                     (if uu____17191
+                     (if uu____17201
                       then
-                        let uu____17207 =
-                          let uu____17216 = inst_tscheme1 (uvs, t)  in
-                          (uu____17216, rng)  in
-                        FStar_Pervasives_Native.Some uu____17207
+                        let uu____17217 =
+                          let uu____17226 = inst_tscheme1 (uvs, t)  in
+                          (uu____17226, rng)  in
+                        FStar_Pervasives_Native.Some uu____17217
                       else FStar_Pervasives_Native.None)
                    else
-                     (let uu____17249 =
-                        let uu____17258 = inst_tscheme1 (uvs, t)  in
-                        (uu____17258, rng)  in
-                      FStar_Pervasives_Native.Some uu____17249)
+                     (let uu____17259 =
+                        let uu____17268 = inst_tscheme1 (uvs, t)  in
+                        (uu____17268, rng)  in
+                      FStar_Pervasives_Native.Some uu____17259)
                | FStar_Util.Inr
                    ({
                       FStar_Syntax_Syntax.sigel =
                         FStar_Syntax_Syntax.Sig_inductive_typ
-                        (lid1,uvs,tps,k,uu____17283,uu____17284);
-                      FStar_Syntax_Syntax.sigrng = uu____17285;
-                      FStar_Syntax_Syntax.sigquals = uu____17286;
-                      FStar_Syntax_Syntax.sigmeta = uu____17287;
-                      FStar_Syntax_Syntax.sigattrs = uu____17288;_},FStar_Pervasives_Native.None
+                        (lid1,uvs,tps,k,uu____17293,uu____17294);
+                      FStar_Syntax_Syntax.sigrng = uu____17295;
+                      FStar_Syntax_Syntax.sigquals = uu____17296;
+                      FStar_Syntax_Syntax.sigmeta = uu____17297;
+                      FStar_Syntax_Syntax.sigattrs = uu____17298;
+                      FStar_Syntax_Syntax.sigopts = uu____17299;_},FStar_Pervasives_Native.None
                     )
                    ->
                    (match tps with
                     | [] ->
-                        let uu____17329 =
-                          let uu____17338 = inst_tscheme1 (uvs, k)  in
-                          (uu____17338, rng)  in
-                        FStar_Pervasives_Native.Some uu____17329
-                    | uu____17359 ->
-                        let uu____17360 =
-                          let uu____17369 =
-                            let uu____17374 =
-                              let uu____17375 =
-                                let uu____17378 =
+                        let uu____17342 =
+                          let uu____17351 = inst_tscheme1 (uvs, k)  in
+                          (uu____17351, rng)  in
+                        FStar_Pervasives_Native.Some uu____17342
+                    | uu____17372 ->
+                        let uu____17373 =
+                          let uu____17382 =
+                            let uu____17387 =
+                              let uu____17388 =
+                                let uu____17391 =
                                   FStar_Syntax_Syntax.mk_Total k  in
-                                FStar_Syntax_Util.flat_arrow tps uu____17378
+                                FStar_Syntax_Util.flat_arrow tps uu____17391
                                  in
-                              (uvs, uu____17375)  in
-                            inst_tscheme1 uu____17374  in
-                          (uu____17369, rng)  in
-                        FStar_Pervasives_Native.Some uu____17360)
+                              (uvs, uu____17388)  in
+                            inst_tscheme1 uu____17387  in
+                          (uu____17382, rng)  in
+                        FStar_Pervasives_Native.Some uu____17373)
                | FStar_Util.Inr
                    ({
                       FStar_Syntax_Syntax.sigel =
                         FStar_Syntax_Syntax.Sig_inductive_typ
-                        (lid1,uvs,tps,k,uu____17401,uu____17402);
-                      FStar_Syntax_Syntax.sigrng = uu____17403;
-                      FStar_Syntax_Syntax.sigquals = uu____17404;
-                      FStar_Syntax_Syntax.sigmeta = uu____17405;
-                      FStar_Syntax_Syntax.sigattrs = uu____17406;_},FStar_Pervasives_Native.Some
+                        (lid1,uvs,tps,k,uu____17414,uu____17415);
+                      FStar_Syntax_Syntax.sigrng = uu____17416;
+                      FStar_Syntax_Syntax.sigquals = uu____17417;
+                      FStar_Syntax_Syntax.sigmeta = uu____17418;
+                      FStar_Syntax_Syntax.sigattrs = uu____17419;
+                      FStar_Syntax_Syntax.sigopts = uu____17420;_},FStar_Pervasives_Native.Some
                     us)
                    ->
                    (match tps with
                     | [] ->
-                        let uu____17448 =
-                          let uu____17457 = inst_tscheme_with (uvs, k) us  in
-                          (uu____17457, rng)  in
-                        FStar_Pervasives_Native.Some uu____17448
-                    | uu____17478 ->
-                        let uu____17479 =
-                          let uu____17488 =
-                            let uu____17493 =
-                              let uu____17494 =
-                                let uu____17497 =
+                        let uu____17464 =
+                          let uu____17473 = inst_tscheme_with (uvs, k) us  in
+                          (uu____17473, rng)  in
+                        FStar_Pervasives_Native.Some uu____17464
+                    | uu____17494 ->
+                        let uu____17495 =
+                          let uu____17504 =
+                            let uu____17509 =
+                              let uu____17510 =
+                                let uu____17513 =
                                   FStar_Syntax_Syntax.mk_Total k  in
-                                FStar_Syntax_Util.flat_arrow tps uu____17497
+                                FStar_Syntax_Util.flat_arrow tps uu____17513
                                  in
-                              (uvs, uu____17494)  in
-                            inst_tscheme_with uu____17493 us  in
-                          (uu____17488, rng)  in
-                        FStar_Pervasives_Native.Some uu____17479)
+                              (uvs, uu____17510)  in
+                            inst_tscheme_with uu____17509 us  in
+                          (uu____17504, rng)  in
+                        FStar_Pervasives_Native.Some uu____17495)
                | FStar_Util.Inr se ->
-                   let uu____17533 =
+                   let uu____17549 =
                      match se with
                      | ({
                           FStar_Syntax_Syntax.sigel =
-                            FStar_Syntax_Syntax.Sig_let uu____17554;
-                          FStar_Syntax_Syntax.sigrng = uu____17555;
-                          FStar_Syntax_Syntax.sigquals = uu____17556;
-                          FStar_Syntax_Syntax.sigmeta = uu____17557;
-                          FStar_Syntax_Syntax.sigattrs = uu____17558;_},FStar_Pervasives_Native.None
+                            FStar_Syntax_Syntax.Sig_let uu____17570;
+                          FStar_Syntax_Syntax.sigrng = uu____17571;
+                          FStar_Syntax_Syntax.sigquals = uu____17572;
+                          FStar_Syntax_Syntax.sigmeta = uu____17573;
+                          FStar_Syntax_Syntax.sigattrs = uu____17574;
+                          FStar_Syntax_Syntax.sigopts = uu____17575;_},FStar_Pervasives_Native.None
                         ) ->
                          lookup_type_of_let us_opt
                            (FStar_Pervasives_Native.fst se) lid
-                     | uu____17573 ->
+                     | uu____17592 ->
                          effect_signature us_opt
                            (FStar_Pervasives_Native.fst se) env.range
                       in
-                   FStar_All.pipe_right uu____17533
+                   FStar_All.pipe_right uu____17549
                      (FStar_Util.map_option
-                        (fun uu____17621  ->
-                           match uu____17621 with
+                        (fun uu____17640  ->
+                           match uu____17640 with
                            | (us_t,rng1) -> (us_t, rng1))))
            in
-        let uu____17652 =
-          let uu____17663 = lookup_qname env lid  in
-          FStar_Util.bind_opt uu____17663 mapper  in
-        match uu____17652 with
+        let uu____17671 =
+          let uu____17682 = lookup_qname env lid  in
+          FStar_Util.bind_opt uu____17682 mapper  in
+        match uu____17671 with
         | FStar_Pervasives_Native.Some ((us,t),r) ->
-            let uu____17737 =
-              let uu____17748 =
-                let uu____17755 =
-                  let uu___854_17758 = t  in
-                  let uu____17759 = FStar_Ident.range_of_lid lid  in
+            let uu____17756 =
+              let uu____17767 =
+                let uu____17774 =
+                  let uu___860_17777 = t  in
+                  let uu____17778 = FStar_Ident.range_of_lid lid  in
                   {
                     FStar_Syntax_Syntax.n =
-                      (uu___854_17758.FStar_Syntax_Syntax.n);
-                    FStar_Syntax_Syntax.pos = uu____17759;
+                      (uu___860_17777.FStar_Syntax_Syntax.n);
+                    FStar_Syntax_Syntax.pos = uu____17778;
                     FStar_Syntax_Syntax.vars =
-                      (uu___854_17758.FStar_Syntax_Syntax.vars)
+                      (uu___860_17777.FStar_Syntax_Syntax.vars)
                   }  in
-                (us, uu____17755)  in
-              (uu____17748, r)  in
-            FStar_Pervasives_Native.Some uu____17737
+                (us, uu____17774)  in
+              (uu____17767, r)  in
+            FStar_Pervasives_Native.Some uu____17756
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
   
 let (lid_exists : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun l  ->
-      let uu____17808 = lookup_qname env l  in
-      match uu____17808 with
+      let uu____17827 = lookup_qname env l  in
+      match uu____17827 with
       | FStar_Pervasives_Native.None  -> false
-      | FStar_Pervasives_Native.Some uu____17829 -> true
+      | FStar_Pervasives_Native.Some uu____17848 -> true
   
 let (lookup_bv :
   env ->
@@ -2816,17 +2823,17 @@ let (lookup_bv :
   fun env  ->
     fun bv  ->
       let bvr = FStar_Syntax_Syntax.range_of_bv bv  in
-      let uu____17883 = try_lookup_bv env bv  in
-      match uu____17883 with
+      let uu____17902 = try_lookup_bv env bv  in
+      match uu____17902 with
       | FStar_Pervasives_Native.None  ->
-          let uu____17898 = variable_not_found bv  in
-          FStar_Errors.raise_error uu____17898 bvr
+          let uu____17917 = variable_not_found bv  in
+          FStar_Errors.raise_error uu____17917 bvr
       | FStar_Pervasives_Native.Some (t,r) ->
-          let uu____17914 = FStar_Syntax_Subst.set_use_range bvr t  in
-          let uu____17915 =
-            let uu____17916 = FStar_Range.use_range bvr  in
-            FStar_Range.set_use_range r uu____17916  in
-          (uu____17914, uu____17915)
+          let uu____17933 = FStar_Syntax_Subst.set_use_range bvr t  in
+          let uu____17934 =
+            let uu____17935 = FStar_Range.use_range bvr  in
+            FStar_Range.set_use_range r uu____17935  in
+          (uu____17933, uu____17934)
   
 let (try_lookup_lid :
   env ->
@@ -2836,22 +2843,22 @@ let (try_lookup_lid :
   =
   fun env  ->
     fun l  ->
-      let uu____17938 = try_lookup_lid_aux FStar_Pervasives_Native.None env l
+      let uu____17957 = try_lookup_lid_aux FStar_Pervasives_Native.None env l
          in
-      match uu____17938 with
+      match uu____17957 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some ((us,t),r) ->
           let use_range1 = FStar_Ident.range_of_lid l  in
           let r1 =
-            let uu____18004 = FStar_Range.use_range use_range1  in
-            FStar_Range.set_use_range r uu____18004  in
-          let uu____18005 =
-            let uu____18014 =
-              let uu____18019 = FStar_Syntax_Subst.set_use_range use_range1 t
+            let uu____18023 = FStar_Range.use_range use_range1  in
+            FStar_Range.set_use_range r uu____18023  in
+          let uu____18024 =
+            let uu____18033 =
+              let uu____18038 = FStar_Syntax_Subst.set_use_range use_range1 t
                  in
-              (us, uu____18019)  in
-            (uu____18014, r1)  in
-          FStar_Pervasives_Native.Some uu____18005
+              (us, uu____18038)  in
+            (uu____18033, r1)  in
+          FStar_Pervasives_Native.Some uu____18024
   
 let (try_lookup_and_inst_lid :
   env ->
@@ -2863,20 +2870,20 @@ let (try_lookup_and_inst_lid :
   fun env  ->
     fun us  ->
       fun l  ->
-        let uu____18054 =
+        let uu____18073 =
           try_lookup_lid_aux (FStar_Pervasives_Native.Some us) env l  in
-        match uu____18054 with
+        match uu____18073 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-        | FStar_Pervasives_Native.Some ((uu____18087,t),r) ->
+        | FStar_Pervasives_Native.Some ((uu____18106,t),r) ->
             let use_range1 = FStar_Ident.range_of_lid l  in
             let r1 =
-              let uu____18112 = FStar_Range.use_range use_range1  in
-              FStar_Range.set_use_range r uu____18112  in
-            let uu____18113 =
-              let uu____18118 = FStar_Syntax_Subst.set_use_range use_range1 t
+              let uu____18131 = FStar_Range.use_range use_range1  in
+              FStar_Range.set_use_range r uu____18131  in
+            let uu____18132 =
+              let uu____18137 = FStar_Syntax_Subst.set_use_range use_range1 t
                  in
-              (uu____18118, r1)  in
-            FStar_Pervasives_Native.Some uu____18113
+              (uu____18137, r1)  in
+            FStar_Pervasives_Native.Some uu____18132
   
 let (lookup_lid :
   env ->
@@ -2886,12 +2893,12 @@ let (lookup_lid :
   =
   fun env  ->
     fun l  ->
-      let uu____18142 = try_lookup_lid env l  in
-      match uu____18142 with
+      let uu____18161 = try_lookup_lid env l  in
+      match uu____18161 with
       | FStar_Pervasives_Native.None  ->
-          let uu____18169 = name_not_found l  in
-          let uu____18175 = FStar_Ident.range_of_lid l  in
-          FStar_Errors.raise_error uu____18169 uu____18175
+          let uu____18188 = name_not_found l  in
+          let uu____18194 = FStar_Ident.range_of_lid l  in
+          FStar_Errors.raise_error uu____18188 uu____18194
       | FStar_Pervasives_Native.Some v1 -> v1
   
 let (lookup_univ : env -> FStar_Syntax_Syntax.univ_name -> Prims.bool) =
@@ -2899,11 +2906,11 @@ let (lookup_univ : env -> FStar_Syntax_Syntax.univ_name -> Prims.bool) =
     fun x  ->
       FStar_All.pipe_right
         (FStar_List.find
-           (fun uu___5_18218  ->
-              match uu___5_18218 with
+           (fun uu___5_18237  ->
+              match uu___5_18237 with
               | FStar_Syntax_Syntax.Binding_univ y ->
                   x.FStar_Ident.idText = y.FStar_Ident.idText
-              | uu____18222 -> false) env.gamma) FStar_Option.isSome
+              | uu____18241 -> false) env.gamma) FStar_Option.isSome
   
 let (try_lookup_val_decl :
   env ->
@@ -2913,28 +2920,29 @@ let (try_lookup_val_decl :
   =
   fun env  ->
     fun lid  ->
-      let uu____18243 = lookup_qname env lid  in
-      match uu____18243 with
+      let uu____18262 = lookup_qname env lid  in
+      match uu____18262 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ
-                (uu____18252,uvs,t);
-              FStar_Syntax_Syntax.sigrng = uu____18255;
+                (uu____18271,uvs,t);
+              FStar_Syntax_Syntax.sigrng = uu____18274;
               FStar_Syntax_Syntax.sigquals = q;
-              FStar_Syntax_Syntax.sigmeta = uu____18257;
-              FStar_Syntax_Syntax.sigattrs = uu____18258;_},FStar_Pervasives_Native.None
-            ),uu____18259)
+              FStar_Syntax_Syntax.sigmeta = uu____18276;
+              FStar_Syntax_Syntax.sigattrs = uu____18277;
+              FStar_Syntax_Syntax.sigopts = uu____18278;_},FStar_Pervasives_Native.None
+            ),uu____18279)
           ->
-          let uu____18308 =
-            let uu____18315 =
-              let uu____18316 =
-                let uu____18319 = FStar_Ident.range_of_lid lid  in
-                FStar_Syntax_Subst.set_use_range uu____18319 t  in
-              (uvs, uu____18316)  in
-            (uu____18315, q)  in
-          FStar_Pervasives_Native.Some uu____18308
-      | uu____18332 -> FStar_Pervasives_Native.None
+          let uu____18330 =
+            let uu____18337 =
+              let uu____18338 =
+                let uu____18341 = FStar_Ident.range_of_lid lid  in
+                FStar_Syntax_Subst.set_use_range uu____18341 t  in
+              (uvs, uu____18338)  in
+            (uu____18337, q)  in
+          FStar_Pervasives_Native.Some uu____18330
+      | uu____18354 -> FStar_Pervasives_Native.None
   
 let (lookup_val_decl :
   env ->
@@ -2943,25 +2951,26 @@ let (lookup_val_decl :
   =
   fun env  ->
     fun lid  ->
-      let uu____18354 = lookup_qname env lid  in
-      match uu____18354 with
+      let uu____18376 = lookup_qname env lid  in
+      match uu____18376 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ
-                (uu____18359,uvs,t);
-              FStar_Syntax_Syntax.sigrng = uu____18362;
-              FStar_Syntax_Syntax.sigquals = uu____18363;
-              FStar_Syntax_Syntax.sigmeta = uu____18364;
-              FStar_Syntax_Syntax.sigattrs = uu____18365;_},FStar_Pervasives_Native.None
-            ),uu____18366)
+                (uu____18381,uvs,t);
+              FStar_Syntax_Syntax.sigrng = uu____18384;
+              FStar_Syntax_Syntax.sigquals = uu____18385;
+              FStar_Syntax_Syntax.sigmeta = uu____18386;
+              FStar_Syntax_Syntax.sigattrs = uu____18387;
+              FStar_Syntax_Syntax.sigopts = uu____18388;_},FStar_Pervasives_Native.None
+            ),uu____18389)
           ->
-          let uu____18415 = FStar_Ident.range_of_lid lid  in
-          inst_tscheme_with_range uu____18415 (uvs, t)
-      | uu____18420 ->
-          let uu____18421 = name_not_found lid  in
-          let uu____18427 = FStar_Ident.range_of_lid lid  in
-          FStar_Errors.raise_error uu____18421 uu____18427
+          let uu____18440 = FStar_Ident.range_of_lid lid  in
+          inst_tscheme_with_range uu____18440 (uvs, t)
+      | uu____18445 ->
+          let uu____18446 = name_not_found lid  in
+          let uu____18452 = FStar_Ident.range_of_lid lid  in
+          FStar_Errors.raise_error uu____18446 uu____18452
   
 let (lookup_datacon :
   env ->
@@ -2970,66 +2979,69 @@ let (lookup_datacon :
   =
   fun env  ->
     fun lid  ->
-      let uu____18447 = lookup_qname env lid  in
-      match uu____18447 with
+      let uu____18472 = lookup_qname env lid  in
+      match uu____18472 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-                (uu____18452,uvs,t,uu____18455,uu____18456,uu____18457);
-              FStar_Syntax_Syntax.sigrng = uu____18458;
-              FStar_Syntax_Syntax.sigquals = uu____18459;
-              FStar_Syntax_Syntax.sigmeta = uu____18460;
-              FStar_Syntax_Syntax.sigattrs = uu____18461;_},FStar_Pervasives_Native.None
-            ),uu____18462)
+                (uu____18477,uvs,t,uu____18480,uu____18481,uu____18482);
+              FStar_Syntax_Syntax.sigrng = uu____18483;
+              FStar_Syntax_Syntax.sigquals = uu____18484;
+              FStar_Syntax_Syntax.sigmeta = uu____18485;
+              FStar_Syntax_Syntax.sigattrs = uu____18486;
+              FStar_Syntax_Syntax.sigopts = uu____18487;_},FStar_Pervasives_Native.None
+            ),uu____18488)
           ->
-          let uu____18517 = FStar_Ident.range_of_lid lid  in
-          inst_tscheme_with_range uu____18517 (uvs, t)
-      | uu____18522 ->
-          let uu____18523 = name_not_found lid  in
-          let uu____18529 = FStar_Ident.range_of_lid lid  in
-          FStar_Errors.raise_error uu____18523 uu____18529
+          let uu____18545 = FStar_Ident.range_of_lid lid  in
+          inst_tscheme_with_range uu____18545 (uvs, t)
+      | uu____18550 ->
+          let uu____18551 = name_not_found lid  in
+          let uu____18557 = FStar_Ident.range_of_lid lid  in
+          FStar_Errors.raise_error uu____18551 uu____18557
   
 let (datacons_of_typ :
   env -> FStar_Ident.lident -> (Prims.bool * FStar_Ident.lident Prims.list))
   =
   fun env  ->
     fun lid  ->
-      let uu____18552 = lookup_qname env lid  in
-      match uu____18552 with
+      let uu____18580 = lookup_qname env lid  in
+      match uu____18580 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel =
                 FStar_Syntax_Syntax.Sig_inductive_typ
-                (uu____18560,uu____18561,uu____18562,uu____18563,uu____18564,dcs);
-              FStar_Syntax_Syntax.sigrng = uu____18566;
-              FStar_Syntax_Syntax.sigquals = uu____18567;
-              FStar_Syntax_Syntax.sigmeta = uu____18568;
-              FStar_Syntax_Syntax.sigattrs = uu____18569;_},uu____18570),uu____18571)
+                (uu____18588,uu____18589,uu____18590,uu____18591,uu____18592,dcs);
+              FStar_Syntax_Syntax.sigrng = uu____18594;
+              FStar_Syntax_Syntax.sigquals = uu____18595;
+              FStar_Syntax_Syntax.sigmeta = uu____18596;
+              FStar_Syntax_Syntax.sigattrs = uu____18597;
+              FStar_Syntax_Syntax.sigopts = uu____18598;_},uu____18599),uu____18600)
           -> (true, dcs)
-      | uu____18634 -> (false, [])
+      | uu____18665 -> (false, [])
   
 let (typ_of_datacon : env -> FStar_Ident.lident -> FStar_Ident.lident) =
   fun env  ->
     fun lid  ->
-      let uu____18650 = lookup_qname env lid  in
-      match uu____18650 with
+      let uu____18681 = lookup_qname env lid  in
+      match uu____18681 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-                (uu____18651,uu____18652,uu____18653,l,uu____18655,uu____18656);
-              FStar_Syntax_Syntax.sigrng = uu____18657;
-              FStar_Syntax_Syntax.sigquals = uu____18658;
-              FStar_Syntax_Syntax.sigmeta = uu____18659;
-              FStar_Syntax_Syntax.sigattrs = uu____18660;_},uu____18661),uu____18662)
+                (uu____18682,uu____18683,uu____18684,l,uu____18686,uu____18687);
+              FStar_Syntax_Syntax.sigrng = uu____18688;
+              FStar_Syntax_Syntax.sigquals = uu____18689;
+              FStar_Syntax_Syntax.sigmeta = uu____18690;
+              FStar_Syntax_Syntax.sigattrs = uu____18691;
+              FStar_Syntax_Syntax.sigopts = uu____18692;_},uu____18693),uu____18694)
           -> l
-      | uu____18719 ->
-          let uu____18720 =
-            let uu____18722 = FStar_Syntax_Print.lid_to_string lid  in
-            FStar_Util.format1 "Not a datacon: %s" uu____18722  in
-          failwith uu____18720
+      | uu____18753 ->
+          let uu____18754 =
+            let uu____18756 = FStar_Syntax_Print.lid_to_string lid  in
+            FStar_Util.format1 "Not a datacon: %s" uu____18756  in
+          failwith uu____18754
   
 let (lookup_definition_qninfo_aux :
   Prims.bool ->
@@ -3053,10 +3065,10 @@ let (lookup_definition_qninfo_aux :
              in
           match qninfo with
           | FStar_Pervasives_Native.Some
-              (FStar_Util.Inr (se,FStar_Pervasives_Native.None ),uu____18792)
+              (FStar_Util.Inr (se,FStar_Pervasives_Native.None ),uu____18826)
               ->
               (match se.FStar_Syntax_Syntax.sigel with
-               | FStar_Syntax_Syntax.Sig_let ((is_rec,lbs),uu____18849) when
+               | FStar_Syntax_Syntax.Sig_let ((is_rec,lbs),uu____18883) when
                    (visible se.FStar_Syntax_Syntax.sigquals) &&
                      ((Prims.op_Negation is_rec) || rec_ok)
                    ->
@@ -3064,16 +3076,16 @@ let (lookup_definition_qninfo_aux :
                      (fun lb  ->
                         let fv =
                           FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
-                        let uu____18873 =
+                        let uu____18907 =
                           FStar_Syntax_Syntax.fv_eq_lid fv lid  in
-                        if uu____18873
+                        if uu____18907
                         then
                           FStar_Pervasives_Native.Some
                             ((lb.FStar_Syntax_Syntax.lbunivs),
                               (lb.FStar_Syntax_Syntax.lbdef))
                         else FStar_Pervasives_Native.None)
-               | uu____18908 -> FStar_Pervasives_Native.None)
-          | uu____18917 -> FStar_Pervasives_Native.None
+               | uu____18942 -> FStar_Pervasives_Native.None)
+          | uu____18951 -> FStar_Pervasives_Native.None
   
 let (lookup_definition_qninfo :
   delta_level Prims.list ->
@@ -3097,9 +3109,9 @@ let (lookup_definition :
   fun delta_levels  ->
     fun env  ->
       fun lid  ->
-        let uu____18979 = lookup_qname env lid  in
+        let uu____19013 = lookup_qname env lid  in
         FStar_All.pipe_left (lookup_definition_qninfo delta_levels lid)
-          uu____18979
+          uu____19013
   
 let (lookup_nonrec_definition :
   delta_level Prims.list ->
@@ -3111,9 +3123,9 @@ let (lookup_nonrec_definition :
   fun delta_levels  ->
     fun env  ->
       fun lid  ->
-        let uu____19012 = lookup_qname env lid  in
+        let uu____19046 = lookup_qname env lid  in
         FStar_All.pipe_left
-          (lookup_definition_qninfo_aux false delta_levels lid) uu____19012
+          (lookup_definition_qninfo_aux false delta_levels lid) uu____19046
   
 let (delta_depth_of_qninfo :
   FStar_Syntax_Syntax.fv ->
@@ -3130,60 +3142,60 @@ let (delta_depth_of_qninfo :
              FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_zero)
          | FStar_Pervasives_Native.Some
-             (FStar_Util.Inl uu____19064,uu____19065) ->
+             (FStar_Util.Inl uu____19098,uu____19099) ->
              FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_zero)
          | FStar_Pervasives_Native.Some
-             (FStar_Util.Inr (se,uu____19114),uu____19115) ->
+             (FStar_Util.Inr (se,uu____19148),uu____19149) ->
              (match se.FStar_Syntax_Syntax.sigel with
-              | FStar_Syntax_Syntax.Sig_inductive_typ uu____19164 ->
+              | FStar_Syntax_Syntax.Sig_inductive_typ uu____19198 ->
                   FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.Delta_constant_at_level
                        Prims.int_zero)
-              | FStar_Syntax_Syntax.Sig_bundle uu____19182 ->
+              | FStar_Syntax_Syntax.Sig_bundle uu____19216 ->
                   FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.Delta_constant_at_level
                        Prims.int_zero)
-              | FStar_Syntax_Syntax.Sig_datacon uu____19192 ->
+              | FStar_Syntax_Syntax.Sig_datacon uu____19226 ->
                   FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.Delta_constant_at_level
                        Prims.int_zero)
-              | FStar_Syntax_Syntax.Sig_declare_typ uu____19209 ->
-                  let uu____19216 =
+              | FStar_Syntax_Syntax.Sig_declare_typ uu____19243 ->
+                  let uu____19250 =
                     FStar_Syntax_DsEnv.delta_depth_of_declaration lid
                       se.FStar_Syntax_Syntax.sigquals
                      in
-                  FStar_Pervasives_Native.Some uu____19216
-              | FStar_Syntax_Syntax.Sig_let ((uu____19217,lbs),uu____19219)
+                  FStar_Pervasives_Native.Some uu____19250
+              | FStar_Syntax_Syntax.Sig_let ((uu____19251,lbs),uu____19253)
                   ->
                   FStar_Util.find_map lbs
                     (fun lb  ->
                        let fv1 =
                          FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
-                       let uu____19235 =
+                       let uu____19269 =
                          FStar_Syntax_Syntax.fv_eq_lid fv1 lid  in
-                       if uu____19235
+                       if uu____19269
                        then
                          FStar_Pervasives_Native.Some
                            (fv1.FStar_Syntax_Syntax.fv_delta)
                        else FStar_Pervasives_Native.None)
-              | FStar_Syntax_Syntax.Sig_splice uu____19242 ->
+              | FStar_Syntax_Syntax.Sig_splice uu____19276 ->
                   FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.Delta_constant_at_level
                        Prims.int_one)
-              | FStar_Syntax_Syntax.Sig_main uu____19250 ->
+              | FStar_Syntax_Syntax.Sig_main uu____19284 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_assume uu____19251 ->
+              | FStar_Syntax_Syntax.Sig_assume uu____19285 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_new_effect uu____19258 ->
+              | FStar_Syntax_Syntax.Sig_new_effect uu____19292 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____19259 ->
+              | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____19293 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_sub_effect uu____19260 ->
+              | FStar_Syntax_Syntax.Sig_sub_effect uu____19294 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_effect_abbrev uu____19261 ->
+              | FStar_Syntax_Syntax.Sig_effect_abbrev uu____19295 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_pragma uu____19274 ->
+              | FStar_Syntax_Syntax.Sig_pragma uu____19308 ->
                   FStar_Pervasives_Native.None))
   
 let (delta_depth_of_fv :
@@ -3194,50 +3206,50 @@ let (delta_depth_of_fv :
       if lid.FStar_Ident.nsstr = "Prims"
       then fv.FStar_Syntax_Syntax.fv_delta
       else
-        (let uu____19292 =
+        (let uu____19326 =
            FStar_All.pipe_right lid.FStar_Ident.str
              (FStar_Util.smap_try_find env.fv_delta_depths)
             in
-         FStar_All.pipe_right uu____19292
+         FStar_All.pipe_right uu____19326
            (fun d_opt  ->
-              let uu____19305 = FStar_All.pipe_right d_opt FStar_Util.is_some
+              let uu____19339 = FStar_All.pipe_right d_opt FStar_Util.is_some
                  in
-              if uu____19305
+              if uu____19339
               then FStar_All.pipe_right d_opt FStar_Util.must
               else
-                (let uu____19315 =
-                   let uu____19318 =
+                (let uu____19349 =
+                   let uu____19352 =
                      lookup_qname env
                        (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                       in
-                   delta_depth_of_qninfo fv uu____19318  in
-                 match uu____19315 with
+                   delta_depth_of_qninfo fv uu____19352  in
+                 match uu____19349 with
                  | FStar_Pervasives_Native.None  ->
-                     let uu____19319 =
-                       let uu____19321 = FStar_Syntax_Print.fv_to_string fv
+                     let uu____19353 =
+                       let uu____19355 = FStar_Syntax_Print.fv_to_string fv
                           in
                        FStar_Util.format1 "Delta depth not found for %s"
-                         uu____19321
+                         uu____19355
                         in
-                     failwith uu____19319
+                     failwith uu____19353
                  | FStar_Pervasives_Native.Some d ->
-                     ((let uu____19326 =
+                     ((let uu____19360 =
                          (d <> fv.FStar_Syntax_Syntax.fv_delta) &&
                            (FStar_Options.debug_any ())
                           in
-                       if uu____19326
+                       if uu____19360
                        then
-                         let uu____19329 = FStar_Syntax_Print.fv_to_string fv
+                         let uu____19363 = FStar_Syntax_Print.fv_to_string fv
                             in
-                         let uu____19331 =
+                         let uu____19365 =
                            FStar_Syntax_Print.delta_depth_to_string
                              fv.FStar_Syntax_Syntax.fv_delta
                             in
-                         let uu____19333 =
+                         let uu____19367 =
                            FStar_Syntax_Print.delta_depth_to_string d  in
                          FStar_Util.print3
                            "WARNING WARNING WARNING fv=%s, delta_depth=%s, env.delta_depth=%s\n"
-                           uu____19329 uu____19331 uu____19333
+                           uu____19363 uu____19365 uu____19367
                        else ());
                       FStar_Util.smap_add env.fv_delta_depths
                         lid.FStar_Ident.str d;
@@ -3250,9 +3262,9 @@ let (quals_of_qninfo :
   fun qninfo  ->
     match qninfo with
     | FStar_Pervasives_Native.Some
-        (FStar_Util.Inr (se,uu____19358),uu____19359) ->
+        (FStar_Util.Inr (se,uu____19392),uu____19393) ->
         FStar_Pervasives_Native.Some (se.FStar_Syntax_Syntax.sigquals)
-    | uu____19408 -> FStar_Pervasives_Native.None
+    | uu____19442 -> FStar_Pervasives_Native.None
   
 let (attrs_of_qninfo :
   qninfo ->
@@ -3261,9 +3273,9 @@ let (attrs_of_qninfo :
   fun qninfo  ->
     match qninfo with
     | FStar_Pervasives_Native.Some
-        (FStar_Util.Inr (se,uu____19430),uu____19431) ->
+        (FStar_Util.Inr (se,uu____19464),uu____19465) ->
         FStar_Pervasives_Native.Some (se.FStar_Syntax_Syntax.sigattrs)
-    | uu____19480 -> FStar_Pervasives_Native.None
+    | uu____19514 -> FStar_Pervasives_Native.None
   
 let (lookup_attrs_of_lid :
   env ->
@@ -3272,8 +3284,8 @@ let (lookup_attrs_of_lid :
   =
   fun env  ->
     fun lid  ->
-      let uu____19502 = lookup_qname env lid  in
-      FStar_All.pipe_left attrs_of_qninfo uu____19502
+      let uu____19536 = lookup_qname env lid  in
+      FStar_All.pipe_left attrs_of_qninfo uu____19536
   
 let (fv_exists_and_has_attr :
   env -> FStar_Ident.lid -> FStar_Ident.lident -> (Prims.bool * Prims.bool))
@@ -3281,31 +3293,31 @@ let (fv_exists_and_has_attr :
   fun env  ->
     fun fv_lid1  ->
       fun attr_lid  ->
-        let uu____19535 = lookup_attrs_of_lid env fv_lid1  in
-        match uu____19535 with
+        let uu____19569 = lookup_attrs_of_lid env fv_lid1  in
+        match uu____19569 with
         | FStar_Pervasives_Native.None  -> (false, false)
         | FStar_Pervasives_Native.Some attrs ->
-            let uu____19557 =
+            let uu____19591 =
               FStar_All.pipe_right attrs
                 (FStar_Util.for_some
                    (fun tm  ->
-                      let uu____19566 =
-                        let uu____19567 = FStar_Syntax_Util.un_uinst tm  in
-                        uu____19567.FStar_Syntax_Syntax.n  in
-                      match uu____19566 with
+                      let uu____19600 =
+                        let uu____19601 = FStar_Syntax_Util.un_uinst tm  in
+                        uu____19601.FStar_Syntax_Syntax.n  in
+                      match uu____19600 with
                       | FStar_Syntax_Syntax.Tm_fvar fv ->
                           FStar_Syntax_Syntax.fv_eq_lid fv attr_lid
-                      | uu____19572 -> false))
+                      | uu____19606 -> false))
                in
-            (true, uu____19557)
+            (true, uu____19591)
   
 let (fv_with_lid_has_attr :
   env -> FStar_Ident.lid -> FStar_Ident.lid -> Prims.bool) =
   fun env  ->
     fun fv_lid1  ->
       fun attr_lid  ->
-        let uu____19595 = fv_exists_and_has_attr env fv_lid1 attr_lid  in
-        FStar_Pervasives_Native.snd uu____19595
+        let uu____19629 = fv_exists_and_has_attr env fv_lid1 attr_lid  in
+        FStar_Pervasives_Native.snd uu____19629
   
 let (fv_has_attr :
   env -> FStar_Syntax_Syntax.fv -> FStar_Ident.lid -> Prims.bool) =
@@ -3324,13 +3336,13 @@ let cache_in_fv_tab :
     fun fv  ->
       fun f  ->
         let s =
-          let uu____19667 = FStar_Syntax_Syntax.lid_of_fv fv  in
-          uu____19667.FStar_Ident.str  in
-        let uu____19668 = FStar_Util.smap_try_find tab s  in
-        match uu____19668 with
+          let uu____19701 = FStar_Syntax_Syntax.lid_of_fv fv  in
+          uu____19701.FStar_Ident.str  in
+        let uu____19702 = FStar_Util.smap_try_find tab s  in
+        match uu____19702 with
         | FStar_Pervasives_Native.None  ->
-            let uu____19671 = f ()  in
-            (match uu____19671 with
+            let uu____19705 = f ()  in
+            (match uu____19705 with
              | (should_cache,res) ->
                  (if should_cache then FStar_Util.smap_add tab s res else ();
                   res))
@@ -3339,37 +3351,37 @@ let cache_in_fv_tab :
 let (type_is_erasable : env -> FStar_Syntax_Syntax.fv -> Prims.bool) =
   fun env  ->
     fun fv  ->
-      let f uu____19709 =
-        let uu____19710 =
+      let f uu____19743 =
+        let uu____19744 =
           fv_exists_and_has_attr env
             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
             FStar_Parser_Const.erasable_attr
            in
-        match uu____19710 with | (ex,erasable1) -> (ex, erasable1)  in
+        match uu____19744 with | (ex,erasable1) -> (ex, erasable1)  in
       cache_in_fv_tab env.erasable_types_tab fv f
   
 let rec (non_informative : env -> FStar_Syntax_Syntax.typ -> Prims.bool) =
   fun env  ->
     fun t  ->
-      let uu____19744 =
-        let uu____19745 = FStar_Syntax_Util.unrefine t  in
-        uu____19745.FStar_Syntax_Syntax.n  in
-      match uu____19744 with
-      | FStar_Syntax_Syntax.Tm_type uu____19749 -> true
+      let uu____19778 =
+        let uu____19779 = FStar_Syntax_Util.unrefine t  in
+        uu____19779.FStar_Syntax_Syntax.n  in
+      match uu____19778 with
+      | FStar_Syntax_Syntax.Tm_type uu____19783 -> true
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           (((FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.unit_lid) ||
               (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid))
              ||
              (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.erased_lid))
             || (type_is_erasable env fv)
-      | FStar_Syntax_Syntax.Tm_app (head1,uu____19753) ->
+      | FStar_Syntax_Syntax.Tm_app (head1,uu____19787) ->
           non_informative env head1
-      | FStar_Syntax_Syntax.Tm_uinst (t1,uu____19779) ->
+      | FStar_Syntax_Syntax.Tm_uinst (t1,uu____19813) ->
           non_informative env t1
-      | FStar_Syntax_Syntax.Tm_arrow (uu____19784,c) ->
+      | FStar_Syntax_Syntax.Tm_arrow (uu____19818,c) ->
           (FStar_Syntax_Util.is_pure_or_ghost_comp c) &&
             (non_informative env (FStar_Syntax_Util.comp_result c))
-      | uu____19806 -> false
+      | uu____19840 -> false
   
 let (fv_has_strict_args :
   env ->
@@ -3378,10 +3390,10 @@ let (fv_has_strict_args :
   =
   fun env  ->
     fun fv  ->
-      let f uu____19839 =
+      let f uu____19873 =
         let attrs =
-          let uu____19845 = FStar_Syntax_Syntax.lid_of_fv fv  in
-          lookup_attrs_of_lid env uu____19845  in
+          let uu____19879 = FStar_Syntax_Syntax.lid_of_fv fv  in
+          lookup_attrs_of_lid env uu____19879  in
         match attrs with
         | FStar_Pervasives_Native.None  ->
             (false, FStar_Pervasives_Native.None)
@@ -3389,11 +3401,11 @@ let (fv_has_strict_args :
             let res =
               FStar_Util.find_map attrs1
                 (fun x  ->
-                   let uu____19885 =
+                   let uu____19919 =
                      FStar_ToSyntax_ToSyntax.parse_attr_with_list false x
                        FStar_Parser_Const.strict_on_arguments_attr
                       in
-                   FStar_Pervasives_Native.fst uu____19885)
+                   FStar_Pervasives_Native.fst uu____19919)
                in
             (true, res)
          in
@@ -3406,31 +3418,31 @@ let (try_lookup_effect_lid :
   =
   fun env  ->
     fun ftv  ->
-      let uu____19930 = lookup_qname env ftv  in
-      match uu____19930 with
+      let uu____19964 = lookup_qname env ftv  in
+      match uu____19964 with
       | FStar_Pervasives_Native.Some
-          (FStar_Util.Inr (se,FStar_Pervasives_Native.None ),uu____19934) ->
-          let uu____19979 =
+          (FStar_Util.Inr (se,FStar_Pervasives_Native.None ),uu____19968) ->
+          let uu____20013 =
             effect_signature FStar_Pervasives_Native.None se env.range  in
-          (match uu____19979 with
+          (match uu____20013 with
            | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-           | FStar_Pervasives_Native.Some ((uu____20000,t),r) ->
-               let uu____20015 =
-                 let uu____20016 = FStar_Ident.range_of_lid ftv  in
-                 FStar_Syntax_Subst.set_use_range uu____20016 t  in
-               FStar_Pervasives_Native.Some uu____20015)
-      | uu____20017 -> FStar_Pervasives_Native.None
+           | FStar_Pervasives_Native.Some ((uu____20034,t),r) ->
+               let uu____20049 =
+                 let uu____20050 = FStar_Ident.range_of_lid ftv  in
+                 FStar_Syntax_Subst.set_use_range uu____20050 t  in
+               FStar_Pervasives_Native.Some uu____20049)
+      | uu____20051 -> FStar_Pervasives_Native.None
   
 let (lookup_effect_lid :
   env -> FStar_Ident.lident -> FStar_Syntax_Syntax.term) =
   fun env  ->
     fun ftv  ->
-      let uu____20029 = try_lookup_effect_lid env ftv  in
-      match uu____20029 with
+      let uu____20063 = try_lookup_effect_lid env ftv  in
+      match uu____20063 with
       | FStar_Pervasives_Native.None  ->
-          let uu____20032 = name_not_found ftv  in
-          let uu____20038 = FStar_Ident.range_of_lid ftv  in
-          FStar_Errors.raise_error uu____20032 uu____20038
+          let uu____20066 = name_not_found ftv  in
+          let uu____20072 = FStar_Ident.range_of_lid ftv  in
+          FStar_Errors.raise_error uu____20066 uu____20072
       | FStar_Pervasives_Native.Some k -> k
   
 let (lookup_effect_abbrev :
@@ -3443,37 +3455,38 @@ let (lookup_effect_abbrev :
   fun env  ->
     fun univ_insts  ->
       fun lid0  ->
-        let uu____20062 = lookup_qname env lid0  in
-        match uu____20062 with
+        let uu____20096 = lookup_qname env lid0  in
+        match uu____20096 with
         | FStar_Pervasives_Native.Some
             (FStar_Util.Inr
              ({
                 FStar_Syntax_Syntax.sigel =
                   FStar_Syntax_Syntax.Sig_effect_abbrev
-                  (lid,univs1,binders,c,uu____20073);
-                FStar_Syntax_Syntax.sigrng = uu____20074;
+                  (lid,univs1,binders,c,uu____20107);
+                FStar_Syntax_Syntax.sigrng = uu____20108;
                 FStar_Syntax_Syntax.sigquals = quals;
-                FStar_Syntax_Syntax.sigmeta = uu____20076;
-                FStar_Syntax_Syntax.sigattrs = uu____20077;_},FStar_Pervasives_Native.None
-              ),uu____20078)
+                FStar_Syntax_Syntax.sigmeta = uu____20110;
+                FStar_Syntax_Syntax.sigattrs = uu____20111;
+                FStar_Syntax_Syntax.sigopts = uu____20112;_},FStar_Pervasives_Native.None
+              ),uu____20113)
             ->
             let lid1 =
-              let uu____20132 =
-                let uu____20133 = FStar_Ident.range_of_lid lid  in
-                let uu____20134 =
-                  let uu____20135 = FStar_Ident.range_of_lid lid0  in
-                  FStar_Range.use_range uu____20135  in
-                FStar_Range.set_use_range uu____20133 uu____20134  in
-              FStar_Ident.set_lid_range lid uu____20132  in
-            let uu____20136 =
+              let uu____20169 =
+                let uu____20170 = FStar_Ident.range_of_lid lid  in
+                let uu____20171 =
+                  let uu____20172 = FStar_Ident.range_of_lid lid0  in
+                  FStar_Range.use_range uu____20172  in
+                FStar_Range.set_use_range uu____20170 uu____20171  in
+              FStar_Ident.set_lid_range lid uu____20169  in
+            let uu____20173 =
               FStar_All.pipe_right quals
                 (FStar_Util.for_some
-                   (fun uu___6_20142  ->
-                      match uu___6_20142 with
+                   (fun uu___6_20179  ->
+                      match uu___6_20179 with
                       | FStar_Syntax_Syntax.Irreducible  -> true
-                      | uu____20145 -> false))
+                      | uu____20182 -> false))
                in
-            if uu____20136
+            if uu____20173
             then FStar_Pervasives_Native.None
             else
               (let insts =
@@ -3482,212 +3495,216 @@ let (lookup_effect_abbrev :
                      (FStar_List.length univs1)
                  then univ_insts
                  else
-                   (let uu____20164 =
-                      let uu____20166 =
-                        let uu____20168 = get_range env  in
-                        FStar_Range.string_of_range uu____20168  in
-                      let uu____20169 = FStar_Syntax_Print.lid_to_string lid1
+                   (let uu____20201 =
+                      let uu____20203 =
+                        let uu____20205 = get_range env  in
+                        FStar_Range.string_of_range uu____20205  in
+                      let uu____20206 = FStar_Syntax_Print.lid_to_string lid1
                          in
-                      let uu____20171 =
+                      let uu____20208 =
                         FStar_All.pipe_right (FStar_List.length univ_insts)
                           FStar_Util.string_of_int
                          in
                       FStar_Util.format3
                         "(%s) Unexpected instantiation of effect %s with %s universes"
-                        uu____20166 uu____20169 uu____20171
+                        uu____20203 uu____20206 uu____20208
                        in
-                    failwith uu____20164)
+                    failwith uu____20201)
                   in
                match (binders, univs1) with
-               | ([],uu____20192) ->
+               | ([],uu____20229) ->
                    failwith
                      "Unexpected effect abbreviation with no arguments"
-               | (uu____20218,uu____20219::uu____20220::uu____20221) ->
-                   let uu____20242 =
-                     let uu____20244 = FStar_Syntax_Print.lid_to_string lid1
+               | (uu____20255,uu____20256::uu____20257::uu____20258) ->
+                   let uu____20279 =
+                     let uu____20281 = FStar_Syntax_Print.lid_to_string lid1
                         in
-                     let uu____20246 =
+                     let uu____20283 =
                        FStar_All.pipe_left FStar_Util.string_of_int
                          (FStar_List.length univs1)
                         in
                      FStar_Util.format2
                        "Unexpected effect abbreviation %s; polymorphic in %s universes"
-                       uu____20244 uu____20246
+                       uu____20281 uu____20283
                       in
-                   failwith uu____20242
-               | uu____20257 ->
-                   let uu____20272 =
-                     let uu____20277 =
-                       let uu____20278 = FStar_Syntax_Util.arrow binders c
+                   failwith uu____20279
+               | uu____20294 ->
+                   let uu____20309 =
+                     let uu____20314 =
+                       let uu____20315 = FStar_Syntax_Util.arrow binders c
                           in
-                       (univs1, uu____20278)  in
-                     inst_tscheme_with uu____20277 insts  in
-                   (match uu____20272 with
-                    | (uu____20291,t) ->
+                       (univs1, uu____20315)  in
+                     inst_tscheme_with uu____20314 insts  in
+                   (match uu____20309 with
+                    | (uu____20328,t) ->
                         let t1 =
-                          let uu____20294 = FStar_Ident.range_of_lid lid1  in
-                          FStar_Syntax_Subst.set_use_range uu____20294 t  in
-                        let uu____20295 =
-                          let uu____20296 = FStar_Syntax_Subst.compress t1
+                          let uu____20331 = FStar_Ident.range_of_lid lid1  in
+                          FStar_Syntax_Subst.set_use_range uu____20331 t  in
+                        let uu____20332 =
+                          let uu____20333 = FStar_Syntax_Subst.compress t1
                              in
-                          uu____20296.FStar_Syntax_Syntax.n  in
-                        (match uu____20295 with
+                          uu____20333.FStar_Syntax_Syntax.n  in
+                        (match uu____20332 with
                          | FStar_Syntax_Syntax.Tm_arrow (binders1,c1) ->
                              FStar_Pervasives_Native.Some (binders1, c1)
-                         | uu____20331 -> failwith "Impossible")))
-        | uu____20339 -> FStar_Pervasives_Native.None
+                         | uu____20368 -> failwith "Impossible")))
+        | uu____20376 -> FStar_Pervasives_Native.None
   
 let (norm_eff_name : env -> FStar_Ident.lident -> FStar_Ident.lident) =
   fun env  ->
     fun l  ->
       let rec find1 l1 =
-        let uu____20363 =
+        let uu____20400 =
           lookup_effect_abbrev env [FStar_Syntax_Syntax.U_unknown] l1  in
-        match uu____20363 with
+        match uu____20400 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-        | FStar_Pervasives_Native.Some (uu____20376,c) ->
+        | FStar_Pervasives_Native.Some (uu____20413,c) ->
             let l2 = FStar_Syntax_Util.comp_effect_name c  in
-            let uu____20383 = find1 l2  in
-            (match uu____20383 with
+            let uu____20420 = find1 l2  in
+            (match uu____20420 with
              | FStar_Pervasives_Native.None  ->
                  FStar_Pervasives_Native.Some l2
              | FStar_Pervasives_Native.Some l' ->
                  FStar_Pervasives_Native.Some l')
          in
       let res =
-        let uu____20390 =
+        let uu____20427 =
           FStar_Util.smap_try_find env.normalized_eff_names l.FStar_Ident.str
            in
-        match uu____20390 with
+        match uu____20427 with
         | FStar_Pervasives_Native.Some l1 -> l1
         | FStar_Pervasives_Native.None  ->
-            let uu____20394 = find1 l  in
-            (match uu____20394 with
+            let uu____20431 = find1 l  in
+            (match uu____20431 with
              | FStar_Pervasives_Native.None  -> l
              | FStar_Pervasives_Native.Some m ->
                  (FStar_Util.smap_add env.normalized_eff_names
                     l.FStar_Ident.str m;
                   m))
          in
-      let uu____20399 = FStar_Ident.range_of_lid l  in
-      FStar_Ident.set_lid_range res uu____20399
+      let uu____20436 = FStar_Ident.range_of_lid l  in
+      FStar_Ident.set_lid_range res uu____20436
   
 let (lookup_effect_quals :
   env -> FStar_Ident.lident -> FStar_Syntax_Syntax.qualifier Prims.list) =
   fun env  ->
     fun l  ->
       let l1 = norm_eff_name env l  in
-      let uu____20414 = lookup_qname env l1  in
-      match uu____20414 with
+      let uu____20451 = lookup_qname env l1  in
+      match uu____20451 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_new_effect
-                uu____20417;
-              FStar_Syntax_Syntax.sigrng = uu____20418;
+                uu____20454;
+              FStar_Syntax_Syntax.sigrng = uu____20455;
               FStar_Syntax_Syntax.sigquals = q;
-              FStar_Syntax_Syntax.sigmeta = uu____20420;
-              FStar_Syntax_Syntax.sigattrs = uu____20421;_},uu____20422),uu____20423)
+              FStar_Syntax_Syntax.sigmeta = uu____20457;
+              FStar_Syntax_Syntax.sigattrs = uu____20458;
+              FStar_Syntax_Syntax.sigopts = uu____20459;_},uu____20460),uu____20461)
           -> q
-      | uu____20474 -> []
+      | uu____20514 -> []
   
 let (lookup_projector :
   env -> FStar_Ident.lident -> Prims.int -> FStar_Ident.lident) =
   fun env  ->
     fun lid  ->
       fun i  ->
-        let fail1 uu____20498 =
-          let uu____20499 =
-            let uu____20501 = FStar_Util.string_of_int i  in
-            let uu____20503 = FStar_Syntax_Print.lid_to_string lid  in
+        let fail1 uu____20538 =
+          let uu____20539 =
+            let uu____20541 = FStar_Util.string_of_int i  in
+            let uu____20543 = FStar_Syntax_Print.lid_to_string lid  in
             FStar_Util.format2
               "Impossible: projecting field #%s from constructor %s is undefined"
-              uu____20501 uu____20503
+              uu____20541 uu____20543
              in
-          failwith uu____20499  in
-        let uu____20506 = lookup_datacon env lid  in
-        match uu____20506 with
-        | (uu____20511,t) ->
-            let uu____20513 =
-              let uu____20514 = FStar_Syntax_Subst.compress t  in
-              uu____20514.FStar_Syntax_Syntax.n  in
-            (match uu____20513 with
-             | FStar_Syntax_Syntax.Tm_arrow (binders,uu____20518) ->
+          failwith uu____20539  in
+        let uu____20546 = lookup_datacon env lid  in
+        match uu____20546 with
+        | (uu____20551,t) ->
+            let uu____20553 =
+              let uu____20554 = FStar_Syntax_Subst.compress t  in
+              uu____20554.FStar_Syntax_Syntax.n  in
+            (match uu____20553 with
+             | FStar_Syntax_Syntax.Tm_arrow (binders,uu____20558) ->
                  if
                    (i < Prims.int_zero) || (i >= (FStar_List.length binders))
                  then fail1 ()
                  else
                    (let b = FStar_List.nth binders i  in
-                    let uu____20562 =
+                    let uu____20602 =
                       FStar_Syntax_Util.mk_field_projector_name lid
                         (FStar_Pervasives_Native.fst b) i
                        in
-                    FStar_All.pipe_right uu____20562
+                    FStar_All.pipe_right uu____20602
                       FStar_Pervasives_Native.fst)
-             | uu____20573 -> fail1 ())
+             | uu____20613 -> fail1 ())
   
 let (is_projector : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun l  ->
-      let uu____20587 = lookup_qname env l  in
-      match uu____20587 with
+      let uu____20627 = lookup_qname env l  in
+      match uu____20627 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ
-                (uu____20589,uu____20590,uu____20591);
-              FStar_Syntax_Syntax.sigrng = uu____20592;
+                (uu____20629,uu____20630,uu____20631);
+              FStar_Syntax_Syntax.sigrng = uu____20632;
               FStar_Syntax_Syntax.sigquals = quals;
-              FStar_Syntax_Syntax.sigmeta = uu____20594;
-              FStar_Syntax_Syntax.sigattrs = uu____20595;_},uu____20596),uu____20597)
+              FStar_Syntax_Syntax.sigmeta = uu____20634;
+              FStar_Syntax_Syntax.sigattrs = uu____20635;
+              FStar_Syntax_Syntax.sigopts = uu____20636;_},uu____20637),uu____20638)
           ->
           FStar_Util.for_some
-            (fun uu___7_20650  ->
-               match uu___7_20650 with
-               | FStar_Syntax_Syntax.Projector uu____20652 -> true
-               | uu____20658 -> false) quals
-      | uu____20660 -> false
+            (fun uu___7_20693  ->
+               match uu___7_20693 with
+               | FStar_Syntax_Syntax.Projector uu____20695 -> true
+               | uu____20701 -> false) quals
+      | uu____20703 -> false
   
 let (is_datacon : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun lid  ->
-      let uu____20674 = lookup_qname env lid  in
-      match uu____20674 with
+      let uu____20717 = lookup_qname env lid  in
+      match uu____20717 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-                (uu____20676,uu____20677,uu____20678,uu____20679,uu____20680,uu____20681);
-              FStar_Syntax_Syntax.sigrng = uu____20682;
-              FStar_Syntax_Syntax.sigquals = uu____20683;
-              FStar_Syntax_Syntax.sigmeta = uu____20684;
-              FStar_Syntax_Syntax.sigattrs = uu____20685;_},uu____20686),uu____20687)
+                (uu____20719,uu____20720,uu____20721,uu____20722,uu____20723,uu____20724);
+              FStar_Syntax_Syntax.sigrng = uu____20725;
+              FStar_Syntax_Syntax.sigquals = uu____20726;
+              FStar_Syntax_Syntax.sigmeta = uu____20727;
+              FStar_Syntax_Syntax.sigattrs = uu____20728;
+              FStar_Syntax_Syntax.sigopts = uu____20729;_},uu____20730),uu____20731)
           -> true
-      | uu____20745 -> false
+      | uu____20791 -> false
   
 let (is_record : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun lid  ->
-      let uu____20759 = lookup_qname env lid  in
-      match uu____20759 with
+      let uu____20805 = lookup_qname env lid  in
+      match uu____20805 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel =
                 FStar_Syntax_Syntax.Sig_inductive_typ
-                (uu____20761,uu____20762,uu____20763,uu____20764,uu____20765,uu____20766);
-              FStar_Syntax_Syntax.sigrng = uu____20767;
+                (uu____20807,uu____20808,uu____20809,uu____20810,uu____20811,uu____20812);
+              FStar_Syntax_Syntax.sigrng = uu____20813;
               FStar_Syntax_Syntax.sigquals = quals;
-              FStar_Syntax_Syntax.sigmeta = uu____20769;
-              FStar_Syntax_Syntax.sigattrs = uu____20770;_},uu____20771),uu____20772)
+              FStar_Syntax_Syntax.sigmeta = uu____20815;
+              FStar_Syntax_Syntax.sigattrs = uu____20816;
+              FStar_Syntax_Syntax.sigopts = uu____20817;_},uu____20818),uu____20819)
           ->
           FStar_Util.for_some
-            (fun uu___8_20833  ->
-               match uu___8_20833 with
-               | FStar_Syntax_Syntax.RecordType uu____20835 -> true
-               | FStar_Syntax_Syntax.RecordConstructor uu____20845 -> true
-               | uu____20855 -> false) quals
-      | uu____20857 -> false
+            (fun uu___8_20882  ->
+               match uu___8_20882 with
+               | FStar_Syntax_Syntax.RecordType uu____20884 -> true
+               | FStar_Syntax_Syntax.RecordConstructor uu____20894 -> true
+               | uu____20904 -> false) quals
+      | uu____20906 -> false
   
 let (qninfo_is_action : qninfo -> Prims.bool) =
   fun qninfo  ->
@@ -3696,24 +3713,25 @@ let (qninfo_is_action : qninfo -> Prims.bool) =
         (FStar_Util.Inr
          ({
             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
-              (uu____20867,uu____20868);
-            FStar_Syntax_Syntax.sigrng = uu____20869;
+              (uu____20916,uu____20917);
+            FStar_Syntax_Syntax.sigrng = uu____20918;
             FStar_Syntax_Syntax.sigquals = quals;
-            FStar_Syntax_Syntax.sigmeta = uu____20871;
-            FStar_Syntax_Syntax.sigattrs = uu____20872;_},uu____20873),uu____20874)
+            FStar_Syntax_Syntax.sigmeta = uu____20920;
+            FStar_Syntax_Syntax.sigattrs = uu____20921;
+            FStar_Syntax_Syntax.sigopts = uu____20922;_},uu____20923),uu____20924)
         ->
         FStar_Util.for_some
-          (fun uu___9_20931  ->
-             match uu___9_20931 with
-             | FStar_Syntax_Syntax.Action uu____20933 -> true
-             | uu____20935 -> false) quals
-    | uu____20937 -> false
+          (fun uu___9_20983  ->
+             match uu___9_20983 with
+             | FStar_Syntax_Syntax.Action uu____20985 -> true
+             | uu____20987 -> false) quals
+    | uu____20989 -> false
   
 let (is_action : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun lid  ->
-      let uu____20951 = lookup_qname env lid  in
-      FStar_All.pipe_left qninfo_is_action uu____20951
+      let uu____21003 = lookup_qname env lid  in
+      FStar_All.pipe_left qninfo_is_action uu____21003
   
 let (is_interpreted : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   let interpreted_symbols =
@@ -3734,51 +3752,51 @@ let (is_interpreted : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
     FStar_Parser_Const.op_Negation]  in
   fun env  ->
     fun head1  ->
-      let uu____20968 =
-        let uu____20969 = FStar_Syntax_Util.un_uinst head1  in
-        uu____20969.FStar_Syntax_Syntax.n  in
-      match uu____20968 with
+      let uu____21020 =
+        let uu____21021 = FStar_Syntax_Util.un_uinst head1  in
+        uu____21021.FStar_Syntax_Syntax.n  in
+      match uu____21020 with
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           (match fv.FStar_Syntax_Syntax.fv_delta with
-           | FStar_Syntax_Syntax.Delta_equational_at_level uu____20975 ->
+           | FStar_Syntax_Syntax.Delta_equational_at_level uu____21027 ->
                true
-           | uu____20978 -> false)
-      | uu____20980 -> false
+           | uu____21030 -> false)
+      | uu____21032 -> false
   
 let (is_irreducible : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun l  ->
-      let uu____20994 = lookup_qname env l  in
-      match uu____20994 with
+      let uu____21046 = lookup_qname env l  in
+      match uu____21046 with
       | FStar_Pervasives_Native.Some
-          (FStar_Util.Inr (se,uu____20997),uu____20998) ->
+          (FStar_Util.Inr (se,uu____21049),uu____21050) ->
           FStar_Util.for_some
-            (fun uu___10_21046  ->
-               match uu___10_21046 with
+            (fun uu___10_21098  ->
+               match uu___10_21098 with
                | FStar_Syntax_Syntax.Irreducible  -> true
-               | uu____21049 -> false) se.FStar_Syntax_Syntax.sigquals
-      | uu____21051 -> false
+               | uu____21101 -> false) se.FStar_Syntax_Syntax.sigquals
+      | uu____21103 -> false
   
 let (is_type_constructor : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun lid  ->
       let mapper x =
         match FStar_Pervasives_Native.fst x with
-        | FStar_Util.Inl uu____21127 -> FStar_Pervasives_Native.Some false
-        | FStar_Util.Inr (se,uu____21145) ->
+        | FStar_Util.Inl uu____21179 -> FStar_Pervasives_Native.Some false
+        | FStar_Util.Inr (se,uu____21197) ->
             (match se.FStar_Syntax_Syntax.sigel with
-             | FStar_Syntax_Syntax.Sig_declare_typ uu____21163 ->
+             | FStar_Syntax_Syntax.Sig_declare_typ uu____21215 ->
                  FStar_Pervasives_Native.Some
                    (FStar_List.contains FStar_Syntax_Syntax.New
                       se.FStar_Syntax_Syntax.sigquals)
-             | FStar_Syntax_Syntax.Sig_inductive_typ uu____21171 ->
+             | FStar_Syntax_Syntax.Sig_inductive_typ uu____21223 ->
                  FStar_Pervasives_Native.Some true
-             | uu____21190 -> FStar_Pervasives_Native.Some false)
+             | uu____21242 -> FStar_Pervasives_Native.Some false)
          in
-      let uu____21193 =
-        let uu____21197 = lookup_qname env lid  in
-        FStar_Util.bind_opt uu____21197 mapper  in
-      match uu____21193 with
+      let uu____21245 =
+        let uu____21249 = lookup_qname env lid  in
+        FStar_Util.bind_opt uu____21249 mapper  in
+      match uu____21245 with
       | FStar_Pervasives_Native.Some b -> b
       | FStar_Pervasives_Native.None  -> false
   
@@ -3786,20 +3804,21 @@ let (num_inductive_ty_params :
   env -> FStar_Ident.lident -> Prims.int FStar_Pervasives_Native.option) =
   fun env  ->
     fun lid  ->
-      let uu____21257 = lookup_qname env lid  in
-      match uu____21257 with
+      let uu____21309 = lookup_qname env lid  in
+      match uu____21309 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel =
                 FStar_Syntax_Syntax.Sig_inductive_typ
-                (uu____21261,uu____21262,tps,uu____21264,uu____21265,uu____21266);
-              FStar_Syntax_Syntax.sigrng = uu____21267;
-              FStar_Syntax_Syntax.sigquals = uu____21268;
-              FStar_Syntax_Syntax.sigmeta = uu____21269;
-              FStar_Syntax_Syntax.sigattrs = uu____21270;_},uu____21271),uu____21272)
+                (uu____21313,uu____21314,tps,uu____21316,uu____21317,uu____21318);
+              FStar_Syntax_Syntax.sigrng = uu____21319;
+              FStar_Syntax_Syntax.sigquals = uu____21320;
+              FStar_Syntax_Syntax.sigmeta = uu____21321;
+              FStar_Syntax_Syntax.sigattrs = uu____21322;
+              FStar_Syntax_Syntax.sigopts = uu____21323;_},uu____21324),uu____21325)
           -> FStar_Pervasives_Native.Some (FStar_List.length tps)
-      | uu____21338 -> FStar_Pervasives_Native.None
+      | uu____21393 -> FStar_Pervasives_Native.None
   
 let (effect_decl_opt :
   env ->
@@ -3811,29 +3830,29 @@ let (effect_decl_opt :
     fun l  ->
       FStar_All.pipe_right (env.effects).decls
         (FStar_Util.find_opt
-           (fun uu____21384  ->
-              match uu____21384 with
-              | (d,uu____21393) ->
+           (fun uu____21439  ->
+              match uu____21439 with
+              | (d,uu____21448) ->
                   FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname l))
   
 let (get_effect_decl :
   env -> FStar_Ident.lident -> FStar_Syntax_Syntax.eff_decl) =
   fun env  ->
     fun l  ->
-      let uu____21409 = effect_decl_opt env l  in
-      match uu____21409 with
+      let uu____21464 = effect_decl_opt env l  in
+      match uu____21464 with
       | FStar_Pervasives_Native.None  ->
-          let uu____21424 = name_not_found l  in
-          let uu____21430 = FStar_Ident.range_of_lid l  in
-          FStar_Errors.raise_error uu____21424 uu____21430
+          let uu____21479 = name_not_found l  in
+          let uu____21485 = FStar_Ident.range_of_lid l  in
+          FStar_Errors.raise_error uu____21479 uu____21485
       | FStar_Pervasives_Native.Some md -> FStar_Pervasives_Native.fst md
   
 let (identity_mlift : mlift) =
   {
-    mlift_wp = (fun uu____21453  -> fun t  -> fun wp  -> wp);
+    mlift_wp = (fun uu____21508  -> fun t  -> fun wp  -> wp);
     mlift_term =
       (FStar_Pervasives_Native.Some
-         (fun uu____21472  ->
+         (fun uu____21527  ->
             fun t  -> fun wp  -> fun e  -> FStar_Util.return_all e))
   } 
 let (join :
@@ -3844,11 +3863,11 @@ let (join :
   fun env  ->
     fun l1  ->
       fun l2  ->
-        let uu____21504 = FStar_Ident.lid_equals l1 l2  in
-        if uu____21504
+        let uu____21559 = FStar_Ident.lid_equals l1 l2  in
+        if uu____21559
         then (l1, identity_mlift, identity_mlift)
         else
-          (let uu____21515 =
+          (let uu____21570 =
              ((FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_GTot_lid)
                 &&
                 (FStar_Ident.lid_equals l2 FStar_Parser_Const.effect_Tot_lid))
@@ -3858,37 +3877,37 @@ let (join :
                   (FStar_Ident.lid_equals l1
                      FStar_Parser_Const.effect_Tot_lid))
               in
-           if uu____21515
+           if uu____21570
            then
              (FStar_Parser_Const.effect_GTot_lid, identity_mlift,
                identity_mlift)
            else
-             (let uu____21526 =
+             (let uu____21581 =
                 FStar_All.pipe_right (env.effects).joins
                   (FStar_Util.find_opt
-                     (fun uu____21579  ->
-                        match uu____21579 with
-                        | (m1,m2,uu____21593,uu____21594,uu____21595) ->
+                     (fun uu____21634  ->
+                        match uu____21634 with
+                        | (m1,m2,uu____21648,uu____21649,uu____21650) ->
                             (FStar_Ident.lid_equals l1 m1) &&
                               (FStar_Ident.lid_equals l2 m2)))
                  in
-              match uu____21526 with
+              match uu____21581 with
               | FStar_Pervasives_Native.None  ->
-                  let uu____21612 =
-                    let uu____21618 =
-                      let uu____21620 = FStar_Syntax_Print.lid_to_string l1
+                  let uu____21667 =
+                    let uu____21673 =
+                      let uu____21675 = FStar_Syntax_Print.lid_to_string l1
                          in
-                      let uu____21622 = FStar_Syntax_Print.lid_to_string l2
+                      let uu____21677 = FStar_Syntax_Print.lid_to_string l2
                          in
                       FStar_Util.format2
-                        "Effects %s and %s cannot be composed" uu____21620
-                        uu____21622
+                        "Effects %s and %s cannot be composed" uu____21675
+                        uu____21677
                        in
-                    (FStar_Errors.Fatal_EffectsCannotBeComposed, uu____21618)
+                    (FStar_Errors.Fatal_EffectsCannotBeComposed, uu____21673)
                      in
-                  FStar_Errors.raise_error uu____21612 env.range
+                  FStar_Errors.raise_error uu____21667 env.range
               | FStar_Pervasives_Native.Some
-                  (uu____21632,uu____21633,m3,j1,j2) -> (m3, j1, j2)))
+                  (uu____21687,uu____21688,m3,j1,j2) -> (m3, j1, j2)))
   
 let (monad_leq :
   env ->
@@ -3898,12 +3917,12 @@ let (monad_leq :
   fun env  ->
     fun l1  ->
       fun l2  ->
-        let uu____21667 =
+        let uu____21722 =
           (FStar_Ident.lid_equals l1 l2) ||
             ((FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_Tot_lid) &&
                (FStar_Ident.lid_equals l2 FStar_Parser_Const.effect_GTot_lid))
            in
-        if uu____21667
+        if uu____21722
         then
           FStar_Pervasives_Native.Some
             { msource = l1; mtarget = l2; mlift = identity_mlift }
@@ -3915,44 +3934,44 @@ let (monad_leq :
                     (FStar_Ident.lid_equals l2 e.mtarget)))
   
 let wp_sig_aux :
-  'Auu____21687 .
-    (FStar_Syntax_Syntax.eff_decl * 'Auu____21687) Prims.list ->
+  'Auu____21742 .
+    (FStar_Syntax_Syntax.eff_decl * 'Auu____21742) Prims.list ->
       FStar_Ident.lident ->
         (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term'
           FStar_Syntax_Syntax.syntax)
   =
   fun decls  ->
     fun m  ->
-      let uu____21716 =
+      let uu____21771 =
         FStar_All.pipe_right decls
           (FStar_Util.find_opt
-             (fun uu____21742  ->
-                match uu____21742 with
-                | (d,uu____21749) ->
+             (fun uu____21797  ->
+                match uu____21797 with
+                | (d,uu____21804) ->
                     FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname m))
          in
-      match uu____21716 with
+      match uu____21771 with
       | FStar_Pervasives_Native.None  ->
-          let uu____21760 =
+          let uu____21815 =
             FStar_Util.format1
               "Impossible: declaration for monad %s not found"
               m.FStar_Ident.str
              in
-          failwith uu____21760
+          failwith uu____21815
       | FStar_Pervasives_Native.Some (md,_q) ->
-          let uu____21775 = inst_tscheme md.FStar_Syntax_Syntax.signature  in
-          (match uu____21775 with
-           | (uu____21786,s) ->
+          let uu____21830 = inst_tscheme md.FStar_Syntax_Syntax.signature  in
+          (match uu____21830 with
+           | (uu____21841,s) ->
                let s1 = FStar_Syntax_Subst.compress s  in
                (match ((md.FStar_Syntax_Syntax.binders),
                         (s1.FStar_Syntax_Syntax.n))
                 with
                 | ([],FStar_Syntax_Syntax.Tm_arrow
-                   ((a,uu____21804)::(wp,uu____21806)::[],c)) when
+                   ((a,uu____21859)::(wp,uu____21861)::[],c)) when
                     FStar_Syntax_Syntax.is_teff
                       (FStar_Syntax_Util.comp_result c)
                     -> (a, (wp.FStar_Syntax_Syntax.sort))
-                | uu____21862 -> failwith "Impossible"))
+                | uu____21917 -> failwith "Impossible"))
   
 let (wp_signature :
   env ->
@@ -3970,7 +3989,7 @@ let (comp_to_comp_typ :
         | FStar_Syntax_Syntax.GTotal (t,FStar_Pervasives_Native.None ) ->
             let u = env.universe_of env t  in
             FStar_Syntax_Syntax.mk_GTotal' t (FStar_Pervasives_Native.Some u)
-        | uu____21927 -> c  in
+        | uu____21982 -> c  in
       FStar_Syntax_Util.comp_to_comp_typ c1
   
 let rec (unfold_effect_abbrev :
@@ -3978,85 +3997,85 @@ let rec (unfold_effect_abbrev :
   fun env  ->
     fun comp  ->
       let c = comp_to_comp_typ env comp  in
-      let uu____21940 =
+      let uu____21995 =
         lookup_effect_abbrev env c.FStar_Syntax_Syntax.comp_univs
           c.FStar_Syntax_Syntax.effect_name
          in
-      match uu____21940 with
+      match uu____21995 with
       | FStar_Pervasives_Native.None  -> c
       | FStar_Pervasives_Native.Some (binders,cdef) ->
-          let uu____21957 = FStar_Syntax_Subst.open_comp binders cdef  in
-          (match uu____21957 with
+          let uu____22012 = FStar_Syntax_Subst.open_comp binders cdef  in
+          (match uu____22012 with
            | (binders1,cdef1) ->
                (if
                   (FStar_List.length binders1) <>
                     ((FStar_List.length c.FStar_Syntax_Syntax.effect_args) +
                        Prims.int_one)
                 then
-                  (let uu____21982 =
-                     let uu____21988 =
-                       let uu____21990 =
+                  (let uu____22037 =
+                     let uu____22043 =
+                       let uu____22045 =
                          FStar_Util.string_of_int
                            (FStar_List.length binders1)
                           in
-                       let uu____21998 =
+                       let uu____22053 =
                          FStar_Util.string_of_int
                            ((FStar_List.length
                                c.FStar_Syntax_Syntax.effect_args)
                               + Prims.int_one)
                           in
-                       let uu____22009 =
-                         let uu____22011 = FStar_Syntax_Syntax.mk_Comp c  in
-                         FStar_Syntax_Print.comp_to_string uu____22011  in
+                       let uu____22064 =
+                         let uu____22066 = FStar_Syntax_Syntax.mk_Comp c  in
+                         FStar_Syntax_Print.comp_to_string uu____22066  in
                        FStar_Util.format3
                          "Effect constructor is not fully applied; expected %s args, got %s args, i.e., %s"
-                         uu____21990 uu____21998 uu____22009
+                         uu____22045 uu____22053 uu____22064
                         in
                      (FStar_Errors.Fatal_ConstructorArgLengthMismatch,
-                       uu____21988)
+                       uu____22043)
                       in
-                   FStar_Errors.raise_error uu____21982
+                   FStar_Errors.raise_error uu____22037
                      comp.FStar_Syntax_Syntax.pos)
                 else ();
                 (let inst1 =
-                   let uu____22019 =
-                     let uu____22030 =
+                   let uu____22074 =
+                     let uu____22085 =
                        FStar_Syntax_Syntax.as_arg
                          c.FStar_Syntax_Syntax.result_typ
                         in
-                     uu____22030 :: (c.FStar_Syntax_Syntax.effect_args)  in
+                     uu____22085 :: (c.FStar_Syntax_Syntax.effect_args)  in
                    FStar_List.map2
-                     (fun uu____22067  ->
-                        fun uu____22068  ->
-                          match (uu____22067, uu____22068) with
-                          | ((x,uu____22098),(t,uu____22100)) ->
+                     (fun uu____22122  ->
+                        fun uu____22123  ->
+                          match (uu____22122, uu____22123) with
+                          | ((x,uu____22153),(t,uu____22155)) ->
                               FStar_Syntax_Syntax.NT (x, t)) binders1
-                     uu____22019
+                     uu____22074
                     in
                  let c1 = FStar_Syntax_Subst.subst_comp inst1 cdef1  in
                  let c2 =
-                   let uu____22131 =
-                     let uu___1579_22132 = comp_to_comp_typ env c1  in
+                   let uu____22186 =
+                     let uu___1597_22187 = comp_to_comp_typ env c1  in
                      {
                        FStar_Syntax_Syntax.comp_univs =
-                         (uu___1579_22132.FStar_Syntax_Syntax.comp_univs);
+                         (uu___1597_22187.FStar_Syntax_Syntax.comp_univs);
                        FStar_Syntax_Syntax.effect_name =
-                         (uu___1579_22132.FStar_Syntax_Syntax.effect_name);
+                         (uu___1597_22187.FStar_Syntax_Syntax.effect_name);
                        FStar_Syntax_Syntax.result_typ =
-                         (uu___1579_22132.FStar_Syntax_Syntax.result_typ);
+                         (uu___1597_22187.FStar_Syntax_Syntax.result_typ);
                        FStar_Syntax_Syntax.effect_args =
-                         (uu___1579_22132.FStar_Syntax_Syntax.effect_args);
+                         (uu___1597_22187.FStar_Syntax_Syntax.effect_args);
                        FStar_Syntax_Syntax.flags =
                          (c.FStar_Syntax_Syntax.flags)
                      }  in
-                   FStar_All.pipe_right uu____22131
+                   FStar_All.pipe_right uu____22186
                      FStar_Syntax_Syntax.mk_Comp
                     in
                  unfold_effect_abbrev env c2)))
   
 let effect_repr_aux :
-  'Auu____22144 .
-    'Auu____22144 ->
+  'Auu____22199 .
+    'Auu____22199 ->
       env ->
         FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
           FStar_Syntax_Syntax.universe ->
@@ -4069,55 +4088,55 @@ let effect_repr_aux :
         fun u_c  ->
           let effect_name =
             norm_eff_name env (FStar_Syntax_Util.comp_effect_name c)  in
-          let uu____22174 = effect_decl_opt env effect_name  in
-          match uu____22174 with
+          let uu____22229 = effect_decl_opt env effect_name  in
+          match uu____22229 with
           | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
           | FStar_Pervasives_Native.Some (ed,qualifiers) ->
               (match (FStar_Pervasives_Native.snd ed.FStar_Syntax_Syntax.repr).FStar_Syntax_Syntax.n
                with
                | FStar_Syntax_Syntax.Tm_unknown  ->
                    FStar_Pervasives_Native.None
-               | uu____22217 ->
+               | uu____22272 ->
                    let c1 = unfold_effect_abbrev env c  in
                    let res_typ = c1.FStar_Syntax_Syntax.result_typ  in
                    let wp =
                      match c1.FStar_Syntax_Syntax.effect_args with
-                     | hd1::uu____22240 -> hd1
+                     | hd1::uu____22295 -> hd1
                      | [] ->
                          let name = FStar_Ident.string_of_lid effect_name  in
                          let message =
-                           let uu____22279 =
+                           let uu____22334 =
                              FStar_Util.format1
                                "Not enough arguments for effect %s. " name
                               in
-                           Prims.op_Hat uu____22279
+                           Prims.op_Hat uu____22334
                              (Prims.op_Hat
                                 "This usually happens when you use a partially applied DM4F effect, "
                                 "like [TAC int] instead of [Tac int].")
                             in
-                         let uu____22284 = get_range env  in
+                         let uu____22339 = get_range env  in
                          FStar_Errors.raise_error
                            (FStar_Errors.Fatal_NotEnoughArgumentsForEffect,
-                             message) uu____22284
+                             message) uu____22339
                       in
                    let repr =
                      inst_effect_fun_with [u_c] env ed
                        ed.FStar_Syntax_Syntax.repr
                       in
-                   let uu____22295 =
-                     let uu____22298 = get_range env  in
-                     let uu____22299 =
-                       let uu____22306 =
-                         let uu____22307 =
-                           let uu____22324 =
-                             let uu____22335 =
+                   let uu____22350 =
+                     let uu____22353 = get_range env  in
+                     let uu____22354 =
+                       let uu____22361 =
+                         let uu____22362 =
+                           let uu____22379 =
+                             let uu____22390 =
                                FStar_Syntax_Syntax.as_arg res_typ  in
-                             [uu____22335; wp]  in
-                           (repr, uu____22324)  in
-                         FStar_Syntax_Syntax.Tm_app uu____22307  in
-                       FStar_Syntax_Syntax.mk uu____22306  in
-                     uu____22299 FStar_Pervasives_Native.None uu____22298  in
-                   FStar_Pervasives_Native.Some uu____22295)
+                             [uu____22390; wp]  in
+                           (repr, uu____22379)  in
+                         FStar_Syntax_Syntax.Tm_app uu____22362  in
+                       FStar_Syntax_Syntax.mk uu____22361  in
+                     uu____22354 FStar_Pervasives_Native.None uu____22353  in
+                   FStar_Pervasives_Native.Some uu____22350)
   
 let (effect_repr :
   env ->
@@ -4157,18 +4176,18 @@ let (is_reifiable_comp : env -> FStar_Syntax_Syntax.comp -> Prims.bool) =
       match c.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Comp ct ->
           is_reifiable_effect env ct.FStar_Syntax_Syntax.effect_name
-      | uu____22479 -> false
+      | uu____22534 -> false
   
 let (is_reifiable_function : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun env  ->
     fun t  ->
-      let uu____22494 =
-        let uu____22495 = FStar_Syntax_Subst.compress t  in
-        uu____22495.FStar_Syntax_Syntax.n  in
-      match uu____22494 with
-      | FStar_Syntax_Syntax.Tm_arrow (uu____22499,c) ->
+      let uu____22549 =
+        let uu____22550 = FStar_Syntax_Subst.compress t  in
+        uu____22550.FStar_Syntax_Syntax.n  in
+      match uu____22549 with
+      | FStar_Syntax_Syntax.Tm_arrow (uu____22554,c) ->
           is_reifiable_comp env c
-      | uu____22521 -> false
+      | uu____22576 -> false
   
 let (reify_comp :
   env ->
@@ -4179,22 +4198,22 @@ let (reify_comp :
     fun c  ->
       fun u_c  ->
         let l = FStar_Syntax_Util.comp_effect_name c  in
-        (let uu____22541 =
-           let uu____22543 = is_reifiable_effect env l  in
-           Prims.op_Negation uu____22543  in
-         if uu____22541
+        (let uu____22596 =
+           let uu____22598 = is_reifiable_effect env l  in
+           Prims.op_Negation uu____22598  in
+         if uu____22596
          then
-           let uu____22546 =
-             let uu____22552 =
-               let uu____22554 = FStar_Ident.string_of_lid l  in
-               FStar_Util.format1 "Effect %s cannot be reified" uu____22554
+           let uu____22601 =
+             let uu____22607 =
+               let uu____22609 = FStar_Ident.string_of_lid l  in
+               FStar_Util.format1 "Effect %s cannot be reified" uu____22609
                 in
-             (FStar_Errors.Fatal_EffectCannotBeReified, uu____22552)  in
-           let uu____22558 = get_range env  in
-           FStar_Errors.raise_error uu____22546 uu____22558
+             (FStar_Errors.Fatal_EffectCannotBeReified, uu____22607)  in
+           let uu____22613 = get_range env  in
+           FStar_Errors.raise_error uu____22601 uu____22613
          else ());
-        (let uu____22561 = effect_repr_aux true env c u_c  in
-         match uu____22561 with
+        (let uu____22616 = effect_repr_aux true env c u_c  in
+         match uu____22616 with
          | FStar_Pervasives_Native.None  ->
              failwith "internal error: reifiable effect has no repr?"
          | FStar_Pervasives_Native.Some tm -> tm)
@@ -4204,53 +4223,53 @@ let (push_sigelt : env -> FStar_Syntax_Syntax.sigelt -> env) =
     fun s  ->
       let sb = ((FStar_Syntax_Util.lids_of_sigelt s), s)  in
       let env1 =
-        let uu___1644_22597 = env  in
+        let uu___1662_22652 = env  in
         {
-          solver = (uu___1644_22597.solver);
-          range = (uu___1644_22597.range);
-          curmodule = (uu___1644_22597.curmodule);
-          gamma = (uu___1644_22597.gamma);
+          solver = (uu___1662_22652.solver);
+          range = (uu___1662_22652.range);
+          curmodule = (uu___1662_22652.curmodule);
+          gamma = (uu___1662_22652.gamma);
           gamma_sig = (sb :: (env.gamma_sig));
-          gamma_cache = (uu___1644_22597.gamma_cache);
-          modules = (uu___1644_22597.modules);
-          expected_typ = (uu___1644_22597.expected_typ);
-          sigtab = (uu___1644_22597.sigtab);
-          attrtab = (uu___1644_22597.attrtab);
-          is_pattern = (uu___1644_22597.is_pattern);
-          instantiate_imp = (uu___1644_22597.instantiate_imp);
-          effects = (uu___1644_22597.effects);
-          generalize = (uu___1644_22597.generalize);
-          letrecs = (uu___1644_22597.letrecs);
-          top_level = (uu___1644_22597.top_level);
-          check_uvars = (uu___1644_22597.check_uvars);
-          use_eq = (uu___1644_22597.use_eq);
-          is_iface = (uu___1644_22597.is_iface);
-          admit = (uu___1644_22597.admit);
-          lax = (uu___1644_22597.lax);
-          lax_universes = (uu___1644_22597.lax_universes);
-          phase1 = (uu___1644_22597.phase1);
-          failhard = (uu___1644_22597.failhard);
-          nosynth = (uu___1644_22597.nosynth);
-          uvar_subtyping = (uu___1644_22597.uvar_subtyping);
-          tc_term = (uu___1644_22597.tc_term);
-          type_of = (uu___1644_22597.type_of);
-          universe_of = (uu___1644_22597.universe_of);
-          check_type_of = (uu___1644_22597.check_type_of);
-          use_bv_sorts = (uu___1644_22597.use_bv_sorts);
-          qtbl_name_and_index = (uu___1644_22597.qtbl_name_and_index);
-          normalized_eff_names = (uu___1644_22597.normalized_eff_names);
-          fv_delta_depths = (uu___1644_22597.fv_delta_depths);
-          proof_ns = (uu___1644_22597.proof_ns);
-          synth_hook = (uu___1644_22597.synth_hook);
-          splice = (uu___1644_22597.splice);
-          postprocess = (uu___1644_22597.postprocess);
-          is_native_tactic = (uu___1644_22597.is_native_tactic);
-          identifier_info = (uu___1644_22597.identifier_info);
-          tc_hooks = (uu___1644_22597.tc_hooks);
-          dsenv = (uu___1644_22597.dsenv);
-          nbe = (uu___1644_22597.nbe);
-          strict_args_tab = (uu___1644_22597.strict_args_tab);
-          erasable_types_tab = (uu___1644_22597.erasable_types_tab)
+          gamma_cache = (uu___1662_22652.gamma_cache);
+          modules = (uu___1662_22652.modules);
+          expected_typ = (uu___1662_22652.expected_typ);
+          sigtab = (uu___1662_22652.sigtab);
+          attrtab = (uu___1662_22652.attrtab);
+          is_pattern = (uu___1662_22652.is_pattern);
+          instantiate_imp = (uu___1662_22652.instantiate_imp);
+          effects = (uu___1662_22652.effects);
+          generalize = (uu___1662_22652.generalize);
+          letrecs = (uu___1662_22652.letrecs);
+          top_level = (uu___1662_22652.top_level);
+          check_uvars = (uu___1662_22652.check_uvars);
+          use_eq = (uu___1662_22652.use_eq);
+          is_iface = (uu___1662_22652.is_iface);
+          admit = (uu___1662_22652.admit);
+          lax = (uu___1662_22652.lax);
+          lax_universes = (uu___1662_22652.lax_universes);
+          phase1 = (uu___1662_22652.phase1);
+          failhard = (uu___1662_22652.failhard);
+          nosynth = (uu___1662_22652.nosynth);
+          uvar_subtyping = (uu___1662_22652.uvar_subtyping);
+          tc_term = (uu___1662_22652.tc_term);
+          type_of = (uu___1662_22652.type_of);
+          universe_of = (uu___1662_22652.universe_of);
+          check_type_of = (uu___1662_22652.check_type_of);
+          use_bv_sorts = (uu___1662_22652.use_bv_sorts);
+          qtbl_name_and_index = (uu___1662_22652.qtbl_name_and_index);
+          normalized_eff_names = (uu___1662_22652.normalized_eff_names);
+          fv_delta_depths = (uu___1662_22652.fv_delta_depths);
+          proof_ns = (uu___1662_22652.proof_ns);
+          synth_hook = (uu___1662_22652.synth_hook);
+          splice = (uu___1662_22652.splice);
+          postprocess = (uu___1662_22652.postprocess);
+          is_native_tactic = (uu___1662_22652.is_native_tactic);
+          identifier_info = (uu___1662_22652.identifier_info);
+          tc_hooks = (uu___1662_22652.tc_hooks);
+          dsenv = (uu___1662_22652.dsenv);
+          nbe = (uu___1662_22652.nbe);
+          strict_args_tab = (uu___1662_22652.strict_args_tab);
+          erasable_types_tab = (uu___1662_22652.erasable_types_tab)
         }  in
       add_sigelt env1 s;
       (env1.tc_hooks).tc_push_in_gamma_hook env1 (FStar_Util.Inr sb);
@@ -4262,63 +4281,63 @@ let (push_new_effect :
       -> env)
   =
   fun env  ->
-    fun uu____22616  ->
-      match uu____22616 with
+    fun uu____22671  ->
+      match uu____22671 with
       | (ed,quals) ->
           let effects =
-            let uu___1653_22630 = env.effects  in
+            let uu___1671_22685 = env.effects  in
             {
               decls = ((ed, quals) :: ((env.effects).decls));
-              order = (uu___1653_22630.order);
-              joins = (uu___1653_22630.joins)
+              order = (uu___1671_22685.order);
+              joins = (uu___1671_22685.joins)
             }  in
-          let uu___1656_22639 = env  in
+          let uu___1674_22694 = env  in
           {
-            solver = (uu___1656_22639.solver);
-            range = (uu___1656_22639.range);
-            curmodule = (uu___1656_22639.curmodule);
-            gamma = (uu___1656_22639.gamma);
-            gamma_sig = (uu___1656_22639.gamma_sig);
-            gamma_cache = (uu___1656_22639.gamma_cache);
-            modules = (uu___1656_22639.modules);
-            expected_typ = (uu___1656_22639.expected_typ);
-            sigtab = (uu___1656_22639.sigtab);
-            attrtab = (uu___1656_22639.attrtab);
-            is_pattern = (uu___1656_22639.is_pattern);
-            instantiate_imp = (uu___1656_22639.instantiate_imp);
+            solver = (uu___1674_22694.solver);
+            range = (uu___1674_22694.range);
+            curmodule = (uu___1674_22694.curmodule);
+            gamma = (uu___1674_22694.gamma);
+            gamma_sig = (uu___1674_22694.gamma_sig);
+            gamma_cache = (uu___1674_22694.gamma_cache);
+            modules = (uu___1674_22694.modules);
+            expected_typ = (uu___1674_22694.expected_typ);
+            sigtab = (uu___1674_22694.sigtab);
+            attrtab = (uu___1674_22694.attrtab);
+            is_pattern = (uu___1674_22694.is_pattern);
+            instantiate_imp = (uu___1674_22694.instantiate_imp);
             effects;
-            generalize = (uu___1656_22639.generalize);
-            letrecs = (uu___1656_22639.letrecs);
-            top_level = (uu___1656_22639.top_level);
-            check_uvars = (uu___1656_22639.check_uvars);
-            use_eq = (uu___1656_22639.use_eq);
-            is_iface = (uu___1656_22639.is_iface);
-            admit = (uu___1656_22639.admit);
-            lax = (uu___1656_22639.lax);
-            lax_universes = (uu___1656_22639.lax_universes);
-            phase1 = (uu___1656_22639.phase1);
-            failhard = (uu___1656_22639.failhard);
-            nosynth = (uu___1656_22639.nosynth);
-            uvar_subtyping = (uu___1656_22639.uvar_subtyping);
-            tc_term = (uu___1656_22639.tc_term);
-            type_of = (uu___1656_22639.type_of);
-            universe_of = (uu___1656_22639.universe_of);
-            check_type_of = (uu___1656_22639.check_type_of);
-            use_bv_sorts = (uu___1656_22639.use_bv_sorts);
-            qtbl_name_and_index = (uu___1656_22639.qtbl_name_and_index);
-            normalized_eff_names = (uu___1656_22639.normalized_eff_names);
-            fv_delta_depths = (uu___1656_22639.fv_delta_depths);
-            proof_ns = (uu___1656_22639.proof_ns);
-            synth_hook = (uu___1656_22639.synth_hook);
-            splice = (uu___1656_22639.splice);
-            postprocess = (uu___1656_22639.postprocess);
-            is_native_tactic = (uu___1656_22639.is_native_tactic);
-            identifier_info = (uu___1656_22639.identifier_info);
-            tc_hooks = (uu___1656_22639.tc_hooks);
-            dsenv = (uu___1656_22639.dsenv);
-            nbe = (uu___1656_22639.nbe);
-            strict_args_tab = (uu___1656_22639.strict_args_tab);
-            erasable_types_tab = (uu___1656_22639.erasable_types_tab)
+            generalize = (uu___1674_22694.generalize);
+            letrecs = (uu___1674_22694.letrecs);
+            top_level = (uu___1674_22694.top_level);
+            check_uvars = (uu___1674_22694.check_uvars);
+            use_eq = (uu___1674_22694.use_eq);
+            is_iface = (uu___1674_22694.is_iface);
+            admit = (uu___1674_22694.admit);
+            lax = (uu___1674_22694.lax);
+            lax_universes = (uu___1674_22694.lax_universes);
+            phase1 = (uu___1674_22694.phase1);
+            failhard = (uu___1674_22694.failhard);
+            nosynth = (uu___1674_22694.nosynth);
+            uvar_subtyping = (uu___1674_22694.uvar_subtyping);
+            tc_term = (uu___1674_22694.tc_term);
+            type_of = (uu___1674_22694.type_of);
+            universe_of = (uu___1674_22694.universe_of);
+            check_type_of = (uu___1674_22694.check_type_of);
+            use_bv_sorts = (uu___1674_22694.use_bv_sorts);
+            qtbl_name_and_index = (uu___1674_22694.qtbl_name_and_index);
+            normalized_eff_names = (uu___1674_22694.normalized_eff_names);
+            fv_delta_depths = (uu___1674_22694.fv_delta_depths);
+            proof_ns = (uu___1674_22694.proof_ns);
+            synth_hook = (uu___1674_22694.synth_hook);
+            splice = (uu___1674_22694.splice);
+            postprocess = (uu___1674_22694.postprocess);
+            is_native_tactic = (uu___1674_22694.is_native_tactic);
+            identifier_info = (uu___1674_22694.identifier_info);
+            tc_hooks = (uu___1674_22694.tc_hooks);
+            dsenv = (uu___1674_22694.dsenv);
+            nbe = (uu___1674_22694.nbe);
+            strict_args_tab = (uu___1674_22694.strict_args_tab);
+            erasable_types_tab = (uu___1674_22694.erasable_types_tab)
           }
   
 let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
@@ -4327,8 +4346,8 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
       let compose_edges e1 e2 =
         let composed_lift =
           let mlift_wp u r wp1 =
-            let uu____22679 = (e1.mlift).mlift_wp u r wp1  in
-            (e2.mlift).mlift_wp u r uu____22679  in
+            let uu____22734 = (e1.mlift).mlift_wp u r wp1  in
+            (e2.mlift).mlift_wp u r uu____22734  in
           let mlift_term =
             match (((e1.mlift).mlift_term), ((e2.mlift).mlift_term)) with
             | (FStar_Pervasives_Native.Some l1,FStar_Pervasives_Native.Some
@@ -4338,10 +4357,10 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
                       fun t  ->
                         fun wp  ->
                           fun e  ->
-                            let uu____22837 = (e1.mlift).mlift_wp u t wp  in
-                            let uu____22838 = l1 u t wp e  in
-                            l2 u t uu____22837 uu____22838))
-            | uu____22839 -> FStar_Pervasives_Native.None  in
+                            let uu____22892 = (e1.mlift).mlift_wp u t wp  in
+                            let uu____22893 = l1 u t wp e  in
+                            l2 u t uu____22892 uu____22893))
+            | uu____22894 -> FStar_Pervasives_Native.None  in
           { mlift_wp; mlift_term }  in
         {
           msource = (e1.msource);
@@ -4349,22 +4368,22 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
           mlift = composed_lift
         }  in
       let mk_mlift_wp lift_t u r wp1 =
-        let uu____22911 = inst_tscheme_with lift_t [u]  in
-        match uu____22911 with
-        | (uu____22918,lift_t1) ->
-            let uu____22920 =
-              let uu____22927 =
-                let uu____22928 =
-                  let uu____22945 =
-                    let uu____22956 = FStar_Syntax_Syntax.as_arg r  in
-                    let uu____22965 =
-                      let uu____22976 = FStar_Syntax_Syntax.as_arg wp1  in
-                      [uu____22976]  in
-                    uu____22956 :: uu____22965  in
-                  (lift_t1, uu____22945)  in
-                FStar_Syntax_Syntax.Tm_app uu____22928  in
-              FStar_Syntax_Syntax.mk uu____22927  in
-            uu____22920 FStar_Pervasives_Native.None
+        let uu____22966 = inst_tscheme_with lift_t [u]  in
+        match uu____22966 with
+        | (uu____22973,lift_t1) ->
+            let uu____22975 =
+              let uu____22982 =
+                let uu____22983 =
+                  let uu____23000 =
+                    let uu____23011 = FStar_Syntax_Syntax.as_arg r  in
+                    let uu____23020 =
+                      let uu____23031 = FStar_Syntax_Syntax.as_arg wp1  in
+                      [uu____23031]  in
+                    uu____23011 :: uu____23020  in
+                  (lift_t1, uu____23000)  in
+                FStar_Syntax_Syntax.Tm_app uu____22983  in
+              FStar_Syntax_Syntax.mk uu____22982  in
+            uu____22975 FStar_Pervasives_Native.None
               wp1.FStar_Syntax_Syntax.pos
          in
       let sub_mlift_wp =
@@ -4374,25 +4393,25 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
             failwith "sub effect should've been elaborated at this stage"
          in
       let mk_mlift_term lift_t u r wp1 e =
-        let uu____23086 = inst_tscheme_with lift_t [u]  in
-        match uu____23086 with
-        | (uu____23093,lift_t1) ->
-            let uu____23095 =
-              let uu____23102 =
-                let uu____23103 =
-                  let uu____23120 =
-                    let uu____23131 = FStar_Syntax_Syntax.as_arg r  in
-                    let uu____23140 =
-                      let uu____23151 = FStar_Syntax_Syntax.as_arg wp1  in
-                      let uu____23160 =
-                        let uu____23171 = FStar_Syntax_Syntax.as_arg e  in
-                        [uu____23171]  in
-                      uu____23151 :: uu____23160  in
-                    uu____23131 :: uu____23140  in
-                  (lift_t1, uu____23120)  in
-                FStar_Syntax_Syntax.Tm_app uu____23103  in
-              FStar_Syntax_Syntax.mk uu____23102  in
-            uu____23095 FStar_Pervasives_Native.None
+        let uu____23141 = inst_tscheme_with lift_t [u]  in
+        match uu____23141 with
+        | (uu____23148,lift_t1) ->
+            let uu____23150 =
+              let uu____23157 =
+                let uu____23158 =
+                  let uu____23175 =
+                    let uu____23186 = FStar_Syntax_Syntax.as_arg r  in
+                    let uu____23195 =
+                      let uu____23206 = FStar_Syntax_Syntax.as_arg wp1  in
+                      let uu____23215 =
+                        let uu____23226 = FStar_Syntax_Syntax.as_arg e  in
+                        [uu____23226]  in
+                      uu____23206 :: uu____23215  in
+                    uu____23186 :: uu____23195  in
+                  (lift_t1, uu____23175)  in
+                FStar_Syntax_Syntax.Tm_app uu____23158  in
+              FStar_Syntax_Syntax.mk uu____23157  in
+            uu____23150 FStar_Pervasives_Native.None
               e.FStar_Syntax_Syntax.pos
          in
       let sub_mlift_term =
@@ -4411,45 +4430,45 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
         }  in
       let print_mlift l =
         let bogus_term s =
-          let uu____23273 =
-            let uu____23274 =
+          let uu____23328 =
+            let uu____23329 =
               FStar_Ident.lid_of_path [s] FStar_Range.dummyRange  in
-            FStar_Syntax_Syntax.lid_as_fv uu____23274
+            FStar_Syntax_Syntax.lid_as_fv uu____23329
               FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
              in
-          FStar_Syntax_Syntax.fv_to_tm uu____23273  in
+          FStar_Syntax_Syntax.fv_to_tm uu____23328  in
         let arg = bogus_term "ARG"  in
         let wp = bogus_term "WP"  in
         let e = bogus_term "COMP"  in
-        let uu____23283 =
-          let uu____23285 = l.mlift_wp FStar_Syntax_Syntax.U_zero arg wp  in
-          FStar_Syntax_Print.term_to_string uu____23285  in
-        let uu____23286 =
-          let uu____23288 =
+        let uu____23338 =
+          let uu____23340 = l.mlift_wp FStar_Syntax_Syntax.U_zero arg wp  in
+          FStar_Syntax_Print.term_to_string uu____23340  in
+        let uu____23341 =
+          let uu____23343 =
             FStar_Util.map_opt l.mlift_term
               (fun l1  ->
-                 let uu____23316 = l1 FStar_Syntax_Syntax.U_zero arg wp e  in
-                 FStar_Syntax_Print.term_to_string uu____23316)
+                 let uu____23371 = l1 FStar_Syntax_Syntax.U_zero arg wp e  in
+                 FStar_Syntax_Print.term_to_string uu____23371)
              in
-          FStar_Util.dflt "none" uu____23288  in
-        FStar_Util.format2 "{ wp : %s ; term : %s }" uu____23283 uu____23286
+          FStar_Util.dflt "none" uu____23343  in
+        FStar_Util.format2 "{ wp : %s ; term : %s }" uu____23338 uu____23341
          in
       let order = edge :: ((env.effects).order)  in
       let ms =
         FStar_All.pipe_right (env.effects).decls
           (FStar_List.map
-             (fun uu____23345  ->
-                match uu____23345 with
-                | (e,uu____23353) -> e.FStar_Syntax_Syntax.mname))
+             (fun uu____23400  ->
+                match uu____23400 with
+                | (e,uu____23408) -> e.FStar_Syntax_Syntax.mname))
          in
-      let find_edge order1 uu____23376 =
-        match uu____23376 with
+      let find_edge order1 uu____23431 =
+        match uu____23431 with
         | (i,j) ->
-            let uu____23387 = FStar_Ident.lid_equals i j  in
-            if uu____23387
+            let uu____23442 = FStar_Ident.lid_equals i j  in
+            if uu____23442
             then
               FStar_All.pipe_right (id_edge i)
-                (fun _23394  -> FStar_Pervasives_Native.Some _23394)
+                (fun _23449  -> FStar_Pervasives_Native.Some _23449)
             else
               FStar_All.pipe_right order1
                 (FStar_Util.find_opt
@@ -4459,37 +4478,37 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
          in
       let order1 =
         let fold_fun order1 k =
-          let uu____23423 =
+          let uu____23478 =
             FStar_All.pipe_right ms
               (FStar_List.collect
                  (fun i  ->
-                    let uu____23433 = FStar_Ident.lid_equals i k  in
-                    if uu____23433
+                    let uu____23488 = FStar_Ident.lid_equals i k  in
+                    if uu____23488
                     then []
                     else
                       FStar_All.pipe_right ms
                         (FStar_List.collect
                            (fun j  ->
-                              let uu____23447 = FStar_Ident.lid_equals j k
+                              let uu____23502 = FStar_Ident.lid_equals j k
                                  in
-                              if uu____23447
+                              if uu____23502
                               then []
                               else
-                                (let uu____23454 =
-                                   let uu____23463 = find_edge order1 (i, k)
+                                (let uu____23509 =
+                                   let uu____23518 = find_edge order1 (i, k)
                                       in
-                                   let uu____23466 = find_edge order1 (k, j)
+                                   let uu____23521 = find_edge order1 (k, j)
                                       in
-                                   (uu____23463, uu____23466)  in
-                                 match uu____23454 with
+                                   (uu____23518, uu____23521)  in
+                                 match uu____23509 with
                                  | (FStar_Pervasives_Native.Some
                                     e1,FStar_Pervasives_Native.Some e2) ->
-                                     let uu____23481 = compose_edges e1 e2
+                                     let uu____23536 = compose_edges e1 e2
                                         in
-                                     [uu____23481]
-                                 | uu____23482 -> [])))))
+                                     [uu____23536]
+                                 | uu____23537 -> [])))))
              in
-          FStar_List.append order1 uu____23423  in
+          FStar_List.append order1 uu____23478  in
         FStar_All.pipe_right ms (FStar_List.fold_left fold_fun order)  in
       let order2 =
         FStar_Util.remove_dups
@@ -4501,28 +4520,28 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
       FStar_All.pipe_right order2
         (FStar_List.iter
            (fun edge1  ->
-              let uu____23512 =
+              let uu____23567 =
                 (FStar_Ident.lid_equals edge1.msource
                    FStar_Parser_Const.effect_DIV_lid)
                   &&
-                  (let uu____23515 = lookup_effect_quals env edge1.mtarget
+                  (let uu____23570 = lookup_effect_quals env edge1.mtarget
                       in
-                   FStar_All.pipe_right uu____23515
+                   FStar_All.pipe_right uu____23570
                      (FStar_List.contains FStar_Syntax_Syntax.TotalEffect))
                  in
-              if uu____23512
+              if uu____23567
               then
-                let uu____23522 =
-                  let uu____23528 =
+                let uu____23577 =
+                  let uu____23583 =
                     FStar_Util.format1
                       "Divergent computations cannot be included in an effect %s marked 'total'"
                       (edge1.mtarget).FStar_Ident.str
                      in
                   (FStar_Errors.Fatal_DivergentComputationCannotBeIncludedInTotal,
-                    uu____23528)
+                    uu____23583)
                    in
-                let uu____23532 = get_range env  in
-                FStar_Errors.raise_error uu____23522 uu____23532
+                let uu____23587 = get_range env  in
+                FStar_Errors.raise_error uu____23577 uu____23587
               else ()));
       (let joins =
          FStar_All.pipe_right ms
@@ -4532,8 +4551,8 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
                    (FStar_List.collect
                       (fun j  ->
                          let join_opt =
-                           let uu____23610 = FStar_Ident.lid_equals i j  in
-                           if uu____23610
+                           let uu____23665 = FStar_Ident.lid_equals i j  in
+                           if uu____23665
                            then
                              FStar_Pervasives_Native.Some
                                (i, (id_edge i), (id_edge i))
@@ -4542,13 +4561,13 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
                                (FStar_List.fold_left
                                   (fun bopt  ->
                                      fun k  ->
-                                       let uu____23662 =
-                                         let uu____23671 =
+                                       let uu____23717 =
+                                         let uu____23726 =
                                            find_edge order2 (i, k)  in
-                                         let uu____23674 =
+                                         let uu____23729 =
                                            find_edge order2 (j, k)  in
-                                         (uu____23671, uu____23674)  in
-                                       match uu____23662 with
+                                         (uu____23726, uu____23729)  in
+                                       match uu____23717 with
                                        | (FStar_Pervasives_Native.Some
                                           ik,FStar_Pervasives_Native.Some jk)
                                            ->
@@ -4558,34 +4577,34 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
                                                 FStar_Pervasives_Native.Some
                                                   (k, ik, jk)
                                             | FStar_Pervasives_Native.Some
-                                                (ub,uu____23716,uu____23717)
+                                                (ub,uu____23771,uu____23772)
                                                 ->
-                                                let uu____23724 =
-                                                  let uu____23731 =
-                                                    let uu____23733 =
+                                                let uu____23779 =
+                                                  let uu____23786 =
+                                                    let uu____23788 =
                                                       find_edge order2
                                                         (k, ub)
                                                        in
                                                     FStar_Util.is_some
-                                                      uu____23733
+                                                      uu____23788
                                                      in
-                                                  let uu____23736 =
-                                                    let uu____23738 =
+                                                  let uu____23791 =
+                                                    let uu____23793 =
                                                       find_edge order2
                                                         (ub, k)
                                                        in
                                                     FStar_Util.is_some
-                                                      uu____23738
+                                                      uu____23793
                                                      in
-                                                  (uu____23731, uu____23736)
+                                                  (uu____23786, uu____23791)
                                                    in
-                                                (match uu____23724 with
+                                                (match uu____23779 with
                                                  | (true ,true ) ->
-                                                     let uu____23755 =
+                                                     let uu____23810 =
                                                        FStar_Ident.lid_equals
                                                          k ub
                                                         in
-                                                     if uu____23755
+                                                     if uu____23810
                                                      then
                                                        (FStar_Errors.log_issue
                                                           FStar_Range.dummyRange
@@ -4600,7 +4619,7 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
                                                      FStar_Pervasives_Native.Some
                                                        (k, ik, jk)
                                                  | (false ,true ) -> bopt))
-                                       | uu____23798 -> bopt)
+                                       | uu____23853 -> bopt)
                                   FStar_Pervasives_Native.None)
                             in
                          match join_opt with
@@ -4609,107 +4628,107 @@ let (update_effect_lattice : env -> FStar_Syntax_Syntax.sub_eff -> env) =
                              [(i, j, k, (e1.mlift), (e2.mlift))]))))
           in
        let effects =
-         let uu___1783_23871 = env.effects  in
-         { decls = (uu___1783_23871.decls); order = order2; joins }  in
-       let uu___1786_23872 = env  in
+         let uu___1801_23926 = env.effects  in
+         { decls = (uu___1801_23926.decls); order = order2; joins }  in
+       let uu___1804_23927 = env  in
        {
-         solver = (uu___1786_23872.solver);
-         range = (uu___1786_23872.range);
-         curmodule = (uu___1786_23872.curmodule);
-         gamma = (uu___1786_23872.gamma);
-         gamma_sig = (uu___1786_23872.gamma_sig);
-         gamma_cache = (uu___1786_23872.gamma_cache);
-         modules = (uu___1786_23872.modules);
-         expected_typ = (uu___1786_23872.expected_typ);
-         sigtab = (uu___1786_23872.sigtab);
-         attrtab = (uu___1786_23872.attrtab);
-         is_pattern = (uu___1786_23872.is_pattern);
-         instantiate_imp = (uu___1786_23872.instantiate_imp);
+         solver = (uu___1804_23927.solver);
+         range = (uu___1804_23927.range);
+         curmodule = (uu___1804_23927.curmodule);
+         gamma = (uu___1804_23927.gamma);
+         gamma_sig = (uu___1804_23927.gamma_sig);
+         gamma_cache = (uu___1804_23927.gamma_cache);
+         modules = (uu___1804_23927.modules);
+         expected_typ = (uu___1804_23927.expected_typ);
+         sigtab = (uu___1804_23927.sigtab);
+         attrtab = (uu___1804_23927.attrtab);
+         is_pattern = (uu___1804_23927.is_pattern);
+         instantiate_imp = (uu___1804_23927.instantiate_imp);
          effects;
-         generalize = (uu___1786_23872.generalize);
-         letrecs = (uu___1786_23872.letrecs);
-         top_level = (uu___1786_23872.top_level);
-         check_uvars = (uu___1786_23872.check_uvars);
-         use_eq = (uu___1786_23872.use_eq);
-         is_iface = (uu___1786_23872.is_iface);
-         admit = (uu___1786_23872.admit);
-         lax = (uu___1786_23872.lax);
-         lax_universes = (uu___1786_23872.lax_universes);
-         phase1 = (uu___1786_23872.phase1);
-         failhard = (uu___1786_23872.failhard);
-         nosynth = (uu___1786_23872.nosynth);
-         uvar_subtyping = (uu___1786_23872.uvar_subtyping);
-         tc_term = (uu___1786_23872.tc_term);
-         type_of = (uu___1786_23872.type_of);
-         universe_of = (uu___1786_23872.universe_of);
-         check_type_of = (uu___1786_23872.check_type_of);
-         use_bv_sorts = (uu___1786_23872.use_bv_sorts);
-         qtbl_name_and_index = (uu___1786_23872.qtbl_name_and_index);
-         normalized_eff_names = (uu___1786_23872.normalized_eff_names);
-         fv_delta_depths = (uu___1786_23872.fv_delta_depths);
-         proof_ns = (uu___1786_23872.proof_ns);
-         synth_hook = (uu___1786_23872.synth_hook);
-         splice = (uu___1786_23872.splice);
-         postprocess = (uu___1786_23872.postprocess);
-         is_native_tactic = (uu___1786_23872.is_native_tactic);
-         identifier_info = (uu___1786_23872.identifier_info);
-         tc_hooks = (uu___1786_23872.tc_hooks);
-         dsenv = (uu___1786_23872.dsenv);
-         nbe = (uu___1786_23872.nbe);
-         strict_args_tab = (uu___1786_23872.strict_args_tab);
-         erasable_types_tab = (uu___1786_23872.erasable_types_tab)
+         generalize = (uu___1804_23927.generalize);
+         letrecs = (uu___1804_23927.letrecs);
+         top_level = (uu___1804_23927.top_level);
+         check_uvars = (uu___1804_23927.check_uvars);
+         use_eq = (uu___1804_23927.use_eq);
+         is_iface = (uu___1804_23927.is_iface);
+         admit = (uu___1804_23927.admit);
+         lax = (uu___1804_23927.lax);
+         lax_universes = (uu___1804_23927.lax_universes);
+         phase1 = (uu___1804_23927.phase1);
+         failhard = (uu___1804_23927.failhard);
+         nosynth = (uu___1804_23927.nosynth);
+         uvar_subtyping = (uu___1804_23927.uvar_subtyping);
+         tc_term = (uu___1804_23927.tc_term);
+         type_of = (uu___1804_23927.type_of);
+         universe_of = (uu___1804_23927.universe_of);
+         check_type_of = (uu___1804_23927.check_type_of);
+         use_bv_sorts = (uu___1804_23927.use_bv_sorts);
+         qtbl_name_and_index = (uu___1804_23927.qtbl_name_and_index);
+         normalized_eff_names = (uu___1804_23927.normalized_eff_names);
+         fv_delta_depths = (uu___1804_23927.fv_delta_depths);
+         proof_ns = (uu___1804_23927.proof_ns);
+         synth_hook = (uu___1804_23927.synth_hook);
+         splice = (uu___1804_23927.splice);
+         postprocess = (uu___1804_23927.postprocess);
+         is_native_tactic = (uu___1804_23927.is_native_tactic);
+         identifier_info = (uu___1804_23927.identifier_info);
+         tc_hooks = (uu___1804_23927.tc_hooks);
+         dsenv = (uu___1804_23927.dsenv);
+         nbe = (uu___1804_23927.nbe);
+         strict_args_tab = (uu___1804_23927.strict_args_tab);
+         erasable_types_tab = (uu___1804_23927.erasable_types_tab)
        })
   
 let (push_local_binding : env -> FStar_Syntax_Syntax.binding -> env) =
   fun env  ->
     fun b  ->
-      let uu___1790_23884 = env  in
+      let uu___1808_23939 = env  in
       {
-        solver = (uu___1790_23884.solver);
-        range = (uu___1790_23884.range);
-        curmodule = (uu___1790_23884.curmodule);
+        solver = (uu___1808_23939.solver);
+        range = (uu___1808_23939.range);
+        curmodule = (uu___1808_23939.curmodule);
         gamma = (b :: (env.gamma));
-        gamma_sig = (uu___1790_23884.gamma_sig);
-        gamma_cache = (uu___1790_23884.gamma_cache);
-        modules = (uu___1790_23884.modules);
-        expected_typ = (uu___1790_23884.expected_typ);
-        sigtab = (uu___1790_23884.sigtab);
-        attrtab = (uu___1790_23884.attrtab);
-        is_pattern = (uu___1790_23884.is_pattern);
-        instantiate_imp = (uu___1790_23884.instantiate_imp);
-        effects = (uu___1790_23884.effects);
-        generalize = (uu___1790_23884.generalize);
-        letrecs = (uu___1790_23884.letrecs);
-        top_level = (uu___1790_23884.top_level);
-        check_uvars = (uu___1790_23884.check_uvars);
-        use_eq = (uu___1790_23884.use_eq);
-        is_iface = (uu___1790_23884.is_iface);
-        admit = (uu___1790_23884.admit);
-        lax = (uu___1790_23884.lax);
-        lax_universes = (uu___1790_23884.lax_universes);
-        phase1 = (uu___1790_23884.phase1);
-        failhard = (uu___1790_23884.failhard);
-        nosynth = (uu___1790_23884.nosynth);
-        uvar_subtyping = (uu___1790_23884.uvar_subtyping);
-        tc_term = (uu___1790_23884.tc_term);
-        type_of = (uu___1790_23884.type_of);
-        universe_of = (uu___1790_23884.universe_of);
-        check_type_of = (uu___1790_23884.check_type_of);
-        use_bv_sorts = (uu___1790_23884.use_bv_sorts);
-        qtbl_name_and_index = (uu___1790_23884.qtbl_name_and_index);
-        normalized_eff_names = (uu___1790_23884.normalized_eff_names);
-        fv_delta_depths = (uu___1790_23884.fv_delta_depths);
-        proof_ns = (uu___1790_23884.proof_ns);
-        synth_hook = (uu___1790_23884.synth_hook);
-        splice = (uu___1790_23884.splice);
-        postprocess = (uu___1790_23884.postprocess);
-        is_native_tactic = (uu___1790_23884.is_native_tactic);
-        identifier_info = (uu___1790_23884.identifier_info);
-        tc_hooks = (uu___1790_23884.tc_hooks);
-        dsenv = (uu___1790_23884.dsenv);
-        nbe = (uu___1790_23884.nbe);
-        strict_args_tab = (uu___1790_23884.strict_args_tab);
-        erasable_types_tab = (uu___1790_23884.erasable_types_tab)
+        gamma_sig = (uu___1808_23939.gamma_sig);
+        gamma_cache = (uu___1808_23939.gamma_cache);
+        modules = (uu___1808_23939.modules);
+        expected_typ = (uu___1808_23939.expected_typ);
+        sigtab = (uu___1808_23939.sigtab);
+        attrtab = (uu___1808_23939.attrtab);
+        is_pattern = (uu___1808_23939.is_pattern);
+        instantiate_imp = (uu___1808_23939.instantiate_imp);
+        effects = (uu___1808_23939.effects);
+        generalize = (uu___1808_23939.generalize);
+        letrecs = (uu___1808_23939.letrecs);
+        top_level = (uu___1808_23939.top_level);
+        check_uvars = (uu___1808_23939.check_uvars);
+        use_eq = (uu___1808_23939.use_eq);
+        is_iface = (uu___1808_23939.is_iface);
+        admit = (uu___1808_23939.admit);
+        lax = (uu___1808_23939.lax);
+        lax_universes = (uu___1808_23939.lax_universes);
+        phase1 = (uu___1808_23939.phase1);
+        failhard = (uu___1808_23939.failhard);
+        nosynth = (uu___1808_23939.nosynth);
+        uvar_subtyping = (uu___1808_23939.uvar_subtyping);
+        tc_term = (uu___1808_23939.tc_term);
+        type_of = (uu___1808_23939.type_of);
+        universe_of = (uu___1808_23939.universe_of);
+        check_type_of = (uu___1808_23939.check_type_of);
+        use_bv_sorts = (uu___1808_23939.use_bv_sorts);
+        qtbl_name_and_index = (uu___1808_23939.qtbl_name_and_index);
+        normalized_eff_names = (uu___1808_23939.normalized_eff_names);
+        fv_delta_depths = (uu___1808_23939.fv_delta_depths);
+        proof_ns = (uu___1808_23939.proof_ns);
+        synth_hook = (uu___1808_23939.synth_hook);
+        splice = (uu___1808_23939.splice);
+        postprocess = (uu___1808_23939.postprocess);
+        is_native_tactic = (uu___1808_23939.is_native_tactic);
+        identifier_info = (uu___1808_23939.identifier_info);
+        tc_hooks = (uu___1808_23939.tc_hooks);
+        dsenv = (uu___1808_23939.dsenv);
+        nbe = (uu___1808_23939.nbe);
+        strict_args_tab = (uu___1808_23939.strict_args_tab);
+        erasable_types_tab = (uu___1808_23939.erasable_types_tab)
       }
   
 let (push_bv : env -> FStar_Syntax_Syntax.bv -> env) =
@@ -4728,63 +4747,63 @@ let (pop_bv :
     | (FStar_Syntax_Syntax.Binding_var x)::rest ->
         FStar_Pervasives_Native.Some
           (x,
-            (let uu___1803_23942 = env  in
+            (let uu___1821_23997 = env  in
              {
-               solver = (uu___1803_23942.solver);
-               range = (uu___1803_23942.range);
-               curmodule = (uu___1803_23942.curmodule);
+               solver = (uu___1821_23997.solver);
+               range = (uu___1821_23997.range);
+               curmodule = (uu___1821_23997.curmodule);
                gamma = rest;
-               gamma_sig = (uu___1803_23942.gamma_sig);
-               gamma_cache = (uu___1803_23942.gamma_cache);
-               modules = (uu___1803_23942.modules);
-               expected_typ = (uu___1803_23942.expected_typ);
-               sigtab = (uu___1803_23942.sigtab);
-               attrtab = (uu___1803_23942.attrtab);
-               is_pattern = (uu___1803_23942.is_pattern);
-               instantiate_imp = (uu___1803_23942.instantiate_imp);
-               effects = (uu___1803_23942.effects);
-               generalize = (uu___1803_23942.generalize);
-               letrecs = (uu___1803_23942.letrecs);
-               top_level = (uu___1803_23942.top_level);
-               check_uvars = (uu___1803_23942.check_uvars);
-               use_eq = (uu___1803_23942.use_eq);
-               is_iface = (uu___1803_23942.is_iface);
-               admit = (uu___1803_23942.admit);
-               lax = (uu___1803_23942.lax);
-               lax_universes = (uu___1803_23942.lax_universes);
-               phase1 = (uu___1803_23942.phase1);
-               failhard = (uu___1803_23942.failhard);
-               nosynth = (uu___1803_23942.nosynth);
-               uvar_subtyping = (uu___1803_23942.uvar_subtyping);
-               tc_term = (uu___1803_23942.tc_term);
-               type_of = (uu___1803_23942.type_of);
-               universe_of = (uu___1803_23942.universe_of);
-               check_type_of = (uu___1803_23942.check_type_of);
-               use_bv_sorts = (uu___1803_23942.use_bv_sorts);
-               qtbl_name_and_index = (uu___1803_23942.qtbl_name_and_index);
-               normalized_eff_names = (uu___1803_23942.normalized_eff_names);
-               fv_delta_depths = (uu___1803_23942.fv_delta_depths);
-               proof_ns = (uu___1803_23942.proof_ns);
-               synth_hook = (uu___1803_23942.synth_hook);
-               splice = (uu___1803_23942.splice);
-               postprocess = (uu___1803_23942.postprocess);
-               is_native_tactic = (uu___1803_23942.is_native_tactic);
-               identifier_info = (uu___1803_23942.identifier_info);
-               tc_hooks = (uu___1803_23942.tc_hooks);
-               dsenv = (uu___1803_23942.dsenv);
-               nbe = (uu___1803_23942.nbe);
-               strict_args_tab = (uu___1803_23942.strict_args_tab);
-               erasable_types_tab = (uu___1803_23942.erasable_types_tab)
+               gamma_sig = (uu___1821_23997.gamma_sig);
+               gamma_cache = (uu___1821_23997.gamma_cache);
+               modules = (uu___1821_23997.modules);
+               expected_typ = (uu___1821_23997.expected_typ);
+               sigtab = (uu___1821_23997.sigtab);
+               attrtab = (uu___1821_23997.attrtab);
+               is_pattern = (uu___1821_23997.is_pattern);
+               instantiate_imp = (uu___1821_23997.instantiate_imp);
+               effects = (uu___1821_23997.effects);
+               generalize = (uu___1821_23997.generalize);
+               letrecs = (uu___1821_23997.letrecs);
+               top_level = (uu___1821_23997.top_level);
+               check_uvars = (uu___1821_23997.check_uvars);
+               use_eq = (uu___1821_23997.use_eq);
+               is_iface = (uu___1821_23997.is_iface);
+               admit = (uu___1821_23997.admit);
+               lax = (uu___1821_23997.lax);
+               lax_universes = (uu___1821_23997.lax_universes);
+               phase1 = (uu___1821_23997.phase1);
+               failhard = (uu___1821_23997.failhard);
+               nosynth = (uu___1821_23997.nosynth);
+               uvar_subtyping = (uu___1821_23997.uvar_subtyping);
+               tc_term = (uu___1821_23997.tc_term);
+               type_of = (uu___1821_23997.type_of);
+               universe_of = (uu___1821_23997.universe_of);
+               check_type_of = (uu___1821_23997.check_type_of);
+               use_bv_sorts = (uu___1821_23997.use_bv_sorts);
+               qtbl_name_and_index = (uu___1821_23997.qtbl_name_and_index);
+               normalized_eff_names = (uu___1821_23997.normalized_eff_names);
+               fv_delta_depths = (uu___1821_23997.fv_delta_depths);
+               proof_ns = (uu___1821_23997.proof_ns);
+               synth_hook = (uu___1821_23997.synth_hook);
+               splice = (uu___1821_23997.splice);
+               postprocess = (uu___1821_23997.postprocess);
+               is_native_tactic = (uu___1821_23997.is_native_tactic);
+               identifier_info = (uu___1821_23997.identifier_info);
+               tc_hooks = (uu___1821_23997.tc_hooks);
+               dsenv = (uu___1821_23997.dsenv);
+               nbe = (uu___1821_23997.nbe);
+               strict_args_tab = (uu___1821_23997.strict_args_tab);
+               erasable_types_tab = (uu___1821_23997.erasable_types_tab)
              }))
-    | uu____23943 -> FStar_Pervasives_Native.None
+    | uu____23998 -> FStar_Pervasives_Native.None
   
 let (push_binders : env -> FStar_Syntax_Syntax.binders -> env) =
   fun env  ->
     fun bs  ->
       FStar_List.fold_left
         (fun env1  ->
-           fun uu____23972  ->
-             match uu____23972 with | (x,uu____23980) -> push_bv env1 x) env
+           fun uu____24027  ->
+             match uu____24027 with | (x,uu____24035) -> push_bv env1 x) env
         bs
   
 let (binding_of_lb :
@@ -4797,12 +4816,12 @@ let (binding_of_lb :
       match x with
       | FStar_Util.Inl x1 ->
           let x2 =
-            let uu___1817_24015 = x1  in
+            let uu___1835_24070 = x1  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___1817_24015.FStar_Syntax_Syntax.ppname);
+                (uu___1835_24070.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___1817_24015.FStar_Syntax_Syntax.index);
+                (uu___1835_24070.FStar_Syntax_Syntax.index);
               FStar_Syntax_Syntax.sort = (FStar_Pervasives_Native.snd t)
             }  in
           FStar_Syntax_Syntax.Binding_var x2
@@ -4834,64 +4853,64 @@ let (open_universes_in :
   fun env  ->
     fun uvs  ->
       fun terms  ->
-        let uu____24088 = FStar_Syntax_Subst.univ_var_opening uvs  in
-        match uu____24088 with
+        let uu____24143 = FStar_Syntax_Subst.univ_var_opening uvs  in
+        match uu____24143 with
         | (univ_subst,univ_vars) ->
             let env' = push_univ_vars env univ_vars  in
-            let uu____24116 =
+            let uu____24171 =
               FStar_List.map (FStar_Syntax_Subst.subst univ_subst) terms  in
-            (env', univ_vars, uu____24116)
+            (env', univ_vars, uu____24171)
   
 let (set_expected_typ : env -> FStar_Syntax_Syntax.typ -> env) =
   fun env  ->
     fun t  ->
-      let uu___1838_24132 = env  in
+      let uu___1856_24187 = env  in
       {
-        solver = (uu___1838_24132.solver);
-        range = (uu___1838_24132.range);
-        curmodule = (uu___1838_24132.curmodule);
-        gamma = (uu___1838_24132.gamma);
-        gamma_sig = (uu___1838_24132.gamma_sig);
-        gamma_cache = (uu___1838_24132.gamma_cache);
-        modules = (uu___1838_24132.modules);
+        solver = (uu___1856_24187.solver);
+        range = (uu___1856_24187.range);
+        curmodule = (uu___1856_24187.curmodule);
+        gamma = (uu___1856_24187.gamma);
+        gamma_sig = (uu___1856_24187.gamma_sig);
+        gamma_cache = (uu___1856_24187.gamma_cache);
+        modules = (uu___1856_24187.modules);
         expected_typ = (FStar_Pervasives_Native.Some t);
-        sigtab = (uu___1838_24132.sigtab);
-        attrtab = (uu___1838_24132.attrtab);
-        is_pattern = (uu___1838_24132.is_pattern);
-        instantiate_imp = (uu___1838_24132.instantiate_imp);
-        effects = (uu___1838_24132.effects);
-        generalize = (uu___1838_24132.generalize);
-        letrecs = (uu___1838_24132.letrecs);
-        top_level = (uu___1838_24132.top_level);
-        check_uvars = (uu___1838_24132.check_uvars);
+        sigtab = (uu___1856_24187.sigtab);
+        attrtab = (uu___1856_24187.attrtab);
+        is_pattern = (uu___1856_24187.is_pattern);
+        instantiate_imp = (uu___1856_24187.instantiate_imp);
+        effects = (uu___1856_24187.effects);
+        generalize = (uu___1856_24187.generalize);
+        letrecs = (uu___1856_24187.letrecs);
+        top_level = (uu___1856_24187.top_level);
+        check_uvars = (uu___1856_24187.check_uvars);
         use_eq = false;
-        is_iface = (uu___1838_24132.is_iface);
-        admit = (uu___1838_24132.admit);
-        lax = (uu___1838_24132.lax);
-        lax_universes = (uu___1838_24132.lax_universes);
-        phase1 = (uu___1838_24132.phase1);
-        failhard = (uu___1838_24132.failhard);
-        nosynth = (uu___1838_24132.nosynth);
-        uvar_subtyping = (uu___1838_24132.uvar_subtyping);
-        tc_term = (uu___1838_24132.tc_term);
-        type_of = (uu___1838_24132.type_of);
-        universe_of = (uu___1838_24132.universe_of);
-        check_type_of = (uu___1838_24132.check_type_of);
-        use_bv_sorts = (uu___1838_24132.use_bv_sorts);
-        qtbl_name_and_index = (uu___1838_24132.qtbl_name_and_index);
-        normalized_eff_names = (uu___1838_24132.normalized_eff_names);
-        fv_delta_depths = (uu___1838_24132.fv_delta_depths);
-        proof_ns = (uu___1838_24132.proof_ns);
-        synth_hook = (uu___1838_24132.synth_hook);
-        splice = (uu___1838_24132.splice);
-        postprocess = (uu___1838_24132.postprocess);
-        is_native_tactic = (uu___1838_24132.is_native_tactic);
-        identifier_info = (uu___1838_24132.identifier_info);
-        tc_hooks = (uu___1838_24132.tc_hooks);
-        dsenv = (uu___1838_24132.dsenv);
-        nbe = (uu___1838_24132.nbe);
-        strict_args_tab = (uu___1838_24132.strict_args_tab);
-        erasable_types_tab = (uu___1838_24132.erasable_types_tab)
+        is_iface = (uu___1856_24187.is_iface);
+        admit = (uu___1856_24187.admit);
+        lax = (uu___1856_24187.lax);
+        lax_universes = (uu___1856_24187.lax_universes);
+        phase1 = (uu___1856_24187.phase1);
+        failhard = (uu___1856_24187.failhard);
+        nosynth = (uu___1856_24187.nosynth);
+        uvar_subtyping = (uu___1856_24187.uvar_subtyping);
+        tc_term = (uu___1856_24187.tc_term);
+        type_of = (uu___1856_24187.type_of);
+        universe_of = (uu___1856_24187.universe_of);
+        check_type_of = (uu___1856_24187.check_type_of);
+        use_bv_sorts = (uu___1856_24187.use_bv_sorts);
+        qtbl_name_and_index = (uu___1856_24187.qtbl_name_and_index);
+        normalized_eff_names = (uu___1856_24187.normalized_eff_names);
+        fv_delta_depths = (uu___1856_24187.fv_delta_depths);
+        proof_ns = (uu___1856_24187.proof_ns);
+        synth_hook = (uu___1856_24187.synth_hook);
+        splice = (uu___1856_24187.splice);
+        postprocess = (uu___1856_24187.postprocess);
+        is_native_tactic = (uu___1856_24187.is_native_tactic);
+        identifier_info = (uu___1856_24187.identifier_info);
+        tc_hooks = (uu___1856_24187.tc_hooks);
+        dsenv = (uu___1856_24187.dsenv);
+        nbe = (uu___1856_24187.nbe);
+        strict_args_tab = (uu___1856_24187.strict_args_tab);
+        erasable_types_tab = (uu___1856_24187.erasable_types_tab)
       }
   
 let (expected_typ :
@@ -4904,124 +4923,124 @@ let (expected_typ :
 let (clear_expected_typ :
   env -> (env * FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option)) =
   fun env_  ->
-    let uu____24163 = expected_typ env_  in
-    ((let uu___1845_24169 = env_  in
+    let uu____24218 = expected_typ env_  in
+    ((let uu___1863_24224 = env_  in
       {
-        solver = (uu___1845_24169.solver);
-        range = (uu___1845_24169.range);
-        curmodule = (uu___1845_24169.curmodule);
-        gamma = (uu___1845_24169.gamma);
-        gamma_sig = (uu___1845_24169.gamma_sig);
-        gamma_cache = (uu___1845_24169.gamma_cache);
-        modules = (uu___1845_24169.modules);
+        solver = (uu___1863_24224.solver);
+        range = (uu___1863_24224.range);
+        curmodule = (uu___1863_24224.curmodule);
+        gamma = (uu___1863_24224.gamma);
+        gamma_sig = (uu___1863_24224.gamma_sig);
+        gamma_cache = (uu___1863_24224.gamma_cache);
+        modules = (uu___1863_24224.modules);
         expected_typ = FStar_Pervasives_Native.None;
-        sigtab = (uu___1845_24169.sigtab);
-        attrtab = (uu___1845_24169.attrtab);
-        is_pattern = (uu___1845_24169.is_pattern);
-        instantiate_imp = (uu___1845_24169.instantiate_imp);
-        effects = (uu___1845_24169.effects);
-        generalize = (uu___1845_24169.generalize);
-        letrecs = (uu___1845_24169.letrecs);
-        top_level = (uu___1845_24169.top_level);
-        check_uvars = (uu___1845_24169.check_uvars);
+        sigtab = (uu___1863_24224.sigtab);
+        attrtab = (uu___1863_24224.attrtab);
+        is_pattern = (uu___1863_24224.is_pattern);
+        instantiate_imp = (uu___1863_24224.instantiate_imp);
+        effects = (uu___1863_24224.effects);
+        generalize = (uu___1863_24224.generalize);
+        letrecs = (uu___1863_24224.letrecs);
+        top_level = (uu___1863_24224.top_level);
+        check_uvars = (uu___1863_24224.check_uvars);
         use_eq = false;
-        is_iface = (uu___1845_24169.is_iface);
-        admit = (uu___1845_24169.admit);
-        lax = (uu___1845_24169.lax);
-        lax_universes = (uu___1845_24169.lax_universes);
-        phase1 = (uu___1845_24169.phase1);
-        failhard = (uu___1845_24169.failhard);
-        nosynth = (uu___1845_24169.nosynth);
-        uvar_subtyping = (uu___1845_24169.uvar_subtyping);
-        tc_term = (uu___1845_24169.tc_term);
-        type_of = (uu___1845_24169.type_of);
-        universe_of = (uu___1845_24169.universe_of);
-        check_type_of = (uu___1845_24169.check_type_of);
-        use_bv_sorts = (uu___1845_24169.use_bv_sorts);
-        qtbl_name_and_index = (uu___1845_24169.qtbl_name_and_index);
-        normalized_eff_names = (uu___1845_24169.normalized_eff_names);
-        fv_delta_depths = (uu___1845_24169.fv_delta_depths);
-        proof_ns = (uu___1845_24169.proof_ns);
-        synth_hook = (uu___1845_24169.synth_hook);
-        splice = (uu___1845_24169.splice);
-        postprocess = (uu___1845_24169.postprocess);
-        is_native_tactic = (uu___1845_24169.is_native_tactic);
-        identifier_info = (uu___1845_24169.identifier_info);
-        tc_hooks = (uu___1845_24169.tc_hooks);
-        dsenv = (uu___1845_24169.dsenv);
-        nbe = (uu___1845_24169.nbe);
-        strict_args_tab = (uu___1845_24169.strict_args_tab);
-        erasable_types_tab = (uu___1845_24169.erasable_types_tab)
-      }), uu____24163)
+        is_iface = (uu___1863_24224.is_iface);
+        admit = (uu___1863_24224.admit);
+        lax = (uu___1863_24224.lax);
+        lax_universes = (uu___1863_24224.lax_universes);
+        phase1 = (uu___1863_24224.phase1);
+        failhard = (uu___1863_24224.failhard);
+        nosynth = (uu___1863_24224.nosynth);
+        uvar_subtyping = (uu___1863_24224.uvar_subtyping);
+        tc_term = (uu___1863_24224.tc_term);
+        type_of = (uu___1863_24224.type_of);
+        universe_of = (uu___1863_24224.universe_of);
+        check_type_of = (uu___1863_24224.check_type_of);
+        use_bv_sorts = (uu___1863_24224.use_bv_sorts);
+        qtbl_name_and_index = (uu___1863_24224.qtbl_name_and_index);
+        normalized_eff_names = (uu___1863_24224.normalized_eff_names);
+        fv_delta_depths = (uu___1863_24224.fv_delta_depths);
+        proof_ns = (uu___1863_24224.proof_ns);
+        synth_hook = (uu___1863_24224.synth_hook);
+        splice = (uu___1863_24224.splice);
+        postprocess = (uu___1863_24224.postprocess);
+        is_native_tactic = (uu___1863_24224.is_native_tactic);
+        identifier_info = (uu___1863_24224.identifier_info);
+        tc_hooks = (uu___1863_24224.tc_hooks);
+        dsenv = (uu___1863_24224.dsenv);
+        nbe = (uu___1863_24224.nbe);
+        strict_args_tab = (uu___1863_24224.strict_args_tab);
+        erasable_types_tab = (uu___1863_24224.erasable_types_tab)
+      }), uu____24218)
   
 let (finish_module : env -> FStar_Syntax_Syntax.modul -> env) =
   let empty_lid =
-    let uu____24181 =
-      let uu____24184 = FStar_Ident.id_of_text ""  in [uu____24184]  in
-    FStar_Ident.lid_of_ids uu____24181  in
+    let uu____24236 =
+      let uu____24239 = FStar_Ident.id_of_text ""  in [uu____24239]  in
+    FStar_Ident.lid_of_ids uu____24236  in
   fun env  ->
     fun m  ->
       let sigs =
-        let uu____24191 =
+        let uu____24246 =
           FStar_Ident.lid_equals m.FStar_Syntax_Syntax.name
             FStar_Parser_Const.prims_lid
            in
-        if uu____24191
+        if uu____24246
         then
-          let uu____24196 =
+          let uu____24251 =
             FStar_All.pipe_right env.gamma_sig
               (FStar_List.map FStar_Pervasives_Native.snd)
              in
-          FStar_All.pipe_right uu____24196 FStar_List.rev
+          FStar_All.pipe_right uu____24251 FStar_List.rev
         else m.FStar_Syntax_Syntax.exports  in
       add_sigelts env sigs;
-      (let uu___1853_24224 = env  in
+      (let uu___1871_24279 = env  in
        {
-         solver = (uu___1853_24224.solver);
-         range = (uu___1853_24224.range);
+         solver = (uu___1871_24279.solver);
+         range = (uu___1871_24279.range);
          curmodule = empty_lid;
          gamma = [];
          gamma_sig = [];
-         gamma_cache = (uu___1853_24224.gamma_cache);
+         gamma_cache = (uu___1871_24279.gamma_cache);
          modules = (m :: (env.modules));
-         expected_typ = (uu___1853_24224.expected_typ);
-         sigtab = (uu___1853_24224.sigtab);
-         attrtab = (uu___1853_24224.attrtab);
-         is_pattern = (uu___1853_24224.is_pattern);
-         instantiate_imp = (uu___1853_24224.instantiate_imp);
-         effects = (uu___1853_24224.effects);
-         generalize = (uu___1853_24224.generalize);
-         letrecs = (uu___1853_24224.letrecs);
-         top_level = (uu___1853_24224.top_level);
-         check_uvars = (uu___1853_24224.check_uvars);
-         use_eq = (uu___1853_24224.use_eq);
-         is_iface = (uu___1853_24224.is_iface);
-         admit = (uu___1853_24224.admit);
-         lax = (uu___1853_24224.lax);
-         lax_universes = (uu___1853_24224.lax_universes);
-         phase1 = (uu___1853_24224.phase1);
-         failhard = (uu___1853_24224.failhard);
-         nosynth = (uu___1853_24224.nosynth);
-         uvar_subtyping = (uu___1853_24224.uvar_subtyping);
-         tc_term = (uu___1853_24224.tc_term);
-         type_of = (uu___1853_24224.type_of);
-         universe_of = (uu___1853_24224.universe_of);
-         check_type_of = (uu___1853_24224.check_type_of);
-         use_bv_sorts = (uu___1853_24224.use_bv_sorts);
-         qtbl_name_and_index = (uu___1853_24224.qtbl_name_and_index);
-         normalized_eff_names = (uu___1853_24224.normalized_eff_names);
-         fv_delta_depths = (uu___1853_24224.fv_delta_depths);
-         proof_ns = (uu___1853_24224.proof_ns);
-         synth_hook = (uu___1853_24224.synth_hook);
-         splice = (uu___1853_24224.splice);
-         postprocess = (uu___1853_24224.postprocess);
-         is_native_tactic = (uu___1853_24224.is_native_tactic);
-         identifier_info = (uu___1853_24224.identifier_info);
-         tc_hooks = (uu___1853_24224.tc_hooks);
-         dsenv = (uu___1853_24224.dsenv);
-         nbe = (uu___1853_24224.nbe);
-         strict_args_tab = (uu___1853_24224.strict_args_tab);
-         erasable_types_tab = (uu___1853_24224.erasable_types_tab)
+         expected_typ = (uu___1871_24279.expected_typ);
+         sigtab = (uu___1871_24279.sigtab);
+         attrtab = (uu___1871_24279.attrtab);
+         is_pattern = (uu___1871_24279.is_pattern);
+         instantiate_imp = (uu___1871_24279.instantiate_imp);
+         effects = (uu___1871_24279.effects);
+         generalize = (uu___1871_24279.generalize);
+         letrecs = (uu___1871_24279.letrecs);
+         top_level = (uu___1871_24279.top_level);
+         check_uvars = (uu___1871_24279.check_uvars);
+         use_eq = (uu___1871_24279.use_eq);
+         is_iface = (uu___1871_24279.is_iface);
+         admit = (uu___1871_24279.admit);
+         lax = (uu___1871_24279.lax);
+         lax_universes = (uu___1871_24279.lax_universes);
+         phase1 = (uu___1871_24279.phase1);
+         failhard = (uu___1871_24279.failhard);
+         nosynth = (uu___1871_24279.nosynth);
+         uvar_subtyping = (uu___1871_24279.uvar_subtyping);
+         tc_term = (uu___1871_24279.tc_term);
+         type_of = (uu___1871_24279.type_of);
+         universe_of = (uu___1871_24279.universe_of);
+         check_type_of = (uu___1871_24279.check_type_of);
+         use_bv_sorts = (uu___1871_24279.use_bv_sorts);
+         qtbl_name_and_index = (uu___1871_24279.qtbl_name_and_index);
+         normalized_eff_names = (uu___1871_24279.normalized_eff_names);
+         fv_delta_depths = (uu___1871_24279.fv_delta_depths);
+         proof_ns = (uu___1871_24279.proof_ns);
+         synth_hook = (uu___1871_24279.synth_hook);
+         splice = (uu___1871_24279.splice);
+         postprocess = (uu___1871_24279.postprocess);
+         is_native_tactic = (uu___1871_24279.is_native_tactic);
+         identifier_info = (uu___1871_24279.identifier_info);
+         tc_hooks = (uu___1871_24279.tc_hooks);
+         dsenv = (uu___1871_24279.dsenv);
+         nbe = (uu___1871_24279.nbe);
+         strict_args_tab = (uu___1871_24279.strict_args_tab);
+         erasable_types_tab = (uu___1871_24279.erasable_types_tab)
        })
   
 let (uvars_in_env : env -> FStar_Syntax_Syntax.uvars) =
@@ -5031,22 +5050,22 @@ let (uvars_in_env : env -> FStar_Syntax_Syntax.uvars) =
     let rec aux out g =
       match g with
       | [] -> out
-      | (FStar_Syntax_Syntax.Binding_univ uu____24276)::tl1 -> aux out tl1
-      | (FStar_Syntax_Syntax.Binding_lid (uu____24280,(uu____24281,t)))::tl1
+      | (FStar_Syntax_Syntax.Binding_univ uu____24331)::tl1 -> aux out tl1
+      | (FStar_Syntax_Syntax.Binding_lid (uu____24335,(uu____24336,t)))::tl1
           ->
-          let uu____24302 =
-            let uu____24305 = FStar_Syntax_Free.uvars t  in
-            ext out uu____24305  in
-          aux uu____24302 tl1
+          let uu____24357 =
+            let uu____24360 = FStar_Syntax_Free.uvars t  in
+            ext out uu____24360  in
+          aux uu____24357 tl1
       | (FStar_Syntax_Syntax.Binding_var
-          { FStar_Syntax_Syntax.ppname = uu____24308;
-            FStar_Syntax_Syntax.index = uu____24309;
+          { FStar_Syntax_Syntax.ppname = uu____24363;
+            FStar_Syntax_Syntax.index = uu____24364;
             FStar_Syntax_Syntax.sort = t;_})::tl1
           ->
-          let uu____24317 =
-            let uu____24320 = FStar_Syntax_Free.uvars t  in
-            ext out uu____24320  in
-          aux uu____24317 tl1
+          let uu____24372 =
+            let uu____24375 = FStar_Syntax_Free.uvars t  in
+            ext out uu____24375  in
+          aux uu____24372 tl1
        in
     aux no_uvs env.gamma
   
@@ -5057,22 +5076,22 @@ let (univ_vars : env -> FStar_Syntax_Syntax.universe_uvar FStar_Util.set) =
     let rec aux out g =
       match g with
       | [] -> out
-      | (FStar_Syntax_Syntax.Binding_univ uu____24378)::tl1 -> aux out tl1
-      | (FStar_Syntax_Syntax.Binding_lid (uu____24382,(uu____24383,t)))::tl1
+      | (FStar_Syntax_Syntax.Binding_univ uu____24433)::tl1 -> aux out tl1
+      | (FStar_Syntax_Syntax.Binding_lid (uu____24437,(uu____24438,t)))::tl1
           ->
-          let uu____24404 =
-            let uu____24407 = FStar_Syntax_Free.univs t  in
-            ext out uu____24407  in
-          aux uu____24404 tl1
+          let uu____24459 =
+            let uu____24462 = FStar_Syntax_Free.univs t  in
+            ext out uu____24462  in
+          aux uu____24459 tl1
       | (FStar_Syntax_Syntax.Binding_var
-          { FStar_Syntax_Syntax.ppname = uu____24410;
-            FStar_Syntax_Syntax.index = uu____24411;
+          { FStar_Syntax_Syntax.ppname = uu____24465;
+            FStar_Syntax_Syntax.index = uu____24466;
             FStar_Syntax_Syntax.sort = t;_})::tl1
           ->
-          let uu____24419 =
-            let uu____24422 = FStar_Syntax_Free.univs t  in
-            ext out uu____24422  in
-          aux uu____24419 tl1
+          let uu____24474 =
+            let uu____24477 = FStar_Syntax_Free.univs t  in
+            ext out uu____24477  in
+          aux uu____24474 tl1
        in
     aux no_univs env.gamma
   
@@ -5084,23 +5103,23 @@ let (univnames : env -> FStar_Syntax_Syntax.univ_name FStar_Util.set) =
       match g with
       | [] -> out
       | (FStar_Syntax_Syntax.Binding_univ uname)::tl1 ->
-          let uu____24484 = FStar_Util.set_add uname out  in
-          aux uu____24484 tl1
-      | (FStar_Syntax_Syntax.Binding_lid (uu____24487,(uu____24488,t)))::tl1
+          let uu____24539 = FStar_Util.set_add uname out  in
+          aux uu____24539 tl1
+      | (FStar_Syntax_Syntax.Binding_lid (uu____24542,(uu____24543,t)))::tl1
           ->
-          let uu____24509 =
-            let uu____24512 = FStar_Syntax_Free.univnames t  in
-            ext out uu____24512  in
-          aux uu____24509 tl1
+          let uu____24564 =
+            let uu____24567 = FStar_Syntax_Free.univnames t  in
+            ext out uu____24567  in
+          aux uu____24564 tl1
       | (FStar_Syntax_Syntax.Binding_var
-          { FStar_Syntax_Syntax.ppname = uu____24515;
-            FStar_Syntax_Syntax.index = uu____24516;
+          { FStar_Syntax_Syntax.ppname = uu____24570;
+            FStar_Syntax_Syntax.index = uu____24571;
             FStar_Syntax_Syntax.sort = t;_})::tl1
           ->
-          let uu____24524 =
-            let uu____24527 = FStar_Syntax_Free.univnames t  in
-            ext out uu____24527  in
-          aux uu____24524 tl1
+          let uu____24579 =
+            let uu____24582 = FStar_Syntax_Free.univnames t  in
+            ext out uu____24582  in
+          aux uu____24579 tl1
        in
     aux no_univ_names env.gamma
   
@@ -5110,21 +5129,21 @@ let (bound_vars_of_bindings :
   fun bs  ->
     FStar_All.pipe_right bs
       (FStar_List.collect
-         (fun uu___11_24548  ->
-            match uu___11_24548 with
+         (fun uu___11_24603  ->
+            match uu___11_24603 with
             | FStar_Syntax_Syntax.Binding_var x -> [x]
-            | FStar_Syntax_Syntax.Binding_lid uu____24552 -> []
-            | FStar_Syntax_Syntax.Binding_univ uu____24565 -> []))
+            | FStar_Syntax_Syntax.Binding_lid uu____24607 -> []
+            | FStar_Syntax_Syntax.Binding_univ uu____24620 -> []))
   
 let (binders_of_bindings :
   FStar_Syntax_Syntax.binding Prims.list -> FStar_Syntax_Syntax.binders) =
   fun bs  ->
-    let uu____24576 =
-      let uu____24585 = bound_vars_of_bindings bs  in
-      FStar_All.pipe_right uu____24585
+    let uu____24631 =
+      let uu____24640 = bound_vars_of_bindings bs  in
+      FStar_All.pipe_right uu____24640
         (FStar_List.map FStar_Syntax_Syntax.mk_binder)
        in
-    FStar_All.pipe_right uu____24576 FStar_List.rev
+    FStar_All.pipe_right uu____24631 FStar_List.rev
   
 let (bound_vars : env -> FStar_Syntax_Syntax.bv Prims.list) =
   fun env  -> bound_vars_of_bindings env.gamma 
@@ -5132,38 +5151,38 @@ let (all_binders : env -> FStar_Syntax_Syntax.binders) =
   fun env  -> binders_of_bindings env.gamma 
 let (print_gamma : FStar_Syntax_Syntax.gamma -> Prims.string) =
   fun gamma  ->
-    let uu____24633 =
+    let uu____24688 =
       FStar_All.pipe_right gamma
         (FStar_List.map
-           (fun uu___12_24646  ->
-              match uu___12_24646 with
+           (fun uu___12_24701  ->
+              match uu___12_24701 with
               | FStar_Syntax_Syntax.Binding_var x ->
-                  let uu____24649 = FStar_Syntax_Print.bv_to_string x  in
-                  Prims.op_Hat "Binding_var " uu____24649
+                  let uu____24704 = FStar_Syntax_Print.bv_to_string x  in
+                  Prims.op_Hat "Binding_var " uu____24704
               | FStar_Syntax_Syntax.Binding_univ u ->
                   Prims.op_Hat "Binding_univ " u.FStar_Ident.idText
-              | FStar_Syntax_Syntax.Binding_lid (l,uu____24655) ->
-                  let uu____24672 = FStar_Ident.string_of_lid l  in
-                  Prims.op_Hat "Binding_lid " uu____24672))
+              | FStar_Syntax_Syntax.Binding_lid (l,uu____24710) ->
+                  let uu____24727 = FStar_Ident.string_of_lid l  in
+                  Prims.op_Hat "Binding_lid " uu____24727))
        in
-    FStar_All.pipe_right uu____24633 (FStar_String.concat "::\n")
+    FStar_All.pipe_right uu____24688 (FStar_String.concat "::\n")
   
 let (string_of_delta_level : delta_level -> Prims.string) =
-  fun uu___13_24686  ->
-    match uu___13_24686 with
+  fun uu___13_24741  ->
+    match uu___13_24741 with
     | NoDelta  -> "NoDelta"
     | InliningDelta  -> "Inlining"
     | Eager_unfolding_only  -> "Eager_unfolding_only"
     | Unfold d ->
-        let uu____24692 = FStar_Syntax_Print.delta_depth_to_string d  in
-        Prims.op_Hat "Unfold " uu____24692
+        let uu____24747 = FStar_Syntax_Print.delta_depth_to_string d  in
+        Prims.op_Hat "Unfold " uu____24747
   
 let (lidents : env -> FStar_Ident.lident Prims.list) =
   fun env  ->
     let keys = FStar_List.collect FStar_Pervasives_Native.fst env.gamma_sig
        in
     FStar_Util.smap_fold (sigtab env)
-      (fun uu____24715  ->
+      (fun uu____24770  ->
          fun v1  ->
            fun keys1  ->
              FStar_List.append (FStar_Syntax_Util.lids_of_sigelt v1) keys1)
@@ -5174,78 +5193,78 @@ let (should_enc_path : env -> Prims.string Prims.list -> Prims.bool) =
     fun path  ->
       let rec str_i_prefix xs ys =
         match (xs, ys) with
-        | ([],uu____24770) -> true
+        | ([],uu____24825) -> true
         | (x::xs1,y::ys1) ->
             ((FStar_String.lowercase x) = (FStar_String.lowercase y)) &&
               (str_i_prefix xs1 ys1)
-        | (uu____24803,uu____24804) -> false  in
-      let uu____24818 =
+        | (uu____24858,uu____24859) -> false  in
+      let uu____24873 =
         FStar_List.tryFind
-          (fun uu____24840  ->
-             match uu____24840 with | (p,uu____24851) -> str_i_prefix p path)
+          (fun uu____24895  ->
+             match uu____24895 with | (p,uu____24906) -> str_i_prefix p path)
           env.proof_ns
          in
-      match uu____24818 with
+      match uu____24873 with
       | FStar_Pervasives_Native.None  -> false
-      | FStar_Pervasives_Native.Some (uu____24870,b) -> b
+      | FStar_Pervasives_Native.Some (uu____24925,b) -> b
   
 let (should_enc_lid : env -> FStar_Ident.lident -> Prims.bool) =
   fun env  ->
     fun lid  ->
-      let uu____24900 = FStar_Ident.path_of_lid lid  in
-      should_enc_path env uu____24900
+      let uu____24955 = FStar_Ident.path_of_lid lid  in
+      should_enc_path env uu____24955
   
 let (cons_proof_ns : Prims.bool -> env -> name_prefix -> env) =
   fun b  ->
     fun e  ->
       fun path  ->
-        let uu___1996_24922 = e  in
+        let uu___2014_24977 = e  in
         {
-          solver = (uu___1996_24922.solver);
-          range = (uu___1996_24922.range);
-          curmodule = (uu___1996_24922.curmodule);
-          gamma = (uu___1996_24922.gamma);
-          gamma_sig = (uu___1996_24922.gamma_sig);
-          gamma_cache = (uu___1996_24922.gamma_cache);
-          modules = (uu___1996_24922.modules);
-          expected_typ = (uu___1996_24922.expected_typ);
-          sigtab = (uu___1996_24922.sigtab);
-          attrtab = (uu___1996_24922.attrtab);
-          is_pattern = (uu___1996_24922.is_pattern);
-          instantiate_imp = (uu___1996_24922.instantiate_imp);
-          effects = (uu___1996_24922.effects);
-          generalize = (uu___1996_24922.generalize);
-          letrecs = (uu___1996_24922.letrecs);
-          top_level = (uu___1996_24922.top_level);
-          check_uvars = (uu___1996_24922.check_uvars);
-          use_eq = (uu___1996_24922.use_eq);
-          is_iface = (uu___1996_24922.is_iface);
-          admit = (uu___1996_24922.admit);
-          lax = (uu___1996_24922.lax);
-          lax_universes = (uu___1996_24922.lax_universes);
-          phase1 = (uu___1996_24922.phase1);
-          failhard = (uu___1996_24922.failhard);
-          nosynth = (uu___1996_24922.nosynth);
-          uvar_subtyping = (uu___1996_24922.uvar_subtyping);
-          tc_term = (uu___1996_24922.tc_term);
-          type_of = (uu___1996_24922.type_of);
-          universe_of = (uu___1996_24922.universe_of);
-          check_type_of = (uu___1996_24922.check_type_of);
-          use_bv_sorts = (uu___1996_24922.use_bv_sorts);
-          qtbl_name_and_index = (uu___1996_24922.qtbl_name_and_index);
-          normalized_eff_names = (uu___1996_24922.normalized_eff_names);
-          fv_delta_depths = (uu___1996_24922.fv_delta_depths);
+          solver = (uu___2014_24977.solver);
+          range = (uu___2014_24977.range);
+          curmodule = (uu___2014_24977.curmodule);
+          gamma = (uu___2014_24977.gamma);
+          gamma_sig = (uu___2014_24977.gamma_sig);
+          gamma_cache = (uu___2014_24977.gamma_cache);
+          modules = (uu___2014_24977.modules);
+          expected_typ = (uu___2014_24977.expected_typ);
+          sigtab = (uu___2014_24977.sigtab);
+          attrtab = (uu___2014_24977.attrtab);
+          is_pattern = (uu___2014_24977.is_pattern);
+          instantiate_imp = (uu___2014_24977.instantiate_imp);
+          effects = (uu___2014_24977.effects);
+          generalize = (uu___2014_24977.generalize);
+          letrecs = (uu___2014_24977.letrecs);
+          top_level = (uu___2014_24977.top_level);
+          check_uvars = (uu___2014_24977.check_uvars);
+          use_eq = (uu___2014_24977.use_eq);
+          is_iface = (uu___2014_24977.is_iface);
+          admit = (uu___2014_24977.admit);
+          lax = (uu___2014_24977.lax);
+          lax_universes = (uu___2014_24977.lax_universes);
+          phase1 = (uu___2014_24977.phase1);
+          failhard = (uu___2014_24977.failhard);
+          nosynth = (uu___2014_24977.nosynth);
+          uvar_subtyping = (uu___2014_24977.uvar_subtyping);
+          tc_term = (uu___2014_24977.tc_term);
+          type_of = (uu___2014_24977.type_of);
+          universe_of = (uu___2014_24977.universe_of);
+          check_type_of = (uu___2014_24977.check_type_of);
+          use_bv_sorts = (uu___2014_24977.use_bv_sorts);
+          qtbl_name_and_index = (uu___2014_24977.qtbl_name_and_index);
+          normalized_eff_names = (uu___2014_24977.normalized_eff_names);
+          fv_delta_depths = (uu___2014_24977.fv_delta_depths);
           proof_ns = ((path, b) :: (e.proof_ns));
-          synth_hook = (uu___1996_24922.synth_hook);
-          splice = (uu___1996_24922.splice);
-          postprocess = (uu___1996_24922.postprocess);
-          is_native_tactic = (uu___1996_24922.is_native_tactic);
-          identifier_info = (uu___1996_24922.identifier_info);
-          tc_hooks = (uu___1996_24922.tc_hooks);
-          dsenv = (uu___1996_24922.dsenv);
-          nbe = (uu___1996_24922.nbe);
-          strict_args_tab = (uu___1996_24922.strict_args_tab);
-          erasable_types_tab = (uu___1996_24922.erasable_types_tab)
+          synth_hook = (uu___2014_24977.synth_hook);
+          splice = (uu___2014_24977.splice);
+          postprocess = (uu___2014_24977.postprocess);
+          is_native_tactic = (uu___2014_24977.is_native_tactic);
+          identifier_info = (uu___2014_24977.identifier_info);
+          tc_hooks = (uu___2014_24977.tc_hooks);
+          dsenv = (uu___2014_24977.dsenv);
+          nbe = (uu___2014_24977.nbe);
+          strict_args_tab = (uu___2014_24977.strict_args_tab);
+          erasable_types_tab = (uu___2014_24977.erasable_types_tab)
         }
   
 let (add_proof_ns : env -> name_prefix -> env) =
@@ -5256,90 +5275,90 @@ let (get_proof_ns : env -> proof_namespace) = fun e  -> e.proof_ns
 let (set_proof_ns : proof_namespace -> env -> env) =
   fun ns  ->
     fun e  ->
-      let uu___2005_24970 = e  in
+      let uu___2023_25025 = e  in
       {
-        solver = (uu___2005_24970.solver);
-        range = (uu___2005_24970.range);
-        curmodule = (uu___2005_24970.curmodule);
-        gamma = (uu___2005_24970.gamma);
-        gamma_sig = (uu___2005_24970.gamma_sig);
-        gamma_cache = (uu___2005_24970.gamma_cache);
-        modules = (uu___2005_24970.modules);
-        expected_typ = (uu___2005_24970.expected_typ);
-        sigtab = (uu___2005_24970.sigtab);
-        attrtab = (uu___2005_24970.attrtab);
-        is_pattern = (uu___2005_24970.is_pattern);
-        instantiate_imp = (uu___2005_24970.instantiate_imp);
-        effects = (uu___2005_24970.effects);
-        generalize = (uu___2005_24970.generalize);
-        letrecs = (uu___2005_24970.letrecs);
-        top_level = (uu___2005_24970.top_level);
-        check_uvars = (uu___2005_24970.check_uvars);
-        use_eq = (uu___2005_24970.use_eq);
-        is_iface = (uu___2005_24970.is_iface);
-        admit = (uu___2005_24970.admit);
-        lax = (uu___2005_24970.lax);
-        lax_universes = (uu___2005_24970.lax_universes);
-        phase1 = (uu___2005_24970.phase1);
-        failhard = (uu___2005_24970.failhard);
-        nosynth = (uu___2005_24970.nosynth);
-        uvar_subtyping = (uu___2005_24970.uvar_subtyping);
-        tc_term = (uu___2005_24970.tc_term);
-        type_of = (uu___2005_24970.type_of);
-        universe_of = (uu___2005_24970.universe_of);
-        check_type_of = (uu___2005_24970.check_type_of);
-        use_bv_sorts = (uu___2005_24970.use_bv_sorts);
-        qtbl_name_and_index = (uu___2005_24970.qtbl_name_and_index);
-        normalized_eff_names = (uu___2005_24970.normalized_eff_names);
-        fv_delta_depths = (uu___2005_24970.fv_delta_depths);
+        solver = (uu___2023_25025.solver);
+        range = (uu___2023_25025.range);
+        curmodule = (uu___2023_25025.curmodule);
+        gamma = (uu___2023_25025.gamma);
+        gamma_sig = (uu___2023_25025.gamma_sig);
+        gamma_cache = (uu___2023_25025.gamma_cache);
+        modules = (uu___2023_25025.modules);
+        expected_typ = (uu___2023_25025.expected_typ);
+        sigtab = (uu___2023_25025.sigtab);
+        attrtab = (uu___2023_25025.attrtab);
+        is_pattern = (uu___2023_25025.is_pattern);
+        instantiate_imp = (uu___2023_25025.instantiate_imp);
+        effects = (uu___2023_25025.effects);
+        generalize = (uu___2023_25025.generalize);
+        letrecs = (uu___2023_25025.letrecs);
+        top_level = (uu___2023_25025.top_level);
+        check_uvars = (uu___2023_25025.check_uvars);
+        use_eq = (uu___2023_25025.use_eq);
+        is_iface = (uu___2023_25025.is_iface);
+        admit = (uu___2023_25025.admit);
+        lax = (uu___2023_25025.lax);
+        lax_universes = (uu___2023_25025.lax_universes);
+        phase1 = (uu___2023_25025.phase1);
+        failhard = (uu___2023_25025.failhard);
+        nosynth = (uu___2023_25025.nosynth);
+        uvar_subtyping = (uu___2023_25025.uvar_subtyping);
+        tc_term = (uu___2023_25025.tc_term);
+        type_of = (uu___2023_25025.type_of);
+        universe_of = (uu___2023_25025.universe_of);
+        check_type_of = (uu___2023_25025.check_type_of);
+        use_bv_sorts = (uu___2023_25025.use_bv_sorts);
+        qtbl_name_and_index = (uu___2023_25025.qtbl_name_and_index);
+        normalized_eff_names = (uu___2023_25025.normalized_eff_names);
+        fv_delta_depths = (uu___2023_25025.fv_delta_depths);
         proof_ns = ns;
-        synth_hook = (uu___2005_24970.synth_hook);
-        splice = (uu___2005_24970.splice);
-        postprocess = (uu___2005_24970.postprocess);
-        is_native_tactic = (uu___2005_24970.is_native_tactic);
-        identifier_info = (uu___2005_24970.identifier_info);
-        tc_hooks = (uu___2005_24970.tc_hooks);
-        dsenv = (uu___2005_24970.dsenv);
-        nbe = (uu___2005_24970.nbe);
-        strict_args_tab = (uu___2005_24970.strict_args_tab);
-        erasable_types_tab = (uu___2005_24970.erasable_types_tab)
+        synth_hook = (uu___2023_25025.synth_hook);
+        splice = (uu___2023_25025.splice);
+        postprocess = (uu___2023_25025.postprocess);
+        is_native_tactic = (uu___2023_25025.is_native_tactic);
+        identifier_info = (uu___2023_25025.identifier_info);
+        tc_hooks = (uu___2023_25025.tc_hooks);
+        dsenv = (uu___2023_25025.dsenv);
+        nbe = (uu___2023_25025.nbe);
+        strict_args_tab = (uu___2023_25025.strict_args_tab);
+        erasable_types_tab = (uu___2023_25025.erasable_types_tab)
       }
   
 let (unbound_vars :
   env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv FStar_Util.set) =
   fun e  ->
     fun t  ->
-      let uu____24986 = FStar_Syntax_Free.names t  in
-      let uu____24989 = bound_vars e  in
+      let uu____25041 = FStar_Syntax_Free.names t  in
+      let uu____25044 = bound_vars e  in
       FStar_List.fold_left (fun s  -> fun bv  -> FStar_Util.set_remove bv s)
-        uu____24986 uu____24989
+        uu____25041 uu____25044
   
 let (closed : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun e  ->
     fun t  ->
-      let uu____25012 = unbound_vars e t  in
-      FStar_Util.set_is_empty uu____25012
+      let uu____25067 = unbound_vars e t  in
+      FStar_Util.set_is_empty uu____25067
   
 let (closed' : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____25022 = FStar_Syntax_Free.names t  in
-    FStar_Util.set_is_empty uu____25022
+    let uu____25077 = FStar_Syntax_Free.names t  in
+    FStar_Util.set_is_empty uu____25077
   
 let (string_of_proof_ns : env -> Prims.string) =
   fun env  ->
-    let aux uu____25043 =
-      match uu____25043 with
+    let aux uu____25098 =
+      match uu____25098 with
       | (p,b) ->
           if (p = []) && b
           then "*"
           else
-            (let uu____25063 = FStar_Ident.text_of_path p  in
-             Prims.op_Hat (if b then "+" else "-") uu____25063)
+            (let uu____25118 = FStar_Ident.text_of_path p  in
+             Prims.op_Hat (if b then "+" else "-") uu____25118)
        in
-    let uu____25071 =
-      let uu____25075 = FStar_List.map aux env.proof_ns  in
-      FStar_All.pipe_right uu____25075 FStar_List.rev  in
-    FStar_All.pipe_right uu____25071 (FStar_String.concat " ")
+    let uu____25126 =
+      let uu____25130 = FStar_List.map aux env.proof_ns  in
+      FStar_All.pipe_right uu____25130 FStar_List.rev  in
+    FStar_All.pipe_right uu____25126 (FStar_String.concat " ")
   
 let (guard_of_guard_formula :
   FStar_TypeChecker_Common.guard_formula -> guard_t) =
@@ -5359,21 +5378,21 @@ let (is_trivial : guard_t -> Prims.bool) =
                 ((imp.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_should_check =
                    FStar_Syntax_Syntax.Allow_unresolved)
                   ||
-                  (let uu____25145 =
+                  (let uu____25200 =
                      FStar_Syntax_Unionfind.find
                        (imp.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head
                       in
-                   match uu____25145 with
-                   | FStar_Pervasives_Native.Some uu____25149 -> true
+                   match uu____25200 with
+                   | FStar_Pervasives_Native.Some uu____25204 -> true
                    | FStar_Pervasives_Native.None  -> false)))
-    | uu____25152 -> false
+    | uu____25207 -> false
   
 let (is_trivial_guard_formula : guard_t -> Prims.bool) =
   fun g  ->
     match g with
-    | { guard_f = FStar_TypeChecker_Common.Trivial ; deferred = uu____25162;
-        univ_ineqs = uu____25163; implicits = uu____25164;_} -> true
-    | uu____25176 -> false
+    | { guard_f = FStar_TypeChecker_Common.Trivial ; deferred = uu____25217;
+        univ_ineqs = uu____25218; implicits = uu____25219;_} -> true
+    | uu____25231 -> false
   
 let (trivial_guard : guard_t) =
   {
@@ -5394,12 +5413,12 @@ let (abstract_guard_n :
               (FStar_Pervasives_Native.Some
                  (FStar_Syntax_Util.residual_tot FStar_Syntax_Util.ktype0))
              in
-          let uu___2049_25207 = g  in
+          let uu___2067_25262 = g  in
           {
             guard_f = (FStar_TypeChecker_Common.NonTrivial f');
-            deferred = (uu___2049_25207.deferred);
-            univ_ineqs = (uu___2049_25207.univ_ineqs);
-            implicits = (uu___2049_25207.implicits)
+            deferred = (uu___2067_25262.deferred);
+            univ_ineqs = (uu___2067_25262.univ_ineqs);
+            implicits = (uu___2067_25262.implicits)
           }
   
 let (abstract_guard : FStar_Syntax_Syntax.binder -> guard_t -> guard_t) =
@@ -5414,31 +5433,31 @@ let (def_check_vars_in_set :
     fun msg  ->
       fun vset  ->
         fun t  ->
-          let uu____25246 = FStar_Options.defensive ()  in
-          if uu____25246
+          let uu____25301 = FStar_Options.defensive ()  in
+          if uu____25301
           then
             let s = FStar_Syntax_Free.names t  in
-            let uu____25252 =
-              let uu____25254 =
-                let uu____25256 = FStar_Util.set_difference s vset  in
-                FStar_All.pipe_left FStar_Util.set_is_empty uu____25256  in
-              Prims.op_Negation uu____25254  in
-            (if uu____25252
+            let uu____25307 =
+              let uu____25309 =
+                let uu____25311 = FStar_Util.set_difference s vset  in
+                FStar_All.pipe_left FStar_Util.set_is_empty uu____25311  in
+              Prims.op_Negation uu____25309  in
+            (if uu____25307
              then
-               let uu____25263 =
-                 let uu____25269 =
-                   let uu____25271 = FStar_Syntax_Print.term_to_string t  in
-                   let uu____25273 =
-                     let uu____25275 = FStar_Util.set_elements s  in
-                     FStar_All.pipe_right uu____25275
+               let uu____25318 =
+                 let uu____25324 =
+                   let uu____25326 = FStar_Syntax_Print.term_to_string t  in
+                   let uu____25328 =
+                     let uu____25330 = FStar_Util.set_elements s  in
+                     FStar_All.pipe_right uu____25330
                        (FStar_Syntax_Print.bvs_to_string ",\n\t")
                       in
                    FStar_Util.format3
                      "Internal: term is not closed (%s).\nt = (%s)\nFVs = (%s)\n"
-                     msg uu____25271 uu____25273
+                     msg uu____25326 uu____25328
                     in
-                 (FStar_Errors.Warning_Defensive, uu____25269)  in
-               FStar_Errors.log_issue rng uu____25263
+                 (FStar_Errors.Warning_Defensive, uu____25324)  in
+               FStar_Errors.log_issue rng uu____25318
              else ())
           else ()
   
@@ -5451,15 +5470,15 @@ let (def_check_closed_in :
     fun msg  ->
       fun l  ->
         fun t  ->
-          let uu____25315 =
-            let uu____25317 = FStar_Options.defensive ()  in
-            Prims.op_Negation uu____25317  in
-          if uu____25315
+          let uu____25370 =
+            let uu____25372 = FStar_Options.defensive ()  in
+            Prims.op_Negation uu____25372  in
+          if uu____25370
           then ()
           else
-            (let uu____25322 =
+            (let uu____25377 =
                FStar_Util.as_set l FStar_Syntax_Syntax.order_bv  in
-             def_check_vars_in_set rng msg uu____25322 t)
+             def_check_vars_in_set rng msg uu____25377 t)
   
 let (def_check_closed_in_env :
   FStar_Range.range ->
@@ -5469,14 +5488,14 @@ let (def_check_closed_in_env :
     fun msg  ->
       fun e  ->
         fun t  ->
-          let uu____25348 =
-            let uu____25350 = FStar_Options.defensive ()  in
-            Prims.op_Negation uu____25350  in
-          if uu____25348
+          let uu____25403 =
+            let uu____25405 = FStar_Options.defensive ()  in
+            Prims.op_Negation uu____25405  in
+          if uu____25403
           then ()
           else
-            (let uu____25355 = bound_vars e  in
-             def_check_closed_in rng msg uu____25355 t)
+            (let uu____25410 = bound_vars e  in
+             def_check_closed_in rng msg uu____25410 t)
   
 let (def_check_guard_wf :
   FStar_Range.range -> Prims.string -> env -> guard_t -> unit) =
@@ -5495,30 +5514,30 @@ let (apply_guard : guard_t -> FStar_Syntax_Syntax.term -> guard_t) =
       match g.guard_f with
       | FStar_TypeChecker_Common.Trivial  -> g
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___2086_25394 = g  in
-          let uu____25395 =
-            let uu____25396 =
-              let uu____25397 =
-                let uu____25404 =
-                  let uu____25405 =
-                    let uu____25422 =
-                      let uu____25433 = FStar_Syntax_Syntax.as_arg e  in
-                      [uu____25433]  in
-                    (f, uu____25422)  in
-                  FStar_Syntax_Syntax.Tm_app uu____25405  in
-                FStar_Syntax_Syntax.mk uu____25404  in
-              uu____25397 FStar_Pervasives_Native.None
+          let uu___2104_25449 = g  in
+          let uu____25450 =
+            let uu____25451 =
+              let uu____25452 =
+                let uu____25459 =
+                  let uu____25460 =
+                    let uu____25477 =
+                      let uu____25488 = FStar_Syntax_Syntax.as_arg e  in
+                      [uu____25488]  in
+                    (f, uu____25477)  in
+                  FStar_Syntax_Syntax.Tm_app uu____25460  in
+                FStar_Syntax_Syntax.mk uu____25459  in
+              uu____25452 FStar_Pervasives_Native.None
                 f.FStar_Syntax_Syntax.pos
                in
             FStar_All.pipe_left
-              (fun _25470  -> FStar_TypeChecker_Common.NonTrivial _25470)
-              uu____25396
+              (fun _25525  -> FStar_TypeChecker_Common.NonTrivial _25525)
+              uu____25451
              in
           {
-            guard_f = uu____25395;
-            deferred = (uu___2086_25394.deferred);
-            univ_ineqs = (uu___2086_25394.univ_ineqs);
-            implicits = (uu___2086_25394.implicits)
+            guard_f = uu____25450;
+            deferred = (uu___2104_25449.deferred);
+            univ_ineqs = (uu___2104_25449.univ_ineqs);
+            implicits = (uu___2104_25449.implicits)
           }
   
 let (map_guard :
@@ -5530,15 +5549,15 @@ let (map_guard :
       match g.guard_f with
       | FStar_TypeChecker_Common.Trivial  -> g
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___2093_25488 = g  in
-          let uu____25489 =
-            let uu____25490 = map1 f  in
-            FStar_TypeChecker_Common.NonTrivial uu____25490  in
+          let uu___2111_25543 = g  in
+          let uu____25544 =
+            let uu____25545 = map1 f  in
+            FStar_TypeChecker_Common.NonTrivial uu____25545  in
           {
-            guard_f = uu____25489;
-            deferred = (uu___2093_25488.deferred);
-            univ_ineqs = (uu___2093_25488.univ_ineqs);
-            implicits = (uu___2093_25488.implicits)
+            guard_f = uu____25544;
+            deferred = (uu___2111_25543.deferred);
+            univ_ineqs = (uu___2111_25543.univ_ineqs);
+            implicits = (uu___2111_25543.implicits)
           }
   
 let (always_map_guard :
@@ -5549,33 +5568,33 @@ let (always_map_guard :
     fun map1  ->
       match g.guard_f with
       | FStar_TypeChecker_Common.Trivial  ->
-          let uu___2098_25507 = g  in
-          let uu____25508 =
-            let uu____25509 = map1 FStar_Syntax_Util.t_true  in
-            FStar_TypeChecker_Common.NonTrivial uu____25509  in
+          let uu___2116_25562 = g  in
+          let uu____25563 =
+            let uu____25564 = map1 FStar_Syntax_Util.t_true  in
+            FStar_TypeChecker_Common.NonTrivial uu____25564  in
           {
-            guard_f = uu____25508;
-            deferred = (uu___2098_25507.deferred);
-            univ_ineqs = (uu___2098_25507.univ_ineqs);
-            implicits = (uu___2098_25507.implicits)
+            guard_f = uu____25563;
+            deferred = (uu___2116_25562.deferred);
+            univ_ineqs = (uu___2116_25562.univ_ineqs);
+            implicits = (uu___2116_25562.implicits)
           }
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___2102_25511 = g  in
-          let uu____25512 =
-            let uu____25513 = map1 f  in
-            FStar_TypeChecker_Common.NonTrivial uu____25513  in
+          let uu___2120_25566 = g  in
+          let uu____25567 =
+            let uu____25568 = map1 f  in
+            FStar_TypeChecker_Common.NonTrivial uu____25568  in
           {
-            guard_f = uu____25512;
-            deferred = (uu___2102_25511.deferred);
-            univ_ineqs = (uu___2102_25511.univ_ineqs);
-            implicits = (uu___2102_25511.implicits)
+            guard_f = uu____25567;
+            deferred = (uu___2120_25566.deferred);
+            univ_ineqs = (uu___2120_25566.univ_ineqs);
+            implicits = (uu___2120_25566.implicits)
           }
   
 let (trivial : FStar_TypeChecker_Common.guard_formula -> unit) =
   fun t  ->
     match t with
     | FStar_TypeChecker_Common.Trivial  -> ()
-    | FStar_TypeChecker_Common.NonTrivial uu____25520 ->
+    | FStar_TypeChecker_Common.NonTrivial uu____25575 ->
         failwith "impossible"
   
 let (conj_guard_f :
@@ -5590,20 +5609,20 @@ let (conj_guard_f :
       | (g,FStar_TypeChecker_Common.Trivial ) -> g
       | (FStar_TypeChecker_Common.NonTrivial
          f1,FStar_TypeChecker_Common.NonTrivial f2) ->
-          let uu____25537 = FStar_Syntax_Util.mk_conj f1 f2  in
-          FStar_TypeChecker_Common.NonTrivial uu____25537
+          let uu____25592 = FStar_Syntax_Util.mk_conj f1 f2  in
+          FStar_TypeChecker_Common.NonTrivial uu____25592
   
 let (check_trivial :
   FStar_Syntax_Syntax.term -> FStar_TypeChecker_Common.guard_formula) =
   fun t  ->
-    let uu____25544 =
-      let uu____25545 = FStar_Syntax_Util.unmeta t  in
-      uu____25545.FStar_Syntax_Syntax.n  in
-    match uu____25544 with
+    let uu____25599 =
+      let uu____25600 = FStar_Syntax_Util.unmeta t  in
+      uu____25600.FStar_Syntax_Syntax.n  in
+    match uu____25599 with
     | FStar_Syntax_Syntax.Tm_fvar tc when
         FStar_Syntax_Syntax.fv_eq_lid tc FStar_Parser_Const.true_lid ->
         FStar_TypeChecker_Common.Trivial
-    | uu____25549 -> FStar_TypeChecker_Common.NonTrivial t
+    | uu____25604 -> FStar_TypeChecker_Common.NonTrivial t
   
 let (imp_guard_f :
   FStar_TypeChecker_Common.guard_formula ->
@@ -5629,9 +5648,9 @@ let (binop_guard :
   fun f  ->
     fun g1  ->
       fun g2  ->
-        let uu____25592 = f g1.guard_f g2.guard_f  in
+        let uu____25647 = f g1.guard_f g2.guard_f  in
         {
-          guard_f = uu____25592;
+          guard_f = uu____25647;
           deferred = (FStar_List.append g1.deferred g2.deferred);
           univ_ineqs =
             ((FStar_List.append (FStar_Pervasives_Native.fst g1.univ_ineqs)
@@ -5662,20 +5681,20 @@ let (close_guard_univs :
                 (fun u  ->
                    fun b  ->
                      fun f1  ->
-                       let uu____25687 = FStar_Syntax_Syntax.is_null_binder b
+                       let uu____25742 = FStar_Syntax_Syntax.is_null_binder b
                           in
-                       if uu____25687
+                       if uu____25742
                        then f1
                        else
                          FStar_Syntax_Util.mk_forall u
                            (FStar_Pervasives_Native.fst b) f1) us bs f
                in
-            let uu___2157_25694 = g  in
+            let uu___2175_25749 = g  in
             {
               guard_f = (FStar_TypeChecker_Common.NonTrivial f1);
-              deferred = (uu___2157_25694.deferred);
-              univ_ineqs = (uu___2157_25694.univ_ineqs);
-              implicits = (uu___2157_25694.implicits)
+              deferred = (uu___2175_25749.deferred);
+              univ_ineqs = (uu___2175_25749.univ_ineqs);
+              implicits = (uu___2175_25749.implicits)
             }
   
 let (close_forall :
@@ -5689,8 +5708,8 @@ let (close_forall :
         FStar_List.fold_right
           (fun b  ->
              fun f1  ->
-               let uu____25728 = FStar_Syntax_Syntax.is_null_binder b  in
-               if uu____25728
+               let uu____25783 = FStar_Syntax_Syntax.is_null_binder b  in
+               if uu____25783
                then f1
                else
                  (let u =
@@ -5708,15 +5727,15 @@ let (close_guard : env -> FStar_Syntax_Syntax.binders -> guard_t -> guard_t)
         match g.guard_f with
         | FStar_TypeChecker_Common.Trivial  -> g
         | FStar_TypeChecker_Common.NonTrivial f ->
-            let uu___2172_25755 = g  in
-            let uu____25756 =
-              let uu____25757 = close_forall env binders f  in
-              FStar_TypeChecker_Common.NonTrivial uu____25757  in
+            let uu___2190_25810 = g  in
+            let uu____25811 =
+              let uu____25812 = close_forall env binders f  in
+              FStar_TypeChecker_Common.NonTrivial uu____25812  in
             {
-              guard_f = uu____25756;
-              deferred = (uu___2172_25755.deferred);
-              univ_ineqs = (uu___2172_25755.univ_ineqs);
-              implicits = (uu___2172_25755.implicits)
+              guard_f = uu____25811;
+              deferred = (uu___2190_25810.deferred);
+              univ_ineqs = (uu___2190_25810.univ_ineqs);
+              implicits = (uu___2190_25810.implicits)
             }
   
 let (new_implicit_var_aux :
@@ -5736,12 +5755,12 @@ let (new_implicit_var_aux :
         fun k  ->
           fun should_check  ->
             fun meta  ->
-              let uu____25815 =
+              let uu____25870 =
                 FStar_Syntax_Util.destruct k FStar_Parser_Const.range_of_lid
                  in
-              match uu____25815 with
+              match uu____25870 with
               | FStar_Pervasives_Native.Some
-                  (uu____25840::(tm,uu____25842)::[]) ->
+                  (uu____25895::(tm,uu____25897)::[]) ->
                   let t =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_constant
@@ -5750,13 +5769,13 @@ let (new_implicit_var_aux :
                       FStar_Pervasives_Native.None tm.FStar_Syntax_Syntax.pos
                      in
                   (t, [], trivial_guard)
-              | uu____25906 ->
+              | uu____25961 ->
                   let binders = all_binders env  in
                   let gamma = env.gamma  in
                   let ctx_uvar =
-                    let uu____25924 = FStar_Syntax_Unionfind.fresh ()  in
+                    let uu____25979 = FStar_Syntax_Unionfind.fresh ()  in
                     {
-                      FStar_Syntax_Syntax.ctx_uvar_head = uu____25924;
+                      FStar_Syntax_Syntax.ctx_uvar_head = uu____25979;
                       FStar_Syntax_Syntax.ctx_uvar_gamma = gamma;
                       FStar_Syntax_Syntax.ctx_uvar_binders = binders;
                       FStar_Syntax_Syntax.ctx_uvar_typ = k;
@@ -5782,33 +5801,33 @@ let (new_implicit_var_aux :
                         imp_range = r
                       }  in
                     let g =
-                      let uu___2194_25956 = trivial_guard  in
+                      let uu___2212_26011 = trivial_guard  in
                       {
-                        guard_f = (uu___2194_25956.guard_f);
-                        deferred = (uu___2194_25956.deferred);
-                        univ_ineqs = (uu___2194_25956.univ_ineqs);
+                        guard_f = (uu___2212_26011.guard_f);
+                        deferred = (uu___2212_26011.deferred);
+                        univ_ineqs = (uu___2212_26011.univ_ineqs);
                         implicits = [imp]
                       }  in
                     (t, [(ctx_uvar, r)], g)))
   
 let (dummy_solver : solver_t) =
   {
-    init = (fun uu____25974  -> ());
-    push = (fun uu____25976  -> ());
-    pop = (fun uu____25979  -> ());
+    init = (fun uu____26029  -> ());
+    push = (fun uu____26031  -> ());
+    pop = (fun uu____26034  -> ());
     snapshot =
-      (fun uu____25982  ->
+      (fun uu____26037  ->
          ((Prims.int_zero, Prims.int_zero, Prims.int_zero), ()));
-    rollback = (fun uu____26001  -> fun uu____26002  -> ());
-    encode_sig = (fun uu____26017  -> fun uu____26018  -> ());
+    rollback = (fun uu____26056  -> fun uu____26057  -> ());
+    encode_sig = (fun uu____26072  -> fun uu____26073  -> ());
     preprocess =
       (fun e  ->
          fun g  ->
-           let uu____26024 =
-             let uu____26031 = FStar_Options.peek ()  in (e, g, uu____26031)
+           let uu____26079 =
+             let uu____26086 = FStar_Options.peek ()  in (e, g, uu____26086)
               in
-           [uu____26024]);
-    solve = (fun uu____26047  -> fun uu____26048  -> fun uu____26049  -> ());
-    finish = (fun uu____26056  -> ());
-    refresh = (fun uu____26058  -> ())
+           [uu____26079]);
+    solve = (fun uu____26102  -> fun uu____26103  -> fun uu____26104  -> ());
+    finish = (fun uu____26111  -> ());
+    refresh = (fun uu____26113  -> ())
   } 

--- a/src/ocaml-output/FStar_TypeChecker_NBE.ml
+++ b/src/ocaml-output/FStar_TypeChecker_NBE.ml
@@ -328,9 +328,10 @@ let (is_constr : FStar_TypeChecker_Env.qninfo -> Prims.bool) =
             FStar_Syntax_Syntax.sigrng = uu____1627;
             FStar_Syntax_Syntax.sigquals = uu____1628;
             FStar_Syntax_Syntax.sigmeta = uu____1629;
-            FStar_Syntax_Syntax.sigattrs = uu____1630;_},uu____1631),uu____1632)
+            FStar_Syntax_Syntax.sigattrs = uu____1630;
+            FStar_Syntax_Syntax.sigopts = uu____1631;_},uu____1632),uu____1633)
         -> true
-    | uu____1690 -> false
+    | uu____1693 -> false
   
 let (translate_univ :
   FStar_TypeChecker_NBETerm.t Prims.list ->
@@ -346,13 +347,13 @@ let (translate_univ :
             then let u' = FStar_List.nth bs i  in un_univ u'
             else failwith "Universe index out of bounds"
         | FStar_Syntax_Syntax.U_succ u3 ->
-            let uu____1722 = aux u3  in FStar_Syntax_Syntax.U_succ uu____1722
+            let uu____1725 = aux u3  in FStar_Syntax_Syntax.U_succ uu____1725
         | FStar_Syntax_Syntax.U_max us ->
-            let uu____1726 = FStar_List.map aux us  in
-            FStar_Syntax_Syntax.U_max uu____1726
+            let uu____1729 = FStar_List.map aux us  in
+            FStar_Syntax_Syntax.U_max uu____1729
         | FStar_Syntax_Syntax.U_unknown  -> u2
-        | FStar_Syntax_Syntax.U_name uu____1729 -> u2
-        | FStar_Syntax_Syntax.U_unif uu____1730 -> u2
+        | FStar_Syntax_Syntax.U_name uu____1732 -> u2
+        | FStar_Syntax_Syntax.U_unif uu____1733 -> u2
         | FStar_Syntax_Syntax.U_zero  -> u2  in
       aux u
   
@@ -366,10 +367,10 @@ let (find_let :
       FStar_Util.find_map lbs
         (fun lb  ->
            match lb.FStar_Syntax_Syntax.lbname with
-           | FStar_Util.Inl uu____1761 -> failwith "find_let : impossible"
+           | FStar_Util.Inl uu____1764 -> failwith "find_let : impossible"
            | FStar_Util.Inr name ->
-               let uu____1766 = FStar_Syntax_Syntax.fv_eq name fvar1  in
-               if uu____1766
+               let uu____1769 = FStar_Syntax_Syntax.fv_eq name fvar1  in
+               if uu____1769
                then FStar_Pervasives_Native.Some lb
                else FStar_Pervasives_Native.None)
   
@@ -386,62 +387,62 @@ let rec (iapp :
             let m = FStar_List.length args  in
             if m < n1
             then
-              let uu____2113 = FStar_List.splitAt m targs  in
-              (match uu____2113 with
-               | (uu____2149,targs') ->
+              let uu____2116 = FStar_List.splitAt m targs  in
+              (match uu____2116 with
+               | (uu____2152,targs') ->
                    let targs'1 =
                      FStar_List.map
                        (fun targ  ->
                           fun l  ->
-                            let uu____2240 =
-                              let uu____2243 =
+                            let uu____2243 =
+                              let uu____2246 =
                                 map_append FStar_Pervasives_Native.fst args l
                                  in
-                              FStar_List.rev uu____2243  in
-                            targ uu____2240) targs'
+                              FStar_List.rev uu____2246  in
+                            targ uu____2243) targs'
                       in
                    FStar_TypeChecker_NBETerm.Lam
                      (((fun l  ->
-                          let uu____2277 =
+                          let uu____2280 =
                             map_append FStar_Pervasives_Native.fst args l  in
-                          f1 uu____2277)), targs'1, (n1 - m), res))
+                          f1 uu____2280)), targs'1, (n1 - m), res))
             else
               if m = n1
               then
-                (let uu____2288 =
+                (let uu____2291 =
                    FStar_List.map FStar_Pervasives_Native.fst args  in
-                 f1 uu____2288)
+                 f1 uu____2291)
               else
-                (let uu____2297 = FStar_List.splitAt n1 args  in
-                 match uu____2297 with
+                (let uu____2300 = FStar_List.splitAt n1 args  in
+                 match uu____2300 with
                  | (args1,args') ->
-                     let uu____2344 =
-                       let uu____2345 =
+                     let uu____2347 =
+                       let uu____2348 =
                          FStar_List.map FStar_Pervasives_Native.fst args1  in
-                       f1 uu____2345  in
-                     iapp cfg uu____2344 args')
+                       f1 uu____2348  in
+                     iapp cfg uu____2347 args')
         | FStar_TypeChecker_NBETerm.Accu (a,ts) ->
             FStar_TypeChecker_NBETerm.Accu
               (a, (FStar_List.rev_append args ts))
         | FStar_TypeChecker_NBETerm.Construct (i,us,ts) ->
             let rec aux args1 us1 ts1 =
               match args1 with
-              | (FStar_TypeChecker_NBETerm.Univ u,uu____2464)::args2 ->
+              | (FStar_TypeChecker_NBETerm.Univ u,uu____2467)::args2 ->
                   aux args2 (u :: us1) ts1
               | a::args2 -> aux args2 us1 (a :: ts1)
               | [] -> (us1, ts1)  in
-            let uu____2508 = aux args us ts  in
-            (match uu____2508 with
+            let uu____2511 = aux args us ts  in
+            (match uu____2511 with
              | (us',ts') -> FStar_TypeChecker_NBETerm.Construct (i, us', ts'))
         | FStar_TypeChecker_NBETerm.FV (i,us,ts) ->
             let rec aux args1 us1 ts1 =
               match args1 with
-              | (FStar_TypeChecker_NBETerm.Univ u,uu____2635)::args2 ->
+              | (FStar_TypeChecker_NBETerm.Univ u,uu____2638)::args2 ->
                   aux args2 (u :: us1) ts1
               | a::args2 -> aux args2 us1 (a :: ts1)
               | [] -> (us1, ts1)  in
-            let uu____2679 = aux args us ts  in
-            (match uu____2679 with
+            let uu____2682 = aux args us ts  in
+            (match uu____2682 with
              | (us',ts') -> FStar_TypeChecker_NBETerm.FV (i, us', ts'))
         | FStar_TypeChecker_NBETerm.Rec (lb,lbs,bs,acc,ar,ar_lst,tr_lb) ->
             let no_args = FStar_List.length args  in
@@ -458,22 +459,22 @@ let rec (iapp :
                     tr_lb)
               else
                 (let full_args = FStar_List.append acc args  in
-                 let uu____2845 = test_args full_args ar_lst  in
-                 match uu____2845 with
+                 let uu____2848 = test_args full_args ar_lst  in
+                 match uu____2848 with
                  | (can_unfold,args1,res) ->
                      if
                        Prims.op_Negation
                          (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta
                      then
                        (debug cfg
-                          (fun uu____2862  ->
-                             let uu____2863 =
+                          (fun uu____2865  ->
+                             let uu____2866 =
                                FStar_Syntax_Print.lbname_to_string
                                  lb.FStar_Syntax_Syntax.lbname
                                 in
                              FStar_Util.print1
                                "Zeta is not set; will not unfold %s\n"
-                               uu____2863);
+                               uu____2866);
                         FStar_TypeChecker_NBETerm.Rec
                           (lb, lbs, bs, full_args, Prims.int_zero, ar_lst,
                             tr_lb))
@@ -481,78 +482,78 @@ let rec (iapp :
                        if can_unfold
                        then
                          (debug cfg
-                            (fun uu____2895  ->
-                               let uu____2896 =
+                            (fun uu____2898  ->
+                               let uu____2899 =
                                  FStar_Syntax_Print.lbname_to_string
                                    lb.FStar_Syntax_Syntax.lbname
                                   in
                                FStar_Util.print1
                                  "Beta reducing recursive function %s\n"
-                                 uu____2896);
+                                 uu____2899);
                           (match res with
                            | [] ->
-                               let uu____2903 =
-                                 let uu____2904 = make_rec_env tr_lb lbs bs
+                               let uu____2906 =
+                                 let uu____2907 = make_rec_env tr_lb lbs bs
                                     in
-                                 tr_lb uu____2904 lb  in
-                               iapp cfg uu____2903 args1
-                           | uu____2907::uu____2908 ->
+                                 tr_lb uu____2907 lb  in
+                               iapp cfg uu____2906 args1
+                           | uu____2910::uu____2911 ->
                                let t =
-                                 let uu____2924 =
-                                   let uu____2925 = make_rec_env tr_lb lbs bs
+                                 let uu____2927 =
+                                   let uu____2928 = make_rec_env tr_lb lbs bs
                                       in
-                                   tr_lb uu____2925 lb  in
-                                 iapp cfg uu____2924 args1  in
+                                   tr_lb uu____2928 lb  in
+                                 iapp cfg uu____2927 args1  in
                                iapp cfg t res))
                        else
                          FStar_TypeChecker_NBETerm.Rec
                            (lb, lbs, bs, full_args, Prims.int_zero, ar_lst,
                              tr_lb))
-        | FStar_TypeChecker_NBETerm.Quote uu____2953 ->
-            let uu____2958 =
-              let uu____2960 = FStar_TypeChecker_NBETerm.t_to_string f  in
-              Prims.op_Hat "NBE ill-typed application: " uu____2960  in
-            failwith uu____2958
-        | FStar_TypeChecker_NBETerm.Reflect uu____2963 ->
-            let uu____2964 =
-              let uu____2966 = FStar_TypeChecker_NBETerm.t_to_string f  in
-              Prims.op_Hat "NBE ill-typed application: " uu____2966  in
-            failwith uu____2964
-        | FStar_TypeChecker_NBETerm.Lazy uu____2969 ->
-            let uu____2984 =
-              let uu____2986 = FStar_TypeChecker_NBETerm.t_to_string f  in
-              Prims.op_Hat "NBE ill-typed application: " uu____2986  in
-            failwith uu____2984
-        | FStar_TypeChecker_NBETerm.Constant uu____2989 ->
-            let uu____2990 =
-              let uu____2992 = FStar_TypeChecker_NBETerm.t_to_string f  in
-              Prims.op_Hat "NBE ill-typed application: " uu____2992  in
-            failwith uu____2990
-        | FStar_TypeChecker_NBETerm.Univ uu____2995 ->
-            let uu____2996 =
-              let uu____2998 = FStar_TypeChecker_NBETerm.t_to_string f  in
-              Prims.op_Hat "NBE ill-typed application: " uu____2998  in
-            failwith uu____2996
-        | FStar_TypeChecker_NBETerm.Type_t uu____3001 ->
-            let uu____3002 =
-              let uu____3004 = FStar_TypeChecker_NBETerm.t_to_string f  in
-              Prims.op_Hat "NBE ill-typed application: " uu____3004  in
-            failwith uu____3002
+        | FStar_TypeChecker_NBETerm.Quote uu____2956 ->
+            let uu____2961 =
+              let uu____2963 = FStar_TypeChecker_NBETerm.t_to_string f  in
+              Prims.op_Hat "NBE ill-typed application: " uu____2963  in
+            failwith uu____2961
+        | FStar_TypeChecker_NBETerm.Reflect uu____2966 ->
+            let uu____2967 =
+              let uu____2969 = FStar_TypeChecker_NBETerm.t_to_string f  in
+              Prims.op_Hat "NBE ill-typed application: " uu____2969  in
+            failwith uu____2967
+        | FStar_TypeChecker_NBETerm.Lazy uu____2972 ->
+            let uu____2987 =
+              let uu____2989 = FStar_TypeChecker_NBETerm.t_to_string f  in
+              Prims.op_Hat "NBE ill-typed application: " uu____2989  in
+            failwith uu____2987
+        | FStar_TypeChecker_NBETerm.Constant uu____2992 ->
+            let uu____2993 =
+              let uu____2995 = FStar_TypeChecker_NBETerm.t_to_string f  in
+              Prims.op_Hat "NBE ill-typed application: " uu____2995  in
+            failwith uu____2993
+        | FStar_TypeChecker_NBETerm.Univ uu____2998 ->
+            let uu____2999 =
+              let uu____3001 = FStar_TypeChecker_NBETerm.t_to_string f  in
+              Prims.op_Hat "NBE ill-typed application: " uu____3001  in
+            failwith uu____2999
+        | FStar_TypeChecker_NBETerm.Type_t uu____3004 ->
+            let uu____3005 =
+              let uu____3007 = FStar_TypeChecker_NBETerm.t_to_string f  in
+              Prims.op_Hat "NBE ill-typed application: " uu____3007  in
+            failwith uu____3005
         | FStar_TypeChecker_NBETerm.Unknown  ->
-            let uu____3007 =
-              let uu____3009 = FStar_TypeChecker_NBETerm.t_to_string f  in
-              Prims.op_Hat "NBE ill-typed application: " uu____3009  in
-            failwith uu____3007
-        | FStar_TypeChecker_NBETerm.Refinement uu____3012 ->
-            let uu____3027 =
-              let uu____3029 = FStar_TypeChecker_NBETerm.t_to_string f  in
-              Prims.op_Hat "NBE ill-typed application: " uu____3029  in
-            failwith uu____3027
-        | FStar_TypeChecker_NBETerm.Arrow uu____3032 ->
-            let uu____3053 =
-              let uu____3055 = FStar_TypeChecker_NBETerm.t_to_string f  in
-              Prims.op_Hat "NBE ill-typed application: " uu____3055  in
-            failwith uu____3053
+            let uu____3010 =
+              let uu____3012 = FStar_TypeChecker_NBETerm.t_to_string f  in
+              Prims.op_Hat "NBE ill-typed application: " uu____3012  in
+            failwith uu____3010
+        | FStar_TypeChecker_NBETerm.Refinement uu____3015 ->
+            let uu____3030 =
+              let uu____3032 = FStar_TypeChecker_NBETerm.t_to_string f  in
+              Prims.op_Hat "NBE ill-typed application: " uu____3032  in
+            failwith uu____3030
+        | FStar_TypeChecker_NBETerm.Arrow uu____3035 ->
+            let uu____3056 =
+              let uu____3058 = FStar_TypeChecker_NBETerm.t_to_string f  in
+              Prims.op_Hat "NBE ill-typed application: " uu____3058  in
+            failwith uu____3056
 
 and (translate_fv :
   FStar_TypeChecker_Cfg.cfg ->
@@ -564,31 +565,31 @@ and (translate_fv :
       fun fvar1  ->
         let debug1 = debug cfg  in
         let qninfo =
-          let uu____3072 = FStar_TypeChecker_Cfg.cfg_env cfg  in
-          let uu____3073 = FStar_Syntax_Syntax.lid_of_fv fvar1  in
-          FStar_TypeChecker_Env.lookup_qname uu____3072 uu____3073  in
-        let uu____3074 = (is_constr qninfo) || (is_constr_fv fvar1)  in
-        if uu____3074
+          let uu____3075 = FStar_TypeChecker_Cfg.cfg_env cfg  in
+          let uu____3076 = FStar_Syntax_Syntax.lid_of_fv fvar1  in
+          FStar_TypeChecker_Env.lookup_qname uu____3075 uu____3076  in
+        let uu____3077 = (is_constr qninfo) || (is_constr_fv fvar1)  in
+        if uu____3077
         then FStar_TypeChecker_NBETerm.mkConstruct fvar1 [] []
         else
-          (let uu____3083 =
+          (let uu____3086 =
              FStar_TypeChecker_Normalize.should_unfold cfg
-               (fun uu____3085  -> cfg.FStar_TypeChecker_Cfg.reifying) fvar1
+               (fun uu____3088  -> cfg.FStar_TypeChecker_Cfg.reifying) fvar1
                qninfo
               in
-           match uu____3083 with
+           match uu____3086 with
            | FStar_TypeChecker_Normalize.Should_unfold_fully  ->
                failwith "Not yet handled"
            | FStar_TypeChecker_Normalize.Should_unfold_no  ->
                (debug1
-                  (fun uu____3092  ->
-                     let uu____3093 = FStar_Syntax_Print.fv_to_string fvar1
+                  (fun uu____3095  ->
+                     let uu____3096 = FStar_Syntax_Print.fv_to_string fvar1
                         in
                      FStar_Util.print1 "(1) Decided to not unfold %s\n"
-                       uu____3093);
-                (let uu____3096 =
+                       uu____3096);
+                (let uu____3099 =
                    FStar_TypeChecker_Cfg.find_prim_step cfg fvar1  in
-                 match uu____3096 with
+                 match uu____3099 with
                  | FStar_Pervasives_Native.Some prim_step when
                      prim_step.FStar_TypeChecker_Cfg.strong_reduction_ok ->
                      let arity =
@@ -596,13 +597,13 @@ and (translate_fv :
                          prim_step.FStar_TypeChecker_Cfg.univ_arity
                         in
                      (debug1
-                        (fun uu____3107  ->
-                           let uu____3108 =
+                        (fun uu____3110  ->
+                           let uu____3111 =
                              FStar_Syntax_Print.fv_to_string fvar1  in
-                           FStar_Util.print1 "Found a primop %s\n" uu____3108);
-                      (let uu____3111 =
-                         let uu____3142 =
-                           let f uu____3170 uu____3171 =
+                           FStar_Util.print1 "Found a primop %s\n" uu____3111);
+                      (let uu____3114 =
+                         let uu____3145 =
+                           let f uu____3173 uu____3174 =
                              ((FStar_TypeChecker_NBETerm.Constant
                                  FStar_TypeChecker_NBETerm.Unit),
                                FStar_Pervasives_Native.None)
@@ -619,59 +620,59 @@ and (translate_fv :
                                  FStar_TypeChecker_NBETerm.translate =
                                    (translate cfg bs)
                                }  in
-                             let uu____3231 =
+                             let uu____3234 =
                                prim_step.FStar_TypeChecker_Cfg.interpretation_nbe
                                  callbacks args'
                                 in
-                             match uu____3231 with
+                             match uu____3234 with
                              | FStar_Pervasives_Native.Some x ->
                                  (debug1
-                                    (fun uu____3242  ->
-                                       let uu____3243 =
+                                    (fun uu____3245  ->
+                                       let uu____3246 =
                                          FStar_Syntax_Print.fv_to_string
                                            fvar1
                                           in
-                                       let uu____3245 =
+                                       let uu____3248 =
                                          FStar_TypeChecker_NBETerm.t_to_string
                                            x
                                           in
                                        FStar_Util.print2
                                          "Primitive operator %s returned %s\n"
-                                         uu____3243 uu____3245);
+                                         uu____3246 uu____3248);
                                   x)
                              | FStar_Pervasives_Native.None  ->
                                  (debug1
-                                    (fun uu____3253  ->
-                                       let uu____3254 =
+                                    (fun uu____3256  ->
+                                       let uu____3257 =
                                          FStar_Syntax_Print.fv_to_string
                                            fvar1
                                           in
                                        FStar_Util.print1
                                          "Primitive operator %s failed\n"
-                                         uu____3254);
-                                  (let uu____3257 =
+                                         uu____3257);
+                                  (let uu____3260 =
                                      FStar_TypeChecker_NBETerm.mkFV fvar1 []
                                        []
                                       in
-                                   iapp cfg uu____3257 args'))), uu____3142,
+                                   iapp cfg uu____3260 args'))), uu____3145,
                            arity, FStar_Pervasives_Native.None)
                           in
-                       FStar_TypeChecker_NBETerm.Lam uu____3111))
-                 | FStar_Pervasives_Native.Some uu____3265 ->
+                       FStar_TypeChecker_NBETerm.Lam uu____3114))
+                 | FStar_Pervasives_Native.Some uu____3268 ->
                      (debug1
-                        (fun uu____3271  ->
-                           let uu____3272 =
+                        (fun uu____3274  ->
+                           let uu____3275 =
                              FStar_Syntax_Print.fv_to_string fvar1  in
                            FStar_Util.print1 "(2) Decided to not unfold %s\n"
-                             uu____3272);
+                             uu____3275);
                       FStar_TypeChecker_NBETerm.mkFV fvar1 [] [])
-                 | uu____3279 ->
+                 | uu____3282 ->
                      (debug1
-                        (fun uu____3287  ->
-                           let uu____3288 =
+                        (fun uu____3290  ->
+                           let uu____3291 =
                              FStar_Syntax_Print.fv_to_string fvar1  in
                            FStar_Util.print1 "(3) Decided to not unfold %s\n"
-                             uu____3288);
+                             uu____3291);
                       FStar_TypeChecker_NBETerm.mkFV fvar1 [] [])))
            | FStar_TypeChecker_Normalize.Should_unfold_reify  ->
                (match qninfo with
@@ -680,10 +681,11 @@ and (translate_fv :
                      ({
                         FStar_Syntax_Syntax.sigel =
                           FStar_Syntax_Syntax.Sig_let ((is_rec,lbs),names1);
-                        FStar_Syntax_Syntax.sigrng = uu____3298;
-                        FStar_Syntax_Syntax.sigquals = uu____3299;
-                        FStar_Syntax_Syntax.sigmeta = uu____3300;
-                        FStar_Syntax_Syntax.sigattrs = uu____3301;_},_us_opt),_rng)
+                        FStar_Syntax_Syntax.sigrng = uu____3301;
+                        FStar_Syntax_Syntax.sigquals = uu____3302;
+                        FStar_Syntax_Syntax.sigmeta = uu____3303;
+                        FStar_Syntax_Syntax.sigattrs = uu____3304;
+                        FStar_Syntax_Syntax.sigopts = uu____3305;_},_us_opt),_rng)
                     ->
                     let lbm = find_let lbs fvar1  in
                     (match lbm with
@@ -692,51 +694,51 @@ and (translate_fv :
                          then mkRec cfg lb [] []
                          else
                            (debug1
-                              (fun uu____3374  ->
+                              (fun uu____3380  ->
                                  FStar_Util.print
                                    "Translate fv: it's a Sig_let\n" []);
                             debug1
-                              (fun uu____3384  ->
-                                 let uu____3385 =
-                                   let uu____3387 =
+                              (fun uu____3390  ->
+                                 let uu____3391 =
+                                   let uu____3393 =
                                      FStar_Syntax_Subst.compress
                                        lb.FStar_Syntax_Syntax.lbtyp
                                       in
-                                   FStar_Syntax_Print.tag_of_term uu____3387
+                                   FStar_Syntax_Print.tag_of_term uu____3393
                                     in
-                                 let uu____3388 =
-                                   let uu____3390 =
+                                 let uu____3394 =
+                                   let uu____3396 =
                                      FStar_Syntax_Subst.compress
                                        lb.FStar_Syntax_Syntax.lbtyp
                                       in
                                    FStar_Syntax_Print.term_to_string
-                                     uu____3390
+                                     uu____3396
                                     in
                                  FStar_Util.print2 "Type of lbdef: %s - %s\n"
-                                   uu____3385 uu____3388);
+                                   uu____3391 uu____3394);
                             debug1
-                              (fun uu____3399  ->
-                                 let uu____3400 =
-                                   let uu____3402 =
+                              (fun uu____3405  ->
+                                 let uu____3406 =
+                                   let uu____3408 =
                                      FStar_Syntax_Subst.compress
                                        lb.FStar_Syntax_Syntax.lbdef
                                       in
-                                   FStar_Syntax_Print.tag_of_term uu____3402
+                                   FStar_Syntax_Print.tag_of_term uu____3408
                                     in
-                                 let uu____3403 =
-                                   let uu____3405 =
+                                 let uu____3409 =
+                                   let uu____3411 =
                                      FStar_Syntax_Subst.compress
                                        lb.FStar_Syntax_Syntax.lbdef
                                       in
                                    FStar_Syntax_Print.term_to_string
-                                     uu____3405
+                                     uu____3411
                                     in
                                  FStar_Util.print2 "Body of lbdef: %s - %s\n"
-                                   uu____3400 uu____3403);
+                                   uu____3406 uu____3409);
                             translate_letbinding cfg bs lb)
                      | FStar_Pervasives_Native.None  ->
                          failwith "Could not find let binding")
-                | uu____3408 -> FStar_TypeChecker_NBETerm.mkFV fvar1 [] [])
+                | uu____3414 -> FStar_TypeChecker_NBETerm.mkFV fvar1 [] [])
            | FStar_TypeChecker_Normalize.Should_unfold_yes  ->
                (match qninfo with
                 | FStar_Pervasives_Native.Some
@@ -744,10 +746,11 @@ and (translate_fv :
                      ({
                         FStar_Syntax_Syntax.sigel =
                           FStar_Syntax_Syntax.Sig_let ((is_rec,lbs),names1);
-                        FStar_Syntax_Syntax.sigrng = uu____3416;
-                        FStar_Syntax_Syntax.sigquals = uu____3417;
-                        FStar_Syntax_Syntax.sigmeta = uu____3418;
-                        FStar_Syntax_Syntax.sigattrs = uu____3419;_},_us_opt),_rng)
+                        FStar_Syntax_Syntax.sigrng = uu____3422;
+                        FStar_Syntax_Syntax.sigquals = uu____3423;
+                        FStar_Syntax_Syntax.sigmeta = uu____3424;
+                        FStar_Syntax_Syntax.sigattrs = uu____3425;
+                        FStar_Syntax_Syntax.sigopts = uu____3426;_},_us_opt),_rng)
                     ->
                     let lbm = find_let lbs fvar1  in
                     (match lbm with
@@ -756,51 +759,51 @@ and (translate_fv :
                          then mkRec cfg lb [] []
                          else
                            (debug1
-                              (fun uu____3492  ->
+                              (fun uu____3501  ->
                                  FStar_Util.print
                                    "Translate fv: it's a Sig_let\n" []);
                             debug1
-                              (fun uu____3502  ->
-                                 let uu____3503 =
-                                   let uu____3505 =
+                              (fun uu____3511  ->
+                                 let uu____3512 =
+                                   let uu____3514 =
                                      FStar_Syntax_Subst.compress
                                        lb.FStar_Syntax_Syntax.lbtyp
                                       in
-                                   FStar_Syntax_Print.tag_of_term uu____3505
+                                   FStar_Syntax_Print.tag_of_term uu____3514
                                     in
-                                 let uu____3506 =
-                                   let uu____3508 =
+                                 let uu____3515 =
+                                   let uu____3517 =
                                      FStar_Syntax_Subst.compress
                                        lb.FStar_Syntax_Syntax.lbtyp
                                       in
                                    FStar_Syntax_Print.term_to_string
-                                     uu____3508
+                                     uu____3517
                                     in
                                  FStar_Util.print2 "Type of lbdef: %s - %s\n"
-                                   uu____3503 uu____3506);
+                                   uu____3512 uu____3515);
                             debug1
-                              (fun uu____3517  ->
-                                 let uu____3518 =
-                                   let uu____3520 =
+                              (fun uu____3526  ->
+                                 let uu____3527 =
+                                   let uu____3529 =
                                      FStar_Syntax_Subst.compress
                                        lb.FStar_Syntax_Syntax.lbdef
                                       in
-                                   FStar_Syntax_Print.tag_of_term uu____3520
+                                   FStar_Syntax_Print.tag_of_term uu____3529
                                     in
-                                 let uu____3521 =
-                                   let uu____3523 =
+                                 let uu____3530 =
+                                   let uu____3532 =
                                      FStar_Syntax_Subst.compress
                                        lb.FStar_Syntax_Syntax.lbdef
                                       in
                                    FStar_Syntax_Print.term_to_string
-                                     uu____3523
+                                     uu____3532
                                     in
                                  FStar_Util.print2 "Body of lbdef: %s - %s\n"
-                                   uu____3518 uu____3521);
+                                   uu____3527 uu____3530);
                             translate_letbinding cfg bs lb)
                      | FStar_Pervasives_Native.None  ->
                          failwith "Could not find let binding")
-                | uu____3526 -> FStar_TypeChecker_NBETerm.mkFV fvar1 [] []))
+                | uu____3535 -> FStar_TypeChecker_NBETerm.mkFV fvar1 [] []))
 
 and (translate_letbinding :
   FStar_TypeChecker_Cfg.cfg ->
@@ -815,11 +818,11 @@ and (translate_letbinding :
         let id1 x = x  in
         match us with
         | [] -> translate cfg bs lb.FStar_Syntax_Syntax.lbdef
-        | uu____3571 ->
-            let uu____3574 =
-              let uu____3605 =
+        | uu____3580 ->
+            let uu____3583 =
+              let uu____3614 =
                 FStar_List.map
-                  (fun uu____3630  ->
+                  (fun uu____3639  ->
                      fun _ts  ->
                        FStar_All.pipe_left id1
                          ((FStar_TypeChecker_NBETerm.Constant
@@ -828,10 +831,10 @@ and (translate_letbinding :
                  in
               ((fun us1  ->
                   translate cfg (FStar_List.rev_append us1 bs)
-                    lb.FStar_Syntax_Syntax.lbdef), uu____3605,
+                    lb.FStar_Syntax_Syntax.lbdef), uu____3614,
                 (FStar_List.length us), FStar_Pervasives_Native.None)
                in
-            FStar_TypeChecker_NBETerm.Lam uu____3574
+            FStar_TypeChecker_NBETerm.Lam uu____3583
 
 and (mkRec' :
   (FStar_TypeChecker_NBETerm.t Prims.list ->
@@ -845,19 +848,19 @@ and (mkRec' :
     fun b  ->
       fun bs  ->
         fun env  ->
-          let uu____3691 = FStar_Syntax_Util.let_rec_arity b  in
-          match uu____3691 with
+          let uu____3700 = FStar_Syntax_Util.let_rec_arity b  in
+          match uu____3700 with
           | (ar,maybe_lst) ->
-              let uu____3716 =
+              let uu____3725 =
                 match maybe_lst with
                 | FStar_Pervasives_Native.None  ->
-                    let uu____3736 =
-                      FStar_Common.tabulate ar (fun uu____3742  -> true)  in
-                    (ar, uu____3736)
+                    let uu____3745 =
+                      FStar_Common.tabulate ar (fun uu____3751  -> true)  in
+                    (ar, uu____3745)
                 | FStar_Pervasives_Native.Some lst ->
                     let l = trim lst  in ((FStar_List.length l), l)
                  in
-              (match uu____3716 with
+              (match uu____3725 with
                | (ar1,ar_lst) ->
                    FStar_TypeChecker_NBETerm.Rec
                      (b, bs, env, [], ar1, ar_lst, callback))
@@ -887,11 +890,11 @@ and (make_rec_env :
           match lbs1 with
           | [] -> bs1
           | lb::lbs' ->
-              let uu____3869 =
-                let uu____3872 = mkRec' callback lb lbs0 bs0  in uu____3872
+              let uu____3878 =
+                let uu____3881 = mkRec' callback lb lbs0 bs0  in uu____3881
                   :: bs1
                  in
-              aux lbs' lbs0 uu____3869 bs0
+              aux lbs' lbs0 uu____3878 bs0
            in
         aux lbs lbs bs bs
 
@@ -902,19 +905,19 @@ and (translate_constant :
     | FStar_Const.Const_unit  -> FStar_TypeChecker_NBETerm.Unit
     | FStar_Const.Const_bool b -> FStar_TypeChecker_NBETerm.Bool b
     | FStar_Const.Const_int (s,FStar_Pervasives_Native.None ) ->
-        let uu____3889 = FStar_BigInt.big_int_of_string s  in
-        FStar_TypeChecker_NBETerm.Int uu____3889
+        let uu____3898 = FStar_BigInt.big_int_of_string s  in
+        FStar_TypeChecker_NBETerm.Int uu____3898
     | FStar_Const.Const_string (s,r) ->
         FStar_TypeChecker_NBETerm.String (s, r)
     | FStar_Const.Const_char c1 -> FStar_TypeChecker_NBETerm.Char c1
     | FStar_Const.Const_range r -> FStar_TypeChecker_NBETerm.Range r
-    | uu____3898 ->
-        let uu____3899 =
-          let uu____3901 =
-            let uu____3903 = FStar_Syntax_Print.const_to_string c  in
-            Prims.op_Hat uu____3903 ": Not yet implemented"  in
-          Prims.op_Hat "Tm_constant " uu____3901  in
-        failwith uu____3899
+    | uu____3907 ->
+        let uu____3908 =
+          let uu____3910 =
+            let uu____3912 = FStar_Syntax_Print.const_to_string c  in
+            Prims.op_Hat uu____3912 ": Not yet implemented"  in
+          Prims.op_Hat "Tm_constant " uu____3910  in
+        failwith uu____3908
 
 and (translate :
   FStar_TypeChecker_Cfg.cfg ->
@@ -926,480 +929,480 @@ and (translate :
       fun e  ->
         let debug1 = debug cfg  in
         debug1
-          (fun uu____3927  ->
-             let uu____3928 =
-               let uu____3930 = FStar_Syntax_Subst.compress e  in
-               FStar_Syntax_Print.tag_of_term uu____3930  in
-             let uu____3931 =
-               let uu____3933 = FStar_Syntax_Subst.compress e  in
-               FStar_Syntax_Print.term_to_string uu____3933  in
-             FStar_Util.print2 "Term: %s - %s\n" uu____3928 uu____3931);
+          (fun uu____3936  ->
+             let uu____3937 =
+               let uu____3939 = FStar_Syntax_Subst.compress e  in
+               FStar_Syntax_Print.tag_of_term uu____3939  in
+             let uu____3940 =
+               let uu____3942 = FStar_Syntax_Subst.compress e  in
+               FStar_Syntax_Print.term_to_string uu____3942  in
+             FStar_Util.print2 "Term: %s - %s\n" uu____3937 uu____3940);
         debug1
-          (fun uu____3940  ->
-             let uu____3941 =
-               let uu____3943 =
+          (fun uu____3949  ->
+             let uu____3950 =
+               let uu____3952 =
                  FStar_List.map
                    (fun x  -> FStar_TypeChecker_NBETerm.t_to_string x) bs
                   in
-               FStar_String.concat ";; " uu____3943  in
-             FStar_Util.print1 "BS list: %s\n" uu____3941);
-        (let uu____3952 =
-           let uu____3953 = FStar_Syntax_Subst.compress e  in
-           uu____3953.FStar_Syntax_Syntax.n  in
-         match uu____3952 with
-         | FStar_Syntax_Syntax.Tm_delayed (uu____3956,uu____3957) ->
+               FStar_String.concat ";; " uu____3952  in
+             FStar_Util.print1 "BS list: %s\n" uu____3950);
+        (let uu____3961 =
+           let uu____3962 = FStar_Syntax_Subst.compress e  in
+           uu____3962.FStar_Syntax_Syntax.n  in
+         match uu____3961 with
+         | FStar_Syntax_Syntax.Tm_delayed (uu____3965,uu____3966) ->
              failwith "Tm_delayed: Impossible"
          | FStar_Syntax_Syntax.Tm_unknown  ->
              FStar_TypeChecker_NBETerm.Unknown
          | FStar_Syntax_Syntax.Tm_constant c ->
-             let uu____3996 = translate_constant c  in
-             FStar_TypeChecker_NBETerm.Constant uu____3996
+             let uu____4005 = translate_constant c  in
+             FStar_TypeChecker_NBETerm.Constant uu____4005
          | FStar_Syntax_Syntax.Tm_bvar db ->
              if db.FStar_Syntax_Syntax.index < (FStar_List.length bs)
              then FStar_List.nth bs db.FStar_Syntax_Syntax.index
              else failwith "de Bruijn index out of bounds"
          | FStar_Syntax_Syntax.Tm_uinst (t,us) ->
              (debug1
-                (fun uu____4015  ->
-                   let uu____4016 = FStar_Syntax_Print.term_to_string t  in
-                   let uu____4018 =
-                     let uu____4020 =
+                (fun uu____4024  ->
+                   let uu____4025 = FStar_Syntax_Print.term_to_string t  in
+                   let uu____4027 =
+                     let uu____4029 =
                        FStar_List.map FStar_Syntax_Print.univ_to_string us
                         in
-                     FStar_All.pipe_right uu____4020
+                     FStar_All.pipe_right uu____4029
                        (FStar_String.concat ", ")
                       in
                    FStar_Util.print2 "Uinst term : %s\nUnivs : %s\n"
-                     uu____4016 uu____4018);
-              (let uu____4031 = translate cfg bs t  in
-               let uu____4032 =
+                     uu____4025 uu____4027);
+              (let uu____4040 = translate cfg bs t  in
+               let uu____4041 =
                  FStar_List.map
                    (fun x  ->
-                      let uu____4036 =
-                        let uu____4037 = translate_univ bs x  in
-                        FStar_TypeChecker_NBETerm.Univ uu____4037  in
-                      FStar_TypeChecker_NBETerm.as_arg uu____4036) us
+                      let uu____4045 =
+                        let uu____4046 = translate_univ bs x  in
+                        FStar_TypeChecker_NBETerm.Univ uu____4046  in
+                      FStar_TypeChecker_NBETerm.as_arg uu____4045) us
                   in
-               iapp cfg uu____4031 uu____4032))
+               iapp cfg uu____4040 uu____4041))
          | FStar_Syntax_Syntax.Tm_type u ->
-             let uu____4039 = translate_univ bs u  in
-             FStar_TypeChecker_NBETerm.Type_t uu____4039
+             let uu____4048 = translate_univ bs u  in
+             FStar_TypeChecker_NBETerm.Type_t uu____4048
          | FStar_Syntax_Syntax.Tm_arrow (xs,c) ->
-             let uu____4062 =
-               let uu____4083 =
+             let uu____4071 =
+               let uu____4092 =
                  FStar_List.fold_right
                    (fun x  ->
                       fun formals  ->
                         let next_formal prefix_of_xs_rev =
-                          let uu____4153 =
+                          let uu____4162 =
                             translate cfg
                               (FStar_List.append prefix_of_xs_rev bs)
                               (FStar_Pervasives_Native.fst x).FStar_Syntax_Syntax.sort
                              in
-                          (uu____4153, (FStar_Pervasives_Native.snd x))  in
+                          (uu____4162, (FStar_Pervasives_Native.snd x))  in
                         next_formal :: formals) xs []
                   in
                ((fun ys  ->
                    translate_comp cfg (FStar_List.rev_append ys bs) c),
-                 uu____4083)
+                 uu____4092)
                 in
-             FStar_TypeChecker_NBETerm.Arrow uu____4062
+             FStar_TypeChecker_NBETerm.Arrow uu____4071
          | FStar_Syntax_Syntax.Tm_refine (bv,tm) ->
              FStar_TypeChecker_NBETerm.Refinement
                (((fun y  -> translate cfg (y :: bs) tm)),
-                 ((fun uu____4222  ->
-                     let uu____4223 =
+                 ((fun uu____4231  ->
+                     let uu____4232 =
                        translate cfg bs bv.FStar_Syntax_Syntax.sort  in
-                     FStar_TypeChecker_NBETerm.as_arg uu____4223)))
-         | FStar_Syntax_Syntax.Tm_ascribed (t,uu____4225,uu____4226) ->
+                     FStar_TypeChecker_NBETerm.as_arg uu____4232)))
+         | FStar_Syntax_Syntax.Tm_ascribed (t,uu____4234,uu____4235) ->
              translate cfg bs t
          | FStar_Syntax_Syntax.Tm_uvar (uvar,t) ->
              (debug_term e; failwith "Tm_uvar: Not yet implemented")
          | FStar_Syntax_Syntax.Tm_name x ->
              FStar_TypeChecker_NBETerm.mkAccuVar x
-         | FStar_Syntax_Syntax.Tm_abs ([],uu____4288,uu____4289) ->
+         | FStar_Syntax_Syntax.Tm_abs ([],uu____4297,uu____4298) ->
              failwith "Impossible: abstraction with no binders"
          | FStar_Syntax_Syntax.Tm_abs (xs,body,resc) ->
-             let uu____4340 =
-               let uu____4371 =
+             let uu____4349 =
+               let uu____4380 =
                  FStar_List.fold_right
                    (fun x  ->
                       fun formals  ->
                         let next_formal prefix_of_xs_rev =
-                          let uu____4441 =
+                          let uu____4450 =
                             translate cfg
                               (FStar_List.append prefix_of_xs_rev bs)
                               (FStar_Pervasives_Native.fst x).FStar_Syntax_Syntax.sort
                              in
-                          (uu____4441, (FStar_Pervasives_Native.snd x))  in
+                          (uu____4450, (FStar_Pervasives_Native.snd x))  in
                         next_formal :: formals) xs []
                   in
-               let uu____4470 =
+               let uu____4479 =
                  FStar_Util.map_opt resc
                    (fun c  ->
-                      fun uu____4482  -> translate_residual_comp cfg bs c)
+                      fun uu____4491  -> translate_residual_comp cfg bs c)
                   in
                ((fun ys  -> translate cfg (FStar_List.rev_append ys bs) body),
-                 uu____4371, (FStar_List.length xs), uu____4470)
+                 uu____4380, (FStar_List.length xs), uu____4479)
                 in
-             FStar_TypeChecker_NBETerm.Lam uu____4340
+             FStar_TypeChecker_NBETerm.Lam uu____4349
          | FStar_Syntax_Syntax.Tm_fvar fvar1 -> translate_fv cfg bs fvar1
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                   (FStar_Const.Const_reify );
-                FStar_Syntax_Syntax.pos = uu____4516;
-                FStar_Syntax_Syntax.vars = uu____4517;_},arg::more::args)
+                FStar_Syntax_Syntax.pos = uu____4525;
+                FStar_Syntax_Syntax.vars = uu____4526;_},arg::more::args)
              ->
-             let uu____4577 = FStar_Syntax_Util.head_and_args e  in
-             (match uu____4577 with
-              | (head1,uu____4595) ->
+             let uu____4586 = FStar_Syntax_Util.head_and_args e  in
+             (match uu____4586 with
+              | (head1,uu____4604) ->
                   let head2 =
                     FStar_Syntax_Syntax.mk_Tm_app head1 [arg]
                       FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
                      in
-                  let uu____4639 =
+                  let uu____4648 =
                     FStar_Syntax_Syntax.mk_Tm_app head2 (more :: args)
                       FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
                      in
-                  translate cfg bs uu____4639)
+                  translate cfg bs uu____4648)
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                  (FStar_Const.Const_reflect uu____4648);
-                FStar_Syntax_Syntax.pos = uu____4649;
-                FStar_Syntax_Syntax.vars = uu____4650;_},arg::more::args)
+                  (FStar_Const.Const_reflect uu____4657);
+                FStar_Syntax_Syntax.pos = uu____4658;
+                FStar_Syntax_Syntax.vars = uu____4659;_},arg::more::args)
              ->
-             let uu____4710 = FStar_Syntax_Util.head_and_args e  in
-             (match uu____4710 with
-              | (head1,uu____4728) ->
+             let uu____4719 = FStar_Syntax_Util.head_and_args e  in
+             (match uu____4719 with
+              | (head1,uu____4737) ->
                   let head2 =
                     FStar_Syntax_Syntax.mk_Tm_app head1 [arg]
                       FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
                      in
-                  let uu____4772 =
+                  let uu____4781 =
                     FStar_Syntax_Syntax.mk_Tm_app head2 (more :: args)
                       FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
                      in
-                  translate cfg bs uu____4772)
+                  translate cfg bs uu____4781)
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                  (FStar_Const.Const_reflect uu____4781);
-                FStar_Syntax_Syntax.pos = uu____4782;
-                FStar_Syntax_Syntax.vars = uu____4783;_},arg::[])
+                  (FStar_Const.Const_reflect uu____4790);
+                FStar_Syntax_Syntax.pos = uu____4791;
+                FStar_Syntax_Syntax.vars = uu____4792;_},arg::[])
              when cfg.FStar_TypeChecker_Cfg.reifying ->
              let cfg1 =
-               let uu___649_4824 = cfg  in
+               let uu___651_4833 = cfg  in
                {
                  FStar_TypeChecker_Cfg.steps =
-                   (uu___649_4824.FStar_TypeChecker_Cfg.steps);
+                   (uu___651_4833.FStar_TypeChecker_Cfg.steps);
                  FStar_TypeChecker_Cfg.tcenv =
-                   (uu___649_4824.FStar_TypeChecker_Cfg.tcenv);
+                   (uu___651_4833.FStar_TypeChecker_Cfg.tcenv);
                  FStar_TypeChecker_Cfg.debug =
-                   (uu___649_4824.FStar_TypeChecker_Cfg.debug);
+                   (uu___651_4833.FStar_TypeChecker_Cfg.debug);
                  FStar_TypeChecker_Cfg.delta_level =
-                   (uu___649_4824.FStar_TypeChecker_Cfg.delta_level);
+                   (uu___651_4833.FStar_TypeChecker_Cfg.delta_level);
                  FStar_TypeChecker_Cfg.primitive_steps =
-                   (uu___649_4824.FStar_TypeChecker_Cfg.primitive_steps);
+                   (uu___651_4833.FStar_TypeChecker_Cfg.primitive_steps);
                  FStar_TypeChecker_Cfg.strong =
-                   (uu___649_4824.FStar_TypeChecker_Cfg.strong);
+                   (uu___651_4833.FStar_TypeChecker_Cfg.strong);
                  FStar_TypeChecker_Cfg.memoize_lazy =
-                   (uu___649_4824.FStar_TypeChecker_Cfg.memoize_lazy);
+                   (uu___651_4833.FStar_TypeChecker_Cfg.memoize_lazy);
                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                   (uu___649_4824.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                   (uu___651_4833.FStar_TypeChecker_Cfg.normalize_pure_lets);
                  FStar_TypeChecker_Cfg.reifying = false
                }  in
              translate cfg1 bs (FStar_Pervasives_Native.fst arg)
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                  (FStar_Const.Const_reflect uu____4830);
-                FStar_Syntax_Syntax.pos = uu____4831;
-                FStar_Syntax_Syntax.vars = uu____4832;_},arg::[])
+                  (FStar_Const.Const_reflect uu____4839);
+                FStar_Syntax_Syntax.pos = uu____4840;
+                FStar_Syntax_Syntax.vars = uu____4841;_},arg::[])
              ->
-             let uu____4872 =
+             let uu____4881 =
                translate cfg bs (FStar_Pervasives_Native.fst arg)  in
-             FStar_TypeChecker_NBETerm.Reflect uu____4872
+             FStar_TypeChecker_NBETerm.Reflect uu____4881
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                   (FStar_Const.Const_reify );
-                FStar_Syntax_Syntax.pos = uu____4877;
-                FStar_Syntax_Syntax.vars = uu____4878;_},arg::[])
+                FStar_Syntax_Syntax.pos = uu____4886;
+                FStar_Syntax_Syntax.vars = uu____4887;_},arg::[])
              when
              (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.reify_
              ->
              let cfg1 =
-               let uu___672_4920 = cfg  in
+               let uu___674_4929 = cfg  in
                {
                  FStar_TypeChecker_Cfg.steps =
-                   (uu___672_4920.FStar_TypeChecker_Cfg.steps);
+                   (uu___674_4929.FStar_TypeChecker_Cfg.steps);
                  FStar_TypeChecker_Cfg.tcenv =
-                   (uu___672_4920.FStar_TypeChecker_Cfg.tcenv);
+                   (uu___674_4929.FStar_TypeChecker_Cfg.tcenv);
                  FStar_TypeChecker_Cfg.debug =
-                   (uu___672_4920.FStar_TypeChecker_Cfg.debug);
+                   (uu___674_4929.FStar_TypeChecker_Cfg.debug);
                  FStar_TypeChecker_Cfg.delta_level =
-                   (uu___672_4920.FStar_TypeChecker_Cfg.delta_level);
+                   (uu___674_4929.FStar_TypeChecker_Cfg.delta_level);
                  FStar_TypeChecker_Cfg.primitive_steps =
-                   (uu___672_4920.FStar_TypeChecker_Cfg.primitive_steps);
+                   (uu___674_4929.FStar_TypeChecker_Cfg.primitive_steps);
                  FStar_TypeChecker_Cfg.strong =
-                   (uu___672_4920.FStar_TypeChecker_Cfg.strong);
+                   (uu___674_4929.FStar_TypeChecker_Cfg.strong);
                  FStar_TypeChecker_Cfg.memoize_lazy =
-                   (uu___672_4920.FStar_TypeChecker_Cfg.memoize_lazy);
+                   (uu___674_4929.FStar_TypeChecker_Cfg.memoize_lazy);
                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                   (uu___672_4920.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                   (uu___674_4929.FStar_TypeChecker_Cfg.normalize_pure_lets);
                  FStar_TypeChecker_Cfg.reifying = true
                }  in
              translate cfg1 bs (FStar_Pervasives_Native.fst arg)
          | FStar_Syntax_Syntax.Tm_app (head1,args) ->
              (debug1
-                (fun uu____4959  ->
-                   let uu____4960 = FStar_Syntax_Print.term_to_string head1
+                (fun uu____4968  ->
+                   let uu____4969 = FStar_Syntax_Print.term_to_string head1
                       in
-                   let uu____4962 = FStar_Syntax_Print.args_to_string args
+                   let uu____4971 = FStar_Syntax_Print.args_to_string args
                       in
-                   FStar_Util.print2 "Application: %s @ %s\n" uu____4960
-                     uu____4962);
-              (let uu____4965 = translate cfg bs head1  in
-               let uu____4966 =
+                   FStar_Util.print2 "Application: %s @ %s\n" uu____4969
+                     uu____4971);
+              (let uu____4974 = translate cfg bs head1  in
+               let uu____4975 =
                  FStar_List.map
                    (fun x  ->
-                      let uu____4988 =
+                      let uu____4997 =
                         translate cfg bs (FStar_Pervasives_Native.fst x)  in
-                      (uu____4988, (FStar_Pervasives_Native.snd x))) args
+                      (uu____4997, (FStar_Pervasives_Native.snd x))) args
                   in
-               iapp cfg uu____4965 uu____4966))
+               iapp cfg uu____4974 uu____4975))
          | FStar_Syntax_Syntax.Tm_match (scrut,branches) ->
              let make_branches readback1 =
                let cfg1 =
-                 let uu___688_5049 = cfg  in
+                 let uu___690_5058 = cfg  in
                  {
                    FStar_TypeChecker_Cfg.steps =
-                     (let uu___690_5052 = cfg.FStar_TypeChecker_Cfg.steps  in
+                     (let uu___692_5061 = cfg.FStar_TypeChecker_Cfg.steps  in
                       {
                         FStar_TypeChecker_Cfg.beta =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.beta);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.beta);
                         FStar_TypeChecker_Cfg.iota =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.iota);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.iota);
                         FStar_TypeChecker_Cfg.zeta = false;
                         FStar_TypeChecker_Cfg.weak =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.weak);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.weak);
                         FStar_TypeChecker_Cfg.hnf =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.hnf);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.hnf);
                         FStar_TypeChecker_Cfg.primops =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.primops);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.primops);
                         FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                         FStar_TypeChecker_Cfg.unfold_until =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.unfold_until);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.unfold_until);
                         FStar_TypeChecker_Cfg.unfold_only =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.unfold_only);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.unfold_only);
                         FStar_TypeChecker_Cfg.unfold_fully =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.unfold_fully);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.unfold_fully);
                         FStar_TypeChecker_Cfg.unfold_attr =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.unfold_attr);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.unfold_attr);
                         FStar_TypeChecker_Cfg.unfold_tac =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.unfold_tac);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.unfold_tac);
                         FStar_TypeChecker_Cfg.pure_subterms_within_computations
                           =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                         FStar_TypeChecker_Cfg.simplify =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.simplify);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.simplify);
                         FStar_TypeChecker_Cfg.erase_universes =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.erase_universes);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.erase_universes);
                         FStar_TypeChecker_Cfg.allow_unbound_universes =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.allow_unbound_universes);
                         FStar_TypeChecker_Cfg.reify_ =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.reify_);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.reify_);
                         FStar_TypeChecker_Cfg.compress_uvars =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.compress_uvars);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.compress_uvars);
                         FStar_TypeChecker_Cfg.no_full_norm =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.no_full_norm);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.no_full_norm);
                         FStar_TypeChecker_Cfg.check_no_uvars =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.check_no_uvars);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.check_no_uvars);
                         FStar_TypeChecker_Cfg.unmeta =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.unmeta);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.unmeta);
                         FStar_TypeChecker_Cfg.unascribe =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.unascribe);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.unascribe);
                         FStar_TypeChecker_Cfg.in_full_norm_request =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.in_full_norm_request);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.in_full_norm_request);
                         FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                         FStar_TypeChecker_Cfg.nbe_step =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.nbe_step);
+                          (uu___692_5061.FStar_TypeChecker_Cfg.nbe_step);
                         FStar_TypeChecker_Cfg.for_extraction =
-                          (uu___690_5052.FStar_TypeChecker_Cfg.for_extraction)
+                          (uu___692_5061.FStar_TypeChecker_Cfg.for_extraction)
                       });
                    FStar_TypeChecker_Cfg.tcenv =
-                     (uu___688_5049.FStar_TypeChecker_Cfg.tcenv);
+                     (uu___690_5058.FStar_TypeChecker_Cfg.tcenv);
                    FStar_TypeChecker_Cfg.debug =
-                     (uu___688_5049.FStar_TypeChecker_Cfg.debug);
+                     (uu___690_5058.FStar_TypeChecker_Cfg.debug);
                    FStar_TypeChecker_Cfg.delta_level =
-                     (uu___688_5049.FStar_TypeChecker_Cfg.delta_level);
+                     (uu___690_5058.FStar_TypeChecker_Cfg.delta_level);
                    FStar_TypeChecker_Cfg.primitive_steps =
-                     (uu___688_5049.FStar_TypeChecker_Cfg.primitive_steps);
+                     (uu___690_5058.FStar_TypeChecker_Cfg.primitive_steps);
                    FStar_TypeChecker_Cfg.strong =
-                     (uu___688_5049.FStar_TypeChecker_Cfg.strong);
+                     (uu___690_5058.FStar_TypeChecker_Cfg.strong);
                    FStar_TypeChecker_Cfg.memoize_lazy =
-                     (uu___688_5049.FStar_TypeChecker_Cfg.memoize_lazy);
+                     (uu___690_5058.FStar_TypeChecker_Cfg.memoize_lazy);
                    FStar_TypeChecker_Cfg.normalize_pure_lets =
-                     (uu___688_5049.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                     (uu___690_5058.FStar_TypeChecker_Cfg.normalize_pure_lets);
                    FStar_TypeChecker_Cfg.reifying =
-                     (uu___688_5049.FStar_TypeChecker_Cfg.reifying)
+                     (uu___690_5058.FStar_TypeChecker_Cfg.reifying)
                  }  in
                let rec process_pattern bs1 p =
-                 let uu____5081 =
+                 let uu____5090 =
                    match p.FStar_Syntax_Syntax.v with
                    | FStar_Syntax_Syntax.Pat_constant c ->
                        (bs1, (FStar_Syntax_Syntax.Pat_constant c))
                    | FStar_Syntax_Syntax.Pat_cons (fvar1,args) ->
-                       let uu____5117 =
+                       let uu____5126 =
                          FStar_List.fold_left
-                           (fun uu____5158  ->
-                              fun uu____5159  ->
-                                match (uu____5158, uu____5159) with
+                           (fun uu____5167  ->
+                              fun uu____5168  ->
+                                match (uu____5167, uu____5168) with
                                 | ((bs2,args1),(arg,b)) ->
-                                    let uu____5251 = process_pattern bs2 arg
+                                    let uu____5260 = process_pattern bs2 arg
                                        in
-                                    (match uu____5251 with
+                                    (match uu____5260 with
                                      | (bs',arg') ->
                                          (bs', ((arg', b) :: args1))))
                            (bs1, []) args
                           in
-                       (match uu____5117 with
+                       (match uu____5126 with
                         | (bs',args') ->
                             (bs',
                               (FStar_Syntax_Syntax.Pat_cons
                                  (fvar1, (FStar_List.rev args')))))
                    | FStar_Syntax_Syntax.Pat_var bvar ->
                        let x =
-                         let uu____5350 =
-                           let uu____5351 =
+                         let uu____5359 =
+                           let uu____5360 =
                              translate cfg1 bs1 bvar.FStar_Syntax_Syntax.sort
                               in
-                           readback1 uu____5351  in
+                           readback1 uu____5360  in
                          FStar_Syntax_Syntax.new_bv
-                           FStar_Pervasives_Native.None uu____5350
+                           FStar_Pervasives_Native.None uu____5359
                           in
-                       let uu____5352 =
-                         let uu____5355 =
+                       let uu____5361 =
+                         let uu____5364 =
                            FStar_TypeChecker_NBETerm.mkAccuVar x  in
-                         uu____5355 :: bs1  in
-                       (uu____5352, (FStar_Syntax_Syntax.Pat_var x))
+                         uu____5364 :: bs1  in
+                       (uu____5361, (FStar_Syntax_Syntax.Pat_var x))
                    | FStar_Syntax_Syntax.Pat_wild bvar ->
                        let x =
-                         let uu____5360 =
-                           let uu____5361 =
+                         let uu____5369 =
+                           let uu____5370 =
                              translate cfg1 bs1 bvar.FStar_Syntax_Syntax.sort
                               in
-                           readback1 uu____5361  in
+                           readback1 uu____5370  in
                          FStar_Syntax_Syntax.new_bv
-                           FStar_Pervasives_Native.None uu____5360
+                           FStar_Pervasives_Native.None uu____5369
                           in
-                       let uu____5362 =
-                         let uu____5365 =
+                       let uu____5371 =
+                         let uu____5374 =
                            FStar_TypeChecker_NBETerm.mkAccuVar x  in
-                         uu____5365 :: bs1  in
-                       (uu____5362, (FStar_Syntax_Syntax.Pat_wild x))
+                         uu____5374 :: bs1  in
+                       (uu____5371, (FStar_Syntax_Syntax.Pat_wild x))
                    | FStar_Syntax_Syntax.Pat_dot_term (bvar,tm) ->
                        let x =
-                         let uu____5375 =
-                           let uu____5376 =
+                         let uu____5384 =
+                           let uu____5385 =
                              translate cfg1 bs1 bvar.FStar_Syntax_Syntax.sort
                               in
-                           readback1 uu____5376  in
+                           readback1 uu____5385  in
                          FStar_Syntax_Syntax.new_bv
-                           FStar_Pervasives_Native.None uu____5375
+                           FStar_Pervasives_Native.None uu____5384
                           in
-                       let uu____5377 =
-                         let uu____5378 =
-                           let uu____5385 =
-                             let uu____5388 = translate cfg1 bs1 tm  in
-                             readback1 uu____5388  in
-                           (x, uu____5385)  in
-                         FStar_Syntax_Syntax.Pat_dot_term uu____5378  in
-                       (bs1, uu____5377)
+                       let uu____5386 =
+                         let uu____5387 =
+                           let uu____5394 =
+                             let uu____5397 = translate cfg1 bs1 tm  in
+                             readback1 uu____5397  in
+                           (x, uu____5394)  in
+                         FStar_Syntax_Syntax.Pat_dot_term uu____5387  in
+                       (bs1, uu____5386)
                     in
-                 match uu____5081 with
+                 match uu____5090 with
                  | (bs2,p_new) ->
                      (bs2,
-                       (let uu___728_5408 = p  in
+                       (let uu___730_5417 = p  in
                         {
                           FStar_Syntax_Syntax.v = p_new;
                           FStar_Syntax_Syntax.p =
-                            (uu___728_5408.FStar_Syntax_Syntax.p)
+                            (uu___730_5417.FStar_Syntax_Syntax.p)
                         }))
                   in
                FStar_List.map
-                 (fun uu____5427  ->
-                    match uu____5427 with
+                 (fun uu____5436  ->
+                    match uu____5436 with
                     | (pat,when_clause,e1) ->
-                        let uu____5449 = process_pattern bs pat  in
-                        (match uu____5449 with
+                        let uu____5458 = process_pattern bs pat  in
+                        (match uu____5458 with
                          | (bs',pat') ->
-                             let uu____5462 =
-                               let uu____5463 =
-                                 let uu____5466 = translate cfg1 bs' e1  in
-                                 readback1 uu____5466  in
-                               (pat', when_clause, uu____5463)  in
-                             FStar_Syntax_Util.branch uu____5462)) branches
+                             let uu____5471 =
+                               let uu____5472 =
+                                 let uu____5475 = translate cfg1 bs' e1  in
+                                 readback1 uu____5475  in
+                               (pat', when_clause, uu____5472)  in
+                             FStar_Syntax_Util.branch uu____5471)) branches
                 in
              let rec case scrut1 =
                debug1
-                 (fun uu____5488  ->
-                    let uu____5489 =
-                      let uu____5491 = readback cfg scrut1  in
-                      FStar_Syntax_Print.term_to_string uu____5491  in
-                    let uu____5492 =
+                 (fun uu____5497  ->
+                    let uu____5498 =
+                      let uu____5500 = readback cfg scrut1  in
+                      FStar_Syntax_Print.term_to_string uu____5500  in
+                    let uu____5501 =
                       FStar_TypeChecker_NBETerm.t_to_string scrut1  in
-                    FStar_Util.print2 "Match case: (%s) -- (%s)\n" uu____5489
-                      uu____5492);
+                    FStar_Util.print2 "Match case: (%s) -- (%s)\n" uu____5498
+                      uu____5501);
                (let scrut2 = unlazy scrut1  in
                 match scrut2 with
                 | FStar_TypeChecker_NBETerm.Construct (c,us,args) ->
                     (debug1
-                       (fun uu____5520  ->
-                          let uu____5521 =
-                            let uu____5523 =
+                       (fun uu____5529  ->
+                          let uu____5530 =
+                            let uu____5532 =
                               FStar_All.pipe_right args
                                 (FStar_List.map
-                                   (fun uu____5549  ->
-                                      match uu____5549 with
+                                   (fun uu____5558  ->
+                                      match uu____5558 with
                                       | (x,q) ->
-                                          let uu____5563 =
+                                          let uu____5572 =
                                             FStar_TypeChecker_NBETerm.t_to_string
                                               x
                                              in
                                           Prims.op_Hat
                                             (if FStar_Util.is_some q
                                              then "#"
-                                             else "") uu____5563))
+                                             else "") uu____5572))
                                in
-                            FStar_All.pipe_right uu____5523
+                            FStar_All.pipe_right uu____5532
                               (FStar_String.concat "; ")
                              in
-                          FStar_Util.print1 "Match args: %s\n" uu____5521);
-                     (let uu____5577 = pickBranch cfg scrut2 branches  in
-                      match uu____5577 with
+                          FStar_Util.print1 "Match args: %s\n" uu____5530);
+                     (let uu____5586 = pickBranch cfg scrut2 branches  in
+                      match uu____5586 with
                       | FStar_Pervasives_Native.Some (branch1,args1) ->
-                          let uu____5598 =
+                          let uu____5607 =
                             FStar_List.fold_left
                               (fun bs1  -> fun x  -> x :: bs1) bs args1
                              in
-                          translate cfg uu____5598 branch1
+                          translate cfg uu____5607 branch1
                       | FStar_Pervasives_Native.None  ->
                           FStar_TypeChecker_NBETerm.mkAccuMatch scrut2 case
                             make_branches))
                 | FStar_TypeChecker_NBETerm.Constant c ->
                     (debug1
-                       (fun uu____5621  ->
-                          let uu____5622 =
+                       (fun uu____5630  ->
+                          let uu____5631 =
                             FStar_TypeChecker_NBETerm.t_to_string scrut2  in
                           FStar_Util.print1 "Match constant : %s\n"
-                            uu____5622);
-                     (let uu____5625 = pickBranch cfg scrut2 branches  in
-                      match uu____5625 with
+                            uu____5631);
+                     (let uu____5634 = pickBranch cfg scrut2 branches  in
+                      match uu____5634 with
                       | FStar_Pervasives_Native.Some (branch1,[]) ->
                           translate cfg bs branch1
                       | FStar_Pervasives_Native.Some (branch1,arg::[]) ->
@@ -1407,14 +1410,14 @@ and (translate :
                       | FStar_Pervasives_Native.None  ->
                           FStar_TypeChecker_NBETerm.mkAccuMatch scrut2 case
                             make_branches
-                      | FStar_Pervasives_Native.Some (uu____5659,hd1::tl1) ->
+                      | FStar_Pervasives_Native.Some (uu____5668,hd1::tl1) ->
                           failwith
                             "Impossible: Matching on constants cannot bind more than one variable"))
-                | uu____5673 ->
+                | uu____5682 ->
                     FStar_TypeChecker_NBETerm.mkAccuMatch scrut2 case
                       make_branches)
                 in
-             let uu____5674 = translate cfg bs scrut  in case uu____5674
+             let uu____5683 = translate cfg bs scrut  in case uu____5683
          | FStar_Syntax_Syntax.Tm_meta
              (e1,FStar_Syntax_Syntax.Meta_monadic (m,t)) when
              cfg.FStar_TypeChecker_Cfg.reifying ->
@@ -1433,15 +1436,15 @@ and (translate :
                 in
              translate cfg bs' body
          | FStar_Syntax_Syntax.Tm_let ((true ,lbs),body) ->
-             let uu____5753 = make_rec_env (translate_letbinding cfg) lbs bs
+             let uu____5762 = make_rec_env (translate_letbinding cfg) lbs bs
                 in
-             translate cfg uu____5753 body
-         | FStar_Syntax_Syntax.Tm_meta (e1,uu____5757) -> translate cfg bs e1
+             translate cfg uu____5762 body
+         | FStar_Syntax_Syntax.Tm_meta (e1,uu____5766) -> translate cfg bs e1
          | FStar_Syntax_Syntax.Tm_quoted (qt,qi) ->
              let close1 t =
                let bvs =
                  FStar_List.map
-                   (fun uu____5778  ->
+                   (fun uu____5787  ->
                       FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
                         FStar_Syntax_Syntax.tun) bs
                   in
@@ -1450,18 +1453,18 @@ and (translate :
                    (fun i  -> fun bv  -> FStar_Syntax_Syntax.DB (i, bv)) bvs
                   in
                let s2 =
-                 let uu____5791 = FStar_List.zip bvs bs  in
+                 let uu____5800 = FStar_List.zip bvs bs  in
                  FStar_List.map
-                   (fun uu____5806  ->
-                      match uu____5806 with
+                   (fun uu____5815  ->
+                      match uu____5815 with
                       | (bv,t1) ->
-                          let uu____5813 =
-                            let uu____5820 = readback cfg t1  in
-                            (bv, uu____5820)  in
-                          FStar_Syntax_Syntax.NT uu____5813) uu____5791
+                          let uu____5822 =
+                            let uu____5829 = readback cfg t1  in
+                            (bv, uu____5829)  in
+                          FStar_Syntax_Syntax.NT uu____5822) uu____5800
                   in
-               let uu____5825 = FStar_Syntax_Subst.subst s1 t  in
-               FStar_Syntax_Subst.subst s2 uu____5825  in
+               let uu____5834 = FStar_Syntax_Subst.subst s1 t  in
+               FStar_Syntax_Subst.subst s2 uu____5834  in
              (match qi.FStar_Syntax_Syntax.qkind with
               | FStar_Syntax_Syntax.Quote_dynamic  ->
                   let qt1 = close1 qt  in
@@ -1470,18 +1473,18 @@ and (translate :
                   let qi1 = FStar_Syntax_Syntax.on_antiquoted close1 qi  in
                   FStar_TypeChecker_NBETerm.Quote (qt, qi1))
          | FStar_Syntax_Syntax.Tm_lazy li ->
-             let f uu____5834 =
+             let f uu____5843 =
                let t = FStar_Syntax_Util.unfold_lazy li  in
                debug1
-                 (fun uu____5841  ->
-                    let uu____5842 = FStar_Syntax_Print.term_to_string t  in
+                 (fun uu____5850  ->
+                    let uu____5851 = FStar_Syntax_Print.term_to_string t  in
                     FStar_Util.print1 ">> Unfolding Tm_lazy to %s\n"
-                      uu____5842);
+                      uu____5851);
                translate cfg bs t  in
-             let uu____5845 =
-               let uu____5860 = FStar_Common.mk_thunk f  in
-               ((FStar_Util.Inl li), uu____5860)  in
-             FStar_TypeChecker_NBETerm.Lazy uu____5845)
+             let uu____5854 =
+               let uu____5869 = FStar_Common.mk_thunk f  in
+               ((FStar_Util.Inl li), uu____5869)  in
+             FStar_TypeChecker_NBETerm.Lazy uu____5854)
 
 and (translate_comp :
   FStar_TypeChecker_Cfg.cfg ->
@@ -1493,20 +1496,20 @@ and (translate_comp :
       fun c  ->
         match c.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Total (typ,u) ->
-            let uu____5892 =
-              let uu____5899 = translate cfg bs typ  in
-              let uu____5900 = fmap_opt (translate_univ bs) u  in
-              (uu____5899, uu____5900)  in
-            FStar_TypeChecker_NBETerm.Tot uu____5892
+            let uu____5901 =
+              let uu____5908 = translate cfg bs typ  in
+              let uu____5909 = fmap_opt (translate_univ bs) u  in
+              (uu____5908, uu____5909)  in
+            FStar_TypeChecker_NBETerm.Tot uu____5901
         | FStar_Syntax_Syntax.GTotal (typ,u) ->
-            let uu____5915 =
-              let uu____5922 = translate cfg bs typ  in
-              let uu____5923 = fmap_opt (translate_univ bs) u  in
-              (uu____5922, uu____5923)  in
-            FStar_TypeChecker_NBETerm.GTot uu____5915
+            let uu____5924 =
+              let uu____5931 = translate cfg bs typ  in
+              let uu____5932 = fmap_opt (translate_univ bs) u  in
+              (uu____5931, uu____5932)  in
+            FStar_TypeChecker_NBETerm.GTot uu____5924
         | FStar_Syntax_Syntax.Comp ctyp ->
-            let uu____5929 = translate_comp_typ cfg bs ctyp  in
-            FStar_TypeChecker_NBETerm.Comp uu____5929
+            let uu____5938 = translate_comp_typ cfg bs ctyp  in
+            FStar_TypeChecker_NBETerm.Comp uu____5938
 
 and (readback_comp :
   FStar_TypeChecker_Cfg.cfg ->
@@ -1517,16 +1520,16 @@ and (readback_comp :
       let c' =
         match c with
         | FStar_TypeChecker_NBETerm.Tot (typ,u) ->
-            let uu____5939 =
-              let uu____5948 = readback cfg typ  in (uu____5948, u)  in
-            FStar_Syntax_Syntax.Total uu____5939
+            let uu____5948 =
+              let uu____5957 = readback cfg typ  in (uu____5957, u)  in
+            FStar_Syntax_Syntax.Total uu____5948
         | FStar_TypeChecker_NBETerm.GTot (typ,u) ->
-            let uu____5961 =
-              let uu____5970 = readback cfg typ  in (uu____5970, u)  in
-            FStar_Syntax_Syntax.GTotal uu____5961
+            let uu____5970 =
+              let uu____5979 = readback cfg typ  in (uu____5979, u)  in
+            FStar_Syntax_Syntax.GTotal uu____5970
         | FStar_TypeChecker_NBETerm.Comp ctyp ->
-            let uu____5978 = readback_comp_typ cfg ctyp  in
-            FStar_Syntax_Syntax.Comp uu____5978
+            let uu____5987 = readback_comp_typ cfg ctyp  in
+            FStar_Syntax_Syntax.Comp uu____5987
          in
       FStar_Syntax_Syntax.mk c' FStar_Pervasives_Native.None
         FStar_Range.dummyRange
@@ -1539,30 +1542,30 @@ and (translate_comp_typ :
   fun cfg  ->
     fun bs  ->
       fun c  ->
-        let uu____5984 = c  in
-        match uu____5984 with
+        let uu____5993 = c  in
+        match uu____5993 with
         | { FStar_Syntax_Syntax.comp_univs = comp_univs;
             FStar_Syntax_Syntax.effect_name = effect_name;
             FStar_Syntax_Syntax.result_typ = result_typ;
             FStar_Syntax_Syntax.effect_args = effect_args;
             FStar_Syntax_Syntax.flags = flags;_} ->
-            let uu____6004 = FStar_List.map (translate_univ bs) comp_univs
+            let uu____6013 = FStar_List.map (translate_univ bs) comp_univs
                in
-            let uu____6005 = translate cfg bs result_typ  in
-            let uu____6006 =
+            let uu____6014 = translate cfg bs result_typ  in
+            let uu____6015 =
               FStar_List.map
                 (fun x  ->
-                   let uu____6034 =
+                   let uu____6043 =
                      translate cfg bs (FStar_Pervasives_Native.fst x)  in
-                   (uu____6034, (FStar_Pervasives_Native.snd x))) effect_args
+                   (uu____6043, (FStar_Pervasives_Native.snd x))) effect_args
                in
-            let uu____6041 = FStar_List.map (translate_flag cfg bs) flags  in
+            let uu____6050 = FStar_List.map (translate_flag cfg bs) flags  in
             {
-              FStar_TypeChecker_NBETerm.comp_univs = uu____6004;
+              FStar_TypeChecker_NBETerm.comp_univs = uu____6013;
               FStar_TypeChecker_NBETerm.effect_name = effect_name;
-              FStar_TypeChecker_NBETerm.result_typ = uu____6005;
-              FStar_TypeChecker_NBETerm.effect_args = uu____6006;
-              FStar_TypeChecker_NBETerm.flags = uu____6041
+              FStar_TypeChecker_NBETerm.result_typ = uu____6014;
+              FStar_TypeChecker_NBETerm.effect_args = uu____6015;
+              FStar_TypeChecker_NBETerm.flags = uu____6050
             }
 
 and (readback_comp_typ :
@@ -1571,17 +1574,17 @@ and (readback_comp_typ :
   =
   fun cfg  ->
     fun c  ->
-      let uu____6046 = readback cfg c.FStar_TypeChecker_NBETerm.result_typ
+      let uu____6055 = readback cfg c.FStar_TypeChecker_NBETerm.result_typ
          in
-      let uu____6049 =
+      let uu____6058 =
         FStar_List.map
           (fun x  ->
-             let uu____6075 = readback cfg (FStar_Pervasives_Native.fst x)
+             let uu____6084 = readback cfg (FStar_Pervasives_Native.fst x)
                 in
-             (uu____6075, (FStar_Pervasives_Native.snd x)))
+             (uu____6084, (FStar_Pervasives_Native.snd x)))
           c.FStar_TypeChecker_NBETerm.effect_args
          in
-      let uu____6076 =
+      let uu____6085 =
         FStar_List.map (readback_flag cfg) c.FStar_TypeChecker_NBETerm.flags
          in
       {
@@ -1589,9 +1592,9 @@ and (readback_comp_typ :
           (c.FStar_TypeChecker_NBETerm.comp_univs);
         FStar_Syntax_Syntax.effect_name =
           (c.FStar_TypeChecker_NBETerm.effect_name);
-        FStar_Syntax_Syntax.result_typ = uu____6046;
-        FStar_Syntax_Syntax.effect_args = uu____6049;
-        FStar_Syntax_Syntax.flags = uu____6076
+        FStar_Syntax_Syntax.result_typ = uu____6055;
+        FStar_Syntax_Syntax.effect_args = uu____6058;
+        FStar_Syntax_Syntax.flags = uu____6085
       }
 
 and (translate_residual_comp :
@@ -1603,19 +1606,19 @@ and (translate_residual_comp :
   fun cfg  ->
     fun bs  ->
       fun c  ->
-        let uu____6084 = c  in
-        match uu____6084 with
+        let uu____6093 = c  in
+        match uu____6093 with
         | { FStar_Syntax_Syntax.residual_effect = residual_effect;
             FStar_Syntax_Syntax.residual_typ = residual_typ;
             FStar_Syntax_Syntax.residual_flags = residual_flags;_} ->
-            let uu____6094 =
+            let uu____6103 =
               FStar_Util.map_opt residual_typ (translate cfg bs)  in
-            let uu____6099 =
+            let uu____6108 =
               FStar_List.map (translate_flag cfg bs) residual_flags  in
             {
               FStar_TypeChecker_NBETerm.residual_effect = residual_effect;
-              FStar_TypeChecker_NBETerm.residual_typ = uu____6094;
-              FStar_TypeChecker_NBETerm.residual_flags = uu____6099
+              FStar_TypeChecker_NBETerm.residual_typ = uu____6103;
+              FStar_TypeChecker_NBETerm.residual_flags = uu____6108
             }
 
 and (readback_residual_comp :
@@ -1625,19 +1628,19 @@ and (readback_residual_comp :
   =
   fun cfg  ->
     fun c  ->
-      let uu____6104 =
+      let uu____6113 =
         FStar_Util.map_opt c.FStar_TypeChecker_NBETerm.residual_typ
           (readback cfg)
          in
-      let uu____6111 =
+      let uu____6120 =
         FStar_List.map (readback_flag cfg)
           c.FStar_TypeChecker_NBETerm.residual_flags
          in
       {
         FStar_Syntax_Syntax.residual_effect =
           (c.FStar_TypeChecker_NBETerm.residual_effect);
-        FStar_Syntax_Syntax.residual_typ = uu____6104;
-        FStar_Syntax_Syntax.residual_flags = uu____6111
+        FStar_Syntax_Syntax.residual_typ = uu____6113;
+        FStar_Syntax_Syntax.residual_flags = uu____6120
       }
 
 and (translate_flag :
@@ -1663,8 +1666,8 @@ and (translate_flag :
         | FStar_Syntax_Syntax.LEMMA  -> FStar_TypeChecker_NBETerm.LEMMA
         | FStar_Syntax_Syntax.CPS  -> FStar_TypeChecker_NBETerm.CPS
         | FStar_Syntax_Syntax.DECREASES tm ->
-            let uu____6122 = translate cfg bs tm  in
-            FStar_TypeChecker_NBETerm.DECREASES uu____6122
+            let uu____6131 = translate cfg bs tm  in
+            FStar_TypeChecker_NBETerm.DECREASES uu____6131
 
 and (readback_flag :
   FStar_TypeChecker_Cfg.cfg ->
@@ -1687,8 +1690,8 @@ and (readback_flag :
       | FStar_TypeChecker_NBETerm.LEMMA  -> FStar_Syntax_Syntax.LEMMA
       | FStar_TypeChecker_NBETerm.CPS  -> FStar_Syntax_Syntax.CPS
       | FStar_TypeChecker_NBETerm.DECREASES t ->
-          let uu____6126 = readback cfg t  in
-          FStar_Syntax_Syntax.DECREASES uu____6126
+          let uu____6135 = readback cfg t  in
+          FStar_Syntax_Syntax.DECREASES uu____6135
 
 and (translate_monadic :
   (FStar_Syntax_Syntax.monad_name * FStar_Syntax_Syntax.term'
@@ -1698,51 +1701,51 @@ and (translate_monadic :
         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
           FStar_TypeChecker_NBETerm.t)
   =
-  fun uu____6129  ->
+  fun uu____6138  ->
     fun cfg  ->
       fun bs  ->
         fun e  ->
-          match uu____6129 with
+          match uu____6138 with
           | (m,ty) ->
               let e1 = FStar_Syntax_Util.unascribe e  in
               (match e1.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) ->
-                   let uu____6167 =
-                     let uu____6176 =
+                   let uu____6176 =
+                     let uu____6185 =
                        FStar_TypeChecker_Env.norm_eff_name
                          cfg.FStar_TypeChecker_Cfg.tcenv m
                         in
                      FStar_TypeChecker_Env.effect_decl_opt
-                       cfg.FStar_TypeChecker_Cfg.tcenv uu____6176
+                       cfg.FStar_TypeChecker_Cfg.tcenv uu____6185
                       in
-                   (match uu____6167 with
+                   (match uu____6176 with
                     | FStar_Pervasives_Native.None  ->
-                        let uu____6183 =
-                          let uu____6185 = FStar_Ident.string_of_lid m  in
+                        let uu____6192 =
+                          let uu____6194 = FStar_Ident.string_of_lid m  in
                           FStar_Util.format1
-                            "Effect declaration not found: %s" uu____6185
+                            "Effect declaration not found: %s" uu____6194
                            in
-                        failwith uu____6183
+                        failwith uu____6192
                     | FStar_Pervasives_Native.Some (ed,q) ->
                         let cfg' =
-                          let uu___936_6201 = cfg  in
+                          let uu___938_6210 = cfg  in
                           {
                             FStar_TypeChecker_Cfg.steps =
-                              (uu___936_6201.FStar_TypeChecker_Cfg.steps);
+                              (uu___938_6210.FStar_TypeChecker_Cfg.steps);
                             FStar_TypeChecker_Cfg.tcenv =
-                              (uu___936_6201.FStar_TypeChecker_Cfg.tcenv);
+                              (uu___938_6210.FStar_TypeChecker_Cfg.tcenv);
                             FStar_TypeChecker_Cfg.debug =
-                              (uu___936_6201.FStar_TypeChecker_Cfg.debug);
+                              (uu___938_6210.FStar_TypeChecker_Cfg.debug);
                             FStar_TypeChecker_Cfg.delta_level =
-                              (uu___936_6201.FStar_TypeChecker_Cfg.delta_level);
+                              (uu___938_6210.FStar_TypeChecker_Cfg.delta_level);
                             FStar_TypeChecker_Cfg.primitive_steps =
-                              (uu___936_6201.FStar_TypeChecker_Cfg.primitive_steps);
+                              (uu___938_6210.FStar_TypeChecker_Cfg.primitive_steps);
                             FStar_TypeChecker_Cfg.strong =
-                              (uu___936_6201.FStar_TypeChecker_Cfg.strong);
+                              (uu___938_6210.FStar_TypeChecker_Cfg.strong);
                             FStar_TypeChecker_Cfg.memoize_lazy =
-                              (uu___936_6201.FStar_TypeChecker_Cfg.memoize_lazy);
+                              (uu___938_6210.FStar_TypeChecker_Cfg.memoize_lazy);
                             FStar_TypeChecker_Cfg.normalize_pure_lets =
-                              (uu___936_6201.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                              (uu___938_6210.FStar_TypeChecker_Cfg.normalize_pure_lets);
                             FStar_TypeChecker_Cfg.reifying = false
                           }  in
                         let body_lam =
@@ -1753,71 +1756,71 @@ and (translate_monadic :
                                 (FStar_Pervasives_Native.Some ty);
                               FStar_Syntax_Syntax.residual_flags = []
                             }  in
-                          let uu____6209 =
-                            let uu____6216 =
-                              let uu____6217 =
-                                let uu____6236 =
-                                  let uu____6245 =
-                                    let uu____6252 =
+                          let uu____6218 =
+                            let uu____6225 =
+                              let uu____6226 =
+                                let uu____6245 =
+                                  let uu____6254 =
+                                    let uu____6261 =
                                       FStar_Util.left
                                         lb.FStar_Syntax_Syntax.lbname
                                        in
-                                    (uu____6252,
+                                    (uu____6261,
                                       FStar_Pervasives_Native.None)
                                      in
-                                  [uu____6245]  in
-                                (uu____6236, body,
+                                  [uu____6254]  in
+                                (uu____6245, body,
                                   (FStar_Pervasives_Native.Some body_rc))
                                  in
-                              FStar_Syntax_Syntax.Tm_abs uu____6217  in
-                            FStar_Syntax_Syntax.mk uu____6216  in
-                          uu____6209 FStar_Pervasives_Native.None
+                              FStar_Syntax_Syntax.Tm_abs uu____6226  in
+                            FStar_Syntax_Syntax.mk uu____6225  in
+                          uu____6218 FStar_Pervasives_Native.None
                             body.FStar_Syntax_Syntax.pos
                            in
                         let maybe_range_arg =
-                          let uu____6286 =
+                          let uu____6295 =
                             FStar_Util.for_some
                               (FStar_Syntax_Util.attr_eq
                                  FStar_Syntax_Util.dm4f_bind_range_attr)
                               ed.FStar_Syntax_Syntax.eff_attrs
                              in
-                          if uu____6286
+                          if uu____6295
                           then
-                            let uu____6295 =
-                              let uu____6300 =
-                                let uu____6301 =
+                            let uu____6304 =
+                              let uu____6309 =
+                                let uu____6310 =
                                   FStar_TypeChecker_Cfg.embed_simple
                                     FStar_Syntax_Embeddings.e_range
                                     lb.FStar_Syntax_Syntax.lbpos
                                     lb.FStar_Syntax_Syntax.lbpos
                                    in
-                                translate cfg [] uu____6301  in
-                              (uu____6300, FStar_Pervasives_Native.None)  in
-                            let uu____6302 =
-                              let uu____6309 =
-                                let uu____6314 =
-                                  let uu____6315 =
+                                translate cfg [] uu____6310  in
+                              (uu____6309, FStar_Pervasives_Native.None)  in
+                            let uu____6311 =
+                              let uu____6318 =
+                                let uu____6323 =
+                                  let uu____6324 =
                                     FStar_TypeChecker_Cfg.embed_simple
                                       FStar_Syntax_Embeddings.e_range
                                       body.FStar_Syntax_Syntax.pos
                                       body.FStar_Syntax_Syntax.pos
                                      in
-                                  translate cfg [] uu____6315  in
-                                (uu____6314, FStar_Pervasives_Native.None)
+                                  translate cfg [] uu____6324  in
+                                (uu____6323, FStar_Pervasives_Native.None)
                                  in
-                              [uu____6309]  in
-                            uu____6295 :: uu____6302
+                              [uu____6318]  in
+                            uu____6304 :: uu____6311
                           else []  in
                         let t =
-                          let uu____6335 =
-                            let uu____6336 =
-                              let uu____6337 =
+                          let uu____6344 =
+                            let uu____6345 =
+                              let uu____6346 =
                                 FStar_Syntax_Util.un_uinst
                                   (FStar_Pervasives_Native.snd
                                      ed.FStar_Syntax_Syntax.bind_repr)
                                  in
-                              translate cfg' [] uu____6337  in
-                            iapp cfg uu____6336
+                              translate cfg' [] uu____6346  in
+                            iapp cfg uu____6345
                               [((FStar_TypeChecker_NBETerm.Univ
                                    FStar_Syntax_Syntax.U_unknown),
                                  FStar_Pervasives_Native.None);
@@ -1825,102 +1828,102 @@ and (translate_monadic :
                                   FStar_Syntax_Syntax.U_unknown),
                                 FStar_Pervasives_Native.None)]
                              in
-                          let uu____6354 =
-                            let uu____6355 =
-                              let uu____6362 =
-                                let uu____6367 =
+                          let uu____6363 =
+                            let uu____6364 =
+                              let uu____6371 =
+                                let uu____6376 =
                                   translate cfg' bs
                                     lb.FStar_Syntax_Syntax.lbtyp
                                    in
-                                (uu____6367, FStar_Pervasives_Native.None)
+                                (uu____6376, FStar_Pervasives_Native.None)
                                  in
-                              let uu____6368 =
-                                let uu____6375 =
-                                  let uu____6380 = translate cfg' bs ty  in
-                                  (uu____6380, FStar_Pervasives_Native.None)
+                              let uu____6377 =
+                                let uu____6384 =
+                                  let uu____6389 = translate cfg' bs ty  in
+                                  (uu____6389, FStar_Pervasives_Native.None)
                                    in
-                                [uu____6375]  in
-                              uu____6362 :: uu____6368  in
-                            let uu____6393 =
-                              let uu____6400 =
-                                let uu____6407 =
-                                  let uu____6414 =
-                                    let uu____6419 =
+                                [uu____6384]  in
+                              uu____6371 :: uu____6377  in
+                            let uu____6402 =
+                              let uu____6409 =
+                                let uu____6416 =
+                                  let uu____6423 =
+                                    let uu____6428 =
                                       translate cfg bs
                                         lb.FStar_Syntax_Syntax.lbdef
                                        in
-                                    (uu____6419,
+                                    (uu____6428,
                                       FStar_Pervasives_Native.None)
                                      in
-                                  let uu____6420 =
-                                    let uu____6427 =
-                                      let uu____6434 =
-                                        let uu____6439 =
+                                  let uu____6429 =
+                                    let uu____6436 =
+                                      let uu____6443 =
+                                        let uu____6448 =
                                           translate cfg bs body_lam  in
-                                        (uu____6439,
+                                        (uu____6448,
                                           FStar_Pervasives_Native.None)
                                          in
-                                      [uu____6434]  in
+                                      [uu____6443]  in
                                     (FStar_TypeChecker_NBETerm.Unknown,
                                       FStar_Pervasives_Native.None) ::
-                                      uu____6427
+                                      uu____6436
                                      in
-                                  uu____6414 :: uu____6420  in
+                                  uu____6423 :: uu____6429  in
                                 (FStar_TypeChecker_NBETerm.Unknown,
-                                  FStar_Pervasives_Native.None) :: uu____6407
+                                  FStar_Pervasives_Native.None) :: uu____6416
                                  in
-                              FStar_List.append maybe_range_arg uu____6400
+                              FStar_List.append maybe_range_arg uu____6409
                                in
-                            FStar_List.append uu____6355 uu____6393  in
-                          iapp cfg uu____6335 uu____6354  in
+                            FStar_List.append uu____6364 uu____6402  in
+                          iapp cfg uu____6344 uu____6363  in
                         (debug cfg
-                           (fun uu____6471  ->
-                              let uu____6472 =
+                           (fun uu____6480  ->
+                              let uu____6481 =
                                 FStar_TypeChecker_NBETerm.t_to_string t  in
                               FStar_Util.print1 "translate_monadic: %s\n"
-                                uu____6472);
+                                uu____6481);
                          t))
                | FStar_Syntax_Syntax.Tm_app
                    ({
                       FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                        (FStar_Const.Const_reflect uu____6475);
-                      FStar_Syntax_Syntax.pos = uu____6476;
-                      FStar_Syntax_Syntax.vars = uu____6477;_},(e2,uu____6479)::[])
+                        (FStar_Const.Const_reflect uu____6484);
+                      FStar_Syntax_Syntax.pos = uu____6485;
+                      FStar_Syntax_Syntax.vars = uu____6486;_},(e2,uu____6488)::[])
                    ->
                    translate
-                     (let uu___958_6520 = cfg  in
+                     (let uu___960_6529 = cfg  in
                       {
                         FStar_TypeChecker_Cfg.steps =
-                          (uu___958_6520.FStar_TypeChecker_Cfg.steps);
+                          (uu___960_6529.FStar_TypeChecker_Cfg.steps);
                         FStar_TypeChecker_Cfg.tcenv =
-                          (uu___958_6520.FStar_TypeChecker_Cfg.tcenv);
+                          (uu___960_6529.FStar_TypeChecker_Cfg.tcenv);
                         FStar_TypeChecker_Cfg.debug =
-                          (uu___958_6520.FStar_TypeChecker_Cfg.debug);
+                          (uu___960_6529.FStar_TypeChecker_Cfg.debug);
                         FStar_TypeChecker_Cfg.delta_level =
-                          (uu___958_6520.FStar_TypeChecker_Cfg.delta_level);
+                          (uu___960_6529.FStar_TypeChecker_Cfg.delta_level);
                         FStar_TypeChecker_Cfg.primitive_steps =
-                          (uu___958_6520.FStar_TypeChecker_Cfg.primitive_steps);
+                          (uu___960_6529.FStar_TypeChecker_Cfg.primitive_steps);
                         FStar_TypeChecker_Cfg.strong =
-                          (uu___958_6520.FStar_TypeChecker_Cfg.strong);
+                          (uu___960_6529.FStar_TypeChecker_Cfg.strong);
                         FStar_TypeChecker_Cfg.memoize_lazy =
-                          (uu___958_6520.FStar_TypeChecker_Cfg.memoize_lazy);
+                          (uu___960_6529.FStar_TypeChecker_Cfg.memoize_lazy);
                         FStar_TypeChecker_Cfg.normalize_pure_lets =
-                          (uu___958_6520.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                          (uu___960_6529.FStar_TypeChecker_Cfg.normalize_pure_lets);
                         FStar_TypeChecker_Cfg.reifying = false
                       }) bs e2
                | FStar_Syntax_Syntax.Tm_app (head1,args) ->
                    (debug cfg
-                      (fun uu____6552  ->
-                         let uu____6553 =
+                      (fun uu____6561  ->
+                         let uu____6562 =
                            FStar_Syntax_Print.term_to_string head1  in
-                         let uu____6555 =
+                         let uu____6564 =
                            FStar_Syntax_Print.args_to_string args  in
                          FStar_Util.print2
-                           "translate_monadic app (%s) @ (%s)\n" uu____6553
-                           uu____6555);
-                    (let fallback1 uu____6563 = translate cfg bs e1  in
-                     let fallback2 uu____6569 =
-                       let uu____6570 =
+                           "translate_monadic app (%s) @ (%s)\n" uu____6562
+                           uu____6564);
+                    (let fallback1 uu____6572 = translate cfg bs e1  in
+                     let fallback2 uu____6578 =
+                       let uu____6579 =
                          FStar_Syntax_Syntax.mk
                            (FStar_Syntax_Syntax.Tm_meta
                               (e1,
@@ -1929,100 +1932,100 @@ and (translate_monadic :
                            e1.FStar_Syntax_Syntax.pos
                           in
                        translate
-                         (let uu___970_6577 = cfg  in
+                         (let uu___972_6586 = cfg  in
                           {
                             FStar_TypeChecker_Cfg.steps =
-                              (uu___970_6577.FStar_TypeChecker_Cfg.steps);
+                              (uu___972_6586.FStar_TypeChecker_Cfg.steps);
                             FStar_TypeChecker_Cfg.tcenv =
-                              (uu___970_6577.FStar_TypeChecker_Cfg.tcenv);
+                              (uu___972_6586.FStar_TypeChecker_Cfg.tcenv);
                             FStar_TypeChecker_Cfg.debug =
-                              (uu___970_6577.FStar_TypeChecker_Cfg.debug);
+                              (uu___972_6586.FStar_TypeChecker_Cfg.debug);
                             FStar_TypeChecker_Cfg.delta_level =
-                              (uu___970_6577.FStar_TypeChecker_Cfg.delta_level);
+                              (uu___972_6586.FStar_TypeChecker_Cfg.delta_level);
                             FStar_TypeChecker_Cfg.primitive_steps =
-                              (uu___970_6577.FStar_TypeChecker_Cfg.primitive_steps);
+                              (uu___972_6586.FStar_TypeChecker_Cfg.primitive_steps);
                             FStar_TypeChecker_Cfg.strong =
-                              (uu___970_6577.FStar_TypeChecker_Cfg.strong);
+                              (uu___972_6586.FStar_TypeChecker_Cfg.strong);
                             FStar_TypeChecker_Cfg.memoize_lazy =
-                              (uu___970_6577.FStar_TypeChecker_Cfg.memoize_lazy);
+                              (uu___972_6586.FStar_TypeChecker_Cfg.memoize_lazy);
                             FStar_TypeChecker_Cfg.normalize_pure_lets =
-                              (uu___970_6577.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                              (uu___972_6586.FStar_TypeChecker_Cfg.normalize_pure_lets);
                             FStar_TypeChecker_Cfg.reifying = false
-                          }) bs uu____6570
+                          }) bs uu____6579
                         in
-                     let uu____6579 =
-                       let uu____6580 = FStar_Syntax_Util.un_uinst head1  in
-                       uu____6580.FStar_Syntax_Syntax.n  in
-                     match uu____6579 with
+                     let uu____6588 =
+                       let uu____6589 = FStar_Syntax_Util.un_uinst head1  in
+                       uu____6589.FStar_Syntax_Syntax.n  in
+                     match uu____6588 with
                      | FStar_Syntax_Syntax.Tm_fvar fv ->
                          let lid = FStar_Syntax_Syntax.lid_of_fv fv  in
                          let qninfo =
                            FStar_TypeChecker_Env.lookup_qname
                              cfg.FStar_TypeChecker_Cfg.tcenv lid
                             in
-                         let uu____6586 =
-                           let uu____6588 =
+                         let uu____6595 =
+                           let uu____6597 =
                              FStar_TypeChecker_Env.is_action
                                cfg.FStar_TypeChecker_Cfg.tcenv lid
                               in
-                           Prims.op_Negation uu____6588  in
-                         if uu____6586
+                           Prims.op_Negation uu____6597  in
+                         if uu____6595
                          then fallback1 ()
                          else
-                           (let uu____6593 =
-                              let uu____6595 =
+                           (let uu____6602 =
+                              let uu____6604 =
                                 FStar_TypeChecker_Env.lookup_definition_qninfo
                                   cfg.FStar_TypeChecker_Cfg.delta_level
                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                   qninfo
                                  in
-                              FStar_Option.isNone uu____6595  in
-                            if uu____6593
+                              FStar_Option.isNone uu____6604  in
+                            if uu____6602
                             then fallback2 ()
                             else
                               (let e2 =
-                                 let uu____6612 =
-                                   let uu____6617 =
+                                 let uu____6621 =
+                                   let uu____6626 =
                                      FStar_Syntax_Util.mk_reify head1  in
-                                   FStar_Syntax_Syntax.mk_Tm_app uu____6617
+                                   FStar_Syntax_Syntax.mk_Tm_app uu____6626
                                      args
                                     in
-                                 uu____6612 FStar_Pervasives_Native.None
+                                 uu____6621 FStar_Pervasives_Native.None
                                    e1.FStar_Syntax_Syntax.pos
                                   in
                                translate
-                                 (let uu___979_6620 = cfg  in
+                                 (let uu___981_6629 = cfg  in
                                   {
                                     FStar_TypeChecker_Cfg.steps =
-                                      (uu___979_6620.FStar_TypeChecker_Cfg.steps);
+                                      (uu___981_6629.FStar_TypeChecker_Cfg.steps);
                                     FStar_TypeChecker_Cfg.tcenv =
-                                      (uu___979_6620.FStar_TypeChecker_Cfg.tcenv);
+                                      (uu___981_6629.FStar_TypeChecker_Cfg.tcenv);
                                     FStar_TypeChecker_Cfg.debug =
-                                      (uu___979_6620.FStar_TypeChecker_Cfg.debug);
+                                      (uu___981_6629.FStar_TypeChecker_Cfg.debug);
                                     FStar_TypeChecker_Cfg.delta_level =
-                                      (uu___979_6620.FStar_TypeChecker_Cfg.delta_level);
+                                      (uu___981_6629.FStar_TypeChecker_Cfg.delta_level);
                                     FStar_TypeChecker_Cfg.primitive_steps =
-                                      (uu___979_6620.FStar_TypeChecker_Cfg.primitive_steps);
+                                      (uu___981_6629.FStar_TypeChecker_Cfg.primitive_steps);
                                     FStar_TypeChecker_Cfg.strong =
-                                      (uu___979_6620.FStar_TypeChecker_Cfg.strong);
+                                      (uu___981_6629.FStar_TypeChecker_Cfg.strong);
                                     FStar_TypeChecker_Cfg.memoize_lazy =
-                                      (uu___979_6620.FStar_TypeChecker_Cfg.memoize_lazy);
+                                      (uu___981_6629.FStar_TypeChecker_Cfg.memoize_lazy);
                                     FStar_TypeChecker_Cfg.normalize_pure_lets
                                       =
-                                      (uu___979_6620.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                      (uu___981_6629.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                     FStar_TypeChecker_Cfg.reifying = false
                                   }) bs e2))
-                     | uu____6622 -> fallback1 ()))
+                     | uu____6631 -> fallback1 ()))
                | FStar_Syntax_Syntax.Tm_match (sc,branches) ->
                    let branches1 =
                      FStar_All.pipe_right branches
                        (FStar_List.map
-                          (fun uu____6743  ->
-                             match uu____6743 with
+                          (fun uu____6752  ->
+                             match uu____6752 with
                              | (pat,wopt,tm) ->
-                                 let uu____6791 =
+                                 let uu____6800 =
                                    FStar_Syntax_Util.mk_reify tm  in
-                                 (pat, wopt, uu____6791)))
+                                 (pat, wopt, uu____6800)))
                       in
                    let tm =
                      FStar_Syntax_Syntax.mk
@@ -2031,39 +2034,39 @@ and (translate_monadic :
                        e1.FStar_Syntax_Syntax.pos
                       in
                    translate
-                     (let uu___992_6825 = cfg  in
+                     (let uu___994_6834 = cfg  in
                       {
                         FStar_TypeChecker_Cfg.steps =
-                          (uu___992_6825.FStar_TypeChecker_Cfg.steps);
+                          (uu___994_6834.FStar_TypeChecker_Cfg.steps);
                         FStar_TypeChecker_Cfg.tcenv =
-                          (uu___992_6825.FStar_TypeChecker_Cfg.tcenv);
+                          (uu___994_6834.FStar_TypeChecker_Cfg.tcenv);
                         FStar_TypeChecker_Cfg.debug =
-                          (uu___992_6825.FStar_TypeChecker_Cfg.debug);
+                          (uu___994_6834.FStar_TypeChecker_Cfg.debug);
                         FStar_TypeChecker_Cfg.delta_level =
-                          (uu___992_6825.FStar_TypeChecker_Cfg.delta_level);
+                          (uu___994_6834.FStar_TypeChecker_Cfg.delta_level);
                         FStar_TypeChecker_Cfg.primitive_steps =
-                          (uu___992_6825.FStar_TypeChecker_Cfg.primitive_steps);
+                          (uu___994_6834.FStar_TypeChecker_Cfg.primitive_steps);
                         FStar_TypeChecker_Cfg.strong =
-                          (uu___992_6825.FStar_TypeChecker_Cfg.strong);
+                          (uu___994_6834.FStar_TypeChecker_Cfg.strong);
                         FStar_TypeChecker_Cfg.memoize_lazy =
-                          (uu___992_6825.FStar_TypeChecker_Cfg.memoize_lazy);
+                          (uu___994_6834.FStar_TypeChecker_Cfg.memoize_lazy);
                         FStar_TypeChecker_Cfg.normalize_pure_lets =
-                          (uu___992_6825.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                          (uu___994_6834.FStar_TypeChecker_Cfg.normalize_pure_lets);
                         FStar_TypeChecker_Cfg.reifying = false
                       }) bs tm
                | FStar_Syntax_Syntax.Tm_meta
-                   (t,FStar_Syntax_Syntax.Meta_monadic uu____6828) ->
+                   (t,FStar_Syntax_Syntax.Meta_monadic uu____6837) ->
                    translate_monadic (m, ty) cfg bs e1
                | FStar_Syntax_Syntax.Tm_meta
                    (t,FStar_Syntax_Syntax.Meta_monadic_lift (msrc,mtgt,ty'))
                    -> translate_monadic_lift (msrc, mtgt, ty') cfg bs e1
-               | uu____6855 ->
-                   let uu____6856 =
-                     let uu____6858 = FStar_Syntax_Print.tag_of_term e1  in
+               | uu____6864 ->
+                   let uu____6865 =
+                     let uu____6867 = FStar_Syntax_Print.tag_of_term e1  in
                      FStar_Util.format1
-                       "Unexpected case in translate_monadic: %s" uu____6858
+                       "Unexpected case in translate_monadic: %s" uu____6867
                       in
-                   failwith uu____6856)
+                   failwith uu____6865)
 
 and (translate_monadic_lift :
   (FStar_Syntax_Syntax.monad_name * FStar_Syntax_Syntax.monad_name *
@@ -2073,128 +2076,128 @@ and (translate_monadic_lift :
         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
           FStar_TypeChecker_NBETerm.t)
   =
-  fun uu____6861  ->
+  fun uu____6870  ->
     fun cfg  ->
       fun bs  ->
         fun e  ->
-          match uu____6861 with
+          match uu____6870 with
           | (msrc,mtgt,ty) ->
               let e1 = FStar_Syntax_Util.unascribe e  in
-              let uu____6885 =
+              let uu____6894 =
                 (FStar_Syntax_Util.is_pure_effect msrc) ||
                   (FStar_Syntax_Util.is_div_effect msrc)
                  in
-              if uu____6885
+              if uu____6894
               then
                 let ed =
-                  let uu____6889 =
+                  let uu____6898 =
                     FStar_TypeChecker_Env.norm_eff_name
                       cfg.FStar_TypeChecker_Cfg.tcenv mtgt
                      in
                   FStar_TypeChecker_Env.get_effect_decl
-                    cfg.FStar_TypeChecker_Cfg.tcenv uu____6889
+                    cfg.FStar_TypeChecker_Cfg.tcenv uu____6898
                    in
                 let ret1 =
-                  let uu____6891 =
-                    let uu____6892 =
+                  let uu____6900 =
+                    let uu____6901 =
                       FStar_Syntax_Subst.compress
                         (FStar_Pervasives_Native.snd
                            ed.FStar_Syntax_Syntax.return_repr)
                        in
-                    uu____6892.FStar_Syntax_Syntax.n  in
-                  match uu____6891 with
-                  | FStar_Syntax_Syntax.Tm_uinst (ret1,uu____6900::[]) ->
+                    uu____6901.FStar_Syntax_Syntax.n  in
+                  match uu____6900 with
+                  | FStar_Syntax_Syntax.Tm_uinst (ret1,uu____6909::[]) ->
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_uinst
                            (ret1, [FStar_Syntax_Syntax.U_unknown]))
                         FStar_Pervasives_Native.None
                         e1.FStar_Syntax_Syntax.pos
-                  | uu____6907 ->
+                  | uu____6916 ->
                       failwith "NYI: Reification of indexed effect (NBE)"
                    in
                 let cfg' =
-                  let uu___1025_6910 = cfg  in
+                  let uu___1027_6919 = cfg  in
                   {
                     FStar_TypeChecker_Cfg.steps =
-                      (uu___1025_6910.FStar_TypeChecker_Cfg.steps);
+                      (uu___1027_6919.FStar_TypeChecker_Cfg.steps);
                     FStar_TypeChecker_Cfg.tcenv =
-                      (uu___1025_6910.FStar_TypeChecker_Cfg.tcenv);
+                      (uu___1027_6919.FStar_TypeChecker_Cfg.tcenv);
                     FStar_TypeChecker_Cfg.debug =
-                      (uu___1025_6910.FStar_TypeChecker_Cfg.debug);
+                      (uu___1027_6919.FStar_TypeChecker_Cfg.debug);
                     FStar_TypeChecker_Cfg.delta_level =
-                      (uu___1025_6910.FStar_TypeChecker_Cfg.delta_level);
+                      (uu___1027_6919.FStar_TypeChecker_Cfg.delta_level);
                     FStar_TypeChecker_Cfg.primitive_steps =
-                      (uu___1025_6910.FStar_TypeChecker_Cfg.primitive_steps);
+                      (uu___1027_6919.FStar_TypeChecker_Cfg.primitive_steps);
                     FStar_TypeChecker_Cfg.strong =
-                      (uu___1025_6910.FStar_TypeChecker_Cfg.strong);
+                      (uu___1027_6919.FStar_TypeChecker_Cfg.strong);
                     FStar_TypeChecker_Cfg.memoize_lazy =
-                      (uu___1025_6910.FStar_TypeChecker_Cfg.memoize_lazy);
+                      (uu___1027_6919.FStar_TypeChecker_Cfg.memoize_lazy);
                     FStar_TypeChecker_Cfg.normalize_pure_lets =
-                      (uu___1025_6910.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                      (uu___1027_6919.FStar_TypeChecker_Cfg.normalize_pure_lets);
                     FStar_TypeChecker_Cfg.reifying = false
                   }  in
                 let t =
-                  let uu____6913 =
-                    let uu____6914 = translate cfg' [] ret1  in
-                    iapp cfg' uu____6914
+                  let uu____6922 =
+                    let uu____6923 = translate cfg' [] ret1  in
+                    iapp cfg' uu____6923
                       [((FStar_TypeChecker_NBETerm.Univ
                            FStar_Syntax_Syntax.U_unknown),
                          FStar_Pervasives_Native.None)]
                      in
-                  let uu____6923 =
-                    let uu____6924 =
-                      let uu____6929 = translate cfg' bs ty  in
-                      (uu____6929, FStar_Pervasives_Native.None)  in
-                    let uu____6930 =
-                      let uu____6937 =
-                        let uu____6942 = translate cfg' bs e1  in
-                        (uu____6942, FStar_Pervasives_Native.None)  in
-                      [uu____6937]  in
-                    uu____6924 :: uu____6930  in
-                  iapp cfg' uu____6913 uu____6923  in
+                  let uu____6932 =
+                    let uu____6933 =
+                      let uu____6938 = translate cfg' bs ty  in
+                      (uu____6938, FStar_Pervasives_Native.None)  in
+                    let uu____6939 =
+                      let uu____6946 =
+                        let uu____6951 = translate cfg' bs e1  in
+                        (uu____6951, FStar_Pervasives_Native.None)  in
+                      [uu____6946]  in
+                    uu____6933 :: uu____6939  in
+                  iapp cfg' uu____6922 uu____6932  in
                 (debug cfg
-                   (fun uu____6958  ->
-                      let uu____6959 =
+                   (fun uu____6967  ->
+                      let uu____6968 =
                         FStar_TypeChecker_NBETerm.t_to_string t  in
                       FStar_Util.print1 "translate_monadic_lift(1): %s\n"
-                        uu____6959);
+                        uu____6968);
                  t)
               else
-                (let uu____6964 =
+                (let uu____6973 =
                    FStar_TypeChecker_Env.monad_leq
                      cfg.FStar_TypeChecker_Cfg.tcenv msrc mtgt
                     in
-                 match uu____6964 with
+                 match uu____6973 with
                  | FStar_Pervasives_Native.None  ->
-                     let uu____6967 =
-                       let uu____6969 = FStar_Ident.text_of_lid msrc  in
-                       let uu____6971 = FStar_Ident.text_of_lid mtgt  in
+                     let uu____6976 =
+                       let uu____6978 = FStar_Ident.text_of_lid msrc  in
+                       let uu____6980 = FStar_Ident.text_of_lid mtgt  in
                        FStar_Util.format2
                          "Impossible : trying to reify a lift between unrelated effects (%s and %s)"
-                         uu____6969 uu____6971
+                         uu____6978 uu____6980
                         in
-                     failwith uu____6967
+                     failwith uu____6976
                  | FStar_Pervasives_Native.Some
-                     { FStar_TypeChecker_Env.msource = uu____6974;
-                       FStar_TypeChecker_Env.mtarget = uu____6975;
+                     { FStar_TypeChecker_Env.msource = uu____6983;
+                       FStar_TypeChecker_Env.mtarget = uu____6984;
                        FStar_TypeChecker_Env.mlift =
-                         { FStar_TypeChecker_Env.mlift_wp = uu____6976;
+                         { FStar_TypeChecker_Env.mlift_wp = uu____6985;
                            FStar_TypeChecker_Env.mlift_term =
                              FStar_Pervasives_Native.None ;_};_}
                      ->
-                     let uu____6998 =
-                       let uu____7000 = FStar_Ident.text_of_lid msrc  in
-                       let uu____7002 = FStar_Ident.text_of_lid mtgt  in
+                     let uu____7007 =
+                       let uu____7009 = FStar_Ident.text_of_lid msrc  in
+                       let uu____7011 = FStar_Ident.text_of_lid mtgt  in
                        FStar_Util.format2
                          "Impossible : trying to reify a non-reifiable lift (from %s to %s)"
-                         uu____7000 uu____7002
+                         uu____7009 uu____7011
                         in
-                     failwith uu____6998
+                     failwith uu____7007
                  | FStar_Pervasives_Native.Some
-                     { FStar_TypeChecker_Env.msource = uu____7005;
-                       FStar_TypeChecker_Env.mtarget = uu____7006;
+                     { FStar_TypeChecker_Env.msource = uu____7014;
+                       FStar_TypeChecker_Env.mtarget = uu____7015;
                        FStar_TypeChecker_Env.mlift =
-                         { FStar_TypeChecker_Env.mlift_wp = uu____7007;
+                         { FStar_TypeChecker_Env.mlift_wp = uu____7016;
                            FStar_TypeChecker_Env.mlift_term =
                              FStar_Pervasives_Native.Some lift;_};_}
                      ->
@@ -2204,51 +2207,51 @@ and (translate_monadic_lift :
                            FStar_Pervasives_Native.None
                            FStar_Syntax_Syntax.tun
                           in
-                       let uu____7046 =
-                         let uu____7049 = FStar_Syntax_Syntax.bv_to_name x
+                       let uu____7055 =
+                         let uu____7058 = FStar_Syntax_Syntax.bv_to_name x
                             in
                          lift FStar_Syntax_Syntax.U_unknown ty
-                           FStar_Syntax_Syntax.tun uu____7049
+                           FStar_Syntax_Syntax.tun uu____7058
                           in
                        FStar_Syntax_Util.abs
-                         [(x, FStar_Pervasives_Native.None)] uu____7046
+                         [(x, FStar_Pervasives_Native.None)] uu____7055
                          FStar_Pervasives_Native.None
                         in
                      let cfg' =
-                       let uu___1049_7065 = cfg  in
+                       let uu___1051_7074 = cfg  in
                        {
                          FStar_TypeChecker_Cfg.steps =
-                           (uu___1049_7065.FStar_TypeChecker_Cfg.steps);
+                           (uu___1051_7074.FStar_TypeChecker_Cfg.steps);
                          FStar_TypeChecker_Cfg.tcenv =
-                           (uu___1049_7065.FStar_TypeChecker_Cfg.tcenv);
+                           (uu___1051_7074.FStar_TypeChecker_Cfg.tcenv);
                          FStar_TypeChecker_Cfg.debug =
-                           (uu___1049_7065.FStar_TypeChecker_Cfg.debug);
+                           (uu___1051_7074.FStar_TypeChecker_Cfg.debug);
                          FStar_TypeChecker_Cfg.delta_level =
-                           (uu___1049_7065.FStar_TypeChecker_Cfg.delta_level);
+                           (uu___1051_7074.FStar_TypeChecker_Cfg.delta_level);
                          FStar_TypeChecker_Cfg.primitive_steps =
-                           (uu___1049_7065.FStar_TypeChecker_Cfg.primitive_steps);
+                           (uu___1051_7074.FStar_TypeChecker_Cfg.primitive_steps);
                          FStar_TypeChecker_Cfg.strong =
-                           (uu___1049_7065.FStar_TypeChecker_Cfg.strong);
+                           (uu___1051_7074.FStar_TypeChecker_Cfg.strong);
                          FStar_TypeChecker_Cfg.memoize_lazy =
-                           (uu___1049_7065.FStar_TypeChecker_Cfg.memoize_lazy);
+                           (uu___1051_7074.FStar_TypeChecker_Cfg.memoize_lazy);
                          FStar_TypeChecker_Cfg.normalize_pure_lets =
-                           (uu___1049_7065.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                           (uu___1051_7074.FStar_TypeChecker_Cfg.normalize_pure_lets);
                          FStar_TypeChecker_Cfg.reifying = false
                        }  in
                      let t =
-                       let uu____7068 = translate cfg' [] lift_lam  in
-                       let uu____7069 =
-                         let uu____7070 =
-                           let uu____7075 = translate cfg bs e1  in
-                           (uu____7075, FStar_Pervasives_Native.None)  in
-                         [uu____7070]  in
-                       iapp cfg uu____7068 uu____7069  in
+                       let uu____7077 = translate cfg' [] lift_lam  in
+                       let uu____7078 =
+                         let uu____7079 =
+                           let uu____7084 = translate cfg bs e1  in
+                           (uu____7084, FStar_Pervasives_Native.None)  in
+                         [uu____7079]  in
+                       iapp cfg uu____7077 uu____7078  in
                      (debug cfg
-                        (fun uu____7087  ->
-                           let uu____7088 =
+                        (fun uu____7096  ->
+                           let uu____7097 =
                              FStar_TypeChecker_NBETerm.t_to_string t  in
                            FStar_Util.print1
-                             "translate_monadic_lift(2): %s\n" uu____7088);
+                             "translate_monadic_lift(2): %s\n" uu____7097);
                       t))
 
 and (readback :
@@ -2259,9 +2262,9 @@ and (readback :
     fun x  ->
       let debug1 = debug cfg  in
       debug1
-        (fun uu____7106  ->
-           let uu____7107 = FStar_TypeChecker_NBETerm.t_to_string x  in
-           FStar_Util.print1 "Readback: %s\n" uu____7107);
+        (fun uu____7115  ->
+           let uu____7116 = FStar_TypeChecker_NBETerm.t_to_string x  in
+           FStar_Util.print1 "Readback: %s\n" uu____7116);
       (match x with
        | FStar_TypeChecker_NBETerm.Univ u ->
            failwith "Readback of universes should not occur"
@@ -2276,8 +2279,8 @@ and (readback :
            (false )) -> FStar_Syntax_Util.exp_false_bool
        | FStar_TypeChecker_NBETerm.Constant (FStar_TypeChecker_NBETerm.Int i)
            ->
-           let uu____7115 = FStar_BigInt.string_of_big_int i  in
-           FStar_All.pipe_right uu____7115 FStar_Syntax_Util.exp_int
+           let uu____7124 = FStar_BigInt.string_of_big_int i  in
+           FStar_All.pipe_right uu____7124 FStar_Syntax_Util.exp_int
        | FStar_TypeChecker_NBETerm.Constant (FStar_TypeChecker_NBETerm.String
            (s,r)) ->
            FStar_Syntax_Syntax.mk
@@ -2294,169 +2297,169 @@ and (readback :
            FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u)
              FStar_Pervasives_Native.None FStar_Range.dummyRange
        | FStar_TypeChecker_NBETerm.Lam (f,targs,arity,resc) ->
-           let uu____7175 =
+           let uu____7184 =
              FStar_List.fold_left
-               (fun uu____7218  ->
+               (fun uu____7227  ->
                   fun tf  ->
-                    match uu____7218 with
+                    match uu____7227 with
                     | (args_rev,accus_rev) ->
-                        let uu____7270 = tf accus_rev  in
-                        (match uu____7270 with
+                        let uu____7279 = tf accus_rev  in
+                        (match uu____7279 with
                          | (xt,q) ->
                              let x1 =
-                               let uu____7290 = readback cfg xt  in
+                               let uu____7299 = readback cfg xt  in
                                FStar_Syntax_Syntax.new_bv
-                                 FStar_Pervasives_Native.None uu____7290
+                                 FStar_Pervasives_Native.None uu____7299
                                 in
-                             let uu____7291 =
-                               let uu____7294 =
+                             let uu____7300 =
+                               let uu____7303 =
                                  FStar_TypeChecker_NBETerm.mkAccuVar x1  in
-                               uu____7294 :: accus_rev  in
-                             (((x1, q) :: args_rev), uu____7291))) ([], [])
+                               uu____7303 :: accus_rev  in
+                             (((x1, q) :: args_rev), uu____7300))) ([], [])
                targs
               in
-           (match uu____7175 with
+           (match uu____7184 with
             | (args_rev,accus_rev) ->
                 let body =
-                  let uu____7338 = f (FStar_List.rev accus_rev)  in
-                  readback cfg uu____7338  in
-                let uu____7339 =
+                  let uu____7347 = f (FStar_List.rev accus_rev)  in
+                  readback cfg uu____7347  in
+                let uu____7348 =
                   FStar_Util.map_opt resc
                     (fun thunk1  ->
-                       let uu____7350 = thunk1 ()  in
-                       readback_residual_comp cfg uu____7350)
+                       let uu____7359 = thunk1 ()  in
+                       readback_residual_comp cfg uu____7359)
                    in
                 FStar_Syntax_Util.abs (FStar_List.rev args_rev) body
-                  uu____7339)
+                  uu____7348)
        | FStar_TypeChecker_NBETerm.Refinement (f,targ) ->
            let x1 =
-             let uu____7378 =
-               let uu____7379 =
-                 let uu____7380 = targ ()  in
-                 FStar_Pervasives_Native.fst uu____7380  in
-               readback cfg uu____7379  in
+             let uu____7387 =
+               let uu____7388 =
+                 let uu____7389 = targ ()  in
+                 FStar_Pervasives_Native.fst uu____7389  in
+               readback cfg uu____7388  in
              FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
-               uu____7378
+               uu____7387
               in
            let body =
-             let uu____7386 =
-               let uu____7387 = FStar_TypeChecker_NBETerm.mkAccuVar x1  in
-               f uu____7387  in
-             readback cfg uu____7386  in
+             let uu____7395 =
+               let uu____7396 = FStar_TypeChecker_NBETerm.mkAccuVar x1  in
+               f uu____7396  in
+             readback cfg uu____7395  in
            FStar_Syntax_Util.refine x1 body
        | FStar_TypeChecker_NBETerm.Reflect t ->
            let tm = readback cfg t  in FStar_Syntax_Util.mk_reflect tm
        | FStar_TypeChecker_NBETerm.Arrow (f,targs) ->
-           let uu____7424 =
+           let uu____7433 =
              FStar_List.fold_left
-               (fun uu____7467  ->
+               (fun uu____7476  ->
                   fun tf  ->
-                    match uu____7467 with
+                    match uu____7476 with
                     | (args_rev,accus_rev) ->
-                        let uu____7519 = tf accus_rev  in
-                        (match uu____7519 with
+                        let uu____7528 = tf accus_rev  in
+                        (match uu____7528 with
                          | (xt,q) ->
                              let x1 =
-                               let uu____7539 = readback cfg xt  in
+                               let uu____7548 = readback cfg xt  in
                                FStar_Syntax_Syntax.new_bv
-                                 FStar_Pervasives_Native.None uu____7539
+                                 FStar_Pervasives_Native.None uu____7548
                                 in
-                             let uu____7540 =
-                               let uu____7543 =
+                             let uu____7549 =
+                               let uu____7552 =
                                  FStar_TypeChecker_NBETerm.mkAccuVar x1  in
-                               uu____7543 :: accus_rev  in
-                             (((x1, q) :: args_rev), uu____7540))) ([], [])
+                               uu____7552 :: accus_rev  in
+                             (((x1, q) :: args_rev), uu____7549))) ([], [])
                targs
               in
-           (match uu____7424 with
+           (match uu____7433 with
             | (args_rev,accus_rev) ->
                 let cmp =
-                  let uu____7587 = f (FStar_List.rev accus_rev)  in
-                  readback_comp cfg uu____7587  in
+                  let uu____7596 = f (FStar_List.rev accus_rev)  in
+                  readback_comp cfg uu____7596  in
                 FStar_Syntax_Util.arrow (FStar_List.rev args_rev) cmp)
        | FStar_TypeChecker_NBETerm.Construct (fv,us,args) ->
            let args1 =
              map_rev
-               (fun uu____7630  ->
-                  match uu____7630 with
+               (fun uu____7639  ->
+                  match uu____7639 with
                   | (x1,q) ->
-                      let uu____7641 = readback cfg x1  in (uu____7641, q))
+                      let uu____7650 = readback cfg x1  in (uu____7650, q))
                args
               in
            let apply1 tm =
              match args1 with
              | [] -> tm
-             | uu____7660 -> FStar_Syntax_Util.mk_app tm args1  in
+             | uu____7669 -> FStar_Syntax_Util.mk_app tm args1  in
            (match us with
-            | uu____7667::uu____7668 ->
-                let uu____7671 =
-                  let uu____7674 =
+            | uu____7676::uu____7677 ->
+                let uu____7680 =
+                  let uu____7683 =
                     FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)
                       FStar_Pervasives_Native.None FStar_Range.dummyRange
                      in
-                  FStar_Syntax_Syntax.mk_Tm_uinst uu____7674
+                  FStar_Syntax_Syntax.mk_Tm_uinst uu____7683
                     (FStar_List.rev us)
                    in
-                apply1 uu____7671
+                apply1 uu____7680
             | [] ->
-                let uu____7675 =
+                let uu____7684 =
                   FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)
                     FStar_Pervasives_Native.None FStar_Range.dummyRange
                    in
-                apply1 uu____7675)
+                apply1 uu____7684)
        | FStar_TypeChecker_NBETerm.FV (fv,us,args) ->
            let args1 =
              map_rev
-               (fun uu____7716  ->
-                  match uu____7716 with
+               (fun uu____7725  ->
+                  match uu____7725 with
                   | (x1,q) ->
-                      let uu____7727 = readback cfg x1  in (uu____7727, q))
+                      let uu____7736 = readback cfg x1  in (uu____7736, q))
                args
               in
            let apply1 tm =
              match args1 with
              | [] -> tm
-             | uu____7746 -> FStar_Syntax_Util.mk_app tm args1  in
+             | uu____7755 -> FStar_Syntax_Util.mk_app tm args1  in
            (match us with
-            | uu____7753::uu____7754 ->
-                let uu____7757 =
-                  let uu____7760 =
+            | uu____7762::uu____7763 ->
+                let uu____7766 =
+                  let uu____7769 =
                     FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)
                       FStar_Pervasives_Native.None FStar_Range.dummyRange
                      in
-                  FStar_Syntax_Syntax.mk_Tm_uinst uu____7760
+                  FStar_Syntax_Syntax.mk_Tm_uinst uu____7769
                     (FStar_List.rev us)
                    in
-                apply1 uu____7757
+                apply1 uu____7766
             | [] ->
-                let uu____7761 =
+                let uu____7770 =
                   FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)
                     FStar_Pervasives_Native.None FStar_Range.dummyRange
                    in
-                apply1 uu____7761)
+                apply1 uu____7770)
        | FStar_TypeChecker_NBETerm.Accu (FStar_TypeChecker_NBETerm.Var bv,[])
            -> FStar_Syntax_Syntax.bv_to_name bv
        | FStar_TypeChecker_NBETerm.Accu (FStar_TypeChecker_NBETerm.Var bv,ts)
            ->
            let args =
              map_rev
-               (fun uu____7808  ->
-                  match uu____7808 with
+               (fun uu____7817  ->
+                  match uu____7817 with
                   | (x1,q) ->
-                      let uu____7819 = readback cfg x1  in (uu____7819, q))
+                      let uu____7828 = readback cfg x1  in (uu____7828, q))
                ts
               in
-           let uu____7820 = FStar_Syntax_Syntax.bv_to_name bv  in
-           FStar_Syntax_Util.mk_app uu____7820 args
+           let uu____7829 = FStar_Syntax_Syntax.bv_to_name bv  in
+           FStar_Syntax_Util.mk_app uu____7829 args
        | FStar_TypeChecker_NBETerm.Accu
            (FStar_TypeChecker_NBETerm.Match (scrut,cases,make_branches),ts)
            ->
            let args =
              map_rev
-               (fun uu____7880  ->
-                  match uu____7880 with
+               (fun uu____7889  ->
+                  match uu____7889 with
                   | (x1,q) ->
-                      let uu____7891 = readback cfg x1  in (uu____7891, q))
+                      let uu____7900 = readback cfg x1  in (uu____7900, q))
                ts
               in
            let head1 =
@@ -2468,7 +2471,7 @@ and (readback :
               in
            (match ts with
             | [] -> head1
-            | uu____7921 -> FStar_Syntax_Util.mk_app head1 args)
+            | uu____7930 -> FStar_Syntax_Util.mk_app head1 args)
        | FStar_TypeChecker_NBETerm.Rec (lb,lbs,bs,args,_ar,_ar_lst,_cfg) ->
            let head1 =
              match lb.FStar_Syntax_Syntax.lbname with
@@ -2481,24 +2484,24 @@ and (readback :
               in
            let args1 =
              map_rev
-               (fun uu____8008  ->
-                  match uu____8008 with
+               (fun uu____8017  ->
+                  match uu____8017 with
                   | (x1,q) ->
-                      let uu____8019 = readback cfg x1  in (uu____8019, q))
+                      let uu____8028 = readback cfg x1  in (uu____8028, q))
                args
               in
            (match args1 with
             | [] -> head1
-            | uu____8024 -> FStar_Syntax_Util.mk_app head1 args1)
+            | uu____8033 -> FStar_Syntax_Util.mk_app head1 args1)
        | FStar_TypeChecker_NBETerm.Quote (qt,qi) ->
            FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_quoted (qt, qi))
              FStar_Pervasives_Native.None FStar_Range.dummyRange
-       | FStar_TypeChecker_NBETerm.Lazy (FStar_Util.Inl li,uu____8036) ->
+       | FStar_TypeChecker_NBETerm.Lazy (FStar_Util.Inl li,uu____8045) ->
            FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_lazy li)
              FStar_Pervasives_Native.None FStar_Range.dummyRange
-       | FStar_TypeChecker_NBETerm.Lazy (uu____8053,thunk1) ->
-           let uu____8075 = FStar_Common.force_thunk thunk1  in
-           readback cfg uu____8075)
+       | FStar_TypeChecker_NBETerm.Lazy (uu____8062,thunk1) ->
+           let uu____8084 = FStar_Common.force_thunk thunk1  in
+           readback cfg uu____8084)
 
 type step =
   | Primops 
@@ -2509,37 +2512,37 @@ type step =
   | Reify 
 let (uu___is_Primops : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Primops  -> true | uu____8104 -> false
+    match projectee with | Primops  -> true | uu____8113 -> false
   
 let (uu___is_UnfoldUntil : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldUntil _0 -> true | uu____8116 -> false
+    match projectee with | UnfoldUntil _0 -> true | uu____8125 -> false
   
 let (__proj__UnfoldUntil__item___0 : step -> FStar_Syntax_Syntax.delta_depth)
   = fun projectee  -> match projectee with | UnfoldUntil _0 -> _0 
 let (uu___is_UnfoldOnly : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldOnly _0 -> true | uu____8137 -> false
+    match projectee with | UnfoldOnly _0 -> true | uu____8146 -> false
   
 let (__proj__UnfoldOnly__item___0 : step -> FStar_Ident.lid Prims.list) =
   fun projectee  -> match projectee with | UnfoldOnly _0 -> _0 
 let (uu___is_UnfoldAttr : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldAttr _0 -> true | uu____8164 -> false
+    match projectee with | UnfoldAttr _0 -> true | uu____8173 -> false
   
 let (__proj__UnfoldAttr__item___0 : step -> FStar_Ident.lid Prims.list) =
   fun projectee  -> match projectee with | UnfoldAttr _0 -> _0 
 let (uu___is_UnfoldTac : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldTac  -> true | uu____8188 -> false
+    match projectee with | UnfoldTac  -> true | uu____8197 -> false
   
 let (uu___is_Reify : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Reify  -> true | uu____8199 -> false
+    match projectee with | Reify  -> true | uu____8208 -> false
   
 let (step_as_normalizer_step : step -> FStar_TypeChecker_Env.step) =
-  fun uu___1_8206  ->
-    match uu___1_8206 with
+  fun uu___1_8215  ->
+    match uu___1_8215 with
     | Primops  -> FStar_TypeChecker_Env.Primops
     | UnfoldUntil d -> FStar_TypeChecker_Env.UnfoldUntil d
     | UnfoldOnly lids -> FStar_TypeChecker_Env.UnfoldOnly lids
@@ -2559,91 +2562,91 @@ let (normalize :
         fun e  ->
           let cfg = FStar_TypeChecker_Cfg.config' psteps steps env  in
           let cfg1 =
-            let uu___1247_8245 = cfg  in
+            let uu___1249_8254 = cfg  in
             {
               FStar_TypeChecker_Cfg.steps =
-                (let uu___1249_8248 = cfg.FStar_TypeChecker_Cfg.steps  in
+                (let uu___1251_8257 = cfg.FStar_TypeChecker_Cfg.steps  in
                  {
                    FStar_TypeChecker_Cfg.beta =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.beta);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.beta);
                    FStar_TypeChecker_Cfg.iota =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.iota);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.iota);
                    FStar_TypeChecker_Cfg.zeta =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.zeta);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.zeta);
                    FStar_TypeChecker_Cfg.weak =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.weak);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.weak);
                    FStar_TypeChecker_Cfg.hnf =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.hnf);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.hnf);
                    FStar_TypeChecker_Cfg.primops =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.primops);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.primops);
                    FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                    FStar_TypeChecker_Cfg.unfold_until =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.unfold_until);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.unfold_until);
                    FStar_TypeChecker_Cfg.unfold_only =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.unfold_only);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.unfold_only);
                    FStar_TypeChecker_Cfg.unfold_fully =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.unfold_fully);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.unfold_fully);
                    FStar_TypeChecker_Cfg.unfold_attr =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.unfold_attr);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.unfold_attr);
                    FStar_TypeChecker_Cfg.unfold_tac =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.unfold_tac);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.unfold_tac);
                    FStar_TypeChecker_Cfg.pure_subterms_within_computations =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                    FStar_TypeChecker_Cfg.simplify =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.simplify);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.simplify);
                    FStar_TypeChecker_Cfg.erase_universes =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.erase_universes);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.erase_universes);
                    FStar_TypeChecker_Cfg.allow_unbound_universes =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.allow_unbound_universes);
                    FStar_TypeChecker_Cfg.reify_ = true;
                    FStar_TypeChecker_Cfg.compress_uvars =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.compress_uvars);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.compress_uvars);
                    FStar_TypeChecker_Cfg.no_full_norm =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.no_full_norm);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.no_full_norm);
                    FStar_TypeChecker_Cfg.check_no_uvars =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.check_no_uvars);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.check_no_uvars);
                    FStar_TypeChecker_Cfg.unmeta =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.unmeta);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.unmeta);
                    FStar_TypeChecker_Cfg.unascribe =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.unascribe);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.unascribe);
                    FStar_TypeChecker_Cfg.in_full_norm_request =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.in_full_norm_request);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.in_full_norm_request);
                    FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                    FStar_TypeChecker_Cfg.nbe_step =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.nbe_step);
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.nbe_step);
                    FStar_TypeChecker_Cfg.for_extraction =
-                     (uu___1249_8248.FStar_TypeChecker_Cfg.for_extraction)
+                     (uu___1251_8257.FStar_TypeChecker_Cfg.for_extraction)
                  });
               FStar_TypeChecker_Cfg.tcenv =
-                (uu___1247_8245.FStar_TypeChecker_Cfg.tcenv);
+                (uu___1249_8254.FStar_TypeChecker_Cfg.tcenv);
               FStar_TypeChecker_Cfg.debug =
-                (uu___1247_8245.FStar_TypeChecker_Cfg.debug);
+                (uu___1249_8254.FStar_TypeChecker_Cfg.debug);
               FStar_TypeChecker_Cfg.delta_level =
-                (uu___1247_8245.FStar_TypeChecker_Cfg.delta_level);
+                (uu___1249_8254.FStar_TypeChecker_Cfg.delta_level);
               FStar_TypeChecker_Cfg.primitive_steps =
-                (uu___1247_8245.FStar_TypeChecker_Cfg.primitive_steps);
+                (uu___1249_8254.FStar_TypeChecker_Cfg.primitive_steps);
               FStar_TypeChecker_Cfg.strong =
-                (uu___1247_8245.FStar_TypeChecker_Cfg.strong);
+                (uu___1249_8254.FStar_TypeChecker_Cfg.strong);
               FStar_TypeChecker_Cfg.memoize_lazy =
-                (uu___1247_8245.FStar_TypeChecker_Cfg.memoize_lazy);
+                (uu___1249_8254.FStar_TypeChecker_Cfg.memoize_lazy);
               FStar_TypeChecker_Cfg.normalize_pure_lets =
-                (uu___1247_8245.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                (uu___1249_8254.FStar_TypeChecker_Cfg.normalize_pure_lets);
               FStar_TypeChecker_Cfg.reifying =
-                (uu___1247_8245.FStar_TypeChecker_Cfg.reifying)
+                (uu___1249_8254.FStar_TypeChecker_Cfg.reifying)
             }  in
           debug cfg1
-            (fun uu____8253  ->
-               let uu____8254 = FStar_Syntax_Print.term_to_string e  in
-               FStar_Util.print1 "Calling NBE with (%s) {\n" uu____8254);
+            (fun uu____8262  ->
+               let uu____8263 = FStar_Syntax_Print.term_to_string e  in
+               FStar_Util.print1 "Calling NBE with (%s) {\n" uu____8263);
           (let r =
-             let uu____8258 = translate cfg1 [] e  in
-             readback cfg1 uu____8258  in
+             let uu____8267 = translate cfg1 [] e  in
+             readback cfg1 uu____8267  in
            debug cfg1
-             (fun uu____8262  ->
-                let uu____8263 = FStar_Syntax_Print.term_to_string r  in
-                FStar_Util.print1 "}\nNBE returned (%s)\n" uu____8263);
+             (fun uu____8271  ->
+                let uu____8272 = FStar_Syntax_Print.term_to_string r  in
+                FStar_Util.print1 "}\nNBE returned (%s)\n" uu____8272);
            r)
   
 let (normalize_for_unit_test :
@@ -2656,90 +2659,90 @@ let (normalize_for_unit_test :
       fun e  ->
         let cfg = FStar_TypeChecker_Cfg.config steps env  in
         let cfg1 =
-          let uu___1264_8288 = cfg  in
+          let uu___1266_8297 = cfg  in
           {
             FStar_TypeChecker_Cfg.steps =
-              (let uu___1266_8291 = cfg.FStar_TypeChecker_Cfg.steps  in
+              (let uu___1268_8300 = cfg.FStar_TypeChecker_Cfg.steps  in
                {
                  FStar_TypeChecker_Cfg.beta =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.beta);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.beta);
                  FStar_TypeChecker_Cfg.iota =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.iota);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.iota);
                  FStar_TypeChecker_Cfg.zeta =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.zeta);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.zeta);
                  FStar_TypeChecker_Cfg.weak =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.weak);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.weak);
                  FStar_TypeChecker_Cfg.hnf =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.hnf);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.hnf);
                  FStar_TypeChecker_Cfg.primops =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.primops);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.primops);
                  FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                  FStar_TypeChecker_Cfg.unfold_until =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.unfold_until);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.unfold_until);
                  FStar_TypeChecker_Cfg.unfold_only =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.unfold_only);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.unfold_only);
                  FStar_TypeChecker_Cfg.unfold_fully =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.unfold_fully);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.unfold_fully);
                  FStar_TypeChecker_Cfg.unfold_attr =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.unfold_attr);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.unfold_attr);
                  FStar_TypeChecker_Cfg.unfold_tac =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.unfold_tac);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.unfold_tac);
                  FStar_TypeChecker_Cfg.pure_subterms_within_computations =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                  FStar_TypeChecker_Cfg.simplify =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.simplify);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.simplify);
                  FStar_TypeChecker_Cfg.erase_universes =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.erase_universes);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.erase_universes);
                  FStar_TypeChecker_Cfg.allow_unbound_universes =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.allow_unbound_universes);
                  FStar_TypeChecker_Cfg.reify_ = true;
                  FStar_TypeChecker_Cfg.compress_uvars =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.compress_uvars);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.compress_uvars);
                  FStar_TypeChecker_Cfg.no_full_norm =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.no_full_norm);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.no_full_norm);
                  FStar_TypeChecker_Cfg.check_no_uvars =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.check_no_uvars);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.check_no_uvars);
                  FStar_TypeChecker_Cfg.unmeta =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.unmeta);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.unmeta);
                  FStar_TypeChecker_Cfg.unascribe =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.unascribe);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.unascribe);
                  FStar_TypeChecker_Cfg.in_full_norm_request =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.in_full_norm_request);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.in_full_norm_request);
                  FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                  FStar_TypeChecker_Cfg.nbe_step =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.nbe_step);
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.nbe_step);
                  FStar_TypeChecker_Cfg.for_extraction =
-                   (uu___1266_8291.FStar_TypeChecker_Cfg.for_extraction)
+                   (uu___1268_8300.FStar_TypeChecker_Cfg.for_extraction)
                });
             FStar_TypeChecker_Cfg.tcenv =
-              (uu___1264_8288.FStar_TypeChecker_Cfg.tcenv);
+              (uu___1266_8297.FStar_TypeChecker_Cfg.tcenv);
             FStar_TypeChecker_Cfg.debug =
-              (uu___1264_8288.FStar_TypeChecker_Cfg.debug);
+              (uu___1266_8297.FStar_TypeChecker_Cfg.debug);
             FStar_TypeChecker_Cfg.delta_level =
-              (uu___1264_8288.FStar_TypeChecker_Cfg.delta_level);
+              (uu___1266_8297.FStar_TypeChecker_Cfg.delta_level);
             FStar_TypeChecker_Cfg.primitive_steps =
-              (uu___1264_8288.FStar_TypeChecker_Cfg.primitive_steps);
+              (uu___1266_8297.FStar_TypeChecker_Cfg.primitive_steps);
             FStar_TypeChecker_Cfg.strong =
-              (uu___1264_8288.FStar_TypeChecker_Cfg.strong);
+              (uu___1266_8297.FStar_TypeChecker_Cfg.strong);
             FStar_TypeChecker_Cfg.memoize_lazy =
-              (uu___1264_8288.FStar_TypeChecker_Cfg.memoize_lazy);
+              (uu___1266_8297.FStar_TypeChecker_Cfg.memoize_lazy);
             FStar_TypeChecker_Cfg.normalize_pure_lets =
-              (uu___1264_8288.FStar_TypeChecker_Cfg.normalize_pure_lets);
+              (uu___1266_8297.FStar_TypeChecker_Cfg.normalize_pure_lets);
             FStar_TypeChecker_Cfg.reifying =
-              (uu___1264_8288.FStar_TypeChecker_Cfg.reifying)
+              (uu___1266_8297.FStar_TypeChecker_Cfg.reifying)
           }  in
         debug cfg1
-          (fun uu____8296  ->
-             let uu____8297 = FStar_Syntax_Print.term_to_string e  in
-             FStar_Util.print1 "Calling NBE with (%s) {\n" uu____8297);
+          (fun uu____8305  ->
+             let uu____8306 = FStar_Syntax_Print.term_to_string e  in
+             FStar_Util.print1 "Calling NBE with (%s) {\n" uu____8306);
         (let r =
-           let uu____8301 = translate cfg1 [] e  in readback cfg1 uu____8301
+           let uu____8310 = translate cfg1 [] e  in readback cfg1 uu____8310
             in
          debug cfg1
-           (fun uu____8305  ->
-              let uu____8306 = FStar_Syntax_Print.term_to_string r  in
-              FStar_Util.print1 "}\nNBE returned (%s)\n" uu____8306);
+           (fun uu____8314  ->
+              let uu____8315 = FStar_Syntax_Print.term_to_string r  in
+              FStar_Util.print1 "}\nNBE returned (%s)\n" uu____8315);
          r)
   

--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -2055,17 +2055,18 @@ let (should_unfold :
                         FStar_Syntax_Syntax.sigrng = uu____7765;
                         FStar_Syntax_Syntax.sigquals = qs;
                         FStar_Syntax_Syntax.sigmeta = uu____7767;
-                        FStar_Syntax_Syntax.sigattrs = uu____7768;_},uu____7769),uu____7770),uu____7771,uu____7772,uu____7773)
+                        FStar_Syntax_Syntax.sigattrs = uu____7768;
+                        FStar_Syntax_Syntax.sigopts = uu____7769;_},uu____7770),uu____7771),uu____7772,uu____7773,uu____7774)
                      when
                      FStar_List.contains FStar_Syntax_Syntax.HasMaskedEffect
                        qs
                      ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____7880  ->
+                        (fun uu____7883  ->
                            FStar_Util.print_string
                              " >> HasMaskedEffect, not unfolding\n");
                       no)
-                 | (uu____7882,uu____7883,uu____7884,uu____7885) when
+                 | (uu____7885,uu____7886,uu____7887,uu____7888) when
                      (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_tac
                        &&
                        (FStar_Util.for_some
@@ -2073,7 +2074,7 @@ let (should_unfold :
                              FStar_Syntax_Util.tac_opaque_attr) attrs)
                      ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____7952  ->
+                        (fun uu____7955  ->
                            FStar_Util.print_string
                              " >> tac_opaque, not unfolding\n");
                       no)
@@ -2082,49 +2083,50 @@ let (should_unfold :
                      ({
                         FStar_Syntax_Syntax.sigel =
                           FStar_Syntax_Syntax.Sig_let
-                          ((is_rec,uu____7955),uu____7956);
-                        FStar_Syntax_Syntax.sigrng = uu____7957;
+                          ((is_rec,uu____7958),uu____7959);
+                        FStar_Syntax_Syntax.sigrng = uu____7960;
                         FStar_Syntax_Syntax.sigquals = qs;
-                        FStar_Syntax_Syntax.sigmeta = uu____7959;
-                        FStar_Syntax_Syntax.sigattrs = uu____7960;_},uu____7961),uu____7962),uu____7963,uu____7964,uu____7965)
+                        FStar_Syntax_Syntax.sigmeta = uu____7962;
+                        FStar_Syntax_Syntax.sigattrs = uu____7963;
+                        FStar_Syntax_Syntax.sigopts = uu____7964;_},uu____7965),uu____7966),uu____7967,uu____7968,uu____7969)
                      when
                      is_rec &&
                        (Prims.op_Negation
                           (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta)
                      ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____8072  ->
+                        (fun uu____8078  ->
                            FStar_Util.print_string
                              " >> It's a recursive definition but we're not doing Zeta, not unfolding\n");
                       no)
-                 | (uu____8074,FStar_Pervasives_Native.Some
-                    uu____8075,uu____8076,uu____8077) ->
+                 | (uu____8080,FStar_Pervasives_Native.Some
+                    uu____8081,uu____8082,uu____8083) ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____8145  ->
-                           let uu____8146 =
+                        (fun uu____8151  ->
+                           let uu____8152 =
                              FStar_Syntax_Print.fv_to_string fv  in
                            FStar_Util.print1
                              "should_unfold: Reached a %s with selective unfolding\n"
-                             uu____8146);
-                      (let uu____8149 =
-                         let uu____8161 =
+                             uu____8152);
+                      (let uu____8155 =
+                         let uu____8167 =
                            match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_only
                            with
                            | FStar_Pervasives_Native.None  -> no
                            | FStar_Pervasives_Native.Some lids ->
-                               let uu____8187 =
+                               let uu____8193 =
                                  FStar_Util.for_some
                                    (FStar_Syntax_Syntax.fv_eq_lid fv) lids
                                   in
-                               FStar_All.pipe_left yesno uu____8187
+                               FStar_All.pipe_left yesno uu____8193
                             in
-                         let uu____8199 =
-                           let uu____8211 =
+                         let uu____8205 =
+                           let uu____8217 =
                              match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_attr
                              with
                              | FStar_Pervasives_Native.None  -> no
                              | FStar_Pervasives_Native.Some lids ->
-                                 let uu____8237 =
+                                 let uu____8243 =
                                    FStar_Util.for_some
                                      (fun at  ->
                                         FStar_Util.for_some
@@ -2132,53 +2134,53 @@ let (should_unfold :
                                              FStar_Syntax_Util.is_fvar lid at)
                                           lids) attrs
                                     in
-                                 FStar_All.pipe_left yesno uu____8237
+                                 FStar_All.pipe_left yesno uu____8243
                               in
-                           let uu____8253 =
-                             let uu____8265 =
+                           let uu____8259 =
+                             let uu____8271 =
                                match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_fully
                                with
                                | FStar_Pervasives_Native.None  -> no
                                | FStar_Pervasives_Native.Some lids ->
-                                   let uu____8291 =
+                                   let uu____8297 =
                                      FStar_Util.for_some
                                        (FStar_Syntax_Syntax.fv_eq_lid fv)
                                        lids
                                       in
-                                   FStar_All.pipe_left fullyno uu____8291
+                                   FStar_All.pipe_left fullyno uu____8297
                                 in
-                             [uu____8265]  in
-                           uu____8211 :: uu____8253  in
-                         uu____8161 :: uu____8199  in
-                       comb_or uu____8149))
-                 | (uu____8339,uu____8340,FStar_Pervasives_Native.Some
-                    uu____8341,uu____8342) ->
+                             [uu____8271]  in
+                           uu____8217 :: uu____8259  in
+                         uu____8167 :: uu____8205  in
+                       comb_or uu____8155))
+                 | (uu____8345,uu____8346,FStar_Pervasives_Native.Some
+                    uu____8347,uu____8348) ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____8410  ->
-                           let uu____8411 =
+                        (fun uu____8416  ->
+                           let uu____8417 =
                              FStar_Syntax_Print.fv_to_string fv  in
                            FStar_Util.print1
                              "should_unfold: Reached a %s with selective unfolding\n"
-                             uu____8411);
-                      (let uu____8414 =
-                         let uu____8426 =
+                             uu____8417);
+                      (let uu____8420 =
+                         let uu____8432 =
                            match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_only
                            with
                            | FStar_Pervasives_Native.None  -> no
                            | FStar_Pervasives_Native.Some lids ->
-                               let uu____8452 =
+                               let uu____8458 =
                                  FStar_Util.for_some
                                    (FStar_Syntax_Syntax.fv_eq_lid fv) lids
                                   in
-                               FStar_All.pipe_left yesno uu____8452
+                               FStar_All.pipe_left yesno uu____8458
                             in
-                         let uu____8464 =
-                           let uu____8476 =
+                         let uu____8470 =
+                           let uu____8482 =
                              match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_attr
                              with
                              | FStar_Pervasives_Native.None  -> no
                              | FStar_Pervasives_Native.Some lids ->
-                                 let uu____8502 =
+                                 let uu____8508 =
                                    FStar_Util.for_some
                                      (fun at  ->
                                         FStar_Util.for_some
@@ -2186,53 +2188,53 @@ let (should_unfold :
                                              FStar_Syntax_Util.is_fvar lid at)
                                           lids) attrs
                                     in
-                                 FStar_All.pipe_left yesno uu____8502
+                                 FStar_All.pipe_left yesno uu____8508
                               in
-                           let uu____8518 =
-                             let uu____8530 =
+                           let uu____8524 =
+                             let uu____8536 =
                                match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_fully
                                with
                                | FStar_Pervasives_Native.None  -> no
                                | FStar_Pervasives_Native.Some lids ->
-                                   let uu____8556 =
+                                   let uu____8562 =
                                      FStar_Util.for_some
                                        (FStar_Syntax_Syntax.fv_eq_lid fv)
                                        lids
                                       in
-                                   FStar_All.pipe_left fullyno uu____8556
+                                   FStar_All.pipe_left fullyno uu____8562
                                 in
-                             [uu____8530]  in
-                           uu____8476 :: uu____8518  in
-                         uu____8426 :: uu____8464  in
-                       comb_or uu____8414))
-                 | (uu____8604,uu____8605,uu____8606,FStar_Pervasives_Native.Some
-                    uu____8607) ->
+                             [uu____8536]  in
+                           uu____8482 :: uu____8524  in
+                         uu____8432 :: uu____8470  in
+                       comb_or uu____8420))
+                 | (uu____8610,uu____8611,uu____8612,FStar_Pervasives_Native.Some
+                    uu____8613) ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____8675  ->
-                           let uu____8676 =
+                        (fun uu____8681  ->
+                           let uu____8682 =
                              FStar_Syntax_Print.fv_to_string fv  in
                            FStar_Util.print1
                              "should_unfold: Reached a %s with selective unfolding\n"
-                             uu____8676);
-                      (let uu____8679 =
-                         let uu____8691 =
+                             uu____8682);
+                      (let uu____8685 =
+                         let uu____8697 =
                            match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_only
                            with
                            | FStar_Pervasives_Native.None  -> no
                            | FStar_Pervasives_Native.Some lids ->
-                               let uu____8717 =
+                               let uu____8723 =
                                  FStar_Util.for_some
                                    (FStar_Syntax_Syntax.fv_eq_lid fv) lids
                                   in
-                               FStar_All.pipe_left yesno uu____8717
+                               FStar_All.pipe_left yesno uu____8723
                             in
-                         let uu____8729 =
-                           let uu____8741 =
+                         let uu____8735 =
+                           let uu____8747 =
                              match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_attr
                              with
                              | FStar_Pervasives_Native.None  -> no
                              | FStar_Pervasives_Native.Some lids ->
-                                 let uu____8767 =
+                                 let uu____8773 =
                                    FStar_Util.for_some
                                      (fun at  ->
                                         FStar_Util.for_some
@@ -2240,92 +2242,92 @@ let (should_unfold :
                                              FStar_Syntax_Util.is_fvar lid at)
                                           lids) attrs
                                     in
-                                 FStar_All.pipe_left yesno uu____8767
+                                 FStar_All.pipe_left yesno uu____8773
                               in
-                           let uu____8783 =
-                             let uu____8795 =
+                           let uu____8789 =
+                             let uu____8801 =
                                match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_fully
                                with
                                | FStar_Pervasives_Native.None  -> no
                                | FStar_Pervasives_Native.Some lids ->
-                                   let uu____8821 =
+                                   let uu____8827 =
                                      FStar_Util.for_some
                                        (FStar_Syntax_Syntax.fv_eq_lid fv)
                                        lids
                                       in
-                                   FStar_All.pipe_left fullyno uu____8821
+                                   FStar_All.pipe_left fullyno uu____8827
                                 in
-                             [uu____8795]  in
-                           uu____8741 :: uu____8783  in
-                         uu____8691 :: uu____8729  in
-                       comb_or uu____8679))
-                 | uu____8869 ->
+                             [uu____8801]  in
+                           uu____8747 :: uu____8789  in
+                         uu____8697 :: uu____8735  in
+                       comb_or uu____8685))
+                 | uu____8875 ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____8915  ->
-                           let uu____8916 =
+                        (fun uu____8921  ->
+                           let uu____8922 =
                              FStar_Syntax_Print.fv_to_string fv  in
-                           let uu____8918 =
+                           let uu____8924 =
                              FStar_Syntax_Print.delta_depth_to_string
                                fv.FStar_Syntax_Syntax.fv_delta
                               in
-                           let uu____8920 =
+                           let uu____8926 =
                              FStar_Common.string_of_list
                                FStar_TypeChecker_Env.string_of_delta_level
                                cfg.FStar_TypeChecker_Cfg.delta_level
                               in
                            FStar_Util.print3
                              "should_unfold: Reached a %s with delta_depth = %s\n >> Our delta_level is %s\n"
-                             uu____8916 uu____8918 uu____8920);
-                      (let uu____8923 =
+                             uu____8922 uu____8924 uu____8926);
+                      (let uu____8929 =
                          FStar_All.pipe_right
                            cfg.FStar_TypeChecker_Cfg.delta_level
                            (FStar_Util.for_some
-                              (fun uu___12_8929  ->
-                                 match uu___12_8929 with
+                              (fun uu___12_8935  ->
+                                 match uu___12_8935 with
                                  | FStar_TypeChecker_Env.NoDelta  -> false
                                  | FStar_TypeChecker_Env.InliningDelta  ->
                                      true
                                  | FStar_TypeChecker_Env.Eager_unfolding_only
                                       -> true
                                  | FStar_TypeChecker_Env.Unfold l ->
-                                     let uu____8935 =
+                                     let uu____8941 =
                                        FStar_TypeChecker_Env.delta_depth_of_fv
                                          cfg.FStar_TypeChecker_Cfg.tcenv fv
                                         in
                                      FStar_TypeChecker_Common.delta_depth_greater_than
-                                       uu____8935 l))
+                                       uu____8941 l))
                           in
-                       FStar_All.pipe_left yesno uu____8923)))
+                       FStar_All.pipe_left yesno uu____8929)))
              in
           FStar_TypeChecker_Cfg.log_unfolding cfg
-            (fun uu____8951  ->
-               let uu____8952 = FStar_Syntax_Print.fv_to_string fv  in
-               let uu____8954 =
-                 let uu____8956 = FStar_Syntax_Syntax.range_of_fv fv  in
-                 FStar_Range.string_of_range uu____8956  in
-               let uu____8957 = string_of_res res  in
+            (fun uu____8957  ->
+               let uu____8958 = FStar_Syntax_Print.fv_to_string fv  in
+               let uu____8960 =
+                 let uu____8962 = FStar_Syntax_Syntax.range_of_fv fv  in
+                 FStar_Range.string_of_range uu____8962  in
+               let uu____8963 = string_of_res res  in
                FStar_Util.print3
                  "should_unfold: For %s (%s), unfolding res = %s\n"
-                 uu____8952 uu____8954 uu____8957);
+                 uu____8958 uu____8960 uu____8963);
           (match res with
-           | (false ,uu____8960,uu____8961) -> Should_unfold_no
+           | (false ,uu____8966,uu____8967) -> Should_unfold_no
            | (true ,false ,false ) -> Should_unfold_yes
            | (true ,true ,false ) -> Should_unfold_fully
            | (true ,false ,true ) -> Should_unfold_reify
-           | uu____8986 ->
-               let uu____8996 =
-                 let uu____8998 = string_of_res res  in
+           | uu____8992 ->
+               let uu____9002 =
+                 let uu____9004 = string_of_res res  in
                  FStar_Util.format1 "Unexpected unfolding result: %s"
-                   uu____8998
+                   uu____9004
                   in
-               FStar_All.pipe_left failwith uu____8996)
+               FStar_All.pipe_left failwith uu____9002)
   
 let decide_unfolding :
-  'Auu____9017 .
+  'Auu____9023 .
     FStar_TypeChecker_Cfg.cfg ->
       env ->
         stack_elt Prims.list ->
-          'Auu____9017 ->
+          'Auu____9023 ->
             FStar_Syntax_Syntax.fv ->
               FStar_TypeChecker_Env.qninfo ->
                 (FStar_TypeChecker_Cfg.cfg * stack_elt Prims.list)
@@ -2347,26 +2349,26 @@ let decide_unfolding :
                   FStar_Pervasives_Native.Some (cfg, stack)
               | Should_unfold_fully  ->
                   let cfg' =
-                    let uu___1144_9086 = cfg  in
+                    let uu___1146_9092 = cfg  in
                     {
                       FStar_TypeChecker_Cfg.steps =
-                        (let uu___1146_9089 = cfg.FStar_TypeChecker_Cfg.steps
+                        (let uu___1148_9095 = cfg.FStar_TypeChecker_Cfg.steps
                             in
                          {
                            FStar_TypeChecker_Cfg.beta =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.beta);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.beta);
                            FStar_TypeChecker_Cfg.iota =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.iota);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.iota);
                            FStar_TypeChecker_Cfg.zeta =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.zeta);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.zeta);
                            FStar_TypeChecker_Cfg.weak =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.weak);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.weak);
                            FStar_TypeChecker_Cfg.hnf =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.hnf);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.hnf);
                            FStar_TypeChecker_Cfg.primops =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.primops);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.primops);
                            FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                            FStar_TypeChecker_Cfg.unfold_until =
                              (FStar_Pervasives_Native.Some
                                 FStar_Syntax_Syntax.delta_constant);
@@ -2377,53 +2379,53 @@ let decide_unfolding :
                            FStar_TypeChecker_Cfg.unfold_attr =
                              FStar_Pervasives_Native.None;
                            FStar_TypeChecker_Cfg.unfold_tac =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.unfold_tac);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.unfold_tac);
                            FStar_TypeChecker_Cfg.pure_subterms_within_computations
                              =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                            FStar_TypeChecker_Cfg.simplify =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.simplify);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.simplify);
                            FStar_TypeChecker_Cfg.erase_universes =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.erase_universes);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.erase_universes);
                            FStar_TypeChecker_Cfg.allow_unbound_universes =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.allow_unbound_universes);
                            FStar_TypeChecker_Cfg.reify_ =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.reify_);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.reify_);
                            FStar_TypeChecker_Cfg.compress_uvars =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.compress_uvars);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.compress_uvars);
                            FStar_TypeChecker_Cfg.no_full_norm =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.no_full_norm);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.no_full_norm);
                            FStar_TypeChecker_Cfg.check_no_uvars =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.check_no_uvars);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.check_no_uvars);
                            FStar_TypeChecker_Cfg.unmeta =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.unmeta);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.unmeta);
                            FStar_TypeChecker_Cfg.unascribe =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.unascribe);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.unascribe);
                            FStar_TypeChecker_Cfg.in_full_norm_request =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.in_full_norm_request);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.in_full_norm_request);
                            FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                            FStar_TypeChecker_Cfg.nbe_step =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.nbe_step);
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.nbe_step);
                            FStar_TypeChecker_Cfg.for_extraction =
-                             (uu___1146_9089.FStar_TypeChecker_Cfg.for_extraction)
+                             (uu___1148_9095.FStar_TypeChecker_Cfg.for_extraction)
                          });
                       FStar_TypeChecker_Cfg.tcenv =
-                        (uu___1144_9086.FStar_TypeChecker_Cfg.tcenv);
+                        (uu___1146_9092.FStar_TypeChecker_Cfg.tcenv);
                       FStar_TypeChecker_Cfg.debug =
-                        (uu___1144_9086.FStar_TypeChecker_Cfg.debug);
+                        (uu___1146_9092.FStar_TypeChecker_Cfg.debug);
                       FStar_TypeChecker_Cfg.delta_level =
-                        (uu___1144_9086.FStar_TypeChecker_Cfg.delta_level);
+                        (uu___1146_9092.FStar_TypeChecker_Cfg.delta_level);
                       FStar_TypeChecker_Cfg.primitive_steps =
-                        (uu___1144_9086.FStar_TypeChecker_Cfg.primitive_steps);
+                        (uu___1146_9092.FStar_TypeChecker_Cfg.primitive_steps);
                       FStar_TypeChecker_Cfg.strong =
-                        (uu___1144_9086.FStar_TypeChecker_Cfg.strong);
+                        (uu___1146_9092.FStar_TypeChecker_Cfg.strong);
                       FStar_TypeChecker_Cfg.memoize_lazy =
-                        (uu___1144_9086.FStar_TypeChecker_Cfg.memoize_lazy);
+                        (uu___1146_9092.FStar_TypeChecker_Cfg.memoize_lazy);
                       FStar_TypeChecker_Cfg.normalize_pure_lets =
-                        (uu___1144_9086.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                        (uu___1146_9092.FStar_TypeChecker_Cfg.normalize_pure_lets);
                       FStar_TypeChecker_Cfg.reifying =
-                        (uu___1144_9086.FStar_TypeChecker_Cfg.reifying)
+                        (uu___1146_9092.FStar_TypeChecker_Cfg.reifying)
                     }  in
                   let stack' =
                     match stack with
@@ -2436,19 +2438,19 @@ let decide_unfolding :
                     match s with
                     | [] -> [e]
                     | (UnivArgs (us,r))::t ->
-                        let uu____9151 = push1 e t  in (UnivArgs (us, r)) ::
-                          uu____9151
+                        let uu____9157 = push1 e t  in (UnivArgs (us, r)) ::
+                          uu____9157
                     | h::t -> e :: h :: t  in
                   let ref =
-                    let uu____9163 =
-                      let uu____9170 =
-                        let uu____9171 =
-                          let uu____9172 = FStar_Syntax_Syntax.lid_of_fv fv
+                    let uu____9169 =
+                      let uu____9176 =
+                        let uu____9177 =
+                          let uu____9178 = FStar_Syntax_Syntax.lid_of_fv fv
                              in
-                          FStar_Const.Const_reflect uu____9172  in
-                        FStar_Syntax_Syntax.Tm_constant uu____9171  in
-                      FStar_Syntax_Syntax.mk uu____9170  in
-                    uu____9163 FStar_Pervasives_Native.None
+                          FStar_Const.Const_reflect uu____9178  in
+                        FStar_Syntax_Syntax.Tm_constant uu____9177  in
+                      FStar_Syntax_Syntax.mk uu____9176  in
+                    uu____9169 FStar_Pervasives_Native.None
                       FStar_Range.dummyRange
                      in
                   let stack1 =
@@ -2476,31 +2478,31 @@ let (is_fext_on_domain :
       FStar_All.pipe_right on_domain_lids
         (FStar_List.existsb (fun l  -> FStar_Syntax_Syntax.fv_eq_lid fv l))
        in
-    let uu____9238 =
-      let uu____9239 = FStar_Syntax_Subst.compress t  in
-      uu____9239.FStar_Syntax_Syntax.n  in
-    match uu____9238 with
+    let uu____9244 =
+      let uu____9245 = FStar_Syntax_Subst.compress t  in
+      uu____9245.FStar_Syntax_Syntax.n  in
+    match uu____9244 with
     | FStar_Syntax_Syntax.Tm_app (hd1,args) ->
-        let uu____9270 =
-          let uu____9271 = FStar_Syntax_Util.un_uinst hd1  in
-          uu____9271.FStar_Syntax_Syntax.n  in
-        (match uu____9270 with
+        let uu____9276 =
+          let uu____9277 = FStar_Syntax_Util.un_uinst hd1  in
+          uu____9277.FStar_Syntax_Syntax.n  in
+        (match uu____9276 with
          | FStar_Syntax_Syntax.Tm_fvar fv when
              (is_on_dom fv) &&
                ((FStar_List.length args) = (Prims.of_int (3)))
              ->
              let f =
-               let uu____9288 =
-                 let uu____9295 =
-                   let uu____9306 = FStar_All.pipe_right args FStar_List.tl
+               let uu____9294 =
+                 let uu____9301 =
+                   let uu____9312 = FStar_All.pipe_right args FStar_List.tl
                       in
-                   FStar_All.pipe_right uu____9306 FStar_List.tl  in
-                 FStar_All.pipe_right uu____9295 FStar_List.hd  in
-               FStar_All.pipe_right uu____9288 FStar_Pervasives_Native.fst
+                   FStar_All.pipe_right uu____9312 FStar_List.tl  in
+                 FStar_All.pipe_right uu____9301 FStar_List.hd  in
+               FStar_All.pipe_right uu____9294 FStar_Pervasives_Native.fst
                 in
              FStar_Pervasives_Native.Some f
-         | uu____9405 -> FStar_Pervasives_Native.None)
-    | uu____9406 -> FStar_Pervasives_Native.None
+         | uu____9411 -> FStar_Pervasives_Native.None)
+    | uu____9412 -> FStar_Pervasives_Native.None
   
 let rec (norm :
   FStar_TypeChecker_Cfg.cfg ->
@@ -2515,93 +2517,93 @@ let rec (norm :
               (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.norm_delayed
             then
               (match t.FStar_Syntax_Syntax.n with
-               | FStar_Syntax_Syntax.Tm_delayed uu____9685 ->
-                   let uu____9708 = FStar_Syntax_Print.term_to_string t  in
-                   FStar_Util.print1 "NORM delayed: %s\n" uu____9708
-               | uu____9711 -> ())
+               | FStar_Syntax_Syntax.Tm_delayed uu____9691 ->
+                   let uu____9714 = FStar_Syntax_Print.term_to_string t  in
+                   FStar_Util.print1 "NORM delayed: %s\n" uu____9714
+               | uu____9717 -> ())
             else ();
             FStar_Syntax_Subst.compress t  in
           FStar_TypeChecker_Cfg.log cfg
-            (fun uu____9721  ->
-               let uu____9722 = FStar_Syntax_Print.tag_of_term t1  in
-               let uu____9724 =
+            (fun uu____9727  ->
+               let uu____9728 = FStar_Syntax_Print.tag_of_term t1  in
+               let uu____9730 =
                  FStar_Util.string_of_bool
                    (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.no_full_norm
                   in
-               let uu____9726 = FStar_Syntax_Print.term_to_string t1  in
-               let uu____9728 =
+               let uu____9732 = FStar_Syntax_Print.term_to_string t1  in
+               let uu____9734 =
                  FStar_Util.string_of_int (FStar_List.length env)  in
-               let uu____9736 =
-                 let uu____9738 =
-                   let uu____9741 = firstn (Prims.of_int (4)) stack  in
-                   FStar_All.pipe_left FStar_Pervasives_Native.fst uu____9741
+               let uu____9742 =
+                 let uu____9744 =
+                   let uu____9747 = firstn (Prims.of_int (4)) stack  in
+                   FStar_All.pipe_left FStar_Pervasives_Native.fst uu____9747
                     in
-                 stack_to_string uu____9738  in
+                 stack_to_string uu____9744  in
                FStar_Util.print5
                  ">>> %s (no_full_norm=%s)\nNorm %s  with with %s env elements top of the stack %s \n"
-                 uu____9722 uu____9724 uu____9726 uu____9728 uu____9736);
+                 uu____9728 uu____9730 uu____9732 uu____9734 uu____9742);
           FStar_TypeChecker_Cfg.log_cfg cfg
-            (fun uu____9769  ->
-               let uu____9770 = FStar_TypeChecker_Cfg.cfg_to_string cfg  in
-               FStar_Util.print1 ">>> cfg = %s\n" uu____9770);
+            (fun uu____9775  ->
+               let uu____9776 = FStar_TypeChecker_Cfg.cfg_to_string cfg  in
+               FStar_Util.print1 ">>> cfg = %s\n" uu____9776);
           (match t1.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Tm_unknown  ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____9776  ->
-                     let uu____9777 = FStar_Syntax_Print.term_to_string t1
+                  (fun uu____9782  ->
+                     let uu____9783 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____9777);
+                       uu____9783);
                 rebuild cfg env stack t1)
-           | FStar_Syntax_Syntax.Tm_constant uu____9780 ->
+           | FStar_Syntax_Syntax.Tm_constant uu____9786 ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____9784  ->
-                     let uu____9785 = FStar_Syntax_Print.term_to_string t1
+                  (fun uu____9790  ->
+                     let uu____9791 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____9785);
+                       uu____9791);
                 rebuild cfg env stack t1)
-           | FStar_Syntax_Syntax.Tm_name uu____9788 ->
+           | FStar_Syntax_Syntax.Tm_name uu____9794 ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____9792  ->
-                     let uu____9793 = FStar_Syntax_Print.term_to_string t1
+                  (fun uu____9798  ->
+                     let uu____9799 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____9793);
+                       uu____9799);
                 rebuild cfg env stack t1)
-           | FStar_Syntax_Syntax.Tm_lazy uu____9796 ->
+           | FStar_Syntax_Syntax.Tm_lazy uu____9802 ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____9800  ->
-                     let uu____9801 = FStar_Syntax_Print.term_to_string t1
+                  (fun uu____9806  ->
+                     let uu____9807 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____9801);
+                       uu____9807);
                 rebuild cfg env stack t1)
            | FStar_Syntax_Syntax.Tm_fvar
-               { FStar_Syntax_Syntax.fv_name = uu____9804;
-                 FStar_Syntax_Syntax.fv_delta = uu____9805;
+               { FStar_Syntax_Syntax.fv_name = uu____9810;
+                 FStar_Syntax_Syntax.fv_delta = uu____9811;
                  FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
                    (FStar_Syntax_Syntax.Data_ctor );_}
                ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____9809  ->
-                     let uu____9810 = FStar_Syntax_Print.term_to_string t1
+                  (fun uu____9815  ->
+                     let uu____9816 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____9810);
+                       uu____9816);
                 rebuild cfg env stack t1)
            | FStar_Syntax_Syntax.Tm_fvar
-               { FStar_Syntax_Syntax.fv_name = uu____9813;
-                 FStar_Syntax_Syntax.fv_delta = uu____9814;
+               { FStar_Syntax_Syntax.fv_name = uu____9819;
+                 FStar_Syntax_Syntax.fv_delta = uu____9820;
                  FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
-                   (FStar_Syntax_Syntax.Record_ctor uu____9815);_}
+                   (FStar_Syntax_Syntax.Record_ctor uu____9821);_}
                ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____9825  ->
-                     let uu____9826 = FStar_Syntax_Print.term_to_string t1
+                  (fun uu____9831  ->
+                     let uu____9832 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____9826);
+                       uu____9832);
                 rebuild cfg env stack t1)
            | FStar_Syntax_Syntax.Tm_fvar fv ->
                let lid = FStar_Syntax_Syntax.lid_of_fv fv  in
@@ -2609,133 +2611,133 @@ let rec (norm :
                  FStar_TypeChecker_Env.lookup_qname
                    cfg.FStar_TypeChecker_Cfg.tcenv lid
                   in
-               let uu____9832 =
+               let uu____9838 =
                  FStar_TypeChecker_Env.delta_depth_of_qninfo fv qninfo  in
-               (match uu____9832 with
+               (match uu____9838 with
                 | FStar_Pervasives_Native.Some
-                    (FStar_Syntax_Syntax.Delta_constant_at_level _9835) when
-                    _9835 = Prims.int_zero ->
+                    (FStar_Syntax_Syntax.Delta_constant_at_level _9841) when
+                    _9841 = Prims.int_zero ->
                     (FStar_TypeChecker_Cfg.log_unfolding cfg
-                       (fun uu____9839  ->
-                          let uu____9840 =
+                       (fun uu____9845  ->
+                          let uu____9846 =
                             FStar_Syntax_Print.term_to_string t1  in
                           FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                            uu____9840);
+                            uu____9846);
                      rebuild cfg env stack t1)
-                | uu____9843 ->
-                    let uu____9846 =
+                | uu____9849 ->
+                    let uu____9852 =
                       decide_unfolding cfg env stack
                         t1.FStar_Syntax_Syntax.pos fv qninfo
                        in
-                    (match uu____9846 with
+                    (match uu____9852 with
                      | FStar_Pervasives_Native.Some (cfg1,stack1) ->
                          do_unfold_fv cfg1 env stack1 t1 qninfo fv
                      | FStar_Pervasives_Native.None  ->
                          rebuild cfg env stack t1))
-           | FStar_Syntax_Syntax.Tm_quoted uu____9873 ->
-               let uu____9880 = closure_as_term cfg env t1  in
-               rebuild cfg env stack uu____9880
+           | FStar_Syntax_Syntax.Tm_quoted uu____9879 ->
+               let uu____9886 = closure_as_term cfg env t1  in
+               rebuild cfg env stack uu____9886
            | FStar_Syntax_Syntax.Tm_app (hd1,args) when
                (should_consider_norm_requests cfg) &&
-                 (let uu____9908 = is_norm_request hd1 args  in
-                  uu____9908 = Norm_request_requires_rejig)
+                 (let uu____9914 = is_norm_request hd1 args  in
+                  uu____9914 = Norm_request_requires_rejig)
                ->
                (if
                   (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
                 then FStar_Util.print_string "Rejigging norm request ... \n"
                 else ();
-                (let uu____9914 = rejig_norm_request hd1 args  in
-                 norm cfg env stack uu____9914))
+                (let uu____9920 = rejig_norm_request hd1 args  in
+                 norm cfg env stack uu____9920))
            | FStar_Syntax_Syntax.Tm_app (hd1,args) when
                (should_consider_norm_requests cfg) &&
-                 (let uu____9942 = is_norm_request hd1 args  in
-                  uu____9942 = Norm_request_ready)
+                 (let uu____9948 = is_norm_request hd1 args  in
+                  uu____9948 = Norm_request_ready)
                ->
                (if
                   (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
                 then FStar_Util.print_string "Potential norm request ... \n"
                 else ();
                 (let cfg' =
-                   let uu___1253_9949 = cfg  in
+                   let uu___1255_9955 = cfg  in
                    {
                      FStar_TypeChecker_Cfg.steps =
-                       (let uu___1255_9952 = cfg.FStar_TypeChecker_Cfg.steps
+                       (let uu___1257_9958 = cfg.FStar_TypeChecker_Cfg.steps
                            in
                         {
                           FStar_TypeChecker_Cfg.beta =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.beta);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.beta);
                           FStar_TypeChecker_Cfg.iota =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.iota);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.iota);
                           FStar_TypeChecker_Cfg.zeta =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.zeta);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.zeta);
                           FStar_TypeChecker_Cfg.weak =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.weak);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.weak);
                           FStar_TypeChecker_Cfg.hnf =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.hnf);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.hnf);
                           FStar_TypeChecker_Cfg.primops =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.primops);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.primops);
                           FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
                             false;
                           FStar_TypeChecker_Cfg.unfold_until =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.unfold_until);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.unfold_until);
                           FStar_TypeChecker_Cfg.unfold_only =
                             FStar_Pervasives_Native.None;
                           FStar_TypeChecker_Cfg.unfold_fully =
                             FStar_Pervasives_Native.None;
                           FStar_TypeChecker_Cfg.unfold_attr =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.unfold_attr);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.unfold_attr);
                           FStar_TypeChecker_Cfg.unfold_tac =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.unfold_tac);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.unfold_tac);
                           FStar_TypeChecker_Cfg.pure_subterms_within_computations
                             =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                           FStar_TypeChecker_Cfg.simplify =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.simplify);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.simplify);
                           FStar_TypeChecker_Cfg.erase_universes =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.erase_universes);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.erase_universes);
                           FStar_TypeChecker_Cfg.allow_unbound_universes =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.allow_unbound_universes);
                           FStar_TypeChecker_Cfg.reify_ =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.reify_);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.reify_);
                           FStar_TypeChecker_Cfg.compress_uvars =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.compress_uvars);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.compress_uvars);
                           FStar_TypeChecker_Cfg.no_full_norm =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.no_full_norm);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.no_full_norm);
                           FStar_TypeChecker_Cfg.check_no_uvars =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.check_no_uvars);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.check_no_uvars);
                           FStar_TypeChecker_Cfg.unmeta =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.unmeta);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.unmeta);
                           FStar_TypeChecker_Cfg.unascribe =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.unascribe);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.unascribe);
                           FStar_TypeChecker_Cfg.in_full_norm_request =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.in_full_norm_request);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.in_full_norm_request);
                           FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                           FStar_TypeChecker_Cfg.nbe_step =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.nbe_step);
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.nbe_step);
                           FStar_TypeChecker_Cfg.for_extraction =
-                            (uu___1255_9952.FStar_TypeChecker_Cfg.for_extraction)
+                            (uu___1257_9958.FStar_TypeChecker_Cfg.for_extraction)
                         });
                      FStar_TypeChecker_Cfg.tcenv =
-                       (uu___1253_9949.FStar_TypeChecker_Cfg.tcenv);
+                       (uu___1255_9955.FStar_TypeChecker_Cfg.tcenv);
                      FStar_TypeChecker_Cfg.debug =
-                       (uu___1253_9949.FStar_TypeChecker_Cfg.debug);
+                       (uu___1255_9955.FStar_TypeChecker_Cfg.debug);
                      FStar_TypeChecker_Cfg.delta_level =
                        [FStar_TypeChecker_Env.Unfold
                           FStar_Syntax_Syntax.delta_constant];
                      FStar_TypeChecker_Cfg.primitive_steps =
-                       (uu___1253_9949.FStar_TypeChecker_Cfg.primitive_steps);
+                       (uu___1255_9955.FStar_TypeChecker_Cfg.primitive_steps);
                      FStar_TypeChecker_Cfg.strong =
-                       (uu___1253_9949.FStar_TypeChecker_Cfg.strong);
+                       (uu___1255_9955.FStar_TypeChecker_Cfg.strong);
                      FStar_TypeChecker_Cfg.memoize_lazy =
-                       (uu___1253_9949.FStar_TypeChecker_Cfg.memoize_lazy);
+                       (uu___1255_9955.FStar_TypeChecker_Cfg.memoize_lazy);
                      FStar_TypeChecker_Cfg.normalize_pure_lets = true;
                      FStar_TypeChecker_Cfg.reifying =
-                       (uu___1253_9949.FStar_TypeChecker_Cfg.reifying)
+                       (uu___1255_9955.FStar_TypeChecker_Cfg.reifying)
                    }  in
-                 let uu____9959 =
+                 let uu____9965 =
                    get_norm_request cfg (norm cfg' env []) args  in
-                 match uu____9959 with
+                 match uu____9965 with
                  | FStar_Pervasives_Native.None  ->
                      (if
                         (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
@@ -2744,45 +2746,45 @@ let rec (norm :
                       (let stack1 =
                          FStar_All.pipe_right stack
                            (FStar_List.fold_right
-                              (fun uu____9995  ->
+                              (fun uu____10001  ->
                                  fun stack1  ->
-                                   match uu____9995 with
+                                   match uu____10001 with
                                    | (a,aq) ->
-                                       let uu____10007 =
-                                         let uu____10008 =
-                                           let uu____10015 =
-                                             let uu____10016 =
-                                               let uu____10048 =
+                                       let uu____10013 =
+                                         let uu____10014 =
+                                           let uu____10021 =
+                                             let uu____10022 =
+                                               let uu____10054 =
                                                  FStar_Util.mk_ref
                                                    FStar_Pervasives_Native.None
                                                   in
-                                               (env, a, uu____10048, false)
+                                               (env, a, uu____10054, false)
                                                 in
-                                             Clos uu____10016  in
-                                           (uu____10015, aq,
+                                             Clos uu____10022  in
+                                           (uu____10021, aq,
                                              (t1.FStar_Syntax_Syntax.pos))
                                             in
-                                         Arg uu____10008  in
-                                       uu____10007 :: stack1) args)
+                                         Arg uu____10014  in
+                                       uu____10013 :: stack1) args)
                           in
                        FStar_TypeChecker_Cfg.log cfg
-                         (fun uu____10116  ->
-                            let uu____10117 =
+                         (fun uu____10122  ->
+                            let uu____10123 =
                               FStar_All.pipe_left FStar_Util.string_of_int
                                 (FStar_List.length args)
                                in
                             FStar_Util.print1 "\tPushed %s arguments\n"
-                              uu____10117);
+                              uu____10123);
                        norm cfg env stack1 hd1))
                  | FStar_Pervasives_Native.Some (s,tm) when is_nbe_request s
                      ->
                      (if
                         (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
                       then
-                        (let uu____10144 =
+                        (let uu____10150 =
                            FStar_Syntax_Print.term_to_string tm  in
                          FStar_Util.print1
-                           "Starting NBE request on %s ... \n" uu____10144)
+                           "Starting NBE request on %s ... \n" uu____10150)
                       else ();
                       (let tm' = closure_as_term cfg env tm  in
                        let start = FStar_Util.now ()  in
@@ -2791,161 +2793,161 @@ let rec (norm :
                        if
                          (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
                        then
-                         (let uu____10155 =
-                            let uu____10157 =
-                              let uu____10159 =
+                         (let uu____10161 =
+                            let uu____10163 =
+                              let uu____10165 =
                                 FStar_Util.time_diff start fin  in
-                              FStar_Pervasives_Native.snd uu____10159  in
-                            FStar_Util.string_of_int uu____10157  in
-                          let uu____10166 =
+                              FStar_Pervasives_Native.snd uu____10165  in
+                            FStar_Util.string_of_int uu____10163  in
+                          let uu____10172 =
                             FStar_Syntax_Print.term_to_string tm'  in
-                          let uu____10168 =
+                          let uu____10174 =
                             FStar_Syntax_Print.term_to_string tm_norm  in
                           FStar_Util.print3 "NBE'd (%s ms) %s\n\tto %s\n"
-                            uu____10155 uu____10166 uu____10168)
+                            uu____10161 uu____10172 uu____10174)
                        else ();
                        norm cfg env stack tm_norm))
                  | FStar_Pervasives_Native.Some (s,tm) ->
                      (if
                         (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
                       then
-                        (let uu____10187 =
+                        (let uu____10193 =
                            FStar_Syntax_Print.term_to_string tm  in
                          FStar_Util.print1
-                           "Starting norm request on %s ... \n" uu____10187)
+                           "Starting norm request on %s ... \n" uu____10193)
                       else ();
                       (let delta_level =
-                         let uu____10195 =
+                         let uu____10201 =
                            FStar_All.pipe_right s
                              (FStar_Util.for_some
-                                (fun uu___13_10202  ->
-                                   match uu___13_10202 with
+                                (fun uu___13_10208  ->
+                                   match uu___13_10208 with
                                    | FStar_TypeChecker_Env.UnfoldUntil
-                                       uu____10204 -> true
-                                   | FStar_TypeChecker_Env.UnfoldOnly
-                                       uu____10206 -> true
-                                   | FStar_TypeChecker_Env.UnfoldFully
                                        uu____10210 -> true
-                                   | uu____10214 -> false))
+                                   | FStar_TypeChecker_Env.UnfoldOnly
+                                       uu____10212 -> true
+                                   | FStar_TypeChecker_Env.UnfoldFully
+                                       uu____10216 -> true
+                                   | uu____10220 -> false))
                             in
-                         if uu____10195
+                         if uu____10201
                          then
                            [FStar_TypeChecker_Env.Unfold
                               FStar_Syntax_Syntax.delta_constant]
                          else [FStar_TypeChecker_Env.NoDelta]  in
                        let cfg'1 =
-                         let uu___1296_10222 = cfg  in
-                         let uu____10223 =
-                           let uu___1298_10224 =
+                         let uu___1298_10228 = cfg  in
+                         let uu____10229 =
+                           let uu___1300_10230 =
                              FStar_TypeChecker_Cfg.to_fsteps s  in
                            {
                              FStar_TypeChecker_Cfg.beta =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.beta);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.beta);
                              FStar_TypeChecker_Cfg.iota =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.iota);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.iota);
                              FStar_TypeChecker_Cfg.zeta =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.zeta);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.zeta);
                              FStar_TypeChecker_Cfg.weak =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.weak);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.weak);
                              FStar_TypeChecker_Cfg.hnf =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.hnf);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.hnf);
                              FStar_TypeChecker_Cfg.primops =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.primops);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.primops);
                              FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                              FStar_TypeChecker_Cfg.unfold_until =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.unfold_until);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.unfold_until);
                              FStar_TypeChecker_Cfg.unfold_only =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.unfold_only);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.unfold_only);
                              FStar_TypeChecker_Cfg.unfold_fully =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.unfold_fully);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.unfold_fully);
                              FStar_TypeChecker_Cfg.unfold_attr =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.unfold_attr);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.unfold_attr);
                              FStar_TypeChecker_Cfg.unfold_tac =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.unfold_tac);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.unfold_tac);
                              FStar_TypeChecker_Cfg.pure_subterms_within_computations
                                =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                              FStar_TypeChecker_Cfg.simplify =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.simplify);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.simplify);
                              FStar_TypeChecker_Cfg.erase_universes =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.erase_universes);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.erase_universes);
                              FStar_TypeChecker_Cfg.allow_unbound_universes =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.allow_unbound_universes);
                              FStar_TypeChecker_Cfg.reify_ =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.reify_);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.reify_);
                              FStar_TypeChecker_Cfg.compress_uvars =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.compress_uvars);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.compress_uvars);
                              FStar_TypeChecker_Cfg.no_full_norm =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.no_full_norm);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.no_full_norm);
                              FStar_TypeChecker_Cfg.check_no_uvars =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.check_no_uvars);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.check_no_uvars);
                              FStar_TypeChecker_Cfg.unmeta =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.unmeta);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.unmeta);
                              FStar_TypeChecker_Cfg.unascribe =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.unascribe);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.unascribe);
                              FStar_TypeChecker_Cfg.in_full_norm_request =
                                true;
                              FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                              FStar_TypeChecker_Cfg.nbe_step =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.nbe_step);
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.nbe_step);
                              FStar_TypeChecker_Cfg.for_extraction =
-                               (uu___1298_10224.FStar_TypeChecker_Cfg.for_extraction)
+                               (uu___1300_10230.FStar_TypeChecker_Cfg.for_extraction)
                            }  in
                          {
-                           FStar_TypeChecker_Cfg.steps = uu____10223;
+                           FStar_TypeChecker_Cfg.steps = uu____10229;
                            FStar_TypeChecker_Cfg.tcenv =
-                             (uu___1296_10222.FStar_TypeChecker_Cfg.tcenv);
+                             (uu___1298_10228.FStar_TypeChecker_Cfg.tcenv);
                            FStar_TypeChecker_Cfg.debug =
-                             (uu___1296_10222.FStar_TypeChecker_Cfg.debug);
+                             (uu___1298_10228.FStar_TypeChecker_Cfg.debug);
                            FStar_TypeChecker_Cfg.delta_level = delta_level;
                            FStar_TypeChecker_Cfg.primitive_steps =
-                             (uu___1296_10222.FStar_TypeChecker_Cfg.primitive_steps);
+                             (uu___1298_10228.FStar_TypeChecker_Cfg.primitive_steps);
                            FStar_TypeChecker_Cfg.strong =
-                             (uu___1296_10222.FStar_TypeChecker_Cfg.strong);
+                             (uu___1298_10228.FStar_TypeChecker_Cfg.strong);
                            FStar_TypeChecker_Cfg.memoize_lazy =
-                             (uu___1296_10222.FStar_TypeChecker_Cfg.memoize_lazy);
+                             (uu___1298_10228.FStar_TypeChecker_Cfg.memoize_lazy);
                            FStar_TypeChecker_Cfg.normalize_pure_lets = true;
                            FStar_TypeChecker_Cfg.reifying =
-                             (uu___1296_10222.FStar_TypeChecker_Cfg.reifying)
+                             (uu___1298_10228.FStar_TypeChecker_Cfg.reifying)
                          }  in
                        let stack' =
                          let tail1 = (Cfg cfg) :: stack  in
                          if
                            (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
                          then
-                           let uu____10232 =
-                             let uu____10233 =
-                               let uu____10238 = FStar_Util.now ()  in
-                               (t1, uu____10238)  in
-                             Debug uu____10233  in
-                           uu____10232 :: tail1
+                           let uu____10238 =
+                             let uu____10239 =
+                               let uu____10244 = FStar_Util.now ()  in
+                               (t1, uu____10244)  in
+                             Debug uu____10239  in
+                           uu____10238 :: tail1
                          else tail1  in
                        norm cfg'1 env stack' tm))))
            | FStar_Syntax_Syntax.Tm_type u ->
                let u1 = norm_universe cfg env u  in
-               let uu____10243 =
+               let uu____10249 =
                  mk (FStar_Syntax_Syntax.Tm_type u1)
                    t1.FStar_Syntax_Syntax.pos
                   in
-               rebuild cfg env stack uu____10243
+               rebuild cfg env stack uu____10249
            | FStar_Syntax_Syntax.Tm_uinst (t',us) ->
                if
                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.erase_universes
                then norm cfg env stack t'
                else
                  (let us1 =
-                    let uu____10254 =
-                      let uu____10261 =
+                    let uu____10260 =
+                      let uu____10267 =
                         FStar_List.map (norm_universe cfg env) us  in
-                      (uu____10261, (t1.FStar_Syntax_Syntax.pos))  in
-                    UnivArgs uu____10254  in
+                      (uu____10267, (t1.FStar_Syntax_Syntax.pos))  in
+                    UnivArgs uu____10260  in
                   let stack1 = us1 :: stack  in norm cfg env stack1 t')
            | FStar_Syntax_Syntax.Tm_bvar x ->
-               let uu____10270 = lookup_bvar env x  in
-               (match uu____10270 with
-                | Univ uu____10271 ->
+               let uu____10276 = lookup_bvar env x  in
+               (match uu____10276 with
+                | Univ uu____10277 ->
                     failwith
                       "Impossible: term variable is bound to a universe"
                 | Dummy  -> failwith "Term variable not found"
@@ -2954,20 +2956,20 @@ let rec (norm :
                       (Prims.op_Negation fix) ||
                         (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta
                     then
-                      let uu____10325 = FStar_ST.op_Bang r  in
-                      (match uu____10325 with
+                      let uu____10331 = FStar_ST.op_Bang r  in
+                      (match uu____10331 with
                        | FStar_Pervasives_Native.Some (env2,t') ->
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____10421  ->
-                                 let uu____10422 =
+                              (fun uu____10427  ->
+                                 let uu____10428 =
                                    FStar_Syntax_Print.term_to_string t1  in
-                                 let uu____10424 =
+                                 let uu____10430 =
                                    FStar_Syntax_Print.term_to_string t'  in
                                  FStar_Util.print2
-                                   "Lazy hit: %s cached to %s\n" uu____10422
-                                   uu____10424);
-                            (let uu____10427 = maybe_weakly_reduced t'  in
-                             if uu____10427
+                                   "Lazy hit: %s cached to %s\n" uu____10428
+                                   uu____10430);
+                            (let uu____10433 = maybe_weakly_reduced t'  in
+                             if uu____10433
                              then
                                match stack with
                                | [] when
@@ -2975,39 +2977,39 @@ let rec (norm :
                                      ||
                                      (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.compress_uvars
                                    -> rebuild cfg env2 stack t'
-                               | uu____10430 -> norm cfg env2 stack t'
+                               | uu____10436 -> norm cfg env2 stack t'
                              else rebuild cfg env2 stack t'))
                        | FStar_Pervasives_Native.None  ->
                            norm cfg env1 ((MemoLazy r) :: stack) t0)
                     else norm cfg env1 stack t0)
            | FStar_Syntax_Syntax.Tm_abs (bs,body,lopt) ->
                (match stack with
-                | (UnivArgs uu____10474)::uu____10475 ->
+                | (UnivArgs uu____10480)::uu____10481 ->
                     failwith
                       "Ill-typed term: universes cannot be applied to term abstraction"
-                | (Arg (c,uu____10486,uu____10487))::stack_rest ->
+                | (Arg (c,uu____10492,uu____10493))::stack_rest ->
                     (match c with
-                     | Univ uu____10491 ->
+                     | Univ uu____10497 ->
                          norm cfg ((FStar_Pervasives_Native.None, c) :: env)
                            stack_rest t1
-                     | uu____10500 ->
+                     | uu____10506 ->
                          (match bs with
                           | [] -> failwith "Impossible"
                           | b::[] ->
                               (FStar_TypeChecker_Cfg.log cfg
-                                 (fun uu____10530  ->
-                                    let uu____10531 = closure_to_string c  in
+                                 (fun uu____10536  ->
+                                    let uu____10537 = closure_to_string c  in
                                     FStar_Util.print1 "\tShifted %s\n"
-                                      uu____10531);
+                                      uu____10537);
                                norm cfg
                                  (((FStar_Pervasives_Native.Some b), c) ::
                                  env) stack_rest body)
                           | b::tl1 ->
                               (FStar_TypeChecker_Cfg.log cfg
-                                 (fun uu____10567  ->
-                                    let uu____10568 = closure_to_string c  in
+                                 (fun uu____10573  ->
+                                    let uu____10574 = closure_to_string c  in
                                     FStar_Util.print1 "\tShifted %s\n"
-                                      uu____10568);
+                                      uu____10574);
                                (let body1 =
                                   mk
                                     (FStar_Syntax_Syntax.Tm_abs
@@ -3021,27 +3023,27 @@ let rec (norm :
                 | (MemoLazy r)::stack1 ->
                     (set_memo cfg r (env, t1);
                      FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____10616  ->
-                          let uu____10617 =
+                       (fun uu____10622  ->
+                          let uu____10623 =
                             FStar_Syntax_Print.term_to_string t1  in
-                          FStar_Util.print1 "\tSet memo %s\n" uu____10617);
+                          FStar_Util.print1 "\tSet memo %s\n" uu____10623);
                      norm cfg env stack1 t1)
-                | (Match uu____10620)::uu____10621 ->
+                | (Match uu____10626)::uu____10627 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env t1  in
                       rebuild cfg env stack t2
                     else
-                      (let uu____10636 =
+                      (let uu____10642 =
                          FStar_Syntax_Subst.open_term' bs body  in
-                       match uu____10636 with
+                       match uu____10642 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env1  ->
-                                     fun uu____10672  -> dummy :: env1) env)
+                                     fun uu____10678  -> dummy :: env1) env)
                               in
                            let lopt1 =
                              match lopt with
@@ -3053,78 +3055,78 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2  ->
-                                          let uu____10716 =
+                                          let uu____10722 =
                                             FStar_Syntax_Subst.subst opening
                                               t2
                                              in
-                                          norm cfg env' [] uu____10716)
+                                          norm cfg env' [] uu____10722)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening)
                                     in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1416_10724 = rc  in
+                                   (let uu___1418_10730 = rc  in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1416_10724.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1418_10730.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1416_10724.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1418_10730.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____10725 -> lopt  in
+                             | uu____10731 -> lopt  in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____10731  ->
-                                 let uu____10732 =
+                              (fun uu____10737  ->
+                                 let uu____10738 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1)
                                     in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____10732);
+                                   uu____10738);
                             (let stack1 = (Cfg cfg) :: stack  in
                              let cfg1 =
-                               let uu___1423_10747 = cfg  in
+                               let uu___1425_10753 = cfg  in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1423_10747.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1425_10753.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1423_10747.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1425_10753.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1423_10747.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1425_10753.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1423_10747.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1425_10753.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1423_10747.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1425_10753.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1423_10747.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1425_10753.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1423_10747.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1425_10753.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1423_10747.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1425_10753.FStar_TypeChecker_Cfg.reifying)
                                }  in
                              norm cfg1 env'
                                ((Abs
                                    (env, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack1) body1)))
-                | (Debug uu____10751)::uu____10752 ->
+                | (Debug uu____10757)::uu____10758 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env t1  in
                       rebuild cfg env stack t2
                     else
-                      (let uu____10763 =
+                      (let uu____10769 =
                          FStar_Syntax_Subst.open_term' bs body  in
-                       match uu____10763 with
+                       match uu____10769 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env1  ->
-                                     fun uu____10799  -> dummy :: env1) env)
+                                     fun uu____10805  -> dummy :: env1) env)
                               in
                            let lopt1 =
                              match lopt with
@@ -3136,78 +3138,78 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2  ->
-                                          let uu____10843 =
+                                          let uu____10849 =
                                             FStar_Syntax_Subst.subst opening
                                               t2
                                              in
-                                          norm cfg env' [] uu____10843)
+                                          norm cfg env' [] uu____10849)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening)
                                     in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1416_10851 = rc  in
+                                   (let uu___1418_10857 = rc  in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1416_10851.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1418_10857.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1416_10851.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1418_10857.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____10852 -> lopt  in
+                             | uu____10858 -> lopt  in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____10858  ->
-                                 let uu____10859 =
+                              (fun uu____10864  ->
+                                 let uu____10865 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1)
                                     in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____10859);
+                                   uu____10865);
                             (let stack1 = (Cfg cfg) :: stack  in
                              let cfg1 =
-                               let uu___1423_10874 = cfg  in
+                               let uu___1425_10880 = cfg  in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1423_10874.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1425_10880.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1423_10874.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1425_10880.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1423_10874.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1425_10880.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1423_10874.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1425_10880.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1423_10874.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1425_10880.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1423_10874.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1425_10880.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1423_10874.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1425_10880.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1423_10874.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1425_10880.FStar_TypeChecker_Cfg.reifying)
                                }  in
                              norm cfg1 env'
                                ((Abs
                                    (env, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack1) body1)))
-                | (Meta uu____10878)::uu____10879 ->
+                | (Meta uu____10884)::uu____10885 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env t1  in
                       rebuild cfg env stack t2
                     else
-                      (let uu____10892 =
+                      (let uu____10898 =
                          FStar_Syntax_Subst.open_term' bs body  in
-                       match uu____10892 with
+                       match uu____10898 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env1  ->
-                                     fun uu____10928  -> dummy :: env1) env)
+                                     fun uu____10934  -> dummy :: env1) env)
                               in
                            let lopt1 =
                              match lopt with
@@ -3219,78 +3221,78 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2  ->
-                                          let uu____10972 =
+                                          let uu____10978 =
                                             FStar_Syntax_Subst.subst opening
                                               t2
                                              in
-                                          norm cfg env' [] uu____10972)
+                                          norm cfg env' [] uu____10978)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening)
                                     in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1416_10980 = rc  in
+                                   (let uu___1418_10986 = rc  in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1416_10980.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1418_10986.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1416_10980.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1418_10986.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____10981 -> lopt  in
+                             | uu____10987 -> lopt  in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____10987  ->
-                                 let uu____10988 =
+                              (fun uu____10993  ->
+                                 let uu____10994 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1)
                                     in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____10988);
+                                   uu____10994);
                             (let stack1 = (Cfg cfg) :: stack  in
                              let cfg1 =
-                               let uu___1423_11003 = cfg  in
+                               let uu___1425_11009 = cfg  in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1423_11003.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1425_11009.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1423_11003.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1425_11009.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1423_11003.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1425_11009.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1423_11003.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1425_11009.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1423_11003.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1425_11009.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1423_11003.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1425_11009.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1423_11003.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1425_11009.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1423_11003.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1425_11009.FStar_TypeChecker_Cfg.reifying)
                                }  in
                              norm cfg1 env'
                                ((Abs
                                    (env, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack1) body1)))
-                | (Let uu____11007)::uu____11008 ->
+                | (Let uu____11013)::uu____11014 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env t1  in
                       rebuild cfg env stack t2
                     else
-                      (let uu____11023 =
+                      (let uu____11029 =
                          FStar_Syntax_Subst.open_term' bs body  in
-                       match uu____11023 with
+                       match uu____11029 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env1  ->
-                                     fun uu____11059  -> dummy :: env1) env)
+                                     fun uu____11065  -> dummy :: env1) env)
                               in
                            let lopt1 =
                              match lopt with
@@ -3302,78 +3304,78 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2  ->
-                                          let uu____11103 =
+                                          let uu____11109 =
                                             FStar_Syntax_Subst.subst opening
                                               t2
                                              in
-                                          norm cfg env' [] uu____11103)
+                                          norm cfg env' [] uu____11109)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening)
                                     in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1416_11111 = rc  in
+                                   (let uu___1418_11117 = rc  in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1416_11111.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1418_11117.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1416_11111.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1418_11117.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____11112 -> lopt  in
+                             | uu____11118 -> lopt  in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____11118  ->
-                                 let uu____11119 =
+                              (fun uu____11124  ->
+                                 let uu____11125 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1)
                                     in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____11119);
+                                   uu____11125);
                             (let stack1 = (Cfg cfg) :: stack  in
                              let cfg1 =
-                               let uu___1423_11134 = cfg  in
+                               let uu___1425_11140 = cfg  in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1423_11134.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1425_11140.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1423_11134.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1425_11140.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1423_11134.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1425_11140.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1423_11134.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1425_11140.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1423_11134.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1425_11140.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1423_11134.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1425_11140.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1423_11134.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1425_11140.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1423_11134.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1425_11140.FStar_TypeChecker_Cfg.reifying)
                                }  in
                              norm cfg1 env'
                                ((Abs
                                    (env, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack1) body1)))
-                | (App uu____11138)::uu____11139 ->
+                | (App uu____11144)::uu____11145 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env t1  in
                       rebuild cfg env stack t2
                     else
-                      (let uu____11154 =
+                      (let uu____11160 =
                          FStar_Syntax_Subst.open_term' bs body  in
-                       match uu____11154 with
+                       match uu____11160 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env1  ->
-                                     fun uu____11190  -> dummy :: env1) env)
+                                     fun uu____11196  -> dummy :: env1) env)
                               in
                            let lopt1 =
                              match lopt with
@@ -3385,78 +3387,78 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2  ->
-                                          let uu____11234 =
+                                          let uu____11240 =
                                             FStar_Syntax_Subst.subst opening
                                               t2
                                              in
-                                          norm cfg env' [] uu____11234)
+                                          norm cfg env' [] uu____11240)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening)
                                     in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1416_11242 = rc  in
+                                   (let uu___1418_11248 = rc  in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1416_11242.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1418_11248.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1416_11242.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1418_11248.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____11243 -> lopt  in
+                             | uu____11249 -> lopt  in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____11249  ->
-                                 let uu____11250 =
+                              (fun uu____11255  ->
+                                 let uu____11256 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1)
                                     in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____11250);
+                                   uu____11256);
                             (let stack1 = (Cfg cfg) :: stack  in
                              let cfg1 =
-                               let uu___1423_11265 = cfg  in
+                               let uu___1425_11271 = cfg  in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1423_11265.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1425_11271.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1423_11265.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1425_11271.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1423_11265.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1425_11271.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1423_11265.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1425_11271.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1423_11265.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1425_11271.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1423_11265.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1425_11271.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1423_11265.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1425_11271.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1423_11265.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1425_11271.FStar_TypeChecker_Cfg.reifying)
                                }  in
                              norm cfg1 env'
                                ((Abs
                                    (env, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack1) body1)))
-                | (Abs uu____11269)::uu____11270 ->
+                | (Abs uu____11275)::uu____11276 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env t1  in
                       rebuild cfg env stack t2
                     else
-                      (let uu____11289 =
+                      (let uu____11295 =
                          FStar_Syntax_Subst.open_term' bs body  in
-                       match uu____11289 with
+                       match uu____11295 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env1  ->
-                                     fun uu____11325  -> dummy :: env1) env)
+                                     fun uu____11331  -> dummy :: env1) env)
                               in
                            let lopt1 =
                              match lopt with
@@ -3468,56 +3470,56 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2  ->
-                                          let uu____11369 =
+                                          let uu____11375 =
                                             FStar_Syntax_Subst.subst opening
                                               t2
                                              in
-                                          norm cfg env' [] uu____11369)
+                                          norm cfg env' [] uu____11375)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening)
                                     in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1416_11377 = rc  in
+                                   (let uu___1418_11383 = rc  in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1416_11377.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1418_11383.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1416_11377.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1418_11383.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____11378 -> lopt  in
+                             | uu____11384 -> lopt  in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____11384  ->
-                                 let uu____11385 =
+                              (fun uu____11390  ->
+                                 let uu____11391 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1)
                                     in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____11385);
+                                   uu____11391);
                             (let stack1 = (Cfg cfg) :: stack  in
                              let cfg1 =
-                               let uu___1423_11400 = cfg  in
+                               let uu___1425_11406 = cfg  in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1423_11400.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1425_11406.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1423_11400.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1425_11406.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1423_11400.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1425_11406.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1423_11400.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1425_11406.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1423_11400.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1425_11406.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1423_11400.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1425_11406.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1423_11400.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1425_11406.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1423_11400.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1425_11406.FStar_TypeChecker_Cfg.reifying)
                                }  in
                              norm cfg1 env'
                                ((Abs
@@ -3531,15 +3533,15 @@ let rec (norm :
                       let t2 = closure_as_term cfg env t1  in
                       rebuild cfg env stack t2
                     else
-                      (let uu____11408 =
+                      (let uu____11414 =
                          FStar_Syntax_Subst.open_term' bs body  in
-                       match uu____11408 with
+                       match uu____11414 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env1  ->
-                                     fun uu____11444  -> dummy :: env1) env)
+                                     fun uu____11450  -> dummy :: env1) env)
                               in
                            let lopt1 =
                              match lopt with
@@ -3551,56 +3553,56 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2  ->
-                                          let uu____11488 =
+                                          let uu____11494 =
                                             FStar_Syntax_Subst.subst opening
                                               t2
                                              in
-                                          norm cfg env' [] uu____11488)
+                                          norm cfg env' [] uu____11494)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening)
                                     in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1416_11496 = rc  in
+                                   (let uu___1418_11502 = rc  in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1416_11496.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1418_11502.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1416_11496.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1418_11502.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____11497 -> lopt  in
+                             | uu____11503 -> lopt  in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____11503  ->
-                                 let uu____11504 =
+                              (fun uu____11509  ->
+                                 let uu____11510 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1)
                                     in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____11504);
+                                   uu____11510);
                             (let stack1 = (Cfg cfg) :: stack  in
                              let cfg1 =
-                               let uu___1423_11519 = cfg  in
+                               let uu___1425_11525 = cfg  in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1423_11519.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1425_11525.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1423_11519.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1425_11525.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1423_11519.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1425_11525.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1423_11519.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1425_11525.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1423_11519.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1425_11525.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1423_11519.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1425_11525.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1423_11519.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1425_11525.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1423_11519.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1425_11525.FStar_TypeChecker_Cfg.reifying)
                                }  in
                              norm cfg1 env'
                                ((Abs
@@ -3609,131 +3611,131 @@ let rec (norm :
                                stack1) body1))))
            | FStar_Syntax_Syntax.Tm_app (head1,args) ->
                let strict_args =
-                 let uu____11555 =
-                   let uu____11556 = FStar_Syntax_Util.un_uinst head1  in
-                   uu____11556.FStar_Syntax_Syntax.n  in
-                 match uu____11555 with
+                 let uu____11561 =
+                   let uu____11562 = FStar_Syntax_Util.un_uinst head1  in
+                   uu____11562.FStar_Syntax_Syntax.n  in
+                 match uu____11561 with
                  | FStar_Syntax_Syntax.Tm_fvar fv ->
                      FStar_TypeChecker_Env.fv_has_strict_args
                        cfg.FStar_TypeChecker_Cfg.tcenv fv
-                 | uu____11565 -> FStar_Pervasives_Native.None  in
+                 | uu____11571 -> FStar_Pervasives_Native.None  in
                (match strict_args with
                 | FStar_Pervasives_Native.None  ->
                     let stack1 =
                       FStar_All.pipe_right stack
                         (FStar_List.fold_right
-                           (fun uu____11586  ->
+                           (fun uu____11592  ->
                               fun stack1  ->
-                                match uu____11586 with
+                                match uu____11592 with
                                 | (a,aq) ->
-                                    let uu____11598 =
-                                      let uu____11599 =
-                                        let uu____11606 =
-                                          let uu____11607 =
-                                            let uu____11639 =
+                                    let uu____11604 =
+                                      let uu____11605 =
+                                        let uu____11612 =
+                                          let uu____11613 =
+                                            let uu____11645 =
                                               FStar_Util.mk_ref
                                                 FStar_Pervasives_Native.None
                                                in
-                                            (env, a, uu____11639, false)  in
-                                          Clos uu____11607  in
-                                        (uu____11606, aq,
+                                            (env, a, uu____11645, false)  in
+                                          Clos uu____11613  in
+                                        (uu____11612, aq,
                                           (t1.FStar_Syntax_Syntax.pos))
                                          in
-                                      Arg uu____11599  in
-                                    uu____11598 :: stack1) args)
+                                      Arg uu____11605  in
+                                    uu____11604 :: stack1) args)
                        in
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____11707  ->
-                          let uu____11708 =
+                       (fun uu____11713  ->
+                          let uu____11714 =
                             FStar_All.pipe_left FStar_Util.string_of_int
                               (FStar_List.length args)
                              in
                           FStar_Util.print1 "\tPushed %s arguments\n"
-                            uu____11708);
+                            uu____11714);
                      norm cfg env stack1 head1)
                 | FStar_Pervasives_Native.Some strict_args1 ->
                     let norm_args =
                       FStar_All.pipe_right args
                         (FStar_List.map
-                           (fun uu____11759  ->
-                              match uu____11759 with
+                           (fun uu____11765  ->
+                              match uu____11765 with
                               | (a,i) ->
-                                  let uu____11770 = norm cfg env [] a  in
-                                  (uu____11770, i)))
+                                  let uu____11776 = norm cfg env [] a  in
+                                  (uu____11776, i)))
                        in
                     let norm_args_len = FStar_List.length norm_args  in
-                    let uu____11776 =
+                    let uu____11782 =
                       FStar_All.pipe_right strict_args1
                         (FStar_List.for_all
                            (fun i  ->
                               if i >= norm_args_len
                               then false
                               else
-                                (let uu____11791 = FStar_List.nth norm_args i
+                                (let uu____11797 = FStar_List.nth norm_args i
                                     in
-                                 match uu____11791 with
-                                 | (arg_i,uu____11802) ->
-                                     let uu____11803 =
+                                 match uu____11797 with
+                                 | (arg_i,uu____11808) ->
+                                     let uu____11809 =
                                        FStar_Syntax_Util.head_and_args arg_i
                                         in
-                                     (match uu____11803 with
-                                      | (head2,uu____11822) ->
-                                          let uu____11847 =
-                                            let uu____11848 =
+                                     (match uu____11809 with
+                                      | (head2,uu____11828) ->
+                                          let uu____11853 =
+                                            let uu____11854 =
                                               FStar_Syntax_Util.un_uinst
                                                 head2
                                                in
-                                            uu____11848.FStar_Syntax_Syntax.n
+                                            uu____11854.FStar_Syntax_Syntax.n
                                              in
-                                          (match uu____11847 with
+                                          (match uu____11853 with
                                            | FStar_Syntax_Syntax.Tm_constant
-                                               uu____11852 -> true
+                                               uu____11858 -> true
                                            | FStar_Syntax_Syntax.Tm_fvar fv
                                                ->
-                                               let uu____11855 =
+                                               let uu____11861 =
                                                  FStar_Syntax_Syntax.lid_of_fv
                                                    fv
                                                   in
                                                FStar_TypeChecker_Env.is_datacon
                                                  cfg.FStar_TypeChecker_Cfg.tcenv
-                                                 uu____11855
-                                           | uu____11856 -> false)))))
+                                                 uu____11861
+                                           | uu____11862 -> false)))))
                        in
-                    if uu____11776
+                    if uu____11782
                     then
                       let stack1 =
                         FStar_All.pipe_right stack
                           (FStar_List.fold_right
-                             (fun uu____11873  ->
+                             (fun uu____11879  ->
                                 fun stack1  ->
-                                  match uu____11873 with
+                                  match uu____11879 with
                                   | (a,aq) ->
-                                      let uu____11885 =
-                                        let uu____11886 =
-                                          let uu____11893 =
-                                            let uu____11894 =
-                                              let uu____11926 =
+                                      let uu____11891 =
+                                        let uu____11892 =
+                                          let uu____11899 =
+                                            let uu____11900 =
+                                              let uu____11932 =
                                                 FStar_Util.mk_ref
                                                   (FStar_Pervasives_Native.Some
                                                      ([], a))
                                                  in
-                                              (env, a, uu____11926, false)
+                                              (env, a, uu____11932, false)
                                                in
-                                            Clos uu____11894  in
-                                          (uu____11893, aq,
+                                            Clos uu____11900  in
+                                          (uu____11899, aq,
                                             (t1.FStar_Syntax_Syntax.pos))
                                            in
-                                        Arg uu____11886  in
-                                      uu____11885 :: stack1) norm_args)
+                                        Arg uu____11892  in
+                                      uu____11891 :: stack1) norm_args)
                          in
                       (FStar_TypeChecker_Cfg.log cfg
-                         (fun uu____12008  ->
-                            let uu____12009 =
+                         (fun uu____12014  ->
+                            let uu____12015 =
                               FStar_All.pipe_left FStar_Util.string_of_int
                                 (FStar_List.length args)
                                in
                             FStar_Util.print1 "\tPushed %s arguments\n"
-                              uu____12009);
+                              uu____12015);
                        norm cfg env stack1 head1)
                     else
                       (let head2 = closure_as_term cfg env head1  in
@@ -3743,7 +3745,7 @@ let rec (norm :
                            t1.FStar_Syntax_Syntax.pos
                           in
                        rebuild cfg env stack term))
-           | FStar_Syntax_Syntax.Tm_refine (x,uu____12029) when
+           | FStar_Syntax_Syntax.Tm_refine (x,uu____12035) when
                (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
                -> norm cfg env stack x.FStar_Syntax_Syntax.sort
            | FStar_Syntax_Syntax.Tm_refine (x,f) ->
@@ -3757,154 +3759,154 @@ let rec (norm :
                       let t2 =
                         mk
                           (FStar_Syntax_Syntax.Tm_refine
-                             ((let uu___1485_12074 = x  in
+                             ((let uu___1487_12080 = x  in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___1485_12074.FStar_Syntax_Syntax.ppname);
+                                   (uu___1487_12080.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___1485_12074.FStar_Syntax_Syntax.index);
+                                   (uu___1487_12080.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = t_x
                                }), f)) t1.FStar_Syntax_Syntax.pos
                          in
                       rebuild cfg env stack t2
-                  | uu____12075 ->
-                      let uu____12090 = closure_as_term cfg env t1  in
-                      rebuild cfg env stack uu____12090)
+                  | uu____12081 ->
+                      let uu____12096 = closure_as_term cfg env t1  in
+                      rebuild cfg env stack uu____12096)
                else
                  (let t_x = norm cfg env [] x.FStar_Syntax_Syntax.sort  in
-                  let uu____12094 =
+                  let uu____12100 =
                     FStar_Syntax_Subst.open_term
                       [(x, FStar_Pervasives_Native.None)] f
                      in
-                  match uu____12094 with
+                  match uu____12100 with
                   | (closing,f1) ->
                       let f2 = norm cfg (dummy :: env) [] f1  in
                       let t2 =
-                        let uu____12125 =
-                          let uu____12126 =
-                            let uu____12133 =
+                        let uu____12131 =
+                          let uu____12132 =
+                            let uu____12139 =
                               FStar_Syntax_Subst.close closing f2  in
-                            ((let uu___1494_12139 = x  in
+                            ((let uu___1496_12145 = x  in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___1494_12139.FStar_Syntax_Syntax.ppname);
+                                  (uu___1496_12145.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___1494_12139.FStar_Syntax_Syntax.index);
+                                  (uu___1496_12145.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = t_x
-                              }), uu____12133)
+                              }), uu____12139)
                              in
-                          FStar_Syntax_Syntax.Tm_refine uu____12126  in
-                        mk uu____12125 t1.FStar_Syntax_Syntax.pos  in
+                          FStar_Syntax_Syntax.Tm_refine uu____12132  in
+                        mk uu____12131 t1.FStar_Syntax_Syntax.pos  in
                       rebuild cfg env stack t2)
            | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
                if
                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                then
-                 let uu____12163 = closure_as_term cfg env t1  in
-                 rebuild cfg env stack uu____12163
+                 let uu____12169 = closure_as_term cfg env t1  in
+                 rebuild cfg env stack uu____12169
                else
-                 (let uu____12166 = FStar_Syntax_Subst.open_comp bs c  in
-                  match uu____12166 with
+                 (let uu____12172 = FStar_Syntax_Subst.open_comp bs c  in
+                  match uu____12172 with
                   | (bs1,c1) ->
                       let c2 =
-                        let uu____12174 =
+                        let uu____12180 =
                           FStar_All.pipe_right bs1
                             (FStar_List.fold_left
                                (fun env1  ->
-                                  fun uu____12200  -> dummy :: env1) env)
+                                  fun uu____12206  -> dummy :: env1) env)
                            in
-                        norm_comp cfg uu____12174 c1  in
+                        norm_comp cfg uu____12180 c1  in
                       let t2 =
-                        let uu____12224 = norm_binders cfg env bs1  in
-                        FStar_Syntax_Util.arrow uu____12224 c2  in
+                        let uu____12230 = norm_binders cfg env bs1  in
+                        FStar_Syntax_Util.arrow uu____12230 c2  in
                       rebuild cfg env stack t2)
            | FStar_Syntax_Syntax.Tm_ascribed (t11,(tc,tacopt),l) when
                (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unascribe
                -> norm cfg env stack t11
            | FStar_Syntax_Syntax.Tm_ascribed (t11,(tc,tacopt),l) ->
                (match stack with
-                | (Match uu____12337)::uu____12338 when
+                | (Match uu____12343)::uu____12344 when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____12351  ->
+                       (fun uu____12357  ->
                           FStar_Util.print_string
                             "+++ Dropping ascription \n");
                      norm cfg env stack t11)
-                | (Arg uu____12353)::uu____12354 when
+                | (Arg uu____12359)::uu____12360 when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____12365  ->
+                       (fun uu____12371  ->
                           FStar_Util.print_string
                             "+++ Dropping ascription \n");
                      norm cfg env stack t11)
                 | (App
-                    (uu____12367,{
+                    (uu____12373,{
                                    FStar_Syntax_Syntax.n =
                                      FStar_Syntax_Syntax.Tm_constant
                                      (FStar_Const.Const_reify );
-                                   FStar_Syntax_Syntax.pos = uu____12368;
-                                   FStar_Syntax_Syntax.vars = uu____12369;_},uu____12370,uu____12371))::uu____12372
+                                   FStar_Syntax_Syntax.pos = uu____12374;
+                                   FStar_Syntax_Syntax.vars = uu____12375;_},uu____12376,uu____12377))::uu____12378
                     when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____12379  ->
+                       (fun uu____12385  ->
                           FStar_Util.print_string
                             "+++ Dropping ascription \n");
                      norm cfg env stack t11)
-                | (MemoLazy uu____12381)::uu____12382 when
+                | (MemoLazy uu____12387)::uu____12388 when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____12393  ->
+                       (fun uu____12399  ->
                           FStar_Util.print_string
                             "+++ Dropping ascription \n");
                      norm cfg env stack t11)
-                | uu____12395 ->
+                | uu____12401 ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____12398  ->
+                       (fun uu____12404  ->
                           FStar_Util.print_string "+++ Keeping ascription \n");
                      (let t12 = norm cfg env [] t11  in
                       FStar_TypeChecker_Cfg.log cfg
-                        (fun uu____12403  ->
+                        (fun uu____12409  ->
                            FStar_Util.print_string
                              "+++ Normalizing ascription \n");
                       (let tc1 =
                          match tc with
                          | FStar_Util.Inl t2 ->
-                             let uu____12429 = norm cfg env [] t2  in
-                             FStar_Util.Inl uu____12429
+                             let uu____12435 = norm cfg env [] t2  in
+                             FStar_Util.Inl uu____12435
                          | FStar_Util.Inr c ->
-                             let uu____12443 = norm_comp cfg env c  in
-                             FStar_Util.Inr uu____12443
+                             let uu____12449 = norm_comp cfg env c  in
+                             FStar_Util.Inr uu____12449
                           in
                        let tacopt1 =
                          FStar_Util.map_opt tacopt (norm cfg env [])  in
                        match stack with
                        | (Cfg cfg1)::stack1 ->
                            let t2 =
-                             let uu____12466 =
-                               let uu____12467 =
-                                 let uu____12494 =
+                             let uu____12472 =
+                               let uu____12473 =
+                                 let uu____12500 =
                                    FStar_Syntax_Util.unascribe t12  in
-                                 (uu____12494, (tc1, tacopt1), l)  in
-                               FStar_Syntax_Syntax.Tm_ascribed uu____12467
+                                 (uu____12500, (tc1, tacopt1), l)  in
+                               FStar_Syntax_Syntax.Tm_ascribed uu____12473
                                 in
-                             mk uu____12466 t1.FStar_Syntax_Syntax.pos  in
+                             mk uu____12472 t1.FStar_Syntax_Syntax.pos  in
                            norm cfg1 env stack1 t2
-                       | uu____12529 ->
-                           let uu____12530 =
-                             let uu____12531 =
-                               let uu____12532 =
-                                 let uu____12559 =
+                       | uu____12535 ->
+                           let uu____12536 =
+                             let uu____12537 =
+                               let uu____12538 =
+                                 let uu____12565 =
                                    FStar_Syntax_Util.unascribe t12  in
-                                 (uu____12559, (tc1, tacopt1), l)  in
-                               FStar_Syntax_Syntax.Tm_ascribed uu____12532
+                                 (uu____12565, (tc1, tacopt1), l)  in
+                               FStar_Syntax_Syntax.Tm_ascribed uu____12538
                                 in
-                             mk uu____12531 t1.FStar_Syntax_Syntax.pos  in
-                           rebuild cfg env stack uu____12530))))
+                             mk uu____12537 t1.FStar_Syntax_Syntax.pos  in
+                           rebuild cfg env stack uu____12536))))
            | FStar_Syntax_Syntax.Tm_match (head1,branches) ->
                let stack1 =
                  (Match (env, branches, cfg, (t1.FStar_Syntax_Syntax.pos)))
@@ -3918,81 +3920,81 @@ let rec (norm :
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak)
                then
                  let cfg' =
-                   let uu___1573_12637 = cfg  in
+                   let uu___1575_12643 = cfg  in
                    {
                      FStar_TypeChecker_Cfg.steps =
-                       (let uu___1575_12640 = cfg.FStar_TypeChecker_Cfg.steps
+                       (let uu___1577_12646 = cfg.FStar_TypeChecker_Cfg.steps
                            in
                         {
                           FStar_TypeChecker_Cfg.beta =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.beta);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.beta);
                           FStar_TypeChecker_Cfg.iota =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.iota);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.iota);
                           FStar_TypeChecker_Cfg.zeta =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.zeta);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.zeta);
                           FStar_TypeChecker_Cfg.weak = true;
                           FStar_TypeChecker_Cfg.hnf =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.hnf);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.hnf);
                           FStar_TypeChecker_Cfg.primops =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.primops);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.primops);
                           FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                           FStar_TypeChecker_Cfg.unfold_until =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.unfold_until);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.unfold_until);
                           FStar_TypeChecker_Cfg.unfold_only =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.unfold_only);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.unfold_only);
                           FStar_TypeChecker_Cfg.unfold_fully =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.unfold_fully);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.unfold_fully);
                           FStar_TypeChecker_Cfg.unfold_attr =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.unfold_attr);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.unfold_attr);
                           FStar_TypeChecker_Cfg.unfold_tac =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.unfold_tac);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.unfold_tac);
                           FStar_TypeChecker_Cfg.pure_subterms_within_computations
                             =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                           FStar_TypeChecker_Cfg.simplify =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.simplify);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.simplify);
                           FStar_TypeChecker_Cfg.erase_universes =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.erase_universes);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.erase_universes);
                           FStar_TypeChecker_Cfg.allow_unbound_universes =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.allow_unbound_universes);
                           FStar_TypeChecker_Cfg.reify_ =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.reify_);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.reify_);
                           FStar_TypeChecker_Cfg.compress_uvars =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.compress_uvars);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.compress_uvars);
                           FStar_TypeChecker_Cfg.no_full_norm =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.no_full_norm);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.no_full_norm);
                           FStar_TypeChecker_Cfg.check_no_uvars =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.check_no_uvars);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.check_no_uvars);
                           FStar_TypeChecker_Cfg.unmeta =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.unmeta);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.unmeta);
                           FStar_TypeChecker_Cfg.unascribe =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.unascribe);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.unascribe);
                           FStar_TypeChecker_Cfg.in_full_norm_request =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.in_full_norm_request);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.in_full_norm_request);
                           FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                           FStar_TypeChecker_Cfg.nbe_step =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.nbe_step);
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.nbe_step);
                           FStar_TypeChecker_Cfg.for_extraction =
-                            (uu___1575_12640.FStar_TypeChecker_Cfg.for_extraction)
+                            (uu___1577_12646.FStar_TypeChecker_Cfg.for_extraction)
                         });
                      FStar_TypeChecker_Cfg.tcenv =
-                       (uu___1573_12637.FStar_TypeChecker_Cfg.tcenv);
+                       (uu___1575_12643.FStar_TypeChecker_Cfg.tcenv);
                      FStar_TypeChecker_Cfg.debug =
-                       (uu___1573_12637.FStar_TypeChecker_Cfg.debug);
+                       (uu___1575_12643.FStar_TypeChecker_Cfg.debug);
                      FStar_TypeChecker_Cfg.delta_level =
-                       (uu___1573_12637.FStar_TypeChecker_Cfg.delta_level);
+                       (uu___1575_12643.FStar_TypeChecker_Cfg.delta_level);
                      FStar_TypeChecker_Cfg.primitive_steps =
-                       (uu___1573_12637.FStar_TypeChecker_Cfg.primitive_steps);
+                       (uu___1575_12643.FStar_TypeChecker_Cfg.primitive_steps);
                      FStar_TypeChecker_Cfg.strong =
-                       (uu___1573_12637.FStar_TypeChecker_Cfg.strong);
+                       (uu___1575_12643.FStar_TypeChecker_Cfg.strong);
                      FStar_TypeChecker_Cfg.memoize_lazy =
-                       (uu___1573_12637.FStar_TypeChecker_Cfg.memoize_lazy);
+                       (uu___1575_12643.FStar_TypeChecker_Cfg.memoize_lazy);
                      FStar_TypeChecker_Cfg.normalize_pure_lets =
-                       (uu___1573_12637.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                       (uu___1575_12643.FStar_TypeChecker_Cfg.normalize_pure_lets);
                      FStar_TypeChecker_Cfg.reifying =
-                       (uu___1573_12637.FStar_TypeChecker_Cfg.reifying)
+                       (uu___1575_12643.FStar_TypeChecker_Cfg.reifying)
                    }  in
                  norm cfg' env ((Cfg cfg) :: stack1) head1
                else norm cfg env stack1 head1
@@ -4004,79 +4006,79 @@ let rec (norm :
                  FStar_All.pipe_right lbs
                    (FStar_List.map
                       (fun lb  ->
-                         let uu____12681 =
+                         let uu____12687 =
                            FStar_Syntax_Subst.univ_var_opening
                              lb.FStar_Syntax_Syntax.lbunivs
                             in
-                         match uu____12681 with
+                         match uu____12687 with
                          | (openings,lbunivs) ->
                              let cfg1 =
-                               let uu___1588_12701 = cfg  in
-                               let uu____12702 =
+                               let uu___1590_12707 = cfg  in
+                               let uu____12708 =
                                  FStar_TypeChecker_Env.push_univ_vars
                                    cfg.FStar_TypeChecker_Cfg.tcenv lbunivs
                                   in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1588_12701.FStar_TypeChecker_Cfg.steps);
-                                 FStar_TypeChecker_Cfg.tcenv = uu____12702;
+                                   (uu___1590_12707.FStar_TypeChecker_Cfg.steps);
+                                 FStar_TypeChecker_Cfg.tcenv = uu____12708;
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1588_12701.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1590_12707.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1588_12701.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1590_12707.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1588_12701.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1590_12707.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong =
-                                   (uu___1588_12701.FStar_TypeChecker_Cfg.strong);
+                                   (uu___1590_12707.FStar_TypeChecker_Cfg.strong);
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1588_12701.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1590_12707.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1588_12701.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1590_12707.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1588_12701.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1590_12707.FStar_TypeChecker_Cfg.reifying)
                                }  in
                              let norm1 t2 =
-                               let uu____12709 =
-                                 let uu____12710 =
+                               let uu____12715 =
+                                 let uu____12716 =
                                    FStar_Syntax_Subst.subst openings t2  in
-                                 norm cfg1 env [] uu____12710  in
+                                 norm cfg1 env [] uu____12716  in
                                FStar_Syntax_Subst.close_univ_vars lbunivs
-                                 uu____12709
+                                 uu____12715
                                 in
                              let lbtyp = norm1 lb.FStar_Syntax_Syntax.lbtyp
                                 in
                              let lbdef = norm1 lb.FStar_Syntax_Syntax.lbdef
                                 in
-                             let uu___1595_12713 = lb  in
+                             let uu___1597_12719 = lb  in
                              {
                                FStar_Syntax_Syntax.lbname =
-                                 (uu___1595_12713.FStar_Syntax_Syntax.lbname);
+                                 (uu___1597_12719.FStar_Syntax_Syntax.lbname);
                                FStar_Syntax_Syntax.lbunivs = lbunivs;
                                FStar_Syntax_Syntax.lbtyp = lbtyp;
                                FStar_Syntax_Syntax.lbeff =
-                                 (uu___1595_12713.FStar_Syntax_Syntax.lbeff);
+                                 (uu___1597_12719.FStar_Syntax_Syntax.lbeff);
                                FStar_Syntax_Syntax.lbdef = lbdef;
                                FStar_Syntax_Syntax.lbattrs =
-                                 (uu___1595_12713.FStar_Syntax_Syntax.lbattrs);
+                                 (uu___1597_12719.FStar_Syntax_Syntax.lbattrs);
                                FStar_Syntax_Syntax.lbpos =
-                                 (uu___1595_12713.FStar_Syntax_Syntax.lbpos)
+                                 (uu___1597_12719.FStar_Syntax_Syntax.lbpos)
                              }))
                   in
-               let uu____12714 =
+               let uu____12720 =
                  mk (FStar_Syntax_Syntax.Tm_let ((b, lbs1), lbody))
                    t1.FStar_Syntax_Syntax.pos
                   in
-               rebuild cfg env stack uu____12714
+               rebuild cfg env stack uu____12720
            | FStar_Syntax_Syntax.Tm_let
-               ((uu____12727,{
+               ((uu____12733,{
                                FStar_Syntax_Syntax.lbname = FStar_Util.Inr
-                                 uu____12728;
-                               FStar_Syntax_Syntax.lbunivs = uu____12729;
-                               FStar_Syntax_Syntax.lbtyp = uu____12730;
-                               FStar_Syntax_Syntax.lbeff = uu____12731;
-                               FStar_Syntax_Syntax.lbdef = uu____12732;
-                               FStar_Syntax_Syntax.lbattrs = uu____12733;
-                               FStar_Syntax_Syntax.lbpos = uu____12734;_}::uu____12735),uu____12736)
+                                 uu____12734;
+                               FStar_Syntax_Syntax.lbunivs = uu____12735;
+                               FStar_Syntax_Syntax.lbtyp = uu____12736;
+                               FStar_Syntax_Syntax.lbeff = uu____12737;
+                               FStar_Syntax_Syntax.lbdef = uu____12738;
+                               FStar_Syntax_Syntax.lbattrs = uu____12739;
+                               FStar_Syntax_Syntax.lbpos = uu____12740;_}::uu____12741),uu____12742)
                -> rebuild cfg env stack t1
            | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) ->
                let n1 =
@@ -4084,7 +4086,7 @@ let rec (norm :
                    cfg.FStar_TypeChecker_Cfg.tcenv
                    lb.FStar_Syntax_Syntax.lbeff
                   in
-               let uu____12782 =
+               let uu____12788 =
                  (Prims.op_Negation
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.do_not_unfold_pure_lets)
                    &&
@@ -4104,26 +4106,26 @@ let rec (norm :
                          (Prims.op_Negation
                             (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.pure_subterms_within_computations)))
                   in
-               if uu____12782
+               if uu____12788
                then
                  let binder =
-                   let uu____12786 =
+                   let uu____12792 =
                      FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-                   FStar_Syntax_Syntax.mk_binder uu____12786  in
+                   FStar_Syntax_Syntax.mk_binder uu____12792  in
                  let env1 =
-                   let uu____12796 =
-                     let uu____12803 =
-                       let uu____12804 =
-                         let uu____12836 =
+                   let uu____12802 =
+                     let uu____12809 =
+                       let uu____12810 =
+                         let uu____12842 =
                            FStar_Util.mk_ref FStar_Pervasives_Native.None  in
-                         (env, (lb.FStar_Syntax_Syntax.lbdef), uu____12836,
+                         (env, (lb.FStar_Syntax_Syntax.lbdef), uu____12842,
                            false)
                           in
-                       Clos uu____12804  in
-                     ((FStar_Pervasives_Native.Some binder), uu____12803)  in
-                   uu____12796 :: env  in
+                       Clos uu____12810  in
+                     ((FStar_Pervasives_Native.Some binder), uu____12809)  in
+                   uu____12802 :: env  in
                  (FStar_TypeChecker_Cfg.log cfg
-                    (fun uu____12911  ->
+                    (fun uu____12917  ->
                        FStar_Util.print_string "+++ Reducing Tm_let\n");
                   norm cfg env1 stack body)
                else
@@ -4131,97 +4133,97 @@ let rec (norm :
                    (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                  then
                    (FStar_TypeChecker_Cfg.log cfg
-                      (fun uu____12918  ->
+                      (fun uu____12924  ->
                          FStar_Util.print_string "+++ Not touching Tm_let\n");
-                    (let uu____12920 = closure_as_term cfg env t1  in
-                     rebuild cfg env stack uu____12920))
+                    (let uu____12926 = closure_as_term cfg env t1  in
+                     rebuild cfg env stack uu____12926))
                  else
-                   (let uu____12923 =
-                      let uu____12928 =
-                        let uu____12929 =
-                          let uu____12936 =
+                   (let uu____12929 =
+                      let uu____12934 =
+                        let uu____12935 =
+                          let uu____12942 =
                             FStar_All.pipe_right
                               lb.FStar_Syntax_Syntax.lbname FStar_Util.left
                              in
-                          FStar_All.pipe_right uu____12936
+                          FStar_All.pipe_right uu____12942
                             FStar_Syntax_Syntax.mk_binder
                            in
-                        [uu____12929]  in
-                      FStar_Syntax_Subst.open_term uu____12928 body  in
-                    match uu____12923 with
+                        [uu____12935]  in
+                      FStar_Syntax_Subst.open_term uu____12934 body  in
+                    match uu____12929 with
                     | (bs,body1) ->
                         (FStar_TypeChecker_Cfg.log cfg
-                           (fun uu____12963  ->
+                           (fun uu____12969  ->
                               FStar_Util.print_string
                                 "+++ Normalizing Tm_let -- type");
                          (let ty =
                             norm cfg env [] lb.FStar_Syntax_Syntax.lbtyp  in
                           let lbname =
                             let x =
-                              let uu____12972 = FStar_List.hd bs  in
-                              FStar_Pervasives_Native.fst uu____12972  in
+                              let uu____12978 = FStar_List.hd bs  in
+                              FStar_Pervasives_Native.fst uu____12978  in
                             FStar_Util.Inl
-                              (let uu___1637_12988 = x  in
+                              (let uu___1639_12994 = x  in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___1637_12988.FStar_Syntax_Syntax.ppname);
+                                   (uu___1639_12994.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___1637_12988.FStar_Syntax_Syntax.index);
+                                   (uu___1639_12994.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = ty
                                })
                              in
                           FStar_TypeChecker_Cfg.log cfg
-                            (fun uu____12991  ->
+                            (fun uu____12997  ->
                                FStar_Util.print_string
                                  "+++ Normalizing Tm_let -- definiens\n");
                           (let lb1 =
-                             let uu___1642_12994 = lb  in
-                             let uu____12995 =
+                             let uu___1644_13000 = lb  in
+                             let uu____13001 =
                                norm cfg env [] lb.FStar_Syntax_Syntax.lbdef
                                 in
                              {
                                FStar_Syntax_Syntax.lbname = lbname;
                                FStar_Syntax_Syntax.lbunivs =
-                                 (uu___1642_12994.FStar_Syntax_Syntax.lbunivs);
+                                 (uu___1644_13000.FStar_Syntax_Syntax.lbunivs);
                                FStar_Syntax_Syntax.lbtyp = ty;
                                FStar_Syntax_Syntax.lbeff =
-                                 (uu___1642_12994.FStar_Syntax_Syntax.lbeff);
-                               FStar_Syntax_Syntax.lbdef = uu____12995;
+                                 (uu___1644_13000.FStar_Syntax_Syntax.lbeff);
+                               FStar_Syntax_Syntax.lbdef = uu____13001;
                                FStar_Syntax_Syntax.lbattrs =
-                                 (uu___1642_12994.FStar_Syntax_Syntax.lbattrs);
+                                 (uu___1644_13000.FStar_Syntax_Syntax.lbattrs);
                                FStar_Syntax_Syntax.lbpos =
-                                 (uu___1642_12994.FStar_Syntax_Syntax.lbpos)
+                                 (uu___1644_13000.FStar_Syntax_Syntax.lbpos)
                              }  in
                            let env' =
                              FStar_All.pipe_right bs
                                (FStar_List.fold_left
                                   (fun env1  ->
-                                     fun uu____13024  -> dummy :: env1) env)
+                                     fun uu____13030  -> dummy :: env1) env)
                               in
                            let stack1 = (Cfg cfg) :: stack  in
                            let cfg1 =
-                             let uu___1649_13049 = cfg  in
+                             let uu___1651_13055 = cfg  in
                              {
                                FStar_TypeChecker_Cfg.steps =
-                                 (uu___1649_13049.FStar_TypeChecker_Cfg.steps);
+                                 (uu___1651_13055.FStar_TypeChecker_Cfg.steps);
                                FStar_TypeChecker_Cfg.tcenv =
-                                 (uu___1649_13049.FStar_TypeChecker_Cfg.tcenv);
+                                 (uu___1651_13055.FStar_TypeChecker_Cfg.tcenv);
                                FStar_TypeChecker_Cfg.debug =
-                                 (uu___1649_13049.FStar_TypeChecker_Cfg.debug);
+                                 (uu___1651_13055.FStar_TypeChecker_Cfg.debug);
                                FStar_TypeChecker_Cfg.delta_level =
-                                 (uu___1649_13049.FStar_TypeChecker_Cfg.delta_level);
+                                 (uu___1651_13055.FStar_TypeChecker_Cfg.delta_level);
                                FStar_TypeChecker_Cfg.primitive_steps =
-                                 (uu___1649_13049.FStar_TypeChecker_Cfg.primitive_steps);
+                                 (uu___1651_13055.FStar_TypeChecker_Cfg.primitive_steps);
                                FStar_TypeChecker_Cfg.strong = true;
                                FStar_TypeChecker_Cfg.memoize_lazy =
-                                 (uu___1649_13049.FStar_TypeChecker_Cfg.memoize_lazy);
+                                 (uu___1651_13055.FStar_TypeChecker_Cfg.memoize_lazy);
                                FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                 (uu___1649_13049.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                 (uu___1651_13055.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                FStar_TypeChecker_Cfg.reifying =
-                                 (uu___1649_13049.FStar_TypeChecker_Cfg.reifying)
+                                 (uu___1651_13055.FStar_TypeChecker_Cfg.reifying)
                              }  in
                            FStar_TypeChecker_Cfg.log cfg1
-                             (fun uu____13053  ->
+                             (fun uu____13059  ->
                                 FStar_Util.print_string
                                   "+++ Normalizing Tm_let -- body\n");
                            norm cfg1 env'
@@ -4236,8 +4238,8 @@ let rec (norm :
                     &&
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.pure_subterms_within_computations)
                ->
-               let uu____13074 = FStar_Syntax_Subst.open_let_rec lbs body  in
-               (match uu____13074 with
+               let uu____13080 = FStar_Syntax_Subst.open_let_rec lbs body  in
+               (match uu____13080 with
                 | (lbs1,body1) ->
                     let lbs2 =
                       FStar_List.map
@@ -4245,46 +4247,46 @@ let rec (norm :
                            let ty =
                              norm cfg env [] lb.FStar_Syntax_Syntax.lbtyp  in
                            let lbname =
-                             let uu____13110 =
-                               let uu___1665_13111 =
+                             let uu____13116 =
+                               let uu___1667_13117 =
                                  FStar_Util.left
                                    lb.FStar_Syntax_Syntax.lbname
                                   in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___1665_13111.FStar_Syntax_Syntax.ppname);
+                                   (uu___1667_13117.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___1665_13111.FStar_Syntax_Syntax.index);
+                                   (uu___1667_13117.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = ty
                                }  in
-                             FStar_Util.Inl uu____13110  in
-                           let uu____13112 =
+                             FStar_Util.Inl uu____13116  in
+                           let uu____13118 =
                              FStar_Syntax_Util.abs_formals
                                lb.FStar_Syntax_Syntax.lbdef
                               in
-                           match uu____13112 with
+                           match uu____13118 with
                            | (xs,def_body,lopt) ->
                                let xs1 = norm_binders cfg env xs  in
                                let env1 =
-                                 let uu____13138 =
-                                   FStar_List.map (fun uu____13154  -> dummy)
+                                 let uu____13144 =
+                                   FStar_List.map (fun uu____13160  -> dummy)
                                      lbs1
                                     in
-                                 let uu____13155 =
-                                   let uu____13164 =
+                                 let uu____13161 =
+                                   let uu____13170 =
                                      FStar_List.map
-                                       (fun uu____13186  -> dummy) xs1
+                                       (fun uu____13192  -> dummy) xs1
                                       in
-                                   FStar_List.append uu____13164 env  in
-                                 FStar_List.append uu____13138 uu____13155
+                                   FStar_List.append uu____13170 env  in
+                                 FStar_List.append uu____13144 uu____13161
                                   in
                                let def_body1 = norm cfg env1 [] def_body  in
                                let lopt1 =
                                  match lopt with
                                  | FStar_Pervasives_Native.Some rc ->
-                                     let uu____13212 =
-                                       let uu___1679_13213 = rc  in
-                                       let uu____13214 =
+                                     let uu____13218 =
+                                       let uu___1681_13219 = rc  in
+                                       let uu____13220 =
                                          FStar_Util.map_opt
                                            rc.FStar_Syntax_Syntax.residual_typ
                                            (norm cfg env1 [])
@@ -4292,76 +4294,76 @@ let rec (norm :
                                        {
                                          FStar_Syntax_Syntax.residual_effect
                                            =
-                                           (uu___1679_13213.FStar_Syntax_Syntax.residual_effect);
+                                           (uu___1681_13219.FStar_Syntax_Syntax.residual_effect);
                                          FStar_Syntax_Syntax.residual_typ =
-                                           uu____13214;
+                                           uu____13220;
                                          FStar_Syntax_Syntax.residual_flags =
-                                           (uu___1679_13213.FStar_Syntax_Syntax.residual_flags)
+                                           (uu___1681_13219.FStar_Syntax_Syntax.residual_flags)
                                        }  in
-                                     FStar_Pervasives_Native.Some uu____13212
-                                 | uu____13223 -> lopt  in
+                                     FStar_Pervasives_Native.Some uu____13218
+                                 | uu____13229 -> lopt  in
                                let def =
                                  FStar_Syntax_Util.abs xs1 def_body1 lopt1
                                   in
-                               let uu___1684_13229 = lb  in
+                               let uu___1686_13235 = lb  in
                                {
                                  FStar_Syntax_Syntax.lbname = lbname;
                                  FStar_Syntax_Syntax.lbunivs =
-                                   (uu___1684_13229.FStar_Syntax_Syntax.lbunivs);
+                                   (uu___1686_13235.FStar_Syntax_Syntax.lbunivs);
                                  FStar_Syntax_Syntax.lbtyp = ty;
                                  FStar_Syntax_Syntax.lbeff =
-                                   (uu___1684_13229.FStar_Syntax_Syntax.lbeff);
+                                   (uu___1686_13235.FStar_Syntax_Syntax.lbeff);
                                  FStar_Syntax_Syntax.lbdef = def;
                                  FStar_Syntax_Syntax.lbattrs =
-                                   (uu___1684_13229.FStar_Syntax_Syntax.lbattrs);
+                                   (uu___1686_13235.FStar_Syntax_Syntax.lbattrs);
                                  FStar_Syntax_Syntax.lbpos =
-                                   (uu___1684_13229.FStar_Syntax_Syntax.lbpos)
+                                   (uu___1686_13235.FStar_Syntax_Syntax.lbpos)
                                }) lbs1
                        in
                     let env' =
-                      let uu____13239 =
-                        FStar_List.map (fun uu____13255  -> dummy) lbs2  in
-                      FStar_List.append uu____13239 env  in
+                      let uu____13245 =
+                        FStar_List.map (fun uu____13261  -> dummy) lbs2  in
+                      FStar_List.append uu____13245 env  in
                     let body2 = norm cfg env' [] body1  in
-                    let uu____13263 =
+                    let uu____13269 =
                       FStar_Syntax_Subst.close_let_rec lbs2 body2  in
-                    (match uu____13263 with
+                    (match uu____13269 with
                      | (lbs3,body3) ->
                          let t2 =
-                           let uu___1693_13279 = t1  in
+                           let uu___1695_13285 = t1  in
                            {
                              FStar_Syntax_Syntax.n =
                                (FStar_Syntax_Syntax.Tm_let
                                   ((true, lbs3), body3));
                              FStar_Syntax_Syntax.pos =
-                               (uu___1693_13279.FStar_Syntax_Syntax.pos);
+                               (uu___1695_13285.FStar_Syntax_Syntax.pos);
                              FStar_Syntax_Syntax.vars =
-                               (uu___1693_13279.FStar_Syntax_Syntax.vars)
+                               (uu___1695_13285.FStar_Syntax_Syntax.vars)
                            }  in
                          rebuild cfg env stack t2))
            | FStar_Syntax_Syntax.Tm_let (lbs,body) when
                Prims.op_Negation
                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta
                ->
-               let uu____13313 = closure_as_term cfg env t1  in
-               rebuild cfg env stack uu____13313
+               let uu____13319 = closure_as_term cfg env t1  in
+               rebuild cfg env stack uu____13319
            | FStar_Syntax_Syntax.Tm_let (lbs,body) ->
-               let uu____13334 =
+               let uu____13340 =
                  FStar_List.fold_right
                    (fun lb  ->
-                      fun uu____13412  ->
-                        match uu____13412 with
+                      fun uu____13418  ->
+                        match uu____13418 with
                         | (rec_env,memos,i) ->
                             let bv =
-                              let uu___1709_13537 =
+                              let uu___1711_13543 =
                                 FStar_Util.left lb.FStar_Syntax_Syntax.lbname
                                  in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___1709_13537.FStar_Syntax_Syntax.ppname);
+                                  (uu___1711_13543.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index = i;
                                 FStar_Syntax_Syntax.sort =
-                                  (uu___1709_13537.FStar_Syntax_Syntax.sort)
+                                  (uu___1711_13543.FStar_Syntax_Syntax.sort)
                               }  in
                             let f_i = FStar_Syntax_Syntax.bv_to_tm bv  in
                             let fix_f_i =
@@ -4379,9 +4381,9 @@ let rec (norm :
                    (FStar_Pervasives_Native.snd lbs)
                    (env, [], Prims.int_zero)
                   in
-               (match uu____13334 with
-                | (rec_env,memos,uu____13728) ->
-                    let uu____13783 =
+               (match uu____13340 with
+                | (rec_env,memos,uu____13734) ->
+                    let uu____13789 =
                       FStar_List.map2
                         (fun lb  ->
                            fun memo  ->
@@ -4394,29 +4396,29 @@ let rec (norm :
                       FStar_List.fold_right
                         (fun lb  ->
                            fun env1  ->
-                             let uu____14032 =
-                               let uu____14039 =
-                                 let uu____14040 =
-                                   let uu____14072 =
+                             let uu____14038 =
+                               let uu____14045 =
+                                 let uu____14046 =
+                                   let uu____14078 =
                                      FStar_Util.mk_ref
                                        FStar_Pervasives_Native.None
                                       in
                                    (rec_env, (lb.FStar_Syntax_Syntax.lbdef),
-                                     uu____14072, false)
+                                     uu____14078, false)
                                     in
-                                 Clos uu____14040  in
-                               (FStar_Pervasives_Native.None, uu____14039)
+                                 Clos uu____14046  in
+                               (FStar_Pervasives_Native.None, uu____14045)
                                 in
-                             uu____14032 :: env1)
+                             uu____14038 :: env1)
                         (FStar_Pervasives_Native.snd lbs) env
                        in
                     norm cfg body_env stack body)
            | FStar_Syntax_Syntax.Tm_meta (head1,m) ->
                (FStar_TypeChecker_Cfg.log cfg
-                  (fun uu____14157  ->
-                     let uu____14158 =
+                  (fun uu____14163  ->
+                     let uu____14164 =
                        FStar_Syntax_Print.metadata_to_string m  in
-                     FStar_Util.print1 ">> metadata = %s\n" uu____14158);
+                     FStar_Util.print1 ">> metadata = %s\n" uu____14164);
                 (match m with
                  | FStar_Syntax_Syntax.Meta_monadic (m1,t2) ->
                      reduce_impure_comp cfg env stack head1
@@ -4424,16 +4426,16 @@ let rec (norm :
                  | FStar_Syntax_Syntax.Meta_monadic_lift (m1,m',t2) ->
                      reduce_impure_comp cfg env stack head1
                        (FStar_Util.Inr (m1, m')) t2
-                 | uu____14182 ->
+                 | uu____14188 ->
                      if
                        (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unmeta
                      then norm cfg env stack head1
                      else
                        (match stack with
-                        | uu____14186::uu____14187 ->
+                        | uu____14192::uu____14193 ->
                             (match m with
                              | FStar_Syntax_Syntax.Meta_labeled
-                                 (l,r,uu____14192) ->
+                                 (l,r,uu____14198) ->
                                  norm cfg env ((Meta (env, m, r)) :: stack)
                                    head1
                              | FStar_Syntax_Syntax.Meta_pattern (names1,args)
@@ -4451,7 +4453,7 @@ let rec (norm :
                                             (names2, args1)),
                                          (t1.FStar_Syntax_Syntax.pos))) ::
                                    stack) head1
-                             | uu____14271 -> norm cfg env stack head1)
+                             | uu____14277 -> norm cfg env stack head1)
                         | [] ->
                             let head2 = norm cfg env [] head1  in
                             let m1 =
@@ -4462,44 +4464,44 @@ let rec (norm :
                                     FStar_All.pipe_right names1
                                       (FStar_List.map (norm cfg env []))
                                      in
-                                  let uu____14319 =
-                                    let uu____14340 =
+                                  let uu____14325 =
+                                    let uu____14346 =
                                       norm_pattern_args cfg env args  in
-                                    (names2, uu____14340)  in
+                                    (names2, uu____14346)  in
                                   FStar_Syntax_Syntax.Meta_pattern
-                                    uu____14319
-                              | uu____14369 -> m  in
+                                    uu____14325
+                              | uu____14375 -> m  in
                             let t2 =
                               mk (FStar_Syntax_Syntax.Tm_meta (head2, m1))
                                 t1.FStar_Syntax_Syntax.pos
                                in
                             rebuild cfg env stack t2)))
-           | FStar_Syntax_Syntax.Tm_delayed uu____14375 ->
+           | FStar_Syntax_Syntax.Tm_delayed uu____14381 ->
                let t2 = FStar_Syntax_Subst.compress t1  in
                norm cfg env stack t2
-           | FStar_Syntax_Syntax.Tm_uvar uu____14399 ->
+           | FStar_Syntax_Syntax.Tm_uvar uu____14405 ->
                let t2 = FStar_Syntax_Subst.compress t1  in
                (match t2.FStar_Syntax_Syntax.n with
-                | FStar_Syntax_Syntax.Tm_uvar uu____14413 ->
+                | FStar_Syntax_Syntax.Tm_uvar uu____14419 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.check_no_uvars
                     then
-                      let uu____14427 =
-                        let uu____14429 =
+                      let uu____14433 =
+                        let uu____14435 =
                           FStar_Range.string_of_range
                             t2.FStar_Syntax_Syntax.pos
                            in
-                        let uu____14431 =
+                        let uu____14437 =
                           FStar_Syntax_Print.term_to_string t2  in
                         FStar_Util.format2
                           "(%s) CheckNoUvars: Unexpected unification variable remains: %s"
-                          uu____14429 uu____14431
+                          uu____14435 uu____14437
                          in
-                      failwith uu____14427
+                      failwith uu____14433
                     else
-                      (let uu____14436 = inline_closure_env cfg env [] t2  in
-                       rebuild cfg env stack uu____14436)
-                | uu____14437 -> norm cfg env stack t2))
+                      (let uu____14442 = inline_closure_env cfg env [] t2  in
+                       rebuild cfg env stack uu____14442)
+                | uu____14443 -> norm cfg env stack t2))
 
 and (do_unfold_fv :
   FStar_TypeChecker_Cfg.cfg ->
@@ -4515,30 +4517,30 @@ and (do_unfold_fv :
         fun t0  ->
           fun qninfo  ->
             fun f  ->
-              let uu____14446 =
+              let uu____14452 =
                 FStar_TypeChecker_Env.lookup_definition_qninfo
                   cfg.FStar_TypeChecker_Cfg.delta_level
                   (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                   qninfo
                  in
-              match uu____14446 with
+              match uu____14452 with
               | FStar_Pervasives_Native.None  ->
                   (FStar_TypeChecker_Cfg.log_unfolding cfg
-                     (fun uu____14460  ->
-                        let uu____14461 = FStar_Syntax_Print.fv_to_string f
+                     (fun uu____14466  ->
+                        let uu____14467 = FStar_Syntax_Print.fv_to_string f
                            in
                         FStar_Util.print1 " >> Tm_fvar case 2 for %s\n"
-                          uu____14461);
+                          uu____14467);
                    rebuild cfg env stack t0)
               | FStar_Pervasives_Native.Some (us,t) ->
                   (FStar_TypeChecker_Cfg.log_unfolding cfg
-                     (fun uu____14474  ->
-                        let uu____14475 =
+                     (fun uu____14480  ->
+                        let uu____14481 =
                           FStar_Syntax_Print.term_to_string t0  in
-                        let uu____14477 = FStar_Syntax_Print.term_to_string t
+                        let uu____14483 = FStar_Syntax_Print.term_to_string t
                            in
                         FStar_Util.print2 " >> Unfolded %s to %s\n"
-                          uu____14475 uu____14477);
+                          uu____14481 uu____14483);
                    (let t1 =
                       if
                         (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_until
@@ -4554,21 +4556,21 @@ and (do_unfold_fv :
                     if n1 > Prims.int_zero
                     then
                       match stack with
-                      | (UnivArgs (us',uu____14490))::stack1 ->
-                          ((let uu____14499 =
+                      | (UnivArgs (us',uu____14496))::stack1 ->
+                          ((let uu____14505 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug
                                    cfg.FStar_TypeChecker_Cfg.tcenv)
                                 (FStar_Options.Other "univ_norm")
                                in
-                            if uu____14499
+                            if uu____14505
                             then
                               FStar_List.iter
                                 (fun x  ->
-                                   let uu____14507 =
+                                   let uu____14513 =
                                      FStar_Syntax_Print.univ_to_string x  in
                                    FStar_Util.print1 "Univ (normalizer) %s\n"
-                                     uu____14507) us'
+                                     uu____14513) us'
                             else ());
                            (let env1 =
                               FStar_All.pipe_right us'
@@ -4580,22 +4582,22 @@ and (do_unfold_fv :
                                         :: env1) env)
                                in
                             norm cfg env1 stack1 t1))
-                      | uu____14543 when
+                      | uu____14549 when
                           (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.erase_universes
                             ||
                             (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.allow_unbound_universes
                           -> norm cfg env stack t1
-                      | uu____14546 ->
-                          let uu____14549 =
-                            let uu____14551 =
+                      | uu____14552 ->
+                          let uu____14555 =
+                            let uu____14557 =
                               FStar_Syntax_Print.lid_to_string
                                 (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                in
                             FStar_Util.format1
                               "Impossible: missing universe instantiation on %s"
-                              uu____14551
+                              uu____14557
                              in
-                          failwith uu____14549
+                          failwith uu____14555
                     else norm cfg env stack t1))
 
 and (reduce_impure_comp :
@@ -4627,30 +4629,30 @@ and (reduce_impure_comp :
                     FStar_TypeChecker_Env.EraseUniverses;
                     FStar_TypeChecker_Env.Exclude FStar_TypeChecker_Env.Zeta;
                     FStar_TypeChecker_Env.Inlining]  in
-                  let uu___1821_14579 = cfg  in
-                  let uu____14580 =
+                  let uu___1823_14585 = cfg  in
+                  let uu____14586 =
                     FStar_List.fold_right FStar_TypeChecker_Cfg.fstep_add_one
                       new_steps cfg.FStar_TypeChecker_Cfg.steps
                      in
                   {
-                    FStar_TypeChecker_Cfg.steps = uu____14580;
+                    FStar_TypeChecker_Cfg.steps = uu____14586;
                     FStar_TypeChecker_Cfg.tcenv =
-                      (uu___1821_14579.FStar_TypeChecker_Cfg.tcenv);
+                      (uu___1823_14585.FStar_TypeChecker_Cfg.tcenv);
                     FStar_TypeChecker_Cfg.debug =
-                      (uu___1821_14579.FStar_TypeChecker_Cfg.debug);
+                      (uu___1823_14585.FStar_TypeChecker_Cfg.debug);
                     FStar_TypeChecker_Cfg.delta_level =
                       [FStar_TypeChecker_Env.InliningDelta;
                       FStar_TypeChecker_Env.Eager_unfolding_only];
                     FStar_TypeChecker_Cfg.primitive_steps =
-                      (uu___1821_14579.FStar_TypeChecker_Cfg.primitive_steps);
+                      (uu___1823_14585.FStar_TypeChecker_Cfg.primitive_steps);
                     FStar_TypeChecker_Cfg.strong =
-                      (uu___1821_14579.FStar_TypeChecker_Cfg.strong);
+                      (uu___1823_14585.FStar_TypeChecker_Cfg.strong);
                     FStar_TypeChecker_Cfg.memoize_lazy =
-                      (uu___1821_14579.FStar_TypeChecker_Cfg.memoize_lazy);
+                      (uu___1823_14585.FStar_TypeChecker_Cfg.memoize_lazy);
                     FStar_TypeChecker_Cfg.normalize_pure_lets =
-                      (uu___1821_14579.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                      (uu___1823_14585.FStar_TypeChecker_Cfg.normalize_pure_lets);
                     FStar_TypeChecker_Cfg.reifying =
-                      (uu___1821_14579.FStar_TypeChecker_Cfg.reifying)
+                      (uu___1823_14585.FStar_TypeChecker_Cfg.reifying)
                   }
                 else cfg  in
               let metadata =
@@ -4682,143 +4684,143 @@ and (do_reify_monadic :
               fun t  ->
                 (match stack with
                  | (App
-                     (uu____14611,{
+                     (uu____14617,{
                                     FStar_Syntax_Syntax.n =
                                       FStar_Syntax_Syntax.Tm_constant
                                       (FStar_Const.Const_reify );
-                                    FStar_Syntax_Syntax.pos = uu____14612;
-                                    FStar_Syntax_Syntax.vars = uu____14613;_},uu____14614,uu____14615))::uu____14616
+                                    FStar_Syntax_Syntax.pos = uu____14618;
+                                    FStar_Syntax_Syntax.vars = uu____14619;_},uu____14620,uu____14621))::uu____14622
                      -> ()
-                 | uu____14621 ->
-                     let uu____14624 =
-                       let uu____14626 = stack_to_string stack  in
+                 | uu____14627 ->
+                     let uu____14630 =
+                       let uu____14632 = stack_to_string stack  in
                        FStar_Util.format1
                          "INTERNAL ERROR: do_reify_monadic: bad stack: %s"
-                         uu____14626
+                         uu____14632
                         in
-                     failwith uu____14624);
+                     failwith uu____14630);
                 (let head0 = head1  in
                  let head2 = FStar_Syntax_Util.unascribe head1  in
                  FStar_TypeChecker_Cfg.log cfg
-                   (fun uu____14635  ->
-                      let uu____14636 = FStar_Syntax_Print.tag_of_term head2
+                   (fun uu____14641  ->
+                      let uu____14642 = FStar_Syntax_Print.tag_of_term head2
                          in
-                      let uu____14638 =
+                      let uu____14644 =
                         FStar_Syntax_Print.term_to_string head2  in
-                      FStar_Util.print2 "Reifying: (%s) %s\n" uu____14636
-                        uu____14638);
+                      FStar_Util.print2 "Reifying: (%s) %s\n" uu____14642
+                        uu____14644);
                  (let head3 = FStar_Syntax_Util.unmeta_safe head2  in
-                  let uu____14642 =
-                    let uu____14643 = FStar_Syntax_Subst.compress head3  in
-                    uu____14643.FStar_Syntax_Syntax.n  in
-                  match uu____14642 with
+                  let uu____14648 =
+                    let uu____14649 = FStar_Syntax_Subst.compress head3  in
+                    uu____14649.FStar_Syntax_Syntax.n  in
+                  match uu____14648 with
                   | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) ->
                       let ed =
-                        let uu____14664 =
+                        let uu____14670 =
                           FStar_TypeChecker_Env.norm_eff_name
                             cfg.FStar_TypeChecker_Cfg.tcenv m
                            in
                         FStar_TypeChecker_Env.get_effect_decl
-                          cfg.FStar_TypeChecker_Cfg.tcenv uu____14664
+                          cfg.FStar_TypeChecker_Cfg.tcenv uu____14670
                          in
-                      let uu____14665 = ed.FStar_Syntax_Syntax.bind_repr  in
-                      (match uu____14665 with
-                       | (uu____14666,bind_repr) ->
+                      let uu____14671 = ed.FStar_Syntax_Syntax.bind_repr  in
+                      (match uu____14671 with
+                       | (uu____14672,bind_repr) ->
                            (match lb.FStar_Syntax_Syntax.lbname with
-                            | FStar_Util.Inr uu____14676 ->
+                            | FStar_Util.Inr uu____14682 ->
                                 failwith
                                   "Cannot reify a top-level let binding"
                             | FStar_Util.Inl x ->
                                 let is_return e =
-                                  let uu____14687 =
-                                    let uu____14688 =
+                                  let uu____14693 =
+                                    let uu____14694 =
                                       FStar_Syntax_Subst.compress e  in
-                                    uu____14688.FStar_Syntax_Syntax.n  in
-                                  match uu____14687 with
+                                    uu____14694.FStar_Syntax_Syntax.n  in
+                                  match uu____14693 with
                                   | FStar_Syntax_Syntax.Tm_meta
                                       (e1,FStar_Syntax_Syntax.Meta_monadic
-                                       (uu____14694,uu____14695))
+                                       (uu____14700,uu____14701))
                                       ->
-                                      let uu____14704 =
-                                        let uu____14705 =
+                                      let uu____14710 =
+                                        let uu____14711 =
                                           FStar_Syntax_Subst.compress e1  in
-                                        uu____14705.FStar_Syntax_Syntax.n  in
-                                      (match uu____14704 with
+                                        uu____14711.FStar_Syntax_Syntax.n  in
+                                      (match uu____14710 with
                                        | FStar_Syntax_Syntax.Tm_meta
                                            (e2,FStar_Syntax_Syntax.Meta_monadic_lift
-                                            (uu____14711,msrc,uu____14713))
+                                            (uu____14717,msrc,uu____14719))
                                            when
                                            FStar_Syntax_Util.is_pure_effect
                                              msrc
                                            ->
-                                           let uu____14722 =
+                                           let uu____14728 =
                                              FStar_Syntax_Subst.compress e2
                                               in
                                            FStar_Pervasives_Native.Some
-                                             uu____14722
-                                       | uu____14723 ->
+                                             uu____14728
+                                       | uu____14729 ->
                                            FStar_Pervasives_Native.None)
-                                  | uu____14724 ->
+                                  | uu____14730 ->
                                       FStar_Pervasives_Native.None
                                    in
-                                let uu____14725 =
+                                let uu____14731 =
                                   is_return lb.FStar_Syntax_Syntax.lbdef  in
-                                (match uu____14725 with
+                                (match uu____14731 with
                                  | FStar_Pervasives_Native.Some e ->
                                      let lb1 =
-                                       let uu___1893_14730 = lb  in
+                                       let uu___1895_14736 = lb  in
                                        {
                                          FStar_Syntax_Syntax.lbname =
-                                           (uu___1893_14730.FStar_Syntax_Syntax.lbname);
+                                           (uu___1895_14736.FStar_Syntax_Syntax.lbname);
                                          FStar_Syntax_Syntax.lbunivs =
-                                           (uu___1893_14730.FStar_Syntax_Syntax.lbunivs);
+                                           (uu___1895_14736.FStar_Syntax_Syntax.lbunivs);
                                          FStar_Syntax_Syntax.lbtyp =
-                                           (uu___1893_14730.FStar_Syntax_Syntax.lbtyp);
+                                           (uu___1895_14736.FStar_Syntax_Syntax.lbtyp);
                                          FStar_Syntax_Syntax.lbeff =
                                            FStar_Parser_Const.effect_PURE_lid;
                                          FStar_Syntax_Syntax.lbdef = e;
                                          FStar_Syntax_Syntax.lbattrs =
-                                           (uu___1893_14730.FStar_Syntax_Syntax.lbattrs);
+                                           (uu___1895_14736.FStar_Syntax_Syntax.lbattrs);
                                          FStar_Syntax_Syntax.lbpos =
-                                           (uu___1893_14730.FStar_Syntax_Syntax.lbpos)
+                                           (uu___1895_14736.FStar_Syntax_Syntax.lbpos)
                                        }  in
-                                     let uu____14731 = FStar_List.tl stack
+                                     let uu____14737 = FStar_List.tl stack
                                         in
-                                     let uu____14732 =
-                                       let uu____14733 =
-                                         let uu____14740 =
-                                           let uu____14741 =
-                                             let uu____14755 =
+                                     let uu____14738 =
+                                       let uu____14739 =
+                                         let uu____14746 =
+                                           let uu____14747 =
+                                             let uu____14761 =
                                                FStar_Syntax_Util.mk_reify
                                                  body
                                                 in
-                                             ((false, [lb1]), uu____14755)
+                                             ((false, [lb1]), uu____14761)
                                               in
                                            FStar_Syntax_Syntax.Tm_let
-                                             uu____14741
+                                             uu____14747
                                             in
-                                         FStar_Syntax_Syntax.mk uu____14740
+                                         FStar_Syntax_Syntax.mk uu____14746
                                           in
-                                       uu____14733
+                                       uu____14739
                                          FStar_Pervasives_Native.None
                                          head3.FStar_Syntax_Syntax.pos
                                         in
-                                     norm cfg env uu____14731 uu____14732
+                                     norm cfg env uu____14737 uu____14738
                                  | FStar_Pervasives_Native.None  ->
-                                     let uu____14771 =
-                                       let uu____14773 = is_return body  in
-                                       match uu____14773 with
+                                     let uu____14777 =
+                                       let uu____14779 = is_return body  in
+                                       match uu____14779 with
                                        | FStar_Pervasives_Native.Some
                                            {
                                              FStar_Syntax_Syntax.n =
                                                FStar_Syntax_Syntax.Tm_bvar y;
                                              FStar_Syntax_Syntax.pos =
-                                               uu____14778;
+                                               uu____14784;
                                              FStar_Syntax_Syntax.vars =
-                                               uu____14779;_}
+                                               uu____14785;_}
                                            -> FStar_Syntax_Syntax.bv_eq x y
-                                       | uu____14782 -> false  in
-                                     if uu____14771
+                                       | uu____14788 -> false  in
+                                     if uu____14777
                                      then
                                        norm cfg env stack
                                          lb.FStar_Syntax_Syntax.lbdef
@@ -4845,353 +4847,353 @@ and (do_reify_monadic :
                                               = []
                                           }  in
                                         let body2 =
-                                          let uu____14806 =
-                                            let uu____14813 =
-                                              let uu____14814 =
-                                                let uu____14833 =
-                                                  let uu____14842 =
+                                          let uu____14812 =
+                                            let uu____14819 =
+                                              let uu____14820 =
+                                                let uu____14839 =
+                                                  let uu____14848 =
                                                     FStar_Syntax_Syntax.mk_binder
                                                       x
                                                      in
-                                                  [uu____14842]  in
-                                                (uu____14833, body1,
+                                                  [uu____14848]  in
+                                                (uu____14839, body1,
                                                   (FStar_Pervasives_Native.Some
                                                      body_rc))
                                                  in
                                               FStar_Syntax_Syntax.Tm_abs
-                                                uu____14814
+                                                uu____14820
                                                in
                                             FStar_Syntax_Syntax.mk
-                                              uu____14813
+                                              uu____14819
                                              in
-                                          uu____14806
+                                          uu____14812
                                             FStar_Pervasives_Native.None
                                             body1.FStar_Syntax_Syntax.pos
                                            in
                                         let close1 = closure_as_term cfg env
                                            in
                                         let bind_inst =
-                                          let uu____14881 =
-                                            let uu____14882 =
+                                          let uu____14887 =
+                                            let uu____14888 =
                                               FStar_Syntax_Subst.compress
                                                 bind_repr
                                                in
-                                            uu____14882.FStar_Syntax_Syntax.n
+                                            uu____14888.FStar_Syntax_Syntax.n
                                              in
-                                          match uu____14881 with
+                                          match uu____14887 with
                                           | FStar_Syntax_Syntax.Tm_uinst
-                                              (bind1,uu____14888::uu____14889::[])
+                                              (bind1,uu____14894::uu____14895::[])
                                               ->
-                                              let uu____14894 =
-                                                let uu____14901 =
-                                                  let uu____14902 =
-                                                    let uu____14909 =
-                                                      let uu____14910 =
-                                                        let uu____14911 =
+                                              let uu____14900 =
+                                                let uu____14907 =
+                                                  let uu____14908 =
+                                                    let uu____14915 =
+                                                      let uu____14916 =
+                                                        let uu____14917 =
                                                           close1
                                                             lb.FStar_Syntax_Syntax.lbtyp
                                                            in
                                                         (cfg.FStar_TypeChecker_Cfg.tcenv).FStar_TypeChecker_Env.universe_of
                                                           cfg.FStar_TypeChecker_Cfg.tcenv
-                                                          uu____14911
+                                                          uu____14917
                                                          in
-                                                      let uu____14912 =
-                                                        let uu____14915 =
-                                                          let uu____14916 =
+                                                      let uu____14918 =
+                                                        let uu____14921 =
+                                                          let uu____14922 =
                                                             close1 t  in
                                                           (cfg.FStar_TypeChecker_Cfg.tcenv).FStar_TypeChecker_Env.universe_of
                                                             cfg.FStar_TypeChecker_Cfg.tcenv
-                                                            uu____14916
+                                                            uu____14922
                                                            in
-                                                        [uu____14915]  in
-                                                      uu____14910 ::
-                                                        uu____14912
+                                                        [uu____14921]  in
+                                                      uu____14916 ::
+                                                        uu____14918
                                                        in
-                                                    (bind1, uu____14909)  in
+                                                    (bind1, uu____14915)  in
                                                   FStar_Syntax_Syntax.Tm_uinst
-                                                    uu____14902
+                                                    uu____14908
                                                    in
                                                 FStar_Syntax_Syntax.mk
-                                                  uu____14901
+                                                  uu____14907
                                                  in
-                                              uu____14894
+                                              uu____14900
                                                 FStar_Pervasives_Native.None
                                                 rng
-                                          | uu____14919 ->
+                                          | uu____14925 ->
                                               failwith
                                                 "NIY : Reification of indexed effects"
                                            in
                                         let maybe_range_arg =
-                                          let uu____14934 =
+                                          let uu____14940 =
                                             FStar_Util.for_some
                                               (FStar_Syntax_Util.attr_eq
                                                  FStar_Syntax_Util.dm4f_bind_range_attr)
                                               ed.FStar_Syntax_Syntax.eff_attrs
                                              in
-                                          if uu____14934
+                                          if uu____14940
                                           then
-                                            let uu____14947 =
-                                              let uu____14956 =
+                                            let uu____14953 =
+                                              let uu____14962 =
                                                 FStar_TypeChecker_Cfg.embed_simple
                                                   FStar_Syntax_Embeddings.e_range
                                                   lb.FStar_Syntax_Syntax.lbpos
                                                   lb.FStar_Syntax_Syntax.lbpos
                                                  in
                                               FStar_Syntax_Syntax.as_arg
-                                                uu____14956
+                                                uu____14962
                                                in
-                                            let uu____14957 =
-                                              let uu____14968 =
-                                                let uu____14977 =
+                                            let uu____14963 =
+                                              let uu____14974 =
+                                                let uu____14983 =
                                                   FStar_TypeChecker_Cfg.embed_simple
                                                     FStar_Syntax_Embeddings.e_range
                                                     body2.FStar_Syntax_Syntax.pos
                                                     body2.FStar_Syntax_Syntax.pos
                                                    in
                                                 FStar_Syntax_Syntax.as_arg
-                                                  uu____14977
+                                                  uu____14983
                                                  in
-                                              [uu____14968]  in
-                                            uu____14947 :: uu____14957
+                                              [uu____14974]  in
+                                            uu____14953 :: uu____14963
                                           else []  in
                                         let reified =
-                                          let uu____15015 =
-                                            let uu____15022 =
-                                              let uu____15023 =
-                                                let uu____15040 =
-                                                  let uu____15051 =
-                                                    let uu____15062 =
+                                          let uu____15021 =
+                                            let uu____15028 =
+                                              let uu____15029 =
+                                                let uu____15046 =
+                                                  let uu____15057 =
+                                                    let uu____15068 =
                                                       FStar_Syntax_Syntax.as_arg
                                                         lb.FStar_Syntax_Syntax.lbtyp
                                                        in
-                                                    let uu____15071 =
-                                                      let uu____15082 =
+                                                    let uu____15077 =
+                                                      let uu____15088 =
                                                         FStar_Syntax_Syntax.as_arg
                                                           t
                                                          in
-                                                      [uu____15082]  in
-                                                    uu____15062 ::
-                                                      uu____15071
+                                                      [uu____15088]  in
+                                                    uu____15068 ::
+                                                      uu____15077
                                                      in
-                                                  let uu____15115 =
-                                                    let uu____15126 =
-                                                      let uu____15137 =
+                                                  let uu____15121 =
+                                                    let uu____15132 =
+                                                      let uu____15143 =
                                                         FStar_Syntax_Syntax.as_arg
                                                           FStar_Syntax_Syntax.tun
                                                          in
-                                                      let uu____15146 =
-                                                        let uu____15157 =
+                                                      let uu____15152 =
+                                                        let uu____15163 =
                                                           FStar_Syntax_Syntax.as_arg
                                                             head4
                                                            in
-                                                        let uu____15166 =
-                                                          let uu____15177 =
+                                                        let uu____15172 =
+                                                          let uu____15183 =
                                                             FStar_Syntax_Syntax.as_arg
                                                               FStar_Syntax_Syntax.tun
                                                              in
-                                                          let uu____15186 =
-                                                            let uu____15197 =
+                                                          let uu____15192 =
+                                                            let uu____15203 =
                                                               FStar_Syntax_Syntax.as_arg
                                                                 body2
                                                                in
-                                                            [uu____15197]  in
-                                                          uu____15177 ::
-                                                            uu____15186
+                                                            [uu____15203]  in
+                                                          uu____15183 ::
+                                                            uu____15192
                                                            in
-                                                        uu____15157 ::
-                                                          uu____15166
+                                                        uu____15163 ::
+                                                          uu____15172
                                                          in
-                                                      uu____15137 ::
-                                                        uu____15146
+                                                      uu____15143 ::
+                                                        uu____15152
                                                        in
                                                     FStar_List.append
                                                       maybe_range_arg
-                                                      uu____15126
+                                                      uu____15132
                                                      in
                                                   FStar_List.append
-                                                    uu____15051 uu____15115
+                                                    uu____15057 uu____15121
                                                    in
-                                                (bind_inst, uu____15040)  in
+                                                (bind_inst, uu____15046)  in
                                               FStar_Syntax_Syntax.Tm_app
-                                                uu____15023
+                                                uu____15029
                                                in
                                             FStar_Syntax_Syntax.mk
-                                              uu____15022
+                                              uu____15028
                                              in
-                                          uu____15015
+                                          uu____15021
                                             FStar_Pervasives_Native.None rng
                                            in
                                         FStar_TypeChecker_Cfg.log cfg
-                                          (fun uu____15278  ->
-                                             let uu____15279 =
+                                          (fun uu____15284  ->
+                                             let uu____15285 =
                                                FStar_Syntax_Print.term_to_string
                                                  head0
                                                 in
-                                             let uu____15281 =
+                                             let uu____15287 =
                                                FStar_Syntax_Print.term_to_string
                                                  reified
                                                 in
                                              FStar_Util.print2
                                                "Reified (1) <%s> to %s\n"
-                                               uu____15279 uu____15281);
-                                        (let uu____15284 =
+                                               uu____15285 uu____15287);
+                                        (let uu____15290 =
                                            FStar_List.tl stack  in
-                                         norm cfg env uu____15284 reified)))))
+                                         norm cfg env uu____15290 reified)))))
                   | FStar_Syntax_Syntax.Tm_app (head_app,args) ->
-                      ((let uu____15312 = FStar_Options.defensive ()  in
-                        if uu____15312
+                      ((let uu____15318 = FStar_Options.defensive ()  in
+                        if uu____15318
                         then
-                          let is_arg_impure uu____15327 =
-                            match uu____15327 with
+                          let is_arg_impure uu____15333 =
+                            match uu____15333 with
                             | (e,q) ->
-                                let uu____15341 =
-                                  let uu____15342 =
+                                let uu____15347 =
+                                  let uu____15348 =
                                     FStar_Syntax_Subst.compress e  in
-                                  uu____15342.FStar_Syntax_Syntax.n  in
-                                (match uu____15341 with
+                                  uu____15348.FStar_Syntax_Syntax.n  in
+                                (match uu____15347 with
                                  | FStar_Syntax_Syntax.Tm_meta
                                      (e0,FStar_Syntax_Syntax.Meta_monadic_lift
                                       (m1,m2,t'))
                                      ->
-                                     let uu____15358 =
+                                     let uu____15364 =
                                        FStar_Syntax_Util.is_pure_effect m1
                                         in
-                                     Prims.op_Negation uu____15358
-                                 | uu____15360 -> false)
+                                     Prims.op_Negation uu____15364
+                                 | uu____15366 -> false)
                              in
-                          let uu____15362 =
-                            let uu____15364 =
-                              let uu____15375 =
+                          let uu____15368 =
+                            let uu____15370 =
+                              let uu____15381 =
                                 FStar_Syntax_Syntax.as_arg head_app  in
-                              uu____15375 :: args  in
-                            FStar_Util.for_some is_arg_impure uu____15364  in
-                          (if uu____15362
+                              uu____15381 :: args  in
+                            FStar_Util.for_some is_arg_impure uu____15370  in
+                          (if uu____15368
                            then
-                             let uu____15401 =
-                               let uu____15407 =
-                                 let uu____15409 =
+                             let uu____15407 =
+                               let uu____15413 =
+                                 let uu____15415 =
                                    FStar_Syntax_Print.term_to_string head3
                                     in
                                  FStar_Util.format1
                                    "Incompatibility between typechecker and normalizer; this monadic application contains impure terms %s\n"
-                                   uu____15409
+                                   uu____15415
                                   in
-                               (FStar_Errors.Warning_Defensive, uu____15407)
+                               (FStar_Errors.Warning_Defensive, uu____15413)
                                 in
                              FStar_Errors.log_issue
-                               head3.FStar_Syntax_Syntax.pos uu____15401
+                               head3.FStar_Syntax_Syntax.pos uu____15407
                            else ())
                         else ());
-                       (let fallback1 uu____15422 =
+                       (let fallback1 uu____15428 =
                           FStar_TypeChecker_Cfg.log cfg
-                            (fun uu____15426  ->
-                               let uu____15427 =
+                            (fun uu____15432  ->
+                               let uu____15433 =
                                  FStar_Syntax_Print.term_to_string head0  in
                                FStar_Util.print2 "Reified (2) <%s> to %s\n"
-                                 uu____15427 "");
-                          (let uu____15431 = FStar_List.tl stack  in
-                           let uu____15432 = FStar_Syntax_Util.mk_reify head3
+                                 uu____15433 "");
+                          (let uu____15437 = FStar_List.tl stack  in
+                           let uu____15438 = FStar_Syntax_Util.mk_reify head3
                               in
-                           norm cfg env uu____15431 uu____15432)
+                           norm cfg env uu____15437 uu____15438)
                            in
-                        let fallback2 uu____15438 =
+                        let fallback2 uu____15444 =
                           FStar_TypeChecker_Cfg.log cfg
-                            (fun uu____15442  ->
-                               let uu____15443 =
+                            (fun uu____15448  ->
+                               let uu____15449 =
                                  FStar_Syntax_Print.term_to_string head0  in
                                FStar_Util.print2 "Reified (3) <%s> to %s\n"
-                                 uu____15443 "");
-                          (let uu____15447 = FStar_List.tl stack  in
-                           let uu____15448 =
+                                 uu____15449 "");
+                          (let uu____15453 = FStar_List.tl stack  in
+                           let uu____15454 =
                              mk
                                (FStar_Syntax_Syntax.Tm_meta
                                   (head3,
                                     (FStar_Syntax_Syntax.Meta_monadic (m, t))))
                                head0.FStar_Syntax_Syntax.pos
                               in
-                           norm cfg env uu____15447 uu____15448)
+                           norm cfg env uu____15453 uu____15454)
                            in
-                        let uu____15453 =
-                          let uu____15454 =
+                        let uu____15459 =
+                          let uu____15460 =
                             FStar_Syntax_Util.un_uinst head_app  in
-                          uu____15454.FStar_Syntax_Syntax.n  in
-                        match uu____15453 with
+                          uu____15460.FStar_Syntax_Syntax.n  in
+                        match uu____15459 with
                         | FStar_Syntax_Syntax.Tm_fvar fv ->
                             let lid = FStar_Syntax_Syntax.lid_of_fv fv  in
                             let qninfo =
                               FStar_TypeChecker_Env.lookup_qname
                                 cfg.FStar_TypeChecker_Cfg.tcenv lid
                                in
-                            let uu____15460 =
-                              let uu____15462 =
+                            let uu____15466 =
+                              let uu____15468 =
                                 FStar_TypeChecker_Env.is_action
                                   cfg.FStar_TypeChecker_Cfg.tcenv lid
                                  in
-                              Prims.op_Negation uu____15462  in
-                            if uu____15460
+                              Prims.op_Negation uu____15468  in
+                            if uu____15466
                             then fallback1 ()
                             else
-                              (let uu____15467 =
-                                 let uu____15469 =
+                              (let uu____15473 =
+                                 let uu____15475 =
                                    FStar_TypeChecker_Env.lookup_definition_qninfo
                                      cfg.FStar_TypeChecker_Cfg.delta_level
                                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                      qninfo
                                     in
-                                 FStar_Option.isNone uu____15469  in
-                               if uu____15467
+                                 FStar_Option.isNone uu____15475  in
+                               if uu____15473
                                then fallback2 ()
                                else
                                  (let t1 =
-                                    let uu____15486 =
-                                      let uu____15491 =
+                                    let uu____15492 =
+                                      let uu____15497 =
                                         FStar_Syntax_Util.mk_reify head_app
                                          in
                                       FStar_Syntax_Syntax.mk_Tm_app
-                                        uu____15491 args
+                                        uu____15497 args
                                        in
-                                    uu____15486 FStar_Pervasives_Native.None
+                                    uu____15492 FStar_Pervasives_Native.None
                                       t.FStar_Syntax_Syntax.pos
                                      in
-                                  let uu____15492 = FStar_List.tl stack  in
-                                  norm cfg env uu____15492 t1))
-                        | uu____15493 -> fallback1 ()))
+                                  let uu____15498 = FStar_List.tl stack  in
+                                  norm cfg env uu____15498 t1))
+                        | uu____15499 -> fallback1 ()))
                   | FStar_Syntax_Syntax.Tm_meta
-                      (e,FStar_Syntax_Syntax.Meta_monadic uu____15495) ->
+                      (e,FStar_Syntax_Syntax.Meta_monadic uu____15501) ->
                       do_reify_monadic fallback cfg env stack e m t
                   | FStar_Syntax_Syntax.Tm_meta
                       (e,FStar_Syntax_Syntax.Meta_monadic_lift
                        (msrc,mtgt,t'))
                       ->
                       let lifted =
-                        let uu____15519 = closure_as_term cfg env t'  in
-                        reify_lift cfg e msrc mtgt uu____15519  in
+                        let uu____15525 = closure_as_term cfg env t'  in
+                        reify_lift cfg e msrc mtgt uu____15525  in
                       (FStar_TypeChecker_Cfg.log cfg
-                         (fun uu____15523  ->
-                            let uu____15524 =
+                         (fun uu____15529  ->
+                            let uu____15530 =
                               FStar_Syntax_Print.term_to_string lifted  in
                             FStar_Util.print1 "Reified lift to (2): %s\n"
-                              uu____15524);
-                       (let uu____15527 = FStar_List.tl stack  in
-                        norm cfg env uu____15527 lifted))
+                              uu____15530);
+                       (let uu____15533 = FStar_List.tl stack  in
+                        norm cfg env uu____15533 lifted))
                   | FStar_Syntax_Syntax.Tm_match (e,branches) ->
                       let branches1 =
                         FStar_All.pipe_right branches
                           (FStar_List.map
-                             (fun uu____15648  ->
-                                match uu____15648 with
+                             (fun uu____15654  ->
+                                match uu____15654 with
                                 | (pat,wopt,tm) ->
-                                    let uu____15696 =
+                                    let uu____15702 =
                                       FStar_Syntax_Util.mk_reify tm  in
-                                    (pat, wopt, uu____15696)))
+                                    (pat, wopt, uu____15702)))
                          in
                       let tm =
                         mk (FStar_Syntax_Syntax.Tm_match (e, branches1))
                           head3.FStar_Syntax_Syntax.pos
                          in
-                      let uu____15728 = FStar_List.tl stack  in
-                      norm cfg env uu____15728 tm
-                  | uu____15729 -> fallback ()))
+                      let uu____15734 = FStar_List.tl stack  in
+                      norm cfg env uu____15734 tm
+                  | uu____15735 -> fallback ()))
 
 and (reify_lift :
   FStar_TypeChecker_Cfg.cfg ->
@@ -5207,108 +5209,108 @@ and (reify_lift :
           fun t  ->
             let env = cfg.FStar_TypeChecker_Cfg.tcenv  in
             FStar_TypeChecker_Cfg.log cfg
-              (fun uu____15743  ->
-                 let uu____15744 = FStar_Ident.string_of_lid msrc  in
-                 let uu____15746 = FStar_Ident.string_of_lid mtgt  in
-                 let uu____15748 = FStar_Syntax_Print.term_to_string e  in
-                 FStar_Util.print3 "Reifying lift %s -> %s: %s\n" uu____15744
-                   uu____15746 uu____15748);
-            (let uu____15751 =
+              (fun uu____15749  ->
+                 let uu____15750 = FStar_Ident.string_of_lid msrc  in
+                 let uu____15752 = FStar_Ident.string_of_lid mtgt  in
+                 let uu____15754 = FStar_Syntax_Print.term_to_string e  in
+                 FStar_Util.print3 "Reifying lift %s -> %s: %s\n" uu____15750
+                   uu____15752 uu____15754);
+            (let uu____15757 =
                (FStar_Syntax_Util.is_pure_effect msrc) ||
                  (FStar_Syntax_Util.is_div_effect msrc)
                 in
-             if uu____15751
+             if uu____15757
              then
                let ed =
-                 let uu____15755 =
+                 let uu____15761 =
                    FStar_TypeChecker_Env.norm_eff_name
                      cfg.FStar_TypeChecker_Cfg.tcenv mtgt
                     in
-                 FStar_TypeChecker_Env.get_effect_decl env uu____15755  in
-               let uu____15756 = ed.FStar_Syntax_Syntax.return_repr  in
-               match uu____15756 with
-               | (uu____15757,return_repr) ->
+                 FStar_TypeChecker_Env.get_effect_decl env uu____15761  in
+               let uu____15762 = ed.FStar_Syntax_Syntax.return_repr  in
+               match uu____15762 with
+               | (uu____15763,return_repr) ->
                    let return_inst =
-                     let uu____15770 =
-                       let uu____15771 =
+                     let uu____15776 =
+                       let uu____15777 =
                          FStar_Syntax_Subst.compress return_repr  in
-                       uu____15771.FStar_Syntax_Syntax.n  in
-                     match uu____15770 with
+                       uu____15777.FStar_Syntax_Syntax.n  in
+                     match uu____15776 with
                      | FStar_Syntax_Syntax.Tm_uinst
-                         (return_tm,uu____15777::[]) ->
-                         let uu____15782 =
-                           let uu____15789 =
-                             let uu____15790 =
-                               let uu____15797 =
-                                 let uu____15798 =
+                         (return_tm,uu____15783::[]) ->
+                         let uu____15788 =
+                           let uu____15795 =
+                             let uu____15796 =
+                               let uu____15803 =
+                                 let uu____15804 =
                                    env.FStar_TypeChecker_Env.universe_of env
                                      t
                                     in
-                                 [uu____15798]  in
-                               (return_tm, uu____15797)  in
-                             FStar_Syntax_Syntax.Tm_uinst uu____15790  in
-                           FStar_Syntax_Syntax.mk uu____15789  in
-                         uu____15782 FStar_Pervasives_Native.None
+                                 [uu____15804]  in
+                               (return_tm, uu____15803)  in
+                             FStar_Syntax_Syntax.Tm_uinst uu____15796  in
+                           FStar_Syntax_Syntax.mk uu____15795  in
+                         uu____15788 FStar_Pervasives_Native.None
                            e.FStar_Syntax_Syntax.pos
-                     | uu____15801 ->
+                     | uu____15807 ->
                          failwith "NIY : Reification of indexed effects"
                       in
-                   let uu____15805 =
-                     let uu____15812 =
-                       let uu____15813 =
-                         let uu____15830 =
-                           let uu____15841 = FStar_Syntax_Syntax.as_arg t  in
-                           let uu____15850 =
-                             let uu____15861 = FStar_Syntax_Syntax.as_arg e
+                   let uu____15811 =
+                     let uu____15818 =
+                       let uu____15819 =
+                         let uu____15836 =
+                           let uu____15847 = FStar_Syntax_Syntax.as_arg t  in
+                           let uu____15856 =
+                             let uu____15867 = FStar_Syntax_Syntax.as_arg e
                                 in
-                             [uu____15861]  in
-                           uu____15841 :: uu____15850  in
-                         (return_inst, uu____15830)  in
-                       FStar_Syntax_Syntax.Tm_app uu____15813  in
-                     FStar_Syntax_Syntax.mk uu____15812  in
-                   uu____15805 FStar_Pervasives_Native.None
+                             [uu____15867]  in
+                           uu____15847 :: uu____15856  in
+                         (return_inst, uu____15836)  in
+                       FStar_Syntax_Syntax.Tm_app uu____15819  in
+                     FStar_Syntax_Syntax.mk uu____15818  in
+                   uu____15811 FStar_Pervasives_Native.None
                      e.FStar_Syntax_Syntax.pos
              else
-               (let uu____15908 =
+               (let uu____15914 =
                   FStar_TypeChecker_Env.monad_leq env msrc mtgt  in
-                match uu____15908 with
+                match uu____15914 with
                 | FStar_Pervasives_Native.None  ->
-                    let uu____15911 =
-                      let uu____15913 = FStar_Ident.text_of_lid msrc  in
-                      let uu____15915 = FStar_Ident.text_of_lid mtgt  in
+                    let uu____15917 =
+                      let uu____15919 = FStar_Ident.text_of_lid msrc  in
+                      let uu____15921 = FStar_Ident.text_of_lid mtgt  in
                       FStar_Util.format2
                         "Impossible : trying to reify a lift between unrelated effects (%s and %s)"
-                        uu____15913 uu____15915
+                        uu____15919 uu____15921
                        in
-                    failwith uu____15911
+                    failwith uu____15917
                 | FStar_Pervasives_Native.Some
-                    { FStar_TypeChecker_Env.msource = uu____15918;
-                      FStar_TypeChecker_Env.mtarget = uu____15919;
+                    { FStar_TypeChecker_Env.msource = uu____15924;
+                      FStar_TypeChecker_Env.mtarget = uu____15925;
                       FStar_TypeChecker_Env.mlift =
-                        { FStar_TypeChecker_Env.mlift_wp = uu____15920;
+                        { FStar_TypeChecker_Env.mlift_wp = uu____15926;
                           FStar_TypeChecker_Env.mlift_term =
                             FStar_Pervasives_Native.None ;_};_}
                     ->
-                    let uu____15942 =
-                      let uu____15944 = FStar_Ident.text_of_lid msrc  in
-                      let uu____15946 = FStar_Ident.text_of_lid mtgt  in
+                    let uu____15948 =
+                      let uu____15950 = FStar_Ident.text_of_lid msrc  in
+                      let uu____15952 = FStar_Ident.text_of_lid mtgt  in
                       FStar_Util.format2
                         "Impossible : trying to reify a non-reifiable lift (from %s to %s)"
-                        uu____15944 uu____15946
+                        uu____15950 uu____15952
                        in
-                    failwith uu____15942
+                    failwith uu____15948
                 | FStar_Pervasives_Native.Some
-                    { FStar_TypeChecker_Env.msource = uu____15949;
-                      FStar_TypeChecker_Env.mtarget = uu____15950;
+                    { FStar_TypeChecker_Env.msource = uu____15955;
+                      FStar_TypeChecker_Env.mtarget = uu____15956;
                       FStar_TypeChecker_Env.mlift =
-                        { FStar_TypeChecker_Env.mlift_wp = uu____15951;
+                        { FStar_TypeChecker_Env.mlift_wp = uu____15957;
                           FStar_TypeChecker_Env.mlift_term =
                             FStar_Pervasives_Native.Some lift;_};_}
                     ->
-                    let uu____15986 =
+                    let uu____15992 =
                       env.FStar_TypeChecker_Env.universe_of env t  in
-                    let uu____15987 = FStar_Syntax_Util.mk_reify e  in
-                    lift uu____15986 t FStar_Syntax_Syntax.tun uu____15987))
+                    let uu____15993 = FStar_Syntax_Util.mk_reify e  in
+                    lift uu____15992 t FStar_Syntax_Syntax.tun uu____15993))
 
 and (norm_pattern_args :
   FStar_TypeChecker_Cfg.cfg ->
@@ -5326,11 +5328,11 @@ and (norm_pattern_args :
         FStar_All.pipe_right args
           (FStar_List.map
              (FStar_List.map
-                (fun uu____16057  ->
-                   match uu____16057 with
+                (fun uu____16063  ->
+                   match uu____16063 with
                    | (a,imp) ->
-                       let uu____16076 = norm cfg env [] a  in
-                       (uu____16076, imp))))
+                       let uu____16082 = norm cfg env [] a  in
+                       (uu____16082, imp))))
 
 and (norm_comp :
   FStar_TypeChecker_Cfg.cfg ->
@@ -5340,75 +5342,75 @@ and (norm_comp :
     fun env  ->
       fun comp  ->
         FStar_TypeChecker_Cfg.log cfg
-          (fun uu____16086  ->
-             let uu____16087 = FStar_Syntax_Print.comp_to_string comp  in
-             let uu____16089 =
+          (fun uu____16092  ->
+             let uu____16093 = FStar_Syntax_Print.comp_to_string comp  in
+             let uu____16095 =
                FStar_Util.string_of_int (FStar_List.length env)  in
              FStar_Util.print2 ">>> %s\nNormComp with with %s env elements\n"
-               uu____16087 uu____16089);
+               uu____16093 uu____16095);
         (match comp.FStar_Syntax_Syntax.n with
          | FStar_Syntax_Syntax.Total (t,uopt) ->
              let t1 = norm cfg env [] t  in
              let uopt1 =
                match uopt with
                | FStar_Pervasives_Native.Some u ->
-                   let uu____16115 = norm_universe cfg env u  in
+                   let uu____16121 = norm_universe cfg env u  in
                    FStar_All.pipe_left
-                     (fun _16118  -> FStar_Pervasives_Native.Some _16118)
-                     uu____16115
+                     (fun _16124  -> FStar_Pervasives_Native.Some _16124)
+                     uu____16121
                | FStar_Pervasives_Native.None  ->
                    FStar_Pervasives_Native.None
                 in
-             let uu___2043_16119 = comp  in
+             let uu___2045_16125 = comp  in
              {
                FStar_Syntax_Syntax.n =
                  (FStar_Syntax_Syntax.Total (t1, uopt1));
                FStar_Syntax_Syntax.pos =
-                 (uu___2043_16119.FStar_Syntax_Syntax.pos);
+                 (uu___2045_16125.FStar_Syntax_Syntax.pos);
                FStar_Syntax_Syntax.vars =
-                 (uu___2043_16119.FStar_Syntax_Syntax.vars)
+                 (uu___2045_16125.FStar_Syntax_Syntax.vars)
              }
          | FStar_Syntax_Syntax.GTotal (t,uopt) ->
              let t1 = norm cfg env [] t  in
              let uopt1 =
                match uopt with
                | FStar_Pervasives_Native.Some u ->
-                   let uu____16141 = norm_universe cfg env u  in
+                   let uu____16147 = norm_universe cfg env u  in
                    FStar_All.pipe_left
-                     (fun _16144  -> FStar_Pervasives_Native.Some _16144)
-                     uu____16141
+                     (fun _16150  -> FStar_Pervasives_Native.Some _16150)
+                     uu____16147
                | FStar_Pervasives_Native.None  ->
                    FStar_Pervasives_Native.None
                 in
-             let uu___2054_16145 = comp  in
+             let uu___2056_16151 = comp  in
              {
                FStar_Syntax_Syntax.n =
                  (FStar_Syntax_Syntax.GTotal (t1, uopt1));
                FStar_Syntax_Syntax.pos =
-                 (uu___2054_16145.FStar_Syntax_Syntax.pos);
+                 (uu___2056_16151.FStar_Syntax_Syntax.pos);
                FStar_Syntax_Syntax.vars =
-                 (uu___2054_16145.FStar_Syntax_Syntax.vars)
+                 (uu___2056_16151.FStar_Syntax_Syntax.vars)
              }
          | FStar_Syntax_Syntax.Comp ct ->
              let norm_args =
                FStar_List.mapi
                  (fun idx  ->
-                    fun uu____16190  ->
-                      match uu____16190 with
+                    fun uu____16196  ->
+                      match uu____16196 with
                       | (a,i) ->
-                          let uu____16210 = norm cfg env [] a  in
-                          (uu____16210, i))
+                          let uu____16216 = norm cfg env [] a  in
+                          (uu____16216, i))
                 in
              let effect_args = norm_args ct.FStar_Syntax_Syntax.effect_args
                 in
              let flags =
                FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags
                  (FStar_List.map
-                    (fun uu___14_16232  ->
-                       match uu___14_16232 with
+                    (fun uu___14_16238  ->
+                       match uu___14_16238 with
                        | FStar_Syntax_Syntax.DECREASES t ->
-                           let uu____16236 = norm cfg env [] t  in
-                           FStar_Syntax_Syntax.DECREASES uu____16236
+                           let uu____16242 = norm cfg env [] t  in
+                           FStar_Syntax_Syntax.DECREASES uu____16242
                        | f -> f))
                 in
              let comp_univs =
@@ -5417,23 +5419,23 @@ and (norm_comp :
                 in
              let result_typ =
                norm cfg env [] ct.FStar_Syntax_Syntax.result_typ  in
-             let uu___2071_16244 = comp  in
+             let uu___2073_16250 = comp  in
              {
                FStar_Syntax_Syntax.n =
                  (FStar_Syntax_Syntax.Comp
-                    (let uu___2073_16247 = ct  in
+                    (let uu___2075_16253 = ct  in
                      {
                        FStar_Syntax_Syntax.comp_univs = comp_univs;
                        FStar_Syntax_Syntax.effect_name =
-                         (uu___2073_16247.FStar_Syntax_Syntax.effect_name);
+                         (uu___2075_16253.FStar_Syntax_Syntax.effect_name);
                        FStar_Syntax_Syntax.result_typ = result_typ;
                        FStar_Syntax_Syntax.effect_args = effect_args;
                        FStar_Syntax_Syntax.flags = flags
                      }));
                FStar_Syntax_Syntax.pos =
-                 (uu___2071_16244.FStar_Syntax_Syntax.pos);
+                 (uu___2073_16250.FStar_Syntax_Syntax.pos);
                FStar_Syntax_Syntax.vars =
-                 (uu___2071_16244.FStar_Syntax_Syntax.vars)
+                 (uu___2073_16250.FStar_Syntax_Syntax.vars)
              })
 
 and (norm_binder :
@@ -5443,27 +5445,27 @@ and (norm_binder :
   fun cfg  ->
     fun env  ->
       fun b  ->
-        let uu____16251 = b  in
-        match uu____16251 with
+        let uu____16257 = b  in
+        match uu____16257 with
         | (x,imp) ->
             let x1 =
-              let uu___2081_16259 = x  in
-              let uu____16260 = norm cfg env [] x.FStar_Syntax_Syntax.sort
+              let uu___2083_16265 = x  in
+              let uu____16266 = norm cfg env [] x.FStar_Syntax_Syntax.sort
                  in
               {
                 FStar_Syntax_Syntax.ppname =
-                  (uu___2081_16259.FStar_Syntax_Syntax.ppname);
+                  (uu___2083_16265.FStar_Syntax_Syntax.ppname);
                 FStar_Syntax_Syntax.index =
-                  (uu___2081_16259.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu____16260
+                  (uu___2083_16265.FStar_Syntax_Syntax.index);
+                FStar_Syntax_Syntax.sort = uu____16266
               }  in
             let imp1 =
               match imp with
               | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta t) ->
-                  let uu____16271 =
-                    let uu____16272 = closure_as_term cfg env t  in
-                    FStar_Syntax_Syntax.Meta uu____16272  in
-                  FStar_Pervasives_Native.Some uu____16271
+                  let uu____16277 =
+                    let uu____16278 = closure_as_term cfg env t  in
+                    FStar_Syntax_Syntax.Meta uu____16278  in
+                  FStar_Pervasives_Native.Some uu____16277
               | i -> i  in
             (x1, imp1)
 
@@ -5474,16 +5476,16 @@ and (norm_binders :
   fun cfg  ->
     fun env  ->
       fun bs  ->
-        let uu____16283 =
+        let uu____16289 =
           FStar_List.fold_left
-            (fun uu____16317  ->
+            (fun uu____16323  ->
                fun b  ->
-                 match uu____16317 with
+                 match uu____16323 with
                  | (nbs',env1) ->
                      let b1 = norm_binder cfg env1 b  in
                      ((b1 :: nbs'), (dummy :: env1))) ([], env) bs
            in
-        match uu____16283 with | (nbs,uu____16397) -> FStar_List.rev nbs
+        match uu____16289 with | (nbs,uu____16403) -> FStar_List.rev nbs
 
 and (norm_lcomp_opt :
   FStar_TypeChecker_Cfg.cfg ->
@@ -5499,21 +5501,21 @@ and (norm_lcomp_opt :
             let flags =
               filter_out_lcomp_cflags rc.FStar_Syntax_Syntax.residual_flags
                in
-            let uu____16429 =
-              let uu___2106_16430 = rc  in
-              let uu____16431 =
+            let uu____16435 =
+              let uu___2108_16436 = rc  in
+              let uu____16437 =
                 FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
                   (norm cfg env [])
                  in
               {
                 FStar_Syntax_Syntax.residual_effect =
-                  (uu___2106_16430.FStar_Syntax_Syntax.residual_effect);
-                FStar_Syntax_Syntax.residual_typ = uu____16431;
+                  (uu___2108_16436.FStar_Syntax_Syntax.residual_effect);
+                FStar_Syntax_Syntax.residual_typ = uu____16437;
                 FStar_Syntax_Syntax.residual_flags =
-                  (uu___2106_16430.FStar_Syntax_Syntax.residual_flags)
+                  (uu___2108_16436.FStar_Syntax_Syntax.residual_flags)
               }  in
-            FStar_Pervasives_Native.Some uu____16429
-        | uu____16440 -> lopt
+            FStar_Pervasives_Native.Some uu____16435
+        | uu____16446 -> lopt
 
 and (maybe_simplify :
   FStar_TypeChecker_Cfg.cfg ->
@@ -5526,36 +5528,36 @@ and (maybe_simplify :
           let tm' = maybe_simplify_aux cfg env stack tm  in
           if (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.b380
           then
-            (let uu____16450 = FStar_Syntax_Print.term_to_string tm  in
-             let uu____16452 = FStar_Syntax_Print.term_to_string tm'  in
+            (let uu____16456 = FStar_Syntax_Print.term_to_string tm  in
+             let uu____16458 = FStar_Syntax_Print.term_to_string tm'  in
              FStar_Util.print3 "%sSimplified\n\t%s to\n\t%s\n"
                (if
                   (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify
                 then ""
-                else "NOT ") uu____16450 uu____16452)
+                else "NOT ") uu____16456 uu____16458)
           else ();
           tm'
 
 and (norm_cb : FStar_TypeChecker_Cfg.cfg -> FStar_Syntax_Embeddings.norm_cb)
   =
   fun cfg  ->
-    fun uu___15_16464  ->
-      match uu___15_16464 with
+    fun uu___15_16470  ->
+      match uu___15_16470 with
       | FStar_Util.Inr x -> norm cfg [] [] x
       | FStar_Util.Inl l ->
-          let uu____16477 =
+          let uu____16483 =
             FStar_Syntax_DsEnv.try_lookup_lid
               (cfg.FStar_TypeChecker_Cfg.tcenv).FStar_TypeChecker_Env.dsenv l
              in
-          (match uu____16477 with
+          (match uu____16483 with
            | FStar_Pervasives_Native.Some t -> t
            | FStar_Pervasives_Native.None  ->
-               let uu____16481 =
+               let uu____16487 =
                  FStar_Syntax_Syntax.lid_as_fv l
                    FStar_Syntax_Syntax.delta_constant
                    FStar_Pervasives_Native.None
                   in
-               FStar_Syntax_Syntax.fv_to_tm uu____16481)
+               FStar_Syntax_Syntax.fv_to_tm uu____16487)
 
 and (maybe_simplify_aux :
   FStar_TypeChecker_Cfg.cfg ->
@@ -5566,29 +5568,29 @@ and (maybe_simplify_aux :
       fun stack  ->
         fun tm  ->
           let tm1 =
-            let uu____16489 = norm_cb cfg  in
-            reduce_primops uu____16489 cfg env tm  in
-          let uu____16494 =
+            let uu____16495 = norm_cb cfg  in
+            reduce_primops uu____16495 cfg env tm  in
+          let uu____16500 =
             FStar_All.pipe_left Prims.op_Negation
               (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify
              in
-          if uu____16494
+          if uu____16500
           then tm1
           else
             (let w t =
-               let uu___2134_16513 = t  in
+               let uu___2136_16519 = t  in
                {
                  FStar_Syntax_Syntax.n =
-                   (uu___2134_16513.FStar_Syntax_Syntax.n);
+                   (uu___2136_16519.FStar_Syntax_Syntax.n);
                  FStar_Syntax_Syntax.pos = (tm1.FStar_Syntax_Syntax.pos);
                  FStar_Syntax_Syntax.vars =
-                   (uu___2134_16513.FStar_Syntax_Syntax.vars)
+                   (uu___2136_16519.FStar_Syntax_Syntax.vars)
                }  in
              let simp_t t =
-               let uu____16525 =
-                 let uu____16526 = FStar_Syntax_Util.unmeta t  in
-                 uu____16526.FStar_Syntax_Syntax.n  in
-               match uu____16525 with
+               let uu____16531 =
+                 let uu____16532 = FStar_Syntax_Util.unmeta t  in
+                 uu____16532.FStar_Syntax_Syntax.n  in
+               match uu____16531 with
                | FStar_Syntax_Syntax.Tm_fvar fv when
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.true_lid
@@ -5597,145 +5599,145 @@ and (maybe_simplify_aux :
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.false_lid
                    -> FStar_Pervasives_Native.Some false
-               | uu____16538 -> FStar_Pervasives_Native.None  in
+               | uu____16544 -> FStar_Pervasives_Native.None  in
              let rec args_are_binders args bs =
                match (args, bs) with
-               | ((t,uu____16602)::args1,(bv,uu____16605)::bs1) ->
-                   let uu____16659 =
-                     let uu____16660 = FStar_Syntax_Subst.compress t  in
-                     uu____16660.FStar_Syntax_Syntax.n  in
-                   (match uu____16659 with
+               | ((t,uu____16608)::args1,(bv,uu____16611)::bs1) ->
+                   let uu____16665 =
+                     let uu____16666 = FStar_Syntax_Subst.compress t  in
+                     uu____16666.FStar_Syntax_Syntax.n  in
+                   (match uu____16665 with
                     | FStar_Syntax_Syntax.Tm_name bv' ->
                         (FStar_Syntax_Syntax.bv_eq bv bv') &&
                           (args_are_binders args1 bs1)
-                    | uu____16665 -> false)
+                    | uu____16671 -> false)
                | ([],[]) -> true
-               | (uu____16696,uu____16697) -> false  in
+               | (uu____16702,uu____16703) -> false  in
              let is_applied bs t =
                if (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                then
-                 (let uu____16748 = FStar_Syntax_Print.term_to_string t  in
-                  let uu____16750 = FStar_Syntax_Print.tag_of_term t  in
-                  FStar_Util.print2 "WPE> is_applied %s -- %s\n" uu____16748
-                    uu____16750)
+                 (let uu____16754 = FStar_Syntax_Print.term_to_string t  in
+                  let uu____16756 = FStar_Syntax_Print.tag_of_term t  in
+                  FStar_Util.print2 "WPE> is_applied %s -- %s\n" uu____16754
+                    uu____16756)
                else ();
-               (let uu____16755 = FStar_Syntax_Util.head_and_args' t  in
-                match uu____16755 with
+               (let uu____16761 = FStar_Syntax_Util.head_and_args' t  in
+                match uu____16761 with
                 | (hd1,args) ->
-                    let uu____16794 =
-                      let uu____16795 = FStar_Syntax_Subst.compress hd1  in
-                      uu____16795.FStar_Syntax_Syntax.n  in
-                    (match uu____16794 with
+                    let uu____16800 =
+                      let uu____16801 = FStar_Syntax_Subst.compress hd1  in
+                      uu____16801.FStar_Syntax_Syntax.n  in
+                    (match uu____16800 with
                      | FStar_Syntax_Syntax.Tm_name bv when
                          args_are_binders args bs ->
                          (if
                             (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                           then
-                            (let uu____16803 =
+                            (let uu____16809 =
                                FStar_Syntax_Print.term_to_string t  in
-                             let uu____16805 =
+                             let uu____16811 =
                                FStar_Syntax_Print.bv_to_string bv  in
-                             let uu____16807 =
+                             let uu____16813 =
                                FStar_Syntax_Print.term_to_string hd1  in
                              FStar_Util.print3
                                "WPE> got it\n>>>>top = %s\n>>>>b = %s\n>>>>hd = %s\n"
-                               uu____16803 uu____16805 uu____16807)
+                               uu____16809 uu____16811 uu____16813)
                           else ();
                           FStar_Pervasives_Native.Some bv)
-                     | uu____16812 -> FStar_Pervasives_Native.None))
+                     | uu____16818 -> FStar_Pervasives_Native.None))
                 in
              let is_applied_maybe_squashed bs t =
                if (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                then
-                 (let uu____16830 = FStar_Syntax_Print.term_to_string t  in
-                  let uu____16832 = FStar_Syntax_Print.tag_of_term t  in
+                 (let uu____16836 = FStar_Syntax_Print.term_to_string t  in
+                  let uu____16838 = FStar_Syntax_Print.tag_of_term t  in
                   FStar_Util.print2
-                    "WPE> is_applied_maybe_squashed %s -- %s\n" uu____16830
-                    uu____16832)
+                    "WPE> is_applied_maybe_squashed %s -- %s\n" uu____16836
+                    uu____16838)
                else ();
-               (let uu____16837 = FStar_Syntax_Util.is_squash t  in
-                match uu____16837 with
-                | FStar_Pervasives_Native.Some (uu____16848,t') ->
+               (let uu____16843 = FStar_Syntax_Util.is_squash t  in
+                match uu____16843 with
+                | FStar_Pervasives_Native.Some (uu____16854,t') ->
                     is_applied bs t'
-                | uu____16860 ->
-                    let uu____16869 = FStar_Syntax_Util.is_auto_squash t  in
-                    (match uu____16869 with
-                     | FStar_Pervasives_Native.Some (uu____16880,t') ->
+                | uu____16866 ->
+                    let uu____16875 = FStar_Syntax_Util.is_auto_squash t  in
+                    (match uu____16875 with
+                     | FStar_Pervasives_Native.Some (uu____16886,t') ->
                          is_applied bs t'
-                     | uu____16892 -> is_applied bs t))
+                     | uu____16898 -> is_applied bs t))
                 in
              let is_quantified_const bv phi =
-               let uu____16916 =
+               let uu____16922 =
                  FStar_Syntax_Util.destruct_typ_as_formula phi  in
-               match uu____16916 with
+               match uu____16922 with
                | FStar_Pervasives_Native.Some (FStar_Syntax_Util.BaseConn
-                   (lid,(p,uu____16923)::(q,uu____16925)::[])) when
+                   (lid,(p,uu____16929)::(q,uu____16931)::[])) when
                    FStar_Ident.lid_equals lid FStar_Parser_Const.imp_lid ->
                    (if
                       (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                     then
-                      (let uu____16968 = FStar_Syntax_Print.term_to_string p
+                      (let uu____16974 = FStar_Syntax_Print.term_to_string p
                           in
-                       let uu____16970 = FStar_Syntax_Print.term_to_string q
+                       let uu____16976 = FStar_Syntax_Print.term_to_string q
                           in
                        FStar_Util.print2 "WPE> p = (%s); q = (%s)\n"
-                         uu____16968 uu____16970)
+                         uu____16974 uu____16976)
                     else ();
-                    (let uu____16975 =
+                    (let uu____16981 =
                        FStar_Syntax_Util.destruct_typ_as_formula p  in
-                     match uu____16975 with
+                     match uu____16981 with
                      | FStar_Pervasives_Native.None  ->
-                         let uu____16980 =
-                           let uu____16981 = FStar_Syntax_Subst.compress p
+                         let uu____16986 =
+                           let uu____16987 = FStar_Syntax_Subst.compress p
                               in
-                           uu____16981.FStar_Syntax_Syntax.n  in
-                         (match uu____16980 with
+                           uu____16987.FStar_Syntax_Syntax.n  in
+                         (match uu____16986 with
                           | FStar_Syntax_Syntax.Tm_bvar bv' when
                               FStar_Syntax_Syntax.bv_eq bv bv' ->
                               (if
                                  (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                                then FStar_Util.print_string "WPE> Case 1\n"
                                else ();
-                               (let uu____16992 =
+                               (let uu____16998 =
                                   FStar_Syntax_Subst.subst
                                     [FStar_Syntax_Syntax.NT
                                        (bv, FStar_Syntax_Util.t_true)] q
                                    in
-                                FStar_Pervasives_Native.Some uu____16992))
-                          | uu____16995 -> FStar_Pervasives_Native.None)
+                                FStar_Pervasives_Native.Some uu____16998))
+                          | uu____17001 -> FStar_Pervasives_Native.None)
                      | FStar_Pervasives_Native.Some
                          (FStar_Syntax_Util.BaseConn
-                         (lid1,(p1,uu____16998)::[])) when
+                         (lid1,(p1,uu____17004)::[])) when
                          FStar_Ident.lid_equals lid1
                            FStar_Parser_Const.not_lid
                          ->
-                         let uu____17023 =
-                           let uu____17024 = FStar_Syntax_Subst.compress p1
+                         let uu____17029 =
+                           let uu____17030 = FStar_Syntax_Subst.compress p1
                               in
-                           uu____17024.FStar_Syntax_Syntax.n  in
-                         (match uu____17023 with
+                           uu____17030.FStar_Syntax_Syntax.n  in
+                         (match uu____17029 with
                           | FStar_Syntax_Syntax.Tm_bvar bv' when
                               FStar_Syntax_Syntax.bv_eq bv bv' ->
                               (if
                                  (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                                then FStar_Util.print_string "WPE> Case 2\n"
                                else ();
-                               (let uu____17035 =
+                               (let uu____17041 =
                                   FStar_Syntax_Subst.subst
                                     [FStar_Syntax_Syntax.NT
                                        (bv, FStar_Syntax_Util.t_false)] q
                                    in
-                                FStar_Pervasives_Native.Some uu____17035))
-                          | uu____17038 -> FStar_Pervasives_Native.None)
+                                FStar_Pervasives_Native.Some uu____17041))
+                          | uu____17044 -> FStar_Pervasives_Native.None)
                      | FStar_Pervasives_Native.Some (FStar_Syntax_Util.QAll
                          (bs,pats,phi1)) ->
-                         let uu____17042 =
+                         let uu____17048 =
                            FStar_Syntax_Util.destruct_typ_as_formula phi1  in
-                         (match uu____17042 with
+                         (match uu____17048 with
                           | FStar_Pervasives_Native.None  ->
-                              let uu____17047 =
+                              let uu____17053 =
                                 is_applied_maybe_squashed bs phi1  in
-                              (match uu____17047 with
+                              (match uu____17053 with
                                | FStar_Pervasives_Native.Some bv' when
                                    FStar_Syntax_Syntax.bv_eq bv bv' ->
                                    (if
@@ -5750,22 +5752,22 @@ and (maybe_simplify_aux :
                                             (FStar_Syntax_Util.residual_tot
                                                FStar_Syntax_Util.ktype0))
                                         in
-                                     let uu____17061 =
+                                     let uu____17067 =
                                        FStar_Syntax_Subst.subst
                                          [FStar_Syntax_Syntax.NT (bv, ftrue)]
                                          q
                                         in
-                                     FStar_Pervasives_Native.Some uu____17061))
-                               | uu____17064 -> FStar_Pervasives_Native.None)
+                                     FStar_Pervasives_Native.Some uu____17067))
+                               | uu____17070 -> FStar_Pervasives_Native.None)
                           | FStar_Pervasives_Native.Some
                               (FStar_Syntax_Util.BaseConn
-                              (lid1,(p1,uu____17069)::[])) when
+                              (lid1,(p1,uu____17075)::[])) when
                               FStar_Ident.lid_equals lid1
                                 FStar_Parser_Const.not_lid
                               ->
-                              let uu____17094 =
+                              let uu____17100 =
                                 is_applied_maybe_squashed bs p1  in
-                              (match uu____17094 with
+                              (match uu____17100 with
                                | FStar_Pervasives_Native.Some bv' when
                                    FStar_Syntax_Syntax.bv_eq bv bv' ->
                                    (if
@@ -5780,86 +5782,86 @@ and (maybe_simplify_aux :
                                             (FStar_Syntax_Util.residual_tot
                                                FStar_Syntax_Util.ktype0))
                                         in
-                                     let uu____17108 =
+                                     let uu____17114 =
                                        FStar_Syntax_Subst.subst
                                          [FStar_Syntax_Syntax.NT (bv, ffalse)]
                                          q
                                         in
-                                     FStar_Pervasives_Native.Some uu____17108))
-                               | uu____17111 -> FStar_Pervasives_Native.None)
-                          | uu____17114 -> FStar_Pervasives_Native.None)
-                     | uu____17117 -> FStar_Pervasives_Native.None))
-               | uu____17120 -> FStar_Pervasives_Native.None  in
+                                     FStar_Pervasives_Native.Some uu____17114))
+                               | uu____17117 -> FStar_Pervasives_Native.None)
+                          | uu____17120 -> FStar_Pervasives_Native.None)
+                     | uu____17123 -> FStar_Pervasives_Native.None))
+               | uu____17126 -> FStar_Pervasives_Native.None  in
              let is_forall_const phi =
-               let uu____17133 =
+               let uu____17139 =
                  FStar_Syntax_Util.destruct_typ_as_formula phi  in
-               match uu____17133 with
+               match uu____17139 with
                | FStar_Pervasives_Native.Some (FStar_Syntax_Util.QAll
-                   ((bv,uu____17139)::[],uu____17140,phi')) ->
+                   ((bv,uu____17145)::[],uu____17146,phi')) ->
                    (if
                       (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                     then
-                      (let uu____17160 = FStar_Syntax_Print.bv_to_string bv
+                      (let uu____17166 = FStar_Syntax_Print.bv_to_string bv
                           in
-                       let uu____17162 =
+                       let uu____17168 =
                          FStar_Syntax_Print.term_to_string phi'  in
-                       FStar_Util.print2 "WPE> QAll [%s] %s\n" uu____17160
-                         uu____17162)
+                       FStar_Util.print2 "WPE> QAll [%s] %s\n" uu____17166
+                         uu____17168)
                     else ();
                     is_quantified_const bv phi')
-               | uu____17167 -> FStar_Pervasives_Native.None  in
+               | uu____17173 -> FStar_Pervasives_Native.None  in
              let is_const_match phi =
-               let uu____17182 =
-                 let uu____17183 = FStar_Syntax_Subst.compress phi  in
-                 uu____17183.FStar_Syntax_Syntax.n  in
-               match uu____17182 with
-               | FStar_Syntax_Syntax.Tm_match (uu____17189,br::brs) ->
-                   let uu____17256 = br  in
-                   (match uu____17256 with
-                    | (uu____17274,uu____17275,e) ->
+               let uu____17188 =
+                 let uu____17189 = FStar_Syntax_Subst.compress phi  in
+                 uu____17189.FStar_Syntax_Syntax.n  in
+               match uu____17188 with
+               | FStar_Syntax_Syntax.Tm_match (uu____17195,br::brs) ->
+                   let uu____17262 = br  in
+                   (match uu____17262 with
+                    | (uu____17280,uu____17281,e) ->
                         let r =
-                          let uu____17297 = simp_t e  in
-                          match uu____17297 with
+                          let uu____17303 = simp_t e  in
+                          match uu____17303 with
                           | FStar_Pervasives_Native.None  ->
                               FStar_Pervasives_Native.None
                           | FStar_Pervasives_Native.Some b ->
-                              let uu____17309 =
+                              let uu____17315 =
                                 FStar_List.for_all
-                                  (fun uu____17328  ->
-                                     match uu____17328 with
-                                     | (uu____17342,uu____17343,e') ->
-                                         let uu____17357 = simp_t e'  in
-                                         uu____17357 =
+                                  (fun uu____17334  ->
+                                     match uu____17334 with
+                                     | (uu____17348,uu____17349,e') ->
+                                         let uu____17363 = simp_t e'  in
+                                         uu____17363 =
                                            (FStar_Pervasives_Native.Some b))
                                   brs
                                  in
-                              if uu____17309
+                              if uu____17315
                               then FStar_Pervasives_Native.Some b
                               else FStar_Pervasives_Native.None
                            in
                         r)
-               | uu____17373 -> FStar_Pervasives_Native.None  in
+               | uu____17379 -> FStar_Pervasives_Native.None  in
              let maybe_auto_squash t =
-               let uu____17383 = FStar_Syntax_Util.is_sub_singleton t  in
-               if uu____17383
+               let uu____17389 = FStar_Syntax_Util.is_sub_singleton t  in
+               if uu____17389
                then t
                else
                  FStar_Syntax_Util.mk_auto_squash FStar_Syntax_Syntax.U_zero
                    t
                 in
              let squashed_head_un_auto_squash_args t =
-               let maybe_un_auto_squash_arg uu____17421 =
-                 match uu____17421 with
+               let maybe_un_auto_squash_arg uu____17427 =
+                 match uu____17427 with
                  | (t1,q) ->
-                     let uu____17442 = FStar_Syntax_Util.is_auto_squash t1
+                     let uu____17448 = FStar_Syntax_Util.is_auto_squash t1
                         in
-                     (match uu____17442 with
+                     (match uu____17448 with
                       | FStar_Pervasives_Native.Some
                           (FStar_Syntax_Syntax.U_zero ,t2) -> (t2, q)
-                      | uu____17474 -> (t1, q))
+                      | uu____17480 -> (t1, q))
                   in
-               let uu____17487 = FStar_Syntax_Util.head_and_args t  in
-               match uu____17487 with
+               let uu____17493 = FStar_Syntax_Util.head_and_args t  in
+               match uu____17493 with
                | (head1,args) ->
                    let args1 = FStar_List.map maybe_un_auto_squash_arg args
                       in
@@ -5867,13 +5869,13 @@ and (maybe_simplify_aux :
                      FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
                 in
              let rec clearly_inhabited ty =
-               let uu____17567 =
-                 let uu____17568 = FStar_Syntax_Util.unmeta ty  in
-                 uu____17568.FStar_Syntax_Syntax.n  in
-               match uu____17567 with
-               | FStar_Syntax_Syntax.Tm_uinst (t,uu____17573) ->
+               let uu____17573 =
+                 let uu____17574 = FStar_Syntax_Util.unmeta ty  in
+                 uu____17574.FStar_Syntax_Syntax.n  in
+               match uu____17573 with
+               | FStar_Syntax_Syntax.Tm_uinst (t,uu____17579) ->
                    clearly_inhabited t
-               | FStar_Syntax_Syntax.Tm_arrow (uu____17578,c) ->
+               | FStar_Syntax_Syntax.Tm_arrow (uu____17584,c) ->
                    clearly_inhabited (FStar_Syntax_Util.comp_result c)
                | FStar_Syntax_Syntax.Tm_fvar fv ->
                    let l = FStar_Syntax_Syntax.lid_of_fv fv  in
@@ -5882,249 +5884,249 @@ and (maybe_simplify_aux :
                       ||
                       (FStar_Ident.lid_equals l FStar_Parser_Const.string_lid))
                      || (FStar_Ident.lid_equals l FStar_Parser_Const.exn_lid)
-               | uu____17602 -> false  in
+               | uu____17608 -> false  in
              let simplify1 arg =
-               let uu____17635 = simp_t (FStar_Pervasives_Native.fst arg)  in
-               (uu____17635, arg)  in
-             let uu____17650 = is_forall_const tm1  in
-             match uu____17650 with
+               let uu____17641 = simp_t (FStar_Pervasives_Native.fst arg)  in
+               (uu____17641, arg)  in
+             let uu____17656 = is_forall_const tm1  in
+             match uu____17656 with
              | FStar_Pervasives_Native.Some tm' ->
                  (if
                     (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                   then
-                    (let uu____17656 = FStar_Syntax_Print.term_to_string tm1
+                    (let uu____17662 = FStar_Syntax_Print.term_to_string tm1
                         in
-                     let uu____17658 = FStar_Syntax_Print.term_to_string tm'
+                     let uu____17664 = FStar_Syntax_Print.term_to_string tm'
                         in
-                     FStar_Util.print2 "WPE> %s ~> %s\n" uu____17656
-                       uu____17658)
+                     FStar_Util.print2 "WPE> %s ~> %s\n" uu____17662
+                       uu____17664)
                   else ();
-                  (let uu____17663 = norm cfg env [] tm'  in
-                   maybe_simplify_aux cfg env stack uu____17663))
+                  (let uu____17669 = norm cfg env [] tm'  in
+                   maybe_simplify_aux cfg env stack uu____17669))
              | FStar_Pervasives_Native.None  ->
-                 let uu____17664 =
-                   let uu____17665 = FStar_Syntax_Subst.compress tm1  in
-                   uu____17665.FStar_Syntax_Syntax.n  in
-                 (match uu____17664 with
+                 let uu____17670 =
+                   let uu____17671 = FStar_Syntax_Subst.compress tm1  in
+                   uu____17671.FStar_Syntax_Syntax.n  in
+                 (match uu____17670 with
                   | FStar_Syntax_Syntax.Tm_app
                       ({
                          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uinst
                            ({
                               FStar_Syntax_Syntax.n =
                                 FStar_Syntax_Syntax.Tm_fvar fv;
-                              FStar_Syntax_Syntax.pos = uu____17669;
-                              FStar_Syntax_Syntax.vars = uu____17670;_},uu____17671);
-                         FStar_Syntax_Syntax.pos = uu____17672;
-                         FStar_Syntax_Syntax.vars = uu____17673;_},args)
+                              FStar_Syntax_Syntax.pos = uu____17675;
+                              FStar_Syntax_Syntax.vars = uu____17676;_},uu____17677);
+                         FStar_Syntax_Syntax.pos = uu____17678;
+                         FStar_Syntax_Syntax.vars = uu____17679;_},args)
                       ->
-                      let uu____17703 =
+                      let uu____17709 =
                         FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.and_lid
                          in
-                      if uu____17703
+                      if uu____17709
                       then
-                        let uu____17706 =
+                        let uu____17712 =
                           FStar_All.pipe_right args
                             (FStar_List.map simplify1)
                            in
-                        (match uu____17706 with
-                         | (FStar_Pervasives_Native.Some (true ),uu____17764)::
-                             (uu____17765,(arg,uu____17767))::[] ->
+                        (match uu____17712 with
+                         | (FStar_Pervasives_Native.Some (true ),uu____17770)::
+                             (uu____17771,(arg,uu____17773))::[] ->
                              maybe_auto_squash arg
-                         | (uu____17840,(arg,uu____17842))::(FStar_Pervasives_Native.Some
+                         | (uu____17846,(arg,uu____17848))::(FStar_Pervasives_Native.Some
                                                              (true
-                                                             ),uu____17843)::[]
+                                                             ),uu____17849)::[]
                              -> maybe_auto_squash arg
                          | (FStar_Pervasives_Native.Some (false
-                            ),uu____17916)::uu____17917::[] ->
+                            ),uu____17922)::uu____17923::[] ->
                              w FStar_Syntax_Util.t_false
-                         | uu____17987::(FStar_Pervasives_Native.Some (false
-                                         ),uu____17988)::[]
+                         | uu____17993::(FStar_Pervasives_Native.Some (false
+                                         ),uu____17994)::[]
                              -> w FStar_Syntax_Util.t_false
-                         | uu____18058 ->
+                         | uu____18064 ->
                              squashed_head_un_auto_squash_args tm1)
                       else
-                        (let uu____18076 =
+                        (let uu____18082 =
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.or_lid
                             in
-                         if uu____18076
+                         if uu____18082
                          then
-                           let uu____18079 =
+                           let uu____18085 =
                              FStar_All.pipe_right args
                                (FStar_List.map simplify1)
                               in
-                           match uu____18079 with
+                           match uu____18085 with
                            | (FStar_Pervasives_Native.Some (true
-                              ),uu____18137)::uu____18138::[] ->
+                              ),uu____18143)::uu____18144::[] ->
                                w FStar_Syntax_Util.t_true
-                           | uu____18208::(FStar_Pervasives_Native.Some (true
-                                           ),uu____18209)::[]
+                           | uu____18214::(FStar_Pervasives_Native.Some (true
+                                           ),uu____18215)::[]
                                -> w FStar_Syntax_Util.t_true
                            | (FStar_Pervasives_Native.Some (false
-                              ),uu____18279)::(uu____18280,(arg,uu____18282))::[]
+                              ),uu____18285)::(uu____18286,(arg,uu____18288))::[]
                                -> maybe_auto_squash arg
-                           | (uu____18355,(arg,uu____18357))::(FStar_Pervasives_Native.Some
+                           | (uu____18361,(arg,uu____18363))::(FStar_Pervasives_Native.Some
                                                                (false
-                                                               ),uu____18358)::[]
+                                                               ),uu____18364)::[]
                                -> maybe_auto_squash arg
-                           | uu____18431 ->
+                           | uu____18437 ->
                                squashed_head_un_auto_squash_args tm1
                          else
-                           (let uu____18449 =
+                           (let uu____18455 =
                               FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.imp_lid
                                in
-                            if uu____18449
+                            if uu____18455
                             then
-                              let uu____18452 =
+                              let uu____18458 =
                                 FStar_All.pipe_right args
                                   (FStar_List.map simplify1)
                                  in
-                              match uu____18452 with
-                              | uu____18510::(FStar_Pervasives_Native.Some
-                                              (true ),uu____18511)::[]
+                              match uu____18458 with
+                              | uu____18516::(FStar_Pervasives_Native.Some
+                                              (true ),uu____18517)::[]
                                   -> w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (false
-                                 ),uu____18581)::uu____18582::[] ->
+                                 ),uu____18587)::uu____18588::[] ->
                                   w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (true
-                                 ),uu____18652)::(uu____18653,(arg,uu____18655))::[]
+                                 ),uu____18658)::(uu____18659,(arg,uu____18661))::[]
                                   -> maybe_auto_squash arg
-                              | (uu____18728,(p,uu____18730))::(uu____18731,
-                                                                (q,uu____18733))::[]
+                              | (uu____18734,(p,uu____18736))::(uu____18737,
+                                                                (q,uu____18739))::[]
                                   ->
-                                  let uu____18805 =
+                                  let uu____18811 =
                                     FStar_Syntax_Util.term_eq p q  in
-                                  (if uu____18805
+                                  (if uu____18811
                                    then w FStar_Syntax_Util.t_true
                                    else squashed_head_un_auto_squash_args tm1)
-                              | uu____18810 ->
+                              | uu____18816 ->
                                   squashed_head_un_auto_squash_args tm1
                             else
-                              (let uu____18828 =
+                              (let uu____18834 =
                                  FStar_Syntax_Syntax.fv_eq_lid fv
                                    FStar_Parser_Const.iff_lid
                                   in
-                               if uu____18828
+                               if uu____18834
                                then
-                                 let uu____18831 =
+                                 let uu____18837 =
                                    FStar_All.pipe_right args
                                      (FStar_List.map simplify1)
                                     in
-                                 match uu____18831 with
+                                 match uu____18837 with
                                  | (FStar_Pervasives_Native.Some (true
-                                    ),uu____18889)::(FStar_Pervasives_Native.Some
-                                                     (true ),uu____18890)::[]
+                                    ),uu____18895)::(FStar_Pervasives_Native.Some
+                                                     (true ),uu____18896)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (false
-                                    ),uu____18964)::(FStar_Pervasives_Native.Some
-                                                     (false ),uu____18965)::[]
+                                    ),uu____18970)::(FStar_Pervasives_Native.Some
+                                                     (false ),uu____18971)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (true
-                                    ),uu____19039)::(FStar_Pervasives_Native.Some
-                                                     (false ),uu____19040)::[]
+                                    ),uu____19045)::(FStar_Pervasives_Native.Some
+                                                     (false ),uu____19046)::[]
                                      -> w FStar_Syntax_Util.t_false
                                  | (FStar_Pervasives_Native.Some (false
-                                    ),uu____19114)::(FStar_Pervasives_Native.Some
-                                                     (true ),uu____19115)::[]
+                                    ),uu____19120)::(FStar_Pervasives_Native.Some
+                                                     (true ),uu____19121)::[]
                                      -> w FStar_Syntax_Util.t_false
-                                 | (uu____19189,(arg,uu____19191))::(FStar_Pervasives_Native.Some
+                                 | (uu____19195,(arg,uu____19197))::(FStar_Pervasives_Native.Some
                                                                     (true
-                                                                    ),uu____19192)::[]
+                                                                    ),uu____19198)::[]
                                      -> maybe_auto_squash arg
                                  | (FStar_Pervasives_Native.Some (true
-                                    ),uu____19265)::(uu____19266,(arg,uu____19268))::[]
+                                    ),uu____19271)::(uu____19272,(arg,uu____19274))::[]
                                      -> maybe_auto_squash arg
-                                 | (uu____19341,(arg,uu____19343))::(FStar_Pervasives_Native.Some
+                                 | (uu____19347,(arg,uu____19349))::(FStar_Pervasives_Native.Some
                                                                     (false
-                                                                    ),uu____19344)::[]
+                                                                    ),uu____19350)::[]
                                      ->
-                                     let uu____19417 =
+                                     let uu____19423 =
                                        FStar_Syntax_Util.mk_neg arg  in
-                                     maybe_auto_squash uu____19417
+                                     maybe_auto_squash uu____19423
                                  | (FStar_Pervasives_Native.Some (false
-                                    ),uu____19418)::(uu____19419,(arg,uu____19421))::[]
+                                    ),uu____19424)::(uu____19425,(arg,uu____19427))::[]
                                      ->
-                                     let uu____19494 =
+                                     let uu____19500 =
                                        FStar_Syntax_Util.mk_neg arg  in
-                                     maybe_auto_squash uu____19494
-                                 | (uu____19495,(p,uu____19497))::(uu____19498,
-                                                                   (q,uu____19500))::[]
+                                     maybe_auto_squash uu____19500
+                                 | (uu____19501,(p,uu____19503))::(uu____19504,
+                                                                   (q,uu____19506))::[]
                                      ->
-                                     let uu____19572 =
+                                     let uu____19578 =
                                        FStar_Syntax_Util.term_eq p q  in
-                                     (if uu____19572
+                                     (if uu____19578
                                       then w FStar_Syntax_Util.t_true
                                       else
                                         squashed_head_un_auto_squash_args tm1)
-                                 | uu____19577 ->
+                                 | uu____19583 ->
                                      squashed_head_un_auto_squash_args tm1
                                else
-                                 (let uu____19595 =
+                                 (let uu____19601 =
                                     FStar_Syntax_Syntax.fv_eq_lid fv
                                       FStar_Parser_Const.not_lid
                                      in
-                                  if uu____19595
+                                  if uu____19601
                                   then
-                                    let uu____19598 =
+                                    let uu____19604 =
                                       FStar_All.pipe_right args
                                         (FStar_List.map simplify1)
                                        in
-                                    match uu____19598 with
+                                    match uu____19604 with
                                     | (FStar_Pervasives_Native.Some (true
-                                       ),uu____19656)::[] ->
+                                       ),uu____19662)::[] ->
                                         w FStar_Syntax_Util.t_false
                                     | (FStar_Pervasives_Native.Some (false
-                                       ),uu____19700)::[] ->
+                                       ),uu____19706)::[] ->
                                         w FStar_Syntax_Util.t_true
-                                    | uu____19744 ->
+                                    | uu____19750 ->
                                         squashed_head_un_auto_squash_args tm1
                                   else
-                                    (let uu____19762 =
+                                    (let uu____19768 =
                                        FStar_Syntax_Syntax.fv_eq_lid fv
                                          FStar_Parser_Const.forall_lid
                                         in
-                                     if uu____19762
+                                     if uu____19768
                                      then
                                        match args with
-                                       | (t,uu____19766)::[] ->
-                                           let uu____19791 =
-                                             let uu____19792 =
+                                       | (t,uu____19772)::[] ->
+                                           let uu____19797 =
+                                             let uu____19798 =
                                                FStar_Syntax_Subst.compress t
                                                 in
-                                             uu____19792.FStar_Syntax_Syntax.n
+                                             uu____19798.FStar_Syntax_Syntax.n
                                               in
-                                           (match uu____19791 with
+                                           (match uu____19797 with
                                             | FStar_Syntax_Syntax.Tm_abs
-                                                (uu____19795::[],body,uu____19797)
+                                                (uu____19801::[],body,uu____19803)
                                                 ->
-                                                let uu____19832 = simp_t body
+                                                let uu____19838 = simp_t body
                                                    in
-                                                (match uu____19832 with
+                                                (match uu____19838 with
                                                  | FStar_Pervasives_Native.Some
                                                      (true ) ->
                                                      w
                                                        FStar_Syntax_Util.t_true
-                                                 | uu____19838 -> tm1)
-                                            | uu____19842 -> tm1)
+                                                 | uu____19844 -> tm1)
+                                            | uu____19848 -> tm1)
                                        | (ty,FStar_Pervasives_Native.Some
                                           (FStar_Syntax_Syntax.Implicit
-                                          uu____19844))::(t,uu____19846)::[]
+                                          uu____19850))::(t,uu____19852)::[]
                                            ->
-                                           let uu____19886 =
-                                             let uu____19887 =
+                                           let uu____19892 =
+                                             let uu____19893 =
                                                FStar_Syntax_Subst.compress t
                                                 in
-                                             uu____19887.FStar_Syntax_Syntax.n
+                                             uu____19893.FStar_Syntax_Syntax.n
                                               in
-                                           (match uu____19886 with
+                                           (match uu____19892 with
                                             | FStar_Syntax_Syntax.Tm_abs
-                                                (uu____19890::[],body,uu____19892)
+                                                (uu____19896::[],body,uu____19898)
                                                 ->
-                                                let uu____19927 = simp_t body
+                                                let uu____19933 = simp_t body
                                                    in
-                                                (match uu____19927 with
+                                                (match uu____19933 with
                                                  | FStar_Pervasives_Native.Some
                                                      (true ) ->
                                                      w
@@ -6134,56 +6136,56 @@ and (maybe_simplify_aux :
                                                      clearly_inhabited ty ->
                                                      w
                                                        FStar_Syntax_Util.t_false
-                                                 | uu____19935 -> tm1)
-                                            | uu____19939 -> tm1)
-                                       | uu____19940 -> tm1
+                                                 | uu____19941 -> tm1)
+                                            | uu____19945 -> tm1)
+                                       | uu____19946 -> tm1
                                      else
-                                       (let uu____19953 =
+                                       (let uu____19959 =
                                           FStar_Syntax_Syntax.fv_eq_lid fv
                                             FStar_Parser_Const.exists_lid
                                            in
-                                        if uu____19953
+                                        if uu____19959
                                         then
                                           match args with
-                                          | (t,uu____19957)::[] ->
-                                              let uu____19982 =
-                                                let uu____19983 =
+                                          | (t,uu____19963)::[] ->
+                                              let uu____19988 =
+                                                let uu____19989 =
                                                   FStar_Syntax_Subst.compress
                                                     t
                                                    in
-                                                uu____19983.FStar_Syntax_Syntax.n
+                                                uu____19989.FStar_Syntax_Syntax.n
                                                  in
-                                              (match uu____19982 with
+                                              (match uu____19988 with
                                                | FStar_Syntax_Syntax.Tm_abs
-                                                   (uu____19986::[],body,uu____19988)
+                                                   (uu____19992::[],body,uu____19994)
                                                    ->
-                                                   let uu____20023 =
+                                                   let uu____20029 =
                                                      simp_t body  in
-                                                   (match uu____20023 with
+                                                   (match uu____20029 with
                                                     | FStar_Pervasives_Native.Some
                                                         (false ) ->
                                                         w
                                                           FStar_Syntax_Util.t_false
-                                                    | uu____20029 -> tm1)
-                                               | uu____20033 -> tm1)
+                                                    | uu____20035 -> tm1)
+                                               | uu____20039 -> tm1)
                                           | (ty,FStar_Pervasives_Native.Some
                                              (FStar_Syntax_Syntax.Implicit
-                                             uu____20035))::(t,uu____20037)::[]
+                                             uu____20041))::(t,uu____20043)::[]
                                               ->
-                                              let uu____20077 =
-                                                let uu____20078 =
+                                              let uu____20083 =
+                                                let uu____20084 =
                                                   FStar_Syntax_Subst.compress
                                                     t
                                                    in
-                                                uu____20078.FStar_Syntax_Syntax.n
+                                                uu____20084.FStar_Syntax_Syntax.n
                                                  in
-                                              (match uu____20077 with
+                                              (match uu____20083 with
                                                | FStar_Syntax_Syntax.Tm_abs
-                                                   (uu____20081::[],body,uu____20083)
+                                                   (uu____20087::[],body,uu____20089)
                                                    ->
-                                                   let uu____20118 =
+                                                   let uu____20124 =
                                                      simp_t body  in
-                                                   (match uu____20118 with
+                                                   (match uu____20124 with
                                                     | FStar_Pervasives_Native.Some
                                                         (false ) ->
                                                         w
@@ -6194,15 +6196,15 @@ and (maybe_simplify_aux :
                                                         ->
                                                         w
                                                           FStar_Syntax_Util.t_true
-                                                    | uu____20126 -> tm1)
-                                               | uu____20130 -> tm1)
-                                          | uu____20131 -> tm1
+                                                    | uu____20132 -> tm1)
+                                               | uu____20136 -> tm1)
+                                          | uu____20137 -> tm1
                                         else
-                                          (let uu____20144 =
+                                          (let uu____20150 =
                                              FStar_Syntax_Syntax.fv_eq_lid fv
                                                FStar_Parser_Const.b2t_lid
                                               in
-                                           if uu____20144
+                                           if uu____20150
                                            then
                                              match args with
                                              | ({
@@ -6211,9 +6213,9 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (true ));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____20147;
+                                                    uu____20153;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____20148;_},uu____20149)::[]
+                                                    uu____20154;_},uu____20155)::[]
                                                  ->
                                                  w FStar_Syntax_Util.t_true
                                              | ({
@@ -6222,19 +6224,19 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (false ));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____20175;
+                                                    uu____20181;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____20176;_},uu____20177)::[]
+                                                    uu____20182;_},uu____20183)::[]
                                                  ->
                                                  w FStar_Syntax_Util.t_false
-                                             | uu____20203 -> tm1
+                                             | uu____20209 -> tm1
                                            else
-                                             (let uu____20216 =
+                                             (let uu____20222 =
                                                 FStar_Syntax_Syntax.fv_eq_lid
                                                   fv
                                                   FStar_Parser_Const.haseq_lid
                                                  in
-                                              if uu____20216
+                                              if uu____20222
                                               then
                                                 let t_has_eq_for_sure t =
                                                   let haseq_lids =
@@ -6243,14 +6245,14 @@ and (maybe_simplify_aux :
                                                     FStar_Parser_Const.unit_lid;
                                                     FStar_Parser_Const.string_lid]
                                                      in
-                                                  let uu____20230 =
-                                                    let uu____20231 =
+                                                  let uu____20236 =
+                                                    let uu____20237 =
                                                       FStar_Syntax_Subst.compress
                                                         t
                                                        in
-                                                    uu____20231.FStar_Syntax_Syntax.n
+                                                    uu____20237.FStar_Syntax_Syntax.n
                                                      in
-                                                  match uu____20230 with
+                                                  match uu____20236 with
                                                   | FStar_Syntax_Syntax.Tm_fvar
                                                       fv1 when
                                                       FStar_All.pipe_right
@@ -6260,93 +6262,93 @@ and (maybe_simplify_aux :
                                                               FStar_Syntax_Syntax.fv_eq_lid
                                                                 fv1 l))
                                                       -> true
-                                                  | uu____20242 -> false  in
+                                                  | uu____20248 -> false  in
                                                 (if
                                                    (FStar_List.length args) =
                                                      Prims.int_one
                                                  then
                                                    let t =
-                                                     let uu____20256 =
+                                                     let uu____20262 =
                                                        FStar_All.pipe_right
                                                          args FStar_List.hd
                                                         in
                                                      FStar_All.pipe_right
-                                                       uu____20256
+                                                       uu____20262
                                                        FStar_Pervasives_Native.fst
                                                       in
-                                                   let uu____20295 =
+                                                   let uu____20301 =
                                                      FStar_All.pipe_right t
                                                        t_has_eq_for_sure
                                                       in
-                                                   (if uu____20295
+                                                   (if uu____20301
                                                     then
                                                       w
                                                         FStar_Syntax_Util.t_true
                                                     else
-                                                      (let uu____20301 =
-                                                         let uu____20302 =
+                                                      (let uu____20307 =
+                                                         let uu____20308 =
                                                            FStar_Syntax_Subst.compress
                                                              t
                                                             in
-                                                         uu____20302.FStar_Syntax_Syntax.n
+                                                         uu____20308.FStar_Syntax_Syntax.n
                                                           in
-                                                       match uu____20301 with
+                                                       match uu____20307 with
                                                        | FStar_Syntax_Syntax.Tm_refine
-                                                           uu____20305 ->
+                                                           uu____20311 ->
                                                            let t1 =
                                                              FStar_Syntax_Util.unrefine
                                                                t
                                                               in
-                                                           let uu____20313 =
+                                                           let uu____20319 =
                                                              FStar_All.pipe_right
                                                                t1
                                                                t_has_eq_for_sure
                                                               in
-                                                           if uu____20313
+                                                           if uu____20319
                                                            then
                                                              w
                                                                FStar_Syntax_Util.t_true
                                                            else
                                                              (let haseq_tm =
-                                                                let uu____20322
+                                                                let uu____20328
                                                                   =
-                                                                  let uu____20323
+                                                                  let uu____20329
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     tm1  in
-                                                                  uu____20323.FStar_Syntax_Syntax.n
+                                                                  uu____20329.FStar_Syntax_Syntax.n
                                                                    in
-                                                                match uu____20322
+                                                                match uu____20328
                                                                 with
                                                                 | FStar_Syntax_Syntax.Tm_app
-                                                                    (hd1,uu____20329)
+                                                                    (hd1,uu____20335)
                                                                     -> hd1
-                                                                | uu____20354
+                                                                | uu____20360
                                                                     ->
                                                                     failwith
                                                                     "Impossible! We have already checked that this is a Tm_app"
                                                                  in
-                                                              let uu____20358
+                                                              let uu____20364
                                                                 =
-                                                                let uu____20369
+                                                                let uu____20375
                                                                   =
                                                                   FStar_All.pipe_right
                                                                     t1
                                                                     FStar_Syntax_Syntax.as_arg
                                                                    in
-                                                                [uu____20369]
+                                                                [uu____20375]
                                                                  in
                                                               FStar_Syntax_Util.mk_app
                                                                 haseq_tm
-                                                                uu____20358)
-                                                       | uu____20402 -> tm1))
+                                                                uu____20364)
+                                                       | uu____20408 -> tm1))
                                                  else tm1)
                                               else
-                                                (let uu____20407 =
+                                                (let uu____20413 =
                                                    FStar_Syntax_Util.is_auto_squash
                                                      tm1
                                                     in
-                                                 match uu____20407 with
+                                                 match uu____20413 with
                                                  | FStar_Pervasives_Native.Some
                                                      (FStar_Syntax_Syntax.U_zero
                                                       ,t)
@@ -6354,229 +6356,229 @@ and (maybe_simplify_aux :
                                                      FStar_Syntax_Util.is_sub_singleton
                                                        t
                                                      -> t
-                                                 | uu____20427 ->
-                                                     let uu____20436 =
-                                                       let uu____20443 =
+                                                 | uu____20433 ->
+                                                     let uu____20442 =
+                                                       let uu____20449 =
                                                          norm_cb cfg  in
                                                        reduce_equality
-                                                         uu____20443 cfg env
+                                                         uu____20449 cfg env
                                                         in
-                                                     uu____20436 tm1)))))))))
+                                                     uu____20442 tm1)))))))))
                   | FStar_Syntax_Syntax.Tm_app
                       ({
                          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
                            fv;
-                         FStar_Syntax_Syntax.pos = uu____20449;
-                         FStar_Syntax_Syntax.vars = uu____20450;_},args)
+                         FStar_Syntax_Syntax.pos = uu____20455;
+                         FStar_Syntax_Syntax.vars = uu____20456;_},args)
                       ->
-                      let uu____20476 =
+                      let uu____20482 =
                         FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.and_lid
                          in
-                      if uu____20476
+                      if uu____20482
                       then
-                        let uu____20479 =
+                        let uu____20485 =
                           FStar_All.pipe_right args
                             (FStar_List.map simplify1)
                            in
-                        (match uu____20479 with
-                         | (FStar_Pervasives_Native.Some (true ),uu____20537)::
-                             (uu____20538,(arg,uu____20540))::[] ->
+                        (match uu____20485 with
+                         | (FStar_Pervasives_Native.Some (true ),uu____20543)::
+                             (uu____20544,(arg,uu____20546))::[] ->
                              maybe_auto_squash arg
-                         | (uu____20613,(arg,uu____20615))::(FStar_Pervasives_Native.Some
+                         | (uu____20619,(arg,uu____20621))::(FStar_Pervasives_Native.Some
                                                              (true
-                                                             ),uu____20616)::[]
+                                                             ),uu____20622)::[]
                              -> maybe_auto_squash arg
                          | (FStar_Pervasives_Native.Some (false
-                            ),uu____20689)::uu____20690::[] ->
+                            ),uu____20695)::uu____20696::[] ->
                              w FStar_Syntax_Util.t_false
-                         | uu____20760::(FStar_Pervasives_Native.Some (false
-                                         ),uu____20761)::[]
+                         | uu____20766::(FStar_Pervasives_Native.Some (false
+                                         ),uu____20767)::[]
                              -> w FStar_Syntax_Util.t_false
-                         | uu____20831 ->
+                         | uu____20837 ->
                              squashed_head_un_auto_squash_args tm1)
                       else
-                        (let uu____20849 =
+                        (let uu____20855 =
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.or_lid
                             in
-                         if uu____20849
+                         if uu____20855
                          then
-                           let uu____20852 =
+                           let uu____20858 =
                              FStar_All.pipe_right args
                                (FStar_List.map simplify1)
                               in
-                           match uu____20852 with
+                           match uu____20858 with
                            | (FStar_Pervasives_Native.Some (true
-                              ),uu____20910)::uu____20911::[] ->
+                              ),uu____20916)::uu____20917::[] ->
                                w FStar_Syntax_Util.t_true
-                           | uu____20981::(FStar_Pervasives_Native.Some (true
-                                           ),uu____20982)::[]
+                           | uu____20987::(FStar_Pervasives_Native.Some (true
+                                           ),uu____20988)::[]
                                -> w FStar_Syntax_Util.t_true
                            | (FStar_Pervasives_Native.Some (false
-                              ),uu____21052)::(uu____21053,(arg,uu____21055))::[]
+                              ),uu____21058)::(uu____21059,(arg,uu____21061))::[]
                                -> maybe_auto_squash arg
-                           | (uu____21128,(arg,uu____21130))::(FStar_Pervasives_Native.Some
+                           | (uu____21134,(arg,uu____21136))::(FStar_Pervasives_Native.Some
                                                                (false
-                                                               ),uu____21131)::[]
+                                                               ),uu____21137)::[]
                                -> maybe_auto_squash arg
-                           | uu____21204 ->
+                           | uu____21210 ->
                                squashed_head_un_auto_squash_args tm1
                          else
-                           (let uu____21222 =
+                           (let uu____21228 =
                               FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.imp_lid
                                in
-                            if uu____21222
+                            if uu____21228
                             then
-                              let uu____21225 =
+                              let uu____21231 =
                                 FStar_All.pipe_right args
                                   (FStar_List.map simplify1)
                                  in
-                              match uu____21225 with
-                              | uu____21283::(FStar_Pervasives_Native.Some
-                                              (true ),uu____21284)::[]
+                              match uu____21231 with
+                              | uu____21289::(FStar_Pervasives_Native.Some
+                                              (true ),uu____21290)::[]
                                   -> w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (false
-                                 ),uu____21354)::uu____21355::[] ->
+                                 ),uu____21360)::uu____21361::[] ->
                                   w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (true
-                                 ),uu____21425)::(uu____21426,(arg,uu____21428))::[]
+                                 ),uu____21431)::(uu____21432,(arg,uu____21434))::[]
                                   -> maybe_auto_squash arg
-                              | (uu____21501,(p,uu____21503))::(uu____21504,
-                                                                (q,uu____21506))::[]
+                              | (uu____21507,(p,uu____21509))::(uu____21510,
+                                                                (q,uu____21512))::[]
                                   ->
-                                  let uu____21578 =
+                                  let uu____21584 =
                                     FStar_Syntax_Util.term_eq p q  in
-                                  (if uu____21578
+                                  (if uu____21584
                                    then w FStar_Syntax_Util.t_true
                                    else squashed_head_un_auto_squash_args tm1)
-                              | uu____21583 ->
+                              | uu____21589 ->
                                   squashed_head_un_auto_squash_args tm1
                             else
-                              (let uu____21601 =
+                              (let uu____21607 =
                                  FStar_Syntax_Syntax.fv_eq_lid fv
                                    FStar_Parser_Const.iff_lid
                                   in
-                               if uu____21601
+                               if uu____21607
                                then
-                                 let uu____21604 =
+                                 let uu____21610 =
                                    FStar_All.pipe_right args
                                      (FStar_List.map simplify1)
                                     in
-                                 match uu____21604 with
+                                 match uu____21610 with
                                  | (FStar_Pervasives_Native.Some (true
-                                    ),uu____21662)::(FStar_Pervasives_Native.Some
-                                                     (true ),uu____21663)::[]
+                                    ),uu____21668)::(FStar_Pervasives_Native.Some
+                                                     (true ),uu____21669)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (false
-                                    ),uu____21737)::(FStar_Pervasives_Native.Some
-                                                     (false ),uu____21738)::[]
+                                    ),uu____21743)::(FStar_Pervasives_Native.Some
+                                                     (false ),uu____21744)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (true
-                                    ),uu____21812)::(FStar_Pervasives_Native.Some
-                                                     (false ),uu____21813)::[]
+                                    ),uu____21818)::(FStar_Pervasives_Native.Some
+                                                     (false ),uu____21819)::[]
                                      -> w FStar_Syntax_Util.t_false
                                  | (FStar_Pervasives_Native.Some (false
-                                    ),uu____21887)::(FStar_Pervasives_Native.Some
-                                                     (true ),uu____21888)::[]
+                                    ),uu____21893)::(FStar_Pervasives_Native.Some
+                                                     (true ),uu____21894)::[]
                                      -> w FStar_Syntax_Util.t_false
-                                 | (uu____21962,(arg,uu____21964))::(FStar_Pervasives_Native.Some
+                                 | (uu____21968,(arg,uu____21970))::(FStar_Pervasives_Native.Some
                                                                     (true
-                                                                    ),uu____21965)::[]
+                                                                    ),uu____21971)::[]
                                      -> maybe_auto_squash arg
                                  | (FStar_Pervasives_Native.Some (true
-                                    ),uu____22038)::(uu____22039,(arg,uu____22041))::[]
+                                    ),uu____22044)::(uu____22045,(arg,uu____22047))::[]
                                      -> maybe_auto_squash arg
-                                 | (uu____22114,(arg,uu____22116))::(FStar_Pervasives_Native.Some
+                                 | (uu____22120,(arg,uu____22122))::(FStar_Pervasives_Native.Some
                                                                     (false
-                                                                    ),uu____22117)::[]
+                                                                    ),uu____22123)::[]
                                      ->
-                                     let uu____22190 =
+                                     let uu____22196 =
                                        FStar_Syntax_Util.mk_neg arg  in
-                                     maybe_auto_squash uu____22190
+                                     maybe_auto_squash uu____22196
                                  | (FStar_Pervasives_Native.Some (false
-                                    ),uu____22191)::(uu____22192,(arg,uu____22194))::[]
+                                    ),uu____22197)::(uu____22198,(arg,uu____22200))::[]
                                      ->
-                                     let uu____22267 =
+                                     let uu____22273 =
                                        FStar_Syntax_Util.mk_neg arg  in
-                                     maybe_auto_squash uu____22267
-                                 | (uu____22268,(p,uu____22270))::(uu____22271,
-                                                                   (q,uu____22273))::[]
+                                     maybe_auto_squash uu____22273
+                                 | (uu____22274,(p,uu____22276))::(uu____22277,
+                                                                   (q,uu____22279))::[]
                                      ->
-                                     let uu____22345 =
+                                     let uu____22351 =
                                        FStar_Syntax_Util.term_eq p q  in
-                                     (if uu____22345
+                                     (if uu____22351
                                       then w FStar_Syntax_Util.t_true
                                       else
                                         squashed_head_un_auto_squash_args tm1)
-                                 | uu____22350 ->
+                                 | uu____22356 ->
                                      squashed_head_un_auto_squash_args tm1
                                else
-                                 (let uu____22368 =
+                                 (let uu____22374 =
                                     FStar_Syntax_Syntax.fv_eq_lid fv
                                       FStar_Parser_Const.not_lid
                                      in
-                                  if uu____22368
+                                  if uu____22374
                                   then
-                                    let uu____22371 =
+                                    let uu____22377 =
                                       FStar_All.pipe_right args
                                         (FStar_List.map simplify1)
                                        in
-                                    match uu____22371 with
+                                    match uu____22377 with
                                     | (FStar_Pervasives_Native.Some (true
-                                       ),uu____22429)::[] ->
+                                       ),uu____22435)::[] ->
                                         w FStar_Syntax_Util.t_false
                                     | (FStar_Pervasives_Native.Some (false
-                                       ),uu____22473)::[] ->
+                                       ),uu____22479)::[] ->
                                         w FStar_Syntax_Util.t_true
-                                    | uu____22517 ->
+                                    | uu____22523 ->
                                         squashed_head_un_auto_squash_args tm1
                                   else
-                                    (let uu____22535 =
+                                    (let uu____22541 =
                                        FStar_Syntax_Syntax.fv_eq_lid fv
                                          FStar_Parser_Const.forall_lid
                                         in
-                                     if uu____22535
+                                     if uu____22541
                                      then
                                        match args with
-                                       | (t,uu____22539)::[] ->
-                                           let uu____22564 =
-                                             let uu____22565 =
+                                       | (t,uu____22545)::[] ->
+                                           let uu____22570 =
+                                             let uu____22571 =
                                                FStar_Syntax_Subst.compress t
                                                 in
-                                             uu____22565.FStar_Syntax_Syntax.n
+                                             uu____22571.FStar_Syntax_Syntax.n
                                               in
-                                           (match uu____22564 with
+                                           (match uu____22570 with
                                             | FStar_Syntax_Syntax.Tm_abs
-                                                (uu____22568::[],body,uu____22570)
+                                                (uu____22574::[],body,uu____22576)
                                                 ->
-                                                let uu____22605 = simp_t body
+                                                let uu____22611 = simp_t body
                                                    in
-                                                (match uu____22605 with
+                                                (match uu____22611 with
                                                  | FStar_Pervasives_Native.Some
                                                      (true ) ->
                                                      w
                                                        FStar_Syntax_Util.t_true
-                                                 | uu____22611 -> tm1)
-                                            | uu____22615 -> tm1)
+                                                 | uu____22617 -> tm1)
+                                            | uu____22621 -> tm1)
                                        | (ty,FStar_Pervasives_Native.Some
                                           (FStar_Syntax_Syntax.Implicit
-                                          uu____22617))::(t,uu____22619)::[]
+                                          uu____22623))::(t,uu____22625)::[]
                                            ->
-                                           let uu____22659 =
-                                             let uu____22660 =
+                                           let uu____22665 =
+                                             let uu____22666 =
                                                FStar_Syntax_Subst.compress t
                                                 in
-                                             uu____22660.FStar_Syntax_Syntax.n
+                                             uu____22666.FStar_Syntax_Syntax.n
                                               in
-                                           (match uu____22659 with
+                                           (match uu____22665 with
                                             | FStar_Syntax_Syntax.Tm_abs
-                                                (uu____22663::[],body,uu____22665)
+                                                (uu____22669::[],body,uu____22671)
                                                 ->
-                                                let uu____22700 = simp_t body
+                                                let uu____22706 = simp_t body
                                                    in
-                                                (match uu____22700 with
+                                                (match uu____22706 with
                                                  | FStar_Pervasives_Native.Some
                                                      (true ) ->
                                                      w
@@ -6586,56 +6588,56 @@ and (maybe_simplify_aux :
                                                      clearly_inhabited ty ->
                                                      w
                                                        FStar_Syntax_Util.t_false
-                                                 | uu____22708 -> tm1)
-                                            | uu____22712 -> tm1)
-                                       | uu____22713 -> tm1
+                                                 | uu____22714 -> tm1)
+                                            | uu____22718 -> tm1)
+                                       | uu____22719 -> tm1
                                      else
-                                       (let uu____22726 =
+                                       (let uu____22732 =
                                           FStar_Syntax_Syntax.fv_eq_lid fv
                                             FStar_Parser_Const.exists_lid
                                            in
-                                        if uu____22726
+                                        if uu____22732
                                         then
                                           match args with
-                                          | (t,uu____22730)::[] ->
-                                              let uu____22755 =
-                                                let uu____22756 =
+                                          | (t,uu____22736)::[] ->
+                                              let uu____22761 =
+                                                let uu____22762 =
                                                   FStar_Syntax_Subst.compress
                                                     t
                                                    in
-                                                uu____22756.FStar_Syntax_Syntax.n
+                                                uu____22762.FStar_Syntax_Syntax.n
                                                  in
-                                              (match uu____22755 with
+                                              (match uu____22761 with
                                                | FStar_Syntax_Syntax.Tm_abs
-                                                   (uu____22759::[],body,uu____22761)
+                                                   (uu____22765::[],body,uu____22767)
                                                    ->
-                                                   let uu____22796 =
+                                                   let uu____22802 =
                                                      simp_t body  in
-                                                   (match uu____22796 with
+                                                   (match uu____22802 with
                                                     | FStar_Pervasives_Native.Some
                                                         (false ) ->
                                                         w
                                                           FStar_Syntax_Util.t_false
-                                                    | uu____22802 -> tm1)
-                                               | uu____22806 -> tm1)
+                                                    | uu____22808 -> tm1)
+                                               | uu____22812 -> tm1)
                                           | (ty,FStar_Pervasives_Native.Some
                                              (FStar_Syntax_Syntax.Implicit
-                                             uu____22808))::(t,uu____22810)::[]
+                                             uu____22814))::(t,uu____22816)::[]
                                               ->
-                                              let uu____22850 =
-                                                let uu____22851 =
+                                              let uu____22856 =
+                                                let uu____22857 =
                                                   FStar_Syntax_Subst.compress
                                                     t
                                                    in
-                                                uu____22851.FStar_Syntax_Syntax.n
+                                                uu____22857.FStar_Syntax_Syntax.n
                                                  in
-                                              (match uu____22850 with
+                                              (match uu____22856 with
                                                | FStar_Syntax_Syntax.Tm_abs
-                                                   (uu____22854::[],body,uu____22856)
+                                                   (uu____22860::[],body,uu____22862)
                                                    ->
-                                                   let uu____22891 =
+                                                   let uu____22897 =
                                                      simp_t body  in
-                                                   (match uu____22891 with
+                                                   (match uu____22897 with
                                                     | FStar_Pervasives_Native.Some
                                                         (false ) ->
                                                         w
@@ -6646,15 +6648,15 @@ and (maybe_simplify_aux :
                                                         ->
                                                         w
                                                           FStar_Syntax_Util.t_true
-                                                    | uu____22899 -> tm1)
-                                               | uu____22903 -> tm1)
-                                          | uu____22904 -> tm1
+                                                    | uu____22905 -> tm1)
+                                               | uu____22909 -> tm1)
+                                          | uu____22910 -> tm1
                                         else
-                                          (let uu____22917 =
+                                          (let uu____22923 =
                                              FStar_Syntax_Syntax.fv_eq_lid fv
                                                FStar_Parser_Const.b2t_lid
                                               in
-                                           if uu____22917
+                                           if uu____22923
                                            then
                                              match args with
                                              | ({
@@ -6663,9 +6665,9 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (true ));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____22920;
+                                                    uu____22926;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____22921;_},uu____22922)::[]
+                                                    uu____22927;_},uu____22928)::[]
                                                  ->
                                                  w FStar_Syntax_Util.t_true
                                              | ({
@@ -6674,19 +6676,19 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (false ));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____22948;
+                                                    uu____22954;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____22949;_},uu____22950)::[]
+                                                    uu____22955;_},uu____22956)::[]
                                                  ->
                                                  w FStar_Syntax_Util.t_false
-                                             | uu____22976 -> tm1
+                                             | uu____22982 -> tm1
                                            else
-                                             (let uu____22989 =
+                                             (let uu____22995 =
                                                 FStar_Syntax_Syntax.fv_eq_lid
                                                   fv
                                                   FStar_Parser_Const.haseq_lid
                                                  in
-                                              if uu____22989
+                                              if uu____22995
                                               then
                                                 let t_has_eq_for_sure t =
                                                   let haseq_lids =
@@ -6695,14 +6697,14 @@ and (maybe_simplify_aux :
                                                     FStar_Parser_Const.unit_lid;
                                                     FStar_Parser_Const.string_lid]
                                                      in
-                                                  let uu____23003 =
-                                                    let uu____23004 =
+                                                  let uu____23009 =
+                                                    let uu____23010 =
                                                       FStar_Syntax_Subst.compress
                                                         t
                                                        in
-                                                    uu____23004.FStar_Syntax_Syntax.n
+                                                    uu____23010.FStar_Syntax_Syntax.n
                                                      in
-                                                  match uu____23003 with
+                                                  match uu____23009 with
                                                   | FStar_Syntax_Syntax.Tm_fvar
                                                       fv1 when
                                                       FStar_All.pipe_right
@@ -6712,93 +6714,93 @@ and (maybe_simplify_aux :
                                                               FStar_Syntax_Syntax.fv_eq_lid
                                                                 fv1 l))
                                                       -> true
-                                                  | uu____23015 -> false  in
+                                                  | uu____23021 -> false  in
                                                 (if
                                                    (FStar_List.length args) =
                                                      Prims.int_one
                                                  then
                                                    let t =
-                                                     let uu____23029 =
+                                                     let uu____23035 =
                                                        FStar_All.pipe_right
                                                          args FStar_List.hd
                                                         in
                                                      FStar_All.pipe_right
-                                                       uu____23029
+                                                       uu____23035
                                                        FStar_Pervasives_Native.fst
                                                       in
-                                                   let uu____23064 =
+                                                   let uu____23070 =
                                                      FStar_All.pipe_right t
                                                        t_has_eq_for_sure
                                                       in
-                                                   (if uu____23064
+                                                   (if uu____23070
                                                     then
                                                       w
                                                         FStar_Syntax_Util.t_true
                                                     else
-                                                      (let uu____23070 =
-                                                         let uu____23071 =
+                                                      (let uu____23076 =
+                                                         let uu____23077 =
                                                            FStar_Syntax_Subst.compress
                                                              t
                                                             in
-                                                         uu____23071.FStar_Syntax_Syntax.n
+                                                         uu____23077.FStar_Syntax_Syntax.n
                                                           in
-                                                       match uu____23070 with
+                                                       match uu____23076 with
                                                        | FStar_Syntax_Syntax.Tm_refine
-                                                           uu____23074 ->
+                                                           uu____23080 ->
                                                            let t1 =
                                                              FStar_Syntax_Util.unrefine
                                                                t
                                                               in
-                                                           let uu____23082 =
+                                                           let uu____23088 =
                                                              FStar_All.pipe_right
                                                                t1
                                                                t_has_eq_for_sure
                                                               in
-                                                           if uu____23082
+                                                           if uu____23088
                                                            then
                                                              w
                                                                FStar_Syntax_Util.t_true
                                                            else
                                                              (let haseq_tm =
-                                                                let uu____23091
+                                                                let uu____23097
                                                                   =
-                                                                  let uu____23092
+                                                                  let uu____23098
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     tm1  in
-                                                                  uu____23092.FStar_Syntax_Syntax.n
+                                                                  uu____23098.FStar_Syntax_Syntax.n
                                                                    in
-                                                                match uu____23091
+                                                                match uu____23097
                                                                 with
                                                                 | FStar_Syntax_Syntax.Tm_app
-                                                                    (hd1,uu____23098)
+                                                                    (hd1,uu____23104)
                                                                     -> hd1
-                                                                | uu____23123
+                                                                | uu____23129
                                                                     ->
                                                                     failwith
                                                                     "Impossible! We have already checked that this is a Tm_app"
                                                                  in
-                                                              let uu____23127
+                                                              let uu____23133
                                                                 =
-                                                                let uu____23138
+                                                                let uu____23144
                                                                   =
                                                                   FStar_All.pipe_right
                                                                     t1
                                                                     FStar_Syntax_Syntax.as_arg
                                                                    in
-                                                                [uu____23138]
+                                                                [uu____23144]
                                                                  in
                                                               FStar_Syntax_Util.mk_app
                                                                 haseq_tm
-                                                                uu____23127)
-                                                       | uu____23171 -> tm1))
+                                                                uu____23133)
+                                                       | uu____23177 -> tm1))
                                                  else tm1)
                                               else
-                                                (let uu____23176 =
+                                                (let uu____23182 =
                                                    FStar_Syntax_Util.is_auto_squash
                                                      tm1
                                                     in
-                                                 match uu____23176 with
+                                                 match uu____23182 with
                                                  | FStar_Pervasives_Native.Some
                                                      (FStar_Syntax_Syntax.U_zero
                                                       ,t)
@@ -6806,30 +6808,30 @@ and (maybe_simplify_aux :
                                                      FStar_Syntax_Util.is_sub_singleton
                                                        t
                                                      -> t
-                                                 | uu____23196 ->
-                                                     let uu____23205 =
-                                                       let uu____23212 =
+                                                 | uu____23202 ->
+                                                     let uu____23211 =
+                                                       let uu____23218 =
                                                          norm_cb cfg  in
                                                        reduce_equality
-                                                         uu____23212 cfg env
+                                                         uu____23218 cfg env
                                                         in
-                                                     uu____23205 tm1)))))))))
+                                                     uu____23211 tm1)))))))))
                   | FStar_Syntax_Syntax.Tm_refine (bv,t) ->
-                      let uu____23223 = simp_t t  in
-                      (match uu____23223 with
+                      let uu____23229 = simp_t t  in
+                      (match uu____23229 with
                        | FStar_Pervasives_Native.Some (true ) ->
                            bv.FStar_Syntax_Syntax.sort
                        | FStar_Pervasives_Native.Some (false ) -> tm1
                        | FStar_Pervasives_Native.None  -> tm1)
-                  | FStar_Syntax_Syntax.Tm_match uu____23232 ->
-                      let uu____23255 = is_const_match tm1  in
-                      (match uu____23255 with
+                  | FStar_Syntax_Syntax.Tm_match uu____23238 ->
+                      let uu____23261 = is_const_match tm1  in
+                      (match uu____23261 with
                        | FStar_Pervasives_Native.Some (true ) ->
                            w FStar_Syntax_Util.t_true
                        | FStar_Pervasives_Native.Some (false ) ->
                            w FStar_Syntax_Util.t_false
                        | FStar_Pervasives_Native.None  -> tm1)
-                  | uu____23264 -> tm1))
+                  | uu____23270 -> tm1))
 
 and (rebuild :
   FStar_TypeChecker_Cfg.cfg ->
@@ -6840,59 +6842,59 @@ and (rebuild :
       fun stack  ->
         fun t  ->
           FStar_TypeChecker_Cfg.log cfg
-            (fun uu____23274  ->
-               (let uu____23276 = FStar_Syntax_Print.tag_of_term t  in
-                let uu____23278 = FStar_Syntax_Print.term_to_string t  in
-                let uu____23280 =
+            (fun uu____23280  ->
+               (let uu____23282 = FStar_Syntax_Print.tag_of_term t  in
+                let uu____23284 = FStar_Syntax_Print.term_to_string t  in
+                let uu____23286 =
                   FStar_Util.string_of_int (FStar_List.length env)  in
-                let uu____23288 =
-                  let uu____23290 =
-                    let uu____23293 = firstn (Prims.of_int (4)) stack  in
+                let uu____23294 =
+                  let uu____23296 =
+                    let uu____23299 = firstn (Prims.of_int (4)) stack  in
                     FStar_All.pipe_left FStar_Pervasives_Native.fst
-                      uu____23293
+                      uu____23299
                      in
-                  stack_to_string uu____23290  in
+                  stack_to_string uu____23296  in
                 FStar_Util.print4
                   ">>> %s\nRebuild %s with %s env elements and top of the stack %s \n"
-                  uu____23276 uu____23278 uu____23280 uu____23288);
-               (let uu____23318 =
+                  uu____23282 uu____23284 uu____23286 uu____23294);
+               (let uu____23324 =
                   FStar_TypeChecker_Env.debug cfg.FStar_TypeChecker_Cfg.tcenv
                     (FStar_Options.Other "NormRebuild")
                    in
-                if uu____23318
+                if uu____23324
                 then
-                  let uu____23322 = FStar_Syntax_Util.unbound_variables t  in
-                  match uu____23322 with
+                  let uu____23328 = FStar_Syntax_Util.unbound_variables t  in
+                  match uu____23328 with
                   | [] -> ()
                   | bvs ->
-                      ((let uu____23329 = FStar_Syntax_Print.tag_of_term t
+                      ((let uu____23335 = FStar_Syntax_Print.tag_of_term t
                            in
-                        let uu____23331 = FStar_Syntax_Print.term_to_string t
+                        let uu____23337 = FStar_Syntax_Print.term_to_string t
                            in
-                        let uu____23333 =
-                          let uu____23335 =
+                        let uu____23339 =
+                          let uu____23341 =
                             FStar_All.pipe_right bvs
                               (FStar_List.map FStar_Syntax_Print.bv_to_string)
                              in
-                          FStar_All.pipe_right uu____23335
+                          FStar_All.pipe_right uu____23341
                             (FStar_String.concat ", ")
                            in
                         FStar_Util.print3
-                          "!!! Rebuild (%s) %s, free vars=%s\n" uu____23329
-                          uu____23331 uu____23333);
+                          "!!! Rebuild (%s) %s, free vars=%s\n" uu____23335
+                          uu____23337 uu____23339);
                        failwith "DIE!")
                 else ()));
           (let f_opt = is_fext_on_domain t  in
-           let uu____23357 =
+           let uu____23363 =
              (FStar_All.pipe_right f_opt FStar_Util.is_some) &&
                (match stack with
-                | (Arg uu____23365)::uu____23366 -> true
-                | uu____23376 -> false)
+                | (Arg uu____23371)::uu____23372 -> true
+                | uu____23382 -> false)
               in
-           if uu____23357
+           if uu____23363
            then
-             let uu____23379 = FStar_All.pipe_right f_opt FStar_Util.must  in
-             FStar_All.pipe_right uu____23379 (norm cfg env stack)
+             let uu____23385 = FStar_All.pipe_right f_opt FStar_Util.must  in
+             FStar_All.pipe_right uu____23385 (norm cfg env stack)
            else
              (let t1 = maybe_simplify cfg env stack t  in
               match stack with
@@ -6902,32 +6904,32 @@ and (rebuild :
                      (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
                    then
                      (let time_now = FStar_Util.now ()  in
-                      let uu____23393 =
-                        let uu____23395 =
-                          let uu____23397 =
+                      let uu____23399 =
+                        let uu____23401 =
+                          let uu____23403 =
                             FStar_Util.time_diff time_then time_now  in
-                          FStar_Pervasives_Native.snd uu____23397  in
-                        FStar_Util.string_of_int uu____23395  in
-                      let uu____23404 = FStar_Syntax_Print.term_to_string tm
+                          FStar_Pervasives_Native.snd uu____23403  in
+                        FStar_Util.string_of_int uu____23401  in
+                      let uu____23410 = FStar_Syntax_Print.term_to_string tm
                          in
-                      let uu____23406 = FStar_Syntax_Print.term_to_string t1
+                      let uu____23412 = FStar_Syntax_Print.term_to_string t1
                          in
                       FStar_Util.print3
                         "Normalized term (%s ms) %s\n\tto term %s\n"
-                        uu____23393 uu____23404 uu____23406)
+                        uu____23399 uu____23410 uu____23412)
                    else ();
                    rebuild cfg env stack1 t1)
               | (Cfg cfg1)::stack1 -> rebuild cfg1 env stack1 t1
-              | (Meta (uu____23415,m,r))::stack1 ->
+              | (Meta (uu____23421,m,r))::stack1 ->
                   let t2 = mk (FStar_Syntax_Syntax.Tm_meta (t1, m)) r  in
                   rebuild cfg env stack1 t2
               | (MemoLazy r)::stack1 ->
                   (set_memo cfg r (env, t1);
                    FStar_TypeChecker_Cfg.log cfg
-                     (fun uu____23444  ->
-                        let uu____23445 =
+                     (fun uu____23450  ->
+                        let uu____23451 =
                           FStar_Syntax_Print.term_to_string t1  in
-                        FStar_Util.print1 "\tSet memo %s\n" uu____23445);
+                        FStar_Util.print1 "\tSet memo %s\n" uu____23451);
                    rebuild cfg env stack1 t1)
               | (Let (env',bs,lb,r))::stack1 ->
                   let body = FStar_Syntax_Subst.close bs t1  in
@@ -6940,44 +6942,44 @@ and (rebuild :
               | (Abs (env',bs,env'',lopt,r))::stack1 ->
                   let bs1 = norm_binders cfg env' bs  in
                   let lopt1 = norm_lcomp_opt cfg env'' lopt  in
-                  let uu____23488 =
-                    let uu___2763_23489 = FStar_Syntax_Util.abs bs1 t1 lopt1
+                  let uu____23494 =
+                    let uu___2765_23495 = FStar_Syntax_Util.abs bs1 t1 lopt1
                        in
                     {
                       FStar_Syntax_Syntax.n =
-                        (uu___2763_23489.FStar_Syntax_Syntax.n);
+                        (uu___2765_23495.FStar_Syntax_Syntax.n);
                       FStar_Syntax_Syntax.pos = r;
                       FStar_Syntax_Syntax.vars =
-                        (uu___2763_23489.FStar_Syntax_Syntax.vars)
+                        (uu___2765_23495.FStar_Syntax_Syntax.vars)
                     }  in
-                  rebuild cfg env stack1 uu____23488
-              | (Arg (Univ uu____23492,uu____23493,uu____23494))::uu____23495
+                  rebuild cfg env stack1 uu____23494
+              | (Arg (Univ uu____23498,uu____23499,uu____23500))::uu____23501
                   -> failwith "Impossible"
-              | (Arg (Dummy ,uu____23499,uu____23500))::uu____23501 ->
+              | (Arg (Dummy ,uu____23505,uu____23506))::uu____23507 ->
                   failwith "Impossible"
               | (UnivArgs (us,r))::stack1 ->
                   let t2 = FStar_Syntax_Syntax.mk_Tm_uinst t1 us  in
                   rebuild cfg env stack1 t2
               | (Arg
-                  (Clos (env_arg,tm,uu____23517,uu____23518),aq,r))::stack1
+                  (Clos (env_arg,tm,uu____23523,uu____23524),aq,r))::stack1
                   when
-                  let uu____23570 = head_of t1  in
-                  FStar_Syntax_Util.is_fstar_tactics_by_tactic uu____23570 ->
+                  let uu____23576 = head_of t1  in
+                  FStar_Syntax_Util.is_fstar_tactics_by_tactic uu____23576 ->
                   let t2 =
-                    let uu____23574 =
-                      let uu____23579 =
-                        let uu____23580 = closure_as_term cfg env_arg tm  in
-                        (uu____23580, aq)  in
-                      FStar_Syntax_Syntax.extend_app t1 uu____23579  in
-                    uu____23574 FStar_Pervasives_Native.None r  in
+                    let uu____23580 =
+                      let uu____23585 =
+                        let uu____23586 = closure_as_term cfg env_arg tm  in
+                        (uu____23586, aq)  in
+                      FStar_Syntax_Syntax.extend_app t1 uu____23585  in
+                    uu____23580 FStar_Pervasives_Native.None r  in
                   rebuild cfg env stack1 t2
-              | (Arg (Clos (env_arg,tm,m,uu____23590),aq,r))::stack1 ->
+              | (Arg (Clos (env_arg,tm,m,uu____23596),aq,r))::stack1 ->
                   (FStar_TypeChecker_Cfg.log cfg
-                     (fun uu____23645  ->
-                        let uu____23646 =
+                     (fun uu____23651  ->
+                        let uu____23652 =
                           FStar_Syntax_Print.term_to_string tm  in
                         FStar_Util.print1 "Rebuilding with arg %s\n"
-                          uu____23646);
+                          uu____23652);
                    if
                      Prims.op_Negation
                        (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.iota
@@ -6995,8 +6997,8 @@ and (rebuild :
                         (let stack2 = (App (env, t1, aq, r)) :: stack1  in
                          norm cfg env_arg stack2 tm))
                    else
-                     (let uu____23666 = FStar_ST.op_Bang m  in
-                      match uu____23666 with
+                     (let uu____23672 = FStar_ST.op_Bang m  in
+                      match uu____23672 with
                       | FStar_Pervasives_Native.None  ->
                           if
                             (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.hnf
@@ -7011,7 +7013,7 @@ and (rebuild :
                             (let stack2 = (MemoLazy m) ::
                                (App (env, t1, aq, r)) :: stack1  in
                              norm cfg env_arg stack2 tm)
-                      | FStar_Pervasives_Native.Some (uu____23754,a) ->
+                      | FStar_Pervasives_Native.Some (uu____23760,a) ->
                           let t2 =
                             FStar_Syntax_Syntax.extend_app t1 (a, aq)
                               FStar_Pervasives_Native.None r
@@ -7020,23 +7022,23 @@ and (rebuild :
               | (App (env1,head1,aq,r))::stack' when should_reify cfg stack
                   ->
                   let t0 = t1  in
-                  let fallback msg uu____23810 =
+                  let fallback msg uu____23816 =
                     FStar_TypeChecker_Cfg.log cfg
-                      (fun uu____23815  ->
-                         let uu____23816 =
+                      (fun uu____23821  ->
+                         let uu____23822 =
                            FStar_Syntax_Print.term_to_string t1  in
                          FStar_Util.print2 "Not reifying%s: %s\n" msg
-                           uu____23816);
+                           uu____23822);
                     (let t2 =
                        FStar_Syntax_Syntax.extend_app head1 (t1, aq)
                          FStar_Pervasives_Native.None r
                         in
                      rebuild cfg env1 stack' t2)
                      in
-                  let uu____23826 =
-                    let uu____23827 = FStar_Syntax_Subst.compress t1  in
-                    uu____23827.FStar_Syntax_Syntax.n  in
-                  (match uu____23826 with
+                  let uu____23832 =
+                    let uu____23833 = FStar_Syntax_Subst.compress t1  in
+                    uu____23833.FStar_Syntax_Syntax.n  in
+                  (match uu____23832 with
                    | FStar_Syntax_Syntax.Tm_meta
                        (t2,FStar_Syntax_Syntax.Meta_monadic (m,ty)) ->
                        do_reify_monadic (fallback " (1)") cfg env1 stack t2 m
@@ -7046,65 +7048,65 @@ and (rebuild :
                         (msrc,mtgt,ty))
                        ->
                        let lifted =
-                         let uu____23855 = closure_as_term cfg env1 ty  in
-                         reify_lift cfg t2 msrc mtgt uu____23855  in
+                         let uu____23861 = closure_as_term cfg env1 ty  in
+                         reify_lift cfg t2 msrc mtgt uu____23861  in
                        (FStar_TypeChecker_Cfg.log cfg
-                          (fun uu____23859  ->
-                             let uu____23860 =
+                          (fun uu____23865  ->
+                             let uu____23866 =
                                FStar_Syntax_Print.term_to_string lifted  in
                              FStar_Util.print1 "Reified lift to (1): %s\n"
-                               uu____23860);
-                        (let uu____23863 = FStar_List.tl stack  in
-                         norm cfg env1 uu____23863 lifted))
+                               uu____23866);
+                        (let uu____23869 = FStar_List.tl stack  in
+                         norm cfg env1 uu____23869 lifted))
                    | FStar_Syntax_Syntax.Tm_app
                        ({
                           FStar_Syntax_Syntax.n =
                             FStar_Syntax_Syntax.Tm_constant
-                            (FStar_Const.Const_reflect uu____23864);
-                          FStar_Syntax_Syntax.pos = uu____23865;
-                          FStar_Syntax_Syntax.vars = uu____23866;_},(e,uu____23868)::[])
+                            (FStar_Const.Const_reflect uu____23870);
+                          FStar_Syntax_Syntax.pos = uu____23871;
+                          FStar_Syntax_Syntax.vars = uu____23872;_},(e,uu____23874)::[])
                        -> norm cfg env1 stack' e
-                   | FStar_Syntax_Syntax.Tm_app uu____23907 when
+                   | FStar_Syntax_Syntax.Tm_app uu____23913 when
                        (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.primops
                        ->
-                       let uu____23924 = FStar_Syntax_Util.head_and_args t1
+                       let uu____23930 = FStar_Syntax_Util.head_and_args t1
                           in
-                       (match uu____23924 with
+                       (match uu____23930 with
                         | (hd1,args) ->
-                            let uu____23967 =
-                              let uu____23968 =
+                            let uu____23973 =
+                              let uu____23974 =
                                 FStar_Syntax_Util.un_uinst hd1  in
-                              uu____23968.FStar_Syntax_Syntax.n  in
-                            (match uu____23967 with
+                              uu____23974.FStar_Syntax_Syntax.n  in
+                            (match uu____23973 with
                              | FStar_Syntax_Syntax.Tm_fvar fv ->
-                                 let uu____23972 =
+                                 let uu____23978 =
                                    FStar_TypeChecker_Cfg.find_prim_step cfg
                                      fv
                                     in
-                                 (match uu____23972 with
+                                 (match uu____23978 with
                                   | FStar_Pervasives_Native.Some
                                       {
                                         FStar_TypeChecker_Cfg.name =
-                                          uu____23975;
+                                          uu____23981;
                                         FStar_TypeChecker_Cfg.arity =
-                                          uu____23976;
+                                          uu____23982;
                                         FStar_TypeChecker_Cfg.univ_arity =
-                                          uu____23977;
+                                          uu____23983;
                                         FStar_TypeChecker_Cfg.auto_reflect =
                                           FStar_Pervasives_Native.Some n1;
                                         FStar_TypeChecker_Cfg.strong_reduction_ok
-                                          = uu____23979;
+                                          = uu____23985;
                                         FStar_TypeChecker_Cfg.requires_binder_substitution
-                                          = uu____23980;
+                                          = uu____23986;
                                         FStar_TypeChecker_Cfg.interpretation
-                                          = uu____23981;
+                                          = uu____23987;
                                         FStar_TypeChecker_Cfg.interpretation_nbe
-                                          = uu____23982;_}
+                                          = uu____23988;_}
                                       when (FStar_List.length args) = n1 ->
                                       norm cfg env1 stack' t1
-                                  | uu____24018 -> fallback " (3)" ())
-                             | uu____24022 -> fallback " (4)" ()))
-                   | uu____24024 -> fallback " (2)" ())
+                                  | uu____24024 -> fallback " (3)" ())
+                             | uu____24028 -> fallback " (4)" ()))
+                   | uu____24030 -> fallback " (2)" ())
               | (App (env1,head1,aq,r))::stack1 ->
                   let t2 =
                     FStar_Syntax_Syntax.extend_app head1 (t1, aq)
@@ -7113,35 +7115,35 @@ and (rebuild :
                   rebuild cfg env1 stack1 t2
               | (Match (env',branches,cfg1,r))::stack1 ->
                   (FStar_TypeChecker_Cfg.log cfg1
-                     (fun uu____24050  ->
-                        let uu____24051 =
+                     (fun uu____24056  ->
+                        let uu____24057 =
                           FStar_Syntax_Print.term_to_string t1  in
                         FStar_Util.print1
                           "Rebuilding with match, scrutinee is %s ...\n"
-                          uu____24051);
+                          uu____24057);
                    (let scrutinee_env = env  in
                     let env1 = env'  in
                     let scrutinee = t1  in
-                    let norm_and_rebuild_match uu____24062 =
+                    let norm_and_rebuild_match uu____24068 =
                       FStar_TypeChecker_Cfg.log cfg1
-                        (fun uu____24067  ->
-                           let uu____24068 =
+                        (fun uu____24073  ->
+                           let uu____24074 =
                              FStar_Syntax_Print.term_to_string scrutinee  in
-                           let uu____24070 =
-                             let uu____24072 =
+                           let uu____24076 =
+                             let uu____24078 =
                                FStar_All.pipe_right branches
                                  (FStar_List.map
-                                    (fun uu____24102  ->
-                                       match uu____24102 with
-                                       | (p,uu____24113,uu____24114) ->
+                                    (fun uu____24108  ->
+                                       match uu____24108 with
+                                       | (p,uu____24119,uu____24120) ->
                                            FStar_Syntax_Print.pat_to_string p))
                                 in
-                             FStar_All.pipe_right uu____24072
+                             FStar_All.pipe_right uu____24078
                                (FStar_String.concat "\n\t")
                               in
                            FStar_Util.print2
                              "match is irreducible: scrutinee=%s\nbranches=%s\n"
-                             uu____24068 uu____24070);
+                             uu____24074 uu____24076);
                       (let whnf =
                          (cfg1.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                            ||
@@ -7152,87 +7154,87 @@ and (rebuild :
                            FStar_All.pipe_right
                              cfg1.FStar_TypeChecker_Cfg.delta_level
                              (FStar_List.filter
-                                (fun uu___16_24136  ->
-                                   match uu___16_24136 with
+                                (fun uu___16_24142  ->
+                                   match uu___16_24142 with
                                    | FStar_TypeChecker_Env.InliningDelta  ->
                                        true
                                    | FStar_TypeChecker_Env.Eager_unfolding_only
                                         -> true
-                                   | uu____24140 -> false))
+                                   | uu____24146 -> false))
                             in
                          let steps =
-                           let uu___2931_24143 =
+                           let uu___2933_24149 =
                              cfg1.FStar_TypeChecker_Cfg.steps  in
                            {
                              FStar_TypeChecker_Cfg.beta =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.beta);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.beta);
                              FStar_TypeChecker_Cfg.iota =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.iota);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.iota);
                              FStar_TypeChecker_Cfg.zeta = false;
                              FStar_TypeChecker_Cfg.weak =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.weak);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.weak);
                              FStar_TypeChecker_Cfg.hnf =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.hnf);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.hnf);
                              FStar_TypeChecker_Cfg.primops =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.primops);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.primops);
                              FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                              FStar_TypeChecker_Cfg.unfold_until =
                                FStar_Pervasives_Native.None;
                              FStar_TypeChecker_Cfg.unfold_only =
                                FStar_Pervasives_Native.None;
                              FStar_TypeChecker_Cfg.unfold_fully =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.unfold_fully);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.unfold_fully);
                              FStar_TypeChecker_Cfg.unfold_attr =
                                FStar_Pervasives_Native.None;
                              FStar_TypeChecker_Cfg.unfold_tac = false;
                              FStar_TypeChecker_Cfg.pure_subterms_within_computations
                                =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                              FStar_TypeChecker_Cfg.simplify =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.simplify);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.simplify);
                              FStar_TypeChecker_Cfg.erase_universes =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.erase_universes);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.erase_universes);
                              FStar_TypeChecker_Cfg.allow_unbound_universes =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.allow_unbound_universes);
                              FStar_TypeChecker_Cfg.reify_ =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.reify_);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.reify_);
                              FStar_TypeChecker_Cfg.compress_uvars =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.compress_uvars);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.compress_uvars);
                              FStar_TypeChecker_Cfg.no_full_norm =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.no_full_norm);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.no_full_norm);
                              FStar_TypeChecker_Cfg.check_no_uvars =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.check_no_uvars);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.check_no_uvars);
                              FStar_TypeChecker_Cfg.unmeta =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.unmeta);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.unmeta);
                              FStar_TypeChecker_Cfg.unascribe =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.unascribe);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.unascribe);
                              FStar_TypeChecker_Cfg.in_full_norm_request =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.in_full_norm_request);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.in_full_norm_request);
                              FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                              FStar_TypeChecker_Cfg.nbe_step =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.nbe_step);
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.nbe_step);
                              FStar_TypeChecker_Cfg.for_extraction =
-                               (uu___2931_24143.FStar_TypeChecker_Cfg.for_extraction)
+                               (uu___2933_24149.FStar_TypeChecker_Cfg.for_extraction)
                            }  in
-                         let uu___2934_24150 = cfg1  in
+                         let uu___2936_24156 = cfg1  in
                          {
                            FStar_TypeChecker_Cfg.steps = steps;
                            FStar_TypeChecker_Cfg.tcenv =
-                             (uu___2934_24150.FStar_TypeChecker_Cfg.tcenv);
+                             (uu___2936_24156.FStar_TypeChecker_Cfg.tcenv);
                            FStar_TypeChecker_Cfg.debug =
-                             (uu___2934_24150.FStar_TypeChecker_Cfg.debug);
+                             (uu___2936_24156.FStar_TypeChecker_Cfg.debug);
                            FStar_TypeChecker_Cfg.delta_level = new_delta;
                            FStar_TypeChecker_Cfg.primitive_steps =
-                             (uu___2934_24150.FStar_TypeChecker_Cfg.primitive_steps);
+                             (uu___2936_24156.FStar_TypeChecker_Cfg.primitive_steps);
                            FStar_TypeChecker_Cfg.strong = true;
                            FStar_TypeChecker_Cfg.memoize_lazy =
-                             (uu___2934_24150.FStar_TypeChecker_Cfg.memoize_lazy);
+                             (uu___2936_24156.FStar_TypeChecker_Cfg.memoize_lazy);
                            FStar_TypeChecker_Cfg.normalize_pure_lets =
-                             (uu___2934_24150.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                             (uu___2936_24156.FStar_TypeChecker_Cfg.normalize_pure_lets);
                            FStar_TypeChecker_Cfg.reifying =
-                             (uu___2934_24150.FStar_TypeChecker_Cfg.reifying)
+                             (uu___2936_24156.FStar_TypeChecker_Cfg.reifying)
                          }  in
                        let norm_or_whnf env2 t2 =
                          if whnf
@@ -7240,111 +7242,111 @@ and (rebuild :
                          else norm cfg_exclude_zeta env2 [] t2  in
                        let rec norm_pat env2 p =
                          match p.FStar_Syntax_Syntax.v with
-                         | FStar_Syntax_Syntax.Pat_constant uu____24225 ->
+                         | FStar_Syntax_Syntax.Pat_constant uu____24231 ->
                              (p, env2)
                          | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-                             let uu____24256 =
+                             let uu____24262 =
                                FStar_All.pipe_right pats
                                  (FStar_List.fold_left
-                                    (fun uu____24345  ->
-                                       fun uu____24346  ->
-                                         match (uu____24345, uu____24346)
+                                    (fun uu____24351  ->
+                                       fun uu____24352  ->
+                                         match (uu____24351, uu____24352)
                                          with
                                          | ((pats1,env3),(p1,b)) ->
-                                             let uu____24496 =
+                                             let uu____24502 =
                                                norm_pat env3 p1  in
-                                             (match uu____24496 with
+                                             (match uu____24502 with
                                               | (p2,env4) ->
                                                   (((p2, b) :: pats1), env4)))
                                     ([], env2))
                                 in
-                             (match uu____24256 with
+                             (match uu____24262 with
                               | (pats1,env3) ->
-                                  ((let uu___2962_24666 = p  in
+                                  ((let uu___2964_24672 = p  in
                                     {
                                       FStar_Syntax_Syntax.v =
                                         (FStar_Syntax_Syntax.Pat_cons
                                            (fv, (FStar_List.rev pats1)));
                                       FStar_Syntax_Syntax.p =
-                                        (uu___2962_24666.FStar_Syntax_Syntax.p)
+                                        (uu___2964_24672.FStar_Syntax_Syntax.p)
                                     }), env3))
                          | FStar_Syntax_Syntax.Pat_var x ->
                              let x1 =
-                               let uu___2966_24687 = x  in
-                               let uu____24688 =
+                               let uu___2968_24693 = x  in
+                               let uu____24694 =
                                  norm_or_whnf env2 x.FStar_Syntax_Syntax.sort
                                   in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___2966_24687.FStar_Syntax_Syntax.ppname);
+                                   (uu___2968_24693.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___2966_24687.FStar_Syntax_Syntax.index);
-                                 FStar_Syntax_Syntax.sort = uu____24688
+                                   (uu___2968_24693.FStar_Syntax_Syntax.index);
+                                 FStar_Syntax_Syntax.sort = uu____24694
                                }  in
-                             ((let uu___2969_24702 = p  in
+                             ((let uu___2971_24708 = p  in
                                {
                                  FStar_Syntax_Syntax.v =
                                    (FStar_Syntax_Syntax.Pat_var x1);
                                  FStar_Syntax_Syntax.p =
-                                   (uu___2969_24702.FStar_Syntax_Syntax.p)
+                                   (uu___2971_24708.FStar_Syntax_Syntax.p)
                                }), (dummy :: env2))
                          | FStar_Syntax_Syntax.Pat_wild x ->
                              let x1 =
-                               let uu___2973_24713 = x  in
-                               let uu____24714 =
+                               let uu___2975_24719 = x  in
+                               let uu____24720 =
                                  norm_or_whnf env2 x.FStar_Syntax_Syntax.sort
                                   in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___2973_24713.FStar_Syntax_Syntax.ppname);
+                                   (uu___2975_24719.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___2973_24713.FStar_Syntax_Syntax.index);
-                                 FStar_Syntax_Syntax.sort = uu____24714
+                                   (uu___2975_24719.FStar_Syntax_Syntax.index);
+                                 FStar_Syntax_Syntax.sort = uu____24720
                                }  in
-                             ((let uu___2976_24728 = p  in
+                             ((let uu___2978_24734 = p  in
                                {
                                  FStar_Syntax_Syntax.v =
                                    (FStar_Syntax_Syntax.Pat_wild x1);
                                  FStar_Syntax_Syntax.p =
-                                   (uu___2976_24728.FStar_Syntax_Syntax.p)
+                                   (uu___2978_24734.FStar_Syntax_Syntax.p)
                                }), (dummy :: env2))
                          | FStar_Syntax_Syntax.Pat_dot_term (x,t2) ->
                              let x1 =
-                               let uu___2982_24744 = x  in
-                               let uu____24745 =
+                               let uu___2984_24750 = x  in
+                               let uu____24751 =
                                  norm_or_whnf env2 x.FStar_Syntax_Syntax.sort
                                   in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___2982_24744.FStar_Syntax_Syntax.ppname);
+                                   (uu___2984_24750.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___2982_24744.FStar_Syntax_Syntax.index);
-                                 FStar_Syntax_Syntax.sort = uu____24745
+                                   (uu___2984_24750.FStar_Syntax_Syntax.index);
+                                 FStar_Syntax_Syntax.sort = uu____24751
                                }  in
                              let t3 = norm_or_whnf env2 t2  in
-                             ((let uu___2986_24760 = p  in
+                             ((let uu___2988_24766 = p  in
                                {
                                  FStar_Syntax_Syntax.v =
                                    (FStar_Syntax_Syntax.Pat_dot_term (x1, t3));
                                  FStar_Syntax_Syntax.p =
-                                   (uu___2986_24760.FStar_Syntax_Syntax.p)
+                                   (uu___2988_24766.FStar_Syntax_Syntax.p)
                                }), env2)
                           in
                        let branches1 =
                          match env1 with
                          | [] when whnf -> branches
-                         | uu____24804 ->
+                         | uu____24810 ->
                              FStar_All.pipe_right branches
                                (FStar_List.map
                                   (fun branch1  ->
-                                     let uu____24834 =
+                                     let uu____24840 =
                                        FStar_Syntax_Subst.open_branch branch1
                                         in
-                                     match uu____24834 with
+                                     match uu____24840 with
                                      | (p,wopt,e) ->
-                                         let uu____24854 = norm_pat env1 p
+                                         let uu____24860 = norm_pat env1 p
                                             in
-                                         (match uu____24854 with
+                                         (match uu____24860 with
                                           | (p1,env2) ->
                                               let wopt1 =
                                                 match wopt with
@@ -7353,10 +7355,10 @@ and (rebuild :
                                                     FStar_Pervasives_Native.None
                                                 | FStar_Pervasives_Native.Some
                                                     w ->
-                                                    let uu____24909 =
+                                                    let uu____24915 =
                                                       norm_or_whnf env2 w  in
                                                     FStar_Pervasives_Native.Some
-                                                      uu____24909
+                                                      uu____24915
                                                  in
                                               let e1 = norm_or_whnf env2 e
                                                  in
@@ -7364,7 +7366,7 @@ and (rebuild :
                                                 (p1, wopt1, e1))))
                           in
                        let scrutinee1 =
-                         let uu____24926 =
+                         let uu____24932 =
                            ((((cfg1.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.iota
                                 &&
                                 (Prims.op_Negation
@@ -7376,121 +7378,121 @@ and (rebuild :
                               (cfg1.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weakly_reduce_scrutinee)
                              && (maybe_weakly_reduced scrutinee)
                             in
-                         if uu____24926
+                         if uu____24932
                          then
                            norm
-                             (let uu___3005_24933 = cfg1  in
+                             (let uu___3007_24939 = cfg1  in
                               {
                                 FStar_TypeChecker_Cfg.steps =
-                                  (let uu___3007_24936 =
+                                  (let uu___3009_24942 =
                                      cfg1.FStar_TypeChecker_Cfg.steps  in
                                    {
                                      FStar_TypeChecker_Cfg.beta =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.beta);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.beta);
                                      FStar_TypeChecker_Cfg.iota =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.iota);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.iota);
                                      FStar_TypeChecker_Cfg.zeta =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.zeta);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.zeta);
                                      FStar_TypeChecker_Cfg.weak =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.weak);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.weak);
                                      FStar_TypeChecker_Cfg.hnf =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.hnf);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.hnf);
                                      FStar_TypeChecker_Cfg.primops =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.primops);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.primops);
                                      FStar_TypeChecker_Cfg.do_not_unfold_pure_lets
                                        =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                                      FStar_TypeChecker_Cfg.unfold_until =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.unfold_until);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.unfold_until);
                                      FStar_TypeChecker_Cfg.unfold_only =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.unfold_only);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.unfold_only);
                                      FStar_TypeChecker_Cfg.unfold_fully =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.unfold_fully);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.unfold_fully);
                                      FStar_TypeChecker_Cfg.unfold_attr =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.unfold_attr);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.unfold_attr);
                                      FStar_TypeChecker_Cfg.unfold_tac =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.unfold_tac);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.unfold_tac);
                                      FStar_TypeChecker_Cfg.pure_subterms_within_computations
                                        =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                                      FStar_TypeChecker_Cfg.simplify =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.simplify);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.simplify);
                                      FStar_TypeChecker_Cfg.erase_universes =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.erase_universes);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.erase_universes);
                                      FStar_TypeChecker_Cfg.allow_unbound_universes
                                        =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.allow_unbound_universes);
                                      FStar_TypeChecker_Cfg.reify_ =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.reify_);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.reify_);
                                      FStar_TypeChecker_Cfg.compress_uvars =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.compress_uvars);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.compress_uvars);
                                      FStar_TypeChecker_Cfg.no_full_norm =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.no_full_norm);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.no_full_norm);
                                      FStar_TypeChecker_Cfg.check_no_uvars =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.check_no_uvars);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.check_no_uvars);
                                      FStar_TypeChecker_Cfg.unmeta =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.unmeta);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.unmeta);
                                      FStar_TypeChecker_Cfg.unascribe =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.unascribe);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.unascribe);
                                      FStar_TypeChecker_Cfg.in_full_norm_request
                                        =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.in_full_norm_request);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.in_full_norm_request);
                                      FStar_TypeChecker_Cfg.weakly_reduce_scrutinee
                                        = false;
                                      FStar_TypeChecker_Cfg.nbe_step =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.nbe_step);
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.nbe_step);
                                      FStar_TypeChecker_Cfg.for_extraction =
-                                       (uu___3007_24936.FStar_TypeChecker_Cfg.for_extraction)
+                                       (uu___3009_24942.FStar_TypeChecker_Cfg.for_extraction)
                                    });
                                 FStar_TypeChecker_Cfg.tcenv =
-                                  (uu___3005_24933.FStar_TypeChecker_Cfg.tcenv);
+                                  (uu___3007_24939.FStar_TypeChecker_Cfg.tcenv);
                                 FStar_TypeChecker_Cfg.debug =
-                                  (uu___3005_24933.FStar_TypeChecker_Cfg.debug);
+                                  (uu___3007_24939.FStar_TypeChecker_Cfg.debug);
                                 FStar_TypeChecker_Cfg.delta_level =
-                                  (uu___3005_24933.FStar_TypeChecker_Cfg.delta_level);
+                                  (uu___3007_24939.FStar_TypeChecker_Cfg.delta_level);
                                 FStar_TypeChecker_Cfg.primitive_steps =
-                                  (uu___3005_24933.FStar_TypeChecker_Cfg.primitive_steps);
+                                  (uu___3007_24939.FStar_TypeChecker_Cfg.primitive_steps);
                                 FStar_TypeChecker_Cfg.strong =
-                                  (uu___3005_24933.FStar_TypeChecker_Cfg.strong);
+                                  (uu___3007_24939.FStar_TypeChecker_Cfg.strong);
                                 FStar_TypeChecker_Cfg.memoize_lazy =
-                                  (uu___3005_24933.FStar_TypeChecker_Cfg.memoize_lazy);
+                                  (uu___3007_24939.FStar_TypeChecker_Cfg.memoize_lazy);
                                 FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                  (uu___3005_24933.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                  (uu___3007_24939.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                 FStar_TypeChecker_Cfg.reifying =
-                                  (uu___3005_24933.FStar_TypeChecker_Cfg.reifying)
+                                  (uu___3007_24939.FStar_TypeChecker_Cfg.reifying)
                               }) scrutinee_env [] scrutinee
                          else scrutinee  in
-                       let uu____24940 =
+                       let uu____24946 =
                          mk
                            (FStar_Syntax_Syntax.Tm_match
                               (scrutinee1, branches1)) r
                           in
-                       rebuild cfg1 env1 stack1 uu____24940)
+                       rebuild cfg1 env1 stack1 uu____24946)
                        in
                     let rec is_cons head1 =
-                      let uu____24966 =
-                        let uu____24967 = FStar_Syntax_Subst.compress head1
+                      let uu____24972 =
+                        let uu____24973 = FStar_Syntax_Subst.compress head1
                            in
-                        uu____24967.FStar_Syntax_Syntax.n  in
-                      match uu____24966 with
-                      | FStar_Syntax_Syntax.Tm_uinst (h,uu____24972) ->
+                        uu____24973.FStar_Syntax_Syntax.n  in
+                      match uu____24972 with
+                      | FStar_Syntax_Syntax.Tm_uinst (h,uu____24978) ->
                           is_cons h
-                      | FStar_Syntax_Syntax.Tm_constant uu____24977 -> true
+                      | FStar_Syntax_Syntax.Tm_constant uu____24983 -> true
                       | FStar_Syntax_Syntax.Tm_fvar
-                          { FStar_Syntax_Syntax.fv_name = uu____24979;
-                            FStar_Syntax_Syntax.fv_delta = uu____24980;
+                          { FStar_Syntax_Syntax.fv_name = uu____24985;
+                            FStar_Syntax_Syntax.fv_delta = uu____24986;
                             FStar_Syntax_Syntax.fv_qual =
                               FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Data_ctor );_}
                           -> true
                       | FStar_Syntax_Syntax.Tm_fvar
-                          { FStar_Syntax_Syntax.fv_name = uu____24982;
-                            FStar_Syntax_Syntax.fv_delta = uu____24983;
+                          { FStar_Syntax_Syntax.fv_name = uu____24988;
+                            FStar_Syntax_Syntax.fv_delta = uu____24989;
                             FStar_Syntax_Syntax.fv_qual =
                               FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Syntax.Record_ctor uu____24984);_}
+                              (FStar_Syntax_Syntax.Record_ctor uu____24990);_}
                           -> true
-                      | uu____24992 -> false  in
+                      | uu____24998 -> false  in
                     let guard_when_clause wopt b rest =
                       match wopt with
                       | FStar_Pervasives_Native.None  -> b
@@ -7509,120 +7511,120 @@ and (rebuild :
                         FStar_Syntax_Util.unmeta scrutinee_orig  in
                       let scrutinee2 = FStar_Syntax_Util.unlazy scrutinee1
                          in
-                      let uu____25161 =
+                      let uu____25167 =
                         FStar_Syntax_Util.head_and_args scrutinee2  in
-                      match uu____25161 with
+                      match uu____25167 with
                       | (head1,args) ->
                           (match p.FStar_Syntax_Syntax.v with
                            | FStar_Syntax_Syntax.Pat_var bv ->
                                FStar_Util.Inl [(bv, scrutinee_orig)]
                            | FStar_Syntax_Syntax.Pat_wild bv ->
                                FStar_Util.Inl [(bv, scrutinee_orig)]
-                           | FStar_Syntax_Syntax.Pat_dot_term uu____25258 ->
+                           | FStar_Syntax_Syntax.Pat_dot_term uu____25264 ->
                                FStar_Util.Inl []
                            | FStar_Syntax_Syntax.Pat_constant s ->
                                (match scrutinee2.FStar_Syntax_Syntax.n with
                                 | FStar_Syntax_Syntax.Tm_constant s' when
                                     FStar_Const.eq_const s s' ->
                                     FStar_Util.Inl []
-                                | uu____25300 ->
-                                    let uu____25301 =
-                                      let uu____25303 = is_cons head1  in
-                                      Prims.op_Negation uu____25303  in
-                                    FStar_Util.Inr uu____25301)
+                                | uu____25306 ->
+                                    let uu____25307 =
+                                      let uu____25309 = is_cons head1  in
+                                      Prims.op_Negation uu____25309  in
+                                    FStar_Util.Inr uu____25307)
                            | FStar_Syntax_Syntax.Pat_cons (fv,arg_pats) ->
-                               let uu____25332 =
-                                 let uu____25333 =
+                               let uu____25338 =
+                                 let uu____25339 =
                                    FStar_Syntax_Util.un_uinst head1  in
-                                 uu____25333.FStar_Syntax_Syntax.n  in
-                               (match uu____25332 with
+                                 uu____25339.FStar_Syntax_Syntax.n  in
+                               (match uu____25338 with
                                 | FStar_Syntax_Syntax.Tm_fvar fv' when
                                     FStar_Syntax_Syntax.fv_eq fv fv' ->
                                     matches_args [] args arg_pats
-                                | uu____25352 ->
-                                    let uu____25353 =
-                                      let uu____25355 = is_cons head1  in
-                                      Prims.op_Negation uu____25355  in
-                                    FStar_Util.Inr uu____25353))
+                                | uu____25358 ->
+                                    let uu____25359 =
+                                      let uu____25361 = is_cons head1  in
+                                      Prims.op_Negation uu____25361  in
+                                    FStar_Util.Inr uu____25359))
                     
                     and matches_args out a p =
                       match (a, p) with
                       | ([],[]) -> FStar_Util.Inl out
-                      | ((t2,uu____25446)::rest_a,(p1,uu____25449)::rest_p)
+                      | ((t2,uu____25452)::rest_a,(p1,uu____25455)::rest_p)
                           ->
-                          let uu____25508 = matches_pat t2 p1  in
-                          (match uu____25508 with
+                          let uu____25514 = matches_pat t2 p1  in
+                          (match uu____25514 with
                            | FStar_Util.Inl s ->
                                matches_args (FStar_List.append out s) rest_a
                                  rest_p
                            | m -> m)
-                      | uu____25561 -> FStar_Util.Inr false
+                      | uu____25567 -> FStar_Util.Inr false
                      in
                     let rec matches scrutinee1 p =
                       match p with
                       | [] -> norm_and_rebuild_match ()
                       | (p1,wopt,b)::rest ->
-                          let uu____25684 = matches_pat scrutinee1 p1  in
-                          (match uu____25684 with
+                          let uu____25690 = matches_pat scrutinee1 p1  in
+                          (match uu____25690 with
                            | FStar_Util.Inr (false ) ->
                                matches scrutinee1 rest
                            | FStar_Util.Inr (true ) ->
                                norm_and_rebuild_match ()
                            | FStar_Util.Inl s ->
                                (FStar_TypeChecker_Cfg.log cfg1
-                                  (fun uu____25730  ->
-                                     let uu____25731 =
+                                  (fun uu____25736  ->
+                                     let uu____25737 =
                                        FStar_Syntax_Print.pat_to_string p1
                                         in
-                                     let uu____25733 =
-                                       let uu____25735 =
+                                     let uu____25739 =
+                                       let uu____25741 =
                                          FStar_List.map
-                                           (fun uu____25747  ->
-                                              match uu____25747 with
-                                              | (uu____25753,t2) ->
+                                           (fun uu____25753  ->
+                                              match uu____25753 with
+                                              | (uu____25759,t2) ->
                                                   FStar_Syntax_Print.term_to_string
                                                     t2) s
                                           in
-                                       FStar_All.pipe_right uu____25735
+                                       FStar_All.pipe_right uu____25741
                                          (FStar_String.concat "; ")
                                         in
                                      FStar_Util.print2
                                        "Matches pattern %s with subst = %s\n"
-                                       uu____25731 uu____25733);
+                                       uu____25737 uu____25739);
                                 (let env0 = env1  in
                                  let env2 =
                                    FStar_List.fold_left
                                      (fun env2  ->
-                                        fun uu____25789  ->
-                                          match uu____25789 with
+                                        fun uu____25795  ->
+                                          match uu____25795 with
                                           | (bv,t2) ->
-                                              let uu____25812 =
-                                                let uu____25819 =
-                                                  let uu____25822 =
+                                              let uu____25818 =
+                                                let uu____25825 =
+                                                  let uu____25828 =
                                                     FStar_Syntax_Syntax.mk_binder
                                                       bv
                                                      in
                                                   FStar_Pervasives_Native.Some
-                                                    uu____25822
+                                                    uu____25828
                                                    in
-                                                let uu____25823 =
-                                                  let uu____25824 =
-                                                    let uu____25856 =
+                                                let uu____25829 =
+                                                  let uu____25830 =
+                                                    let uu____25862 =
                                                       FStar_Util.mk_ref
                                                         (FStar_Pervasives_Native.Some
                                                            ([], t2))
                                                        in
-                                                    ([], t2, uu____25856,
+                                                    ([], t2, uu____25862,
                                                       false)
                                                      in
-                                                  Clos uu____25824  in
-                                                (uu____25819, uu____25823)
+                                                  Clos uu____25830  in
+                                                (uu____25825, uu____25829)
                                                  in
-                                              uu____25812 :: env2) env1 s
+                                              uu____25818 :: env2) env1 s
                                     in
-                                 let uu____25949 =
+                                 let uu____25955 =
                                    guard_when_clause wopt b rest  in
-                                 norm cfg1 env2 stack1 uu____25949)))
+                                 norm cfg1 env2 stack1 uu____25955)))
                        in
                     if
                       (cfg1.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.iota
@@ -7641,59 +7643,59 @@ let (normalize_with_primitive_steps :
         fun t  ->
           let c = FStar_TypeChecker_Cfg.config' ps s e  in
           FStar_TypeChecker_Cfg.log_cfg c
-            (fun uu____25982  ->
-               let uu____25983 = FStar_TypeChecker_Cfg.cfg_to_string c  in
-               FStar_Util.print1 "Cfg = %s\n" uu____25983);
-          (let uu____25986 = is_nbe_request s  in
-           if uu____25986
+            (fun uu____25988  ->
+               let uu____25989 = FStar_TypeChecker_Cfg.cfg_to_string c  in
+               FStar_Util.print1 "Cfg = %s\n" uu____25989);
+          (let uu____25992 = is_nbe_request s  in
+           if uu____25992
            then
              (FStar_TypeChecker_Cfg.log_top c
-                (fun uu____25992  ->
-                   let uu____25993 = FStar_Syntax_Print.term_to_string t  in
-                   FStar_Util.print1 "Starting NBE for (%s) {\n" uu____25993);
+                (fun uu____25998  ->
+                   let uu____25999 = FStar_Syntax_Print.term_to_string t  in
+                   FStar_Util.print1 "Starting NBE for (%s) {\n" uu____25999);
               FStar_TypeChecker_Cfg.log_top c
-                (fun uu____25999  ->
-                   let uu____26000 = FStar_TypeChecker_Cfg.cfg_to_string c
+                (fun uu____26005  ->
+                   let uu____26006 = FStar_TypeChecker_Cfg.cfg_to_string c
                       in
-                   FStar_Util.print1 ">>> cfg = %s\n" uu____26000);
-              (let uu____26003 =
-                 FStar_Util.record_time (fun uu____26010  -> nbe_eval c s t)
+                   FStar_Util.print1 ">>> cfg = %s\n" uu____26006);
+              (let uu____26009 =
+                 FStar_Util.record_time (fun uu____26016  -> nbe_eval c s t)
                   in
-               match uu____26003 with
+               match uu____26009 with
                | (r,ms) ->
                    (FStar_TypeChecker_Cfg.log_top c
-                      (fun uu____26019  ->
-                         let uu____26020 =
+                      (fun uu____26025  ->
+                         let uu____26026 =
                            FStar_Syntax_Print.term_to_string r  in
-                         let uu____26022 = FStar_Util.string_of_int ms  in
+                         let uu____26028 = FStar_Util.string_of_int ms  in
                          FStar_Util.print2
                            "}\nNormalization result = (%s) in %s ms\n"
-                           uu____26020 uu____26022);
+                           uu____26026 uu____26028);
                     r)))
            else
              (FStar_TypeChecker_Cfg.log_top c
-                (fun uu____26030  ->
-                   let uu____26031 = FStar_Syntax_Print.term_to_string t  in
+                (fun uu____26036  ->
+                   let uu____26037 = FStar_Syntax_Print.term_to_string t  in
                    FStar_Util.print1 "Starting normalizer for (%s) {\n"
-                     uu____26031);
+                     uu____26037);
               FStar_TypeChecker_Cfg.log_top c
-                (fun uu____26037  ->
-                   let uu____26038 = FStar_TypeChecker_Cfg.cfg_to_string c
+                (fun uu____26043  ->
+                   let uu____26044 = FStar_TypeChecker_Cfg.cfg_to_string c
                       in
-                   FStar_Util.print1 ">>> cfg = %s\n" uu____26038);
-              (let uu____26041 =
-                 FStar_Util.record_time (fun uu____26048  -> norm c [] [] t)
+                   FStar_Util.print1 ">>> cfg = %s\n" uu____26044);
+              (let uu____26047 =
+                 FStar_Util.record_time (fun uu____26054  -> norm c [] [] t)
                   in
-               match uu____26041 with
+               match uu____26047 with
                | (r,ms) ->
                    (FStar_TypeChecker_Cfg.log_top c
-                      (fun uu____26063  ->
-                         let uu____26064 =
+                      (fun uu____26069  ->
+                         let uu____26070 =
                            FStar_Syntax_Print.term_to_string r  in
-                         let uu____26066 = FStar_Util.string_of_int ms  in
+                         let uu____26072 = FStar_Util.string_of_int ms  in
                          FStar_Util.print2
                            "}\nNormalization result = (%s) in %s ms\n"
-                           uu____26064 uu____26066);
+                           uu____26070 uu____26072);
                     r))))
   
 let (normalize :
@@ -7704,14 +7706,14 @@ let (normalize :
   fun s  ->
     fun e  ->
       fun t  ->
-        let uu____26085 =
-          let uu____26089 =
-            let uu____26091 = FStar_TypeChecker_Env.current_module e  in
-            FStar_Ident.string_of_lid uu____26091  in
-          FStar_Pervasives_Native.Some uu____26089  in
+        let uu____26091 =
+          let uu____26095 =
+            let uu____26097 = FStar_TypeChecker_Env.current_module e  in
+            FStar_Ident.string_of_lid uu____26097  in
+          FStar_Pervasives_Native.Some uu____26095  in
         FStar_Profiling.profile
-          (fun uu____26094  -> normalize_with_primitive_steps [] s e t)
-          uu____26085 "FStar.TypeChecker.Normalize"
+          (fun uu____26100  -> normalize_with_primitive_steps [] s e t)
+          uu____26091 "FStar.TypeChecker.Normalize"
   
 let (normalize_comp :
   FStar_TypeChecker_Env.steps ->
@@ -7721,8 +7723,8 @@ let (normalize_comp :
   fun s  ->
     fun e  ->
       fun t  ->
-        let uu____26112 = FStar_TypeChecker_Cfg.config s e  in
-        norm_comp uu____26112 [] t
+        let uu____26118 = FStar_TypeChecker_Cfg.config s e  in
+        norm_comp uu____26118 [] t
   
 let (normalize_universe :
   FStar_TypeChecker_Env.env ->
@@ -7730,8 +7732,8 @@ let (normalize_universe :
   =
   fun env  ->
     fun u  ->
-      let uu____26130 = FStar_TypeChecker_Cfg.config [] env  in
-      norm_universe uu____26130 [] u
+      let uu____26136 = FStar_TypeChecker_Cfg.config [] env  in
+      norm_universe uu____26136 [] u
   
 let (ghost_to_pure :
   FStar_TypeChecker_Env.env ->
@@ -7749,18 +7751,18 @@ let (ghost_to_pure :
           FStar_TypeChecker_Env.ForExtraction] env
          in
       let non_info t =
-        let uu____26156 = norm cfg [] [] t  in
-        FStar_TypeChecker_Env.non_informative env uu____26156  in
+        let uu____26162 = norm cfg [] [] t  in
+        FStar_TypeChecker_Env.non_informative env uu____26162  in
       match c.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Total uu____26163 -> c
+      | FStar_Syntax_Syntax.Total uu____26169 -> c
       | FStar_Syntax_Syntax.GTotal (t,uopt) when non_info t ->
-          let uu___3164_26182 = c  in
+          let uu___3166_26188 = c  in
           {
             FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Total (t, uopt));
             FStar_Syntax_Syntax.pos =
-              (uu___3164_26182.FStar_Syntax_Syntax.pos);
+              (uu___3166_26188.FStar_Syntax_Syntax.pos);
             FStar_Syntax_Syntax.vars =
-              (uu___3164_26182.FStar_Syntax_Syntax.vars)
+              (uu___3166_26188.FStar_Syntax_Syntax.vars)
           }
       | FStar_Syntax_Syntax.Comp ct ->
           let l =
@@ -7768,37 +7770,37 @@ let (ghost_to_pure :
               cfg.FStar_TypeChecker_Cfg.tcenv
               ct.FStar_Syntax_Syntax.effect_name
              in
-          let uu____26189 =
+          let uu____26195 =
             (FStar_Syntax_Util.is_ghost_effect l) &&
               (non_info ct.FStar_Syntax_Syntax.result_typ)
              in
-          if uu____26189
+          if uu____26195
           then
             let ct1 =
-              let uu____26193 =
+              let uu____26199 =
                 downgrade_ghost_effect_name
                   ct.FStar_Syntax_Syntax.effect_name
                  in
-              match uu____26193 with
+              match uu____26199 with
               | FStar_Pervasives_Native.Some pure_eff ->
                   let flags =
-                    let uu____26200 =
+                    let uu____26206 =
                       FStar_Ident.lid_equals pure_eff
                         FStar_Parser_Const.effect_Tot_lid
                        in
-                    if uu____26200
+                    if uu____26206
                     then FStar_Syntax_Syntax.TOTAL ::
                       (ct.FStar_Syntax_Syntax.flags)
                     else ct.FStar_Syntax_Syntax.flags  in
-                  let uu___3174_26207 = ct  in
+                  let uu___3176_26213 = ct  in
                   {
                     FStar_Syntax_Syntax.comp_univs =
-                      (uu___3174_26207.FStar_Syntax_Syntax.comp_univs);
+                      (uu___3176_26213.FStar_Syntax_Syntax.comp_univs);
                     FStar_Syntax_Syntax.effect_name = pure_eff;
                     FStar_Syntax_Syntax.result_typ =
-                      (uu___3174_26207.FStar_Syntax_Syntax.result_typ);
+                      (uu___3176_26213.FStar_Syntax_Syntax.result_typ);
                     FStar_Syntax_Syntax.effect_args =
-                      (uu___3174_26207.FStar_Syntax_Syntax.effect_args);
+                      (uu___3176_26213.FStar_Syntax_Syntax.effect_args);
                     FStar_Syntax_Syntax.flags = flags
                   }
               | FStar_Pervasives_Native.None  ->
@@ -7806,30 +7808,30 @@ let (ghost_to_pure :
                     FStar_TypeChecker_Env.unfold_effect_abbrev
                       cfg.FStar_TypeChecker_Cfg.tcenv c
                      in
-                  let uu___3178_26209 = ct1  in
+                  let uu___3180_26215 = ct1  in
                   {
                     FStar_Syntax_Syntax.comp_univs =
-                      (uu___3178_26209.FStar_Syntax_Syntax.comp_univs);
+                      (uu___3180_26215.FStar_Syntax_Syntax.comp_univs);
                     FStar_Syntax_Syntax.effect_name =
                       FStar_Parser_Const.effect_PURE_lid;
                     FStar_Syntax_Syntax.result_typ =
-                      (uu___3178_26209.FStar_Syntax_Syntax.result_typ);
+                      (uu___3180_26215.FStar_Syntax_Syntax.result_typ);
                     FStar_Syntax_Syntax.effect_args =
-                      (uu___3178_26209.FStar_Syntax_Syntax.effect_args);
+                      (uu___3180_26215.FStar_Syntax_Syntax.effect_args);
                     FStar_Syntax_Syntax.flags =
-                      (uu___3178_26209.FStar_Syntax_Syntax.flags)
+                      (uu___3180_26215.FStar_Syntax_Syntax.flags)
                   }
                in
-            let uu___3181_26210 = c  in
+            let uu___3183_26216 = c  in
             {
               FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Comp ct1);
               FStar_Syntax_Syntax.pos =
-                (uu___3181_26210.FStar_Syntax_Syntax.pos);
+                (uu___3183_26216.FStar_Syntax_Syntax.pos);
               FStar_Syntax_Syntax.vars =
-                (uu___3181_26210.FStar_Syntax_Syntax.vars)
+                (uu___3183_26216.FStar_Syntax_Syntax.vars)
             }
           else c
-      | uu____26213 -> c
+      | uu____26219 -> c
   
 let (ghost_to_pure_lcomp :
   FStar_TypeChecker_Env.env ->
@@ -7848,23 +7850,23 @@ let (ghost_to_pure_lcomp :
           FStar_TypeChecker_Env.ForExtraction] env
          in
       let non_info t =
-        let uu____26233 = norm cfg [] [] t  in
-        FStar_TypeChecker_Env.non_informative env uu____26233  in
-      let uu____26240 =
+        let uu____26239 = norm cfg [] [] t  in
+        FStar_TypeChecker_Env.non_informative env uu____26239  in
+      let uu____26246 =
         (FStar_Syntax_Util.is_ghost_effect lc.FStar_Syntax_Syntax.eff_name)
           && (non_info lc.FStar_Syntax_Syntax.res_typ)
          in
-      if uu____26240
+      if uu____26246
       then
-        let uu____26243 =
+        let uu____26249 =
           downgrade_ghost_effect_name lc.FStar_Syntax_Syntax.eff_name  in
-        match uu____26243 with
+        match uu____26249 with
         | FStar_Pervasives_Native.Some pure_eff ->
             FStar_Syntax_Syntax.mk_lcomp pure_eff
               lc.FStar_Syntax_Syntax.res_typ lc.FStar_Syntax_Syntax.cflags
-              (fun uu____26249  ->
-                 let uu____26250 = FStar_Syntax_Syntax.lcomp_comp lc  in
-                 ghost_to_pure env uu____26250)
+              (fun uu____26255  ->
+                 let uu____26256 = FStar_Syntax_Syntax.lcomp_comp lc  in
+                 ghost_to_pure env uu____26256)
         | FStar_Pervasives_Native.None  -> lc
       else lc
   
@@ -7874,22 +7876,22 @@ let (term_to_string :
     fun t  ->
       let t1 =
         try
-          (fun uu___3197_26267  ->
+          (fun uu___3199_26273  ->
              match () with
              | () ->
                  normalize [FStar_TypeChecker_Env.AllowUnboundUniverses] env
                    t) ()
         with
-        | uu___3196_26270 ->
-            ((let uu____26272 =
-                let uu____26278 =
-                  let uu____26280 = FStar_Util.message_of_exn uu___3196_26270
+        | uu___3198_26276 ->
+            ((let uu____26278 =
+                let uu____26284 =
+                  let uu____26286 = FStar_Util.message_of_exn uu___3198_26276
                      in
                   FStar_Util.format1 "Normalization failed with error %s\n"
-                    uu____26280
+                    uu____26286
                    in
-                (FStar_Errors.Warning_NormalizationFailure, uu____26278)  in
-              FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____26272);
+                (FStar_Errors.Warning_NormalizationFailure, uu____26284)  in
+              FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____26278);
              t)
          in
       FStar_Syntax_Print.term_to_string' env.FStar_TypeChecker_Env.dsenv t1
@@ -7900,25 +7902,25 @@ let (comp_to_string :
     fun c  ->
       let c1 =
         try
-          (fun uu___3207_26299  ->
+          (fun uu___3209_26305  ->
              match () with
              | () ->
-                 let uu____26300 =
+                 let uu____26306 =
                    FStar_TypeChecker_Cfg.config
                      [FStar_TypeChecker_Env.AllowUnboundUniverses] env
                     in
-                 norm_comp uu____26300 [] c) ()
+                 norm_comp uu____26306 [] c) ()
         with
-        | uu___3206_26309 ->
-            ((let uu____26311 =
-                let uu____26317 =
-                  let uu____26319 = FStar_Util.message_of_exn uu___3206_26309
+        | uu___3208_26315 ->
+            ((let uu____26317 =
+                let uu____26323 =
+                  let uu____26325 = FStar_Util.message_of_exn uu___3208_26315
                      in
                   FStar_Util.format1 "Normalization failed with error %s\n"
-                    uu____26319
+                    uu____26325
                    in
-                (FStar_Errors.Warning_NormalizationFailure, uu____26317)  in
-              FStar_Errors.log_issue c.FStar_Syntax_Syntax.pos uu____26311);
+                (FStar_Errors.Warning_NormalizationFailure, uu____26323)  in
+              FStar_Errors.log_issue c.FStar_Syntax_Syntax.pos uu____26317);
              c)
          in
       FStar_Syntax_Print.comp_to_string' env.FStar_TypeChecker_Env.dsenv c1
@@ -7942,15 +7944,15 @@ let (normalize_refinement :
               let t01 = aux x.FStar_Syntax_Syntax.sort  in
               (match t01.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_refine (y,phi1) ->
-                   let uu____26368 =
-                     let uu____26369 =
-                       let uu____26376 =
+                   let uu____26374 =
+                     let uu____26375 =
+                       let uu____26382 =
                          FStar_Syntax_Util.mk_conj_simp phi1 phi  in
-                       (y, uu____26376)  in
-                     FStar_Syntax_Syntax.Tm_refine uu____26369  in
-                   mk uu____26368 t01.FStar_Syntax_Syntax.pos
-               | uu____26381 -> t2)
-          | uu____26382 -> t2  in
+                       (y, uu____26382)  in
+                     FStar_Syntax_Syntax.Tm_refine uu____26375  in
+                   mk uu____26374 t01.FStar_Syntax_Syntax.pos
+               | uu____26387 -> t2)
+          | uu____26388 -> t2  in
         aux t
   
 let (whnf_steps : FStar_TypeChecker_Env.step Prims.list) =
@@ -8006,32 +8008,32 @@ let (eta_expand_with_type :
   fun env  ->
     fun e  ->
       fun t_e  ->
-        let uu____26476 = FStar_Syntax_Util.arrow_formals_comp t_e  in
-        match uu____26476 with
+        let uu____26482 = FStar_Syntax_Util.arrow_formals_comp t_e  in
+        match uu____26482 with
         | (formals,c) ->
             (match formals with
              | [] -> e
-             | uu____26513 ->
-                 let uu____26522 = FStar_Syntax_Util.abs_formals e  in
-                 (match uu____26522 with
-                  | (actuals,uu____26532,uu____26533) ->
+             | uu____26519 ->
+                 let uu____26528 = FStar_Syntax_Util.abs_formals e  in
+                 (match uu____26528 with
+                  | (actuals,uu____26538,uu____26539) ->
                       if
                         (FStar_List.length actuals) =
                           (FStar_List.length formals)
                       then e
                       else
-                        (let uu____26553 =
+                        (let uu____26559 =
                            FStar_All.pipe_right formals
                              FStar_Syntax_Util.args_of_binders
                             in
-                         match uu____26553 with
+                         match uu____26559 with
                          | (binders,args) ->
-                             let uu____26564 =
+                             let uu____26570 =
                                FStar_Syntax_Syntax.mk_Tm_app e args
                                  FStar_Pervasives_Native.None
                                  e.FStar_Syntax_Syntax.pos
                                 in
-                             FStar_Syntax_Util.abs binders uu____26564
+                             FStar_Syntax_Util.abs binders uu____26570
                                (FStar_Pervasives_Native.Some
                                   (FStar_Syntax_Util.residual_comp_of_comp c)))))
   
@@ -8044,224 +8046,224 @@ let (eta_expand :
       match t.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_name x ->
           eta_expand_with_type env t x.FStar_Syntax_Syntax.sort
-      | uu____26579 ->
-          let uu____26580 = FStar_Syntax_Util.head_and_args t  in
-          (match uu____26580 with
+      | uu____26585 ->
+          let uu____26586 = FStar_Syntax_Util.head_and_args t  in
+          (match uu____26586 with
            | (head1,args) ->
-               let uu____26623 =
-                 let uu____26624 = FStar_Syntax_Subst.compress head1  in
-                 uu____26624.FStar_Syntax_Syntax.n  in
-               (match uu____26623 with
+               let uu____26629 =
+                 let uu____26630 = FStar_Syntax_Subst.compress head1  in
+                 uu____26630.FStar_Syntax_Syntax.n  in
+               (match uu____26629 with
                 | FStar_Syntax_Syntax.Tm_uvar (u,s) ->
-                    let uu____26645 =
-                      let uu____26660 =
+                    let uu____26651 =
+                      let uu____26666 =
                         FStar_Syntax_Subst.subst' s
                           u.FStar_Syntax_Syntax.ctx_uvar_typ
                          in
-                      FStar_Syntax_Util.arrow_formals uu____26660  in
-                    (match uu____26645 with
+                      FStar_Syntax_Util.arrow_formals uu____26666  in
+                    (match uu____26651 with
                      | (formals,_tres) ->
                          if
                            (FStar_List.length formals) =
                              (FStar_List.length args)
                          then t
                          else
-                           (let uu____26700 =
+                           (let uu____26706 =
                               env.FStar_TypeChecker_Env.type_of
-                                (let uu___3277_26708 = env  in
+                                (let uu___3279_26714 = env  in
                                  {
                                    FStar_TypeChecker_Env.solver =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.solver);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.solver);
                                    FStar_TypeChecker_Env.range =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.range);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.range);
                                    FStar_TypeChecker_Env.curmodule =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.curmodule);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.curmodule);
                                    FStar_TypeChecker_Env.gamma =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.gamma);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.gamma);
                                    FStar_TypeChecker_Env.gamma_sig =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.gamma_sig);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.gamma_sig);
                                    FStar_TypeChecker_Env.gamma_cache =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.gamma_cache);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.gamma_cache);
                                    FStar_TypeChecker_Env.modules =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.modules);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.modules);
                                    FStar_TypeChecker_Env.expected_typ =
                                      FStar_Pervasives_Native.None;
                                    FStar_TypeChecker_Env.sigtab =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.sigtab);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.sigtab);
                                    FStar_TypeChecker_Env.attrtab =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.attrtab);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.attrtab);
                                    FStar_TypeChecker_Env.is_pattern =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.is_pattern);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.is_pattern);
                                    FStar_TypeChecker_Env.instantiate_imp =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.instantiate_imp);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.instantiate_imp);
                                    FStar_TypeChecker_Env.effects =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.effects);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.effects);
                                    FStar_TypeChecker_Env.generalize =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.generalize);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.generalize);
                                    FStar_TypeChecker_Env.letrecs =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.letrecs);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.letrecs);
                                    FStar_TypeChecker_Env.top_level =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.top_level);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.top_level);
                                    FStar_TypeChecker_Env.check_uvars =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.check_uvars);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.check_uvars);
                                    FStar_TypeChecker_Env.use_eq =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.use_eq);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.use_eq);
                                    FStar_TypeChecker_Env.is_iface =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.is_iface);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.is_iface);
                                    FStar_TypeChecker_Env.admit =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.admit);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.admit);
                                    FStar_TypeChecker_Env.lax = true;
                                    FStar_TypeChecker_Env.lax_universes =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.lax_universes);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.lax_universes);
                                    FStar_TypeChecker_Env.phase1 =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.phase1);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.phase1);
                                    FStar_TypeChecker_Env.failhard =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.failhard);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.failhard);
                                    FStar_TypeChecker_Env.nosynth =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.nosynth);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.nosynth);
                                    FStar_TypeChecker_Env.uvar_subtyping =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.uvar_subtyping);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.uvar_subtyping);
                                    FStar_TypeChecker_Env.tc_term =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.tc_term);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.tc_term);
                                    FStar_TypeChecker_Env.type_of =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.type_of);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.type_of);
                                    FStar_TypeChecker_Env.universe_of =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.universe_of);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.universe_of);
                                    FStar_TypeChecker_Env.check_type_of =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.check_type_of);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.check_type_of);
                                    FStar_TypeChecker_Env.use_bv_sorts = true;
                                    FStar_TypeChecker_Env.qtbl_name_and_index
                                      =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.qtbl_name_and_index);
                                    FStar_TypeChecker_Env.normalized_eff_names
                                      =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.normalized_eff_names);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.normalized_eff_names);
                                    FStar_TypeChecker_Env.fv_delta_depths =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.fv_delta_depths);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.fv_delta_depths);
                                    FStar_TypeChecker_Env.proof_ns =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.proof_ns);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.proof_ns);
                                    FStar_TypeChecker_Env.synth_hook =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.synth_hook);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.synth_hook);
                                    FStar_TypeChecker_Env.splice =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.splice);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.splice);
                                    FStar_TypeChecker_Env.postprocess =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.postprocess);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.postprocess);
                                    FStar_TypeChecker_Env.is_native_tactic =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.is_native_tactic);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.is_native_tactic);
                                    FStar_TypeChecker_Env.identifier_info =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.identifier_info);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.identifier_info);
                                    FStar_TypeChecker_Env.tc_hooks =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.tc_hooks);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.tc_hooks);
                                    FStar_TypeChecker_Env.dsenv =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.dsenv);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.dsenv);
                                    FStar_TypeChecker_Env.nbe =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.nbe);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.nbe);
                                    FStar_TypeChecker_Env.strict_args_tab =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.strict_args_tab);
+                                     (uu___3279_26714.FStar_TypeChecker_Env.strict_args_tab);
                                    FStar_TypeChecker_Env.erasable_types_tab =
-                                     (uu___3277_26708.FStar_TypeChecker_Env.erasable_types_tab)
+                                     (uu___3279_26714.FStar_TypeChecker_Env.erasable_types_tab)
                                  }) t
                                in
-                            match uu____26700 with
-                            | (uu____26711,ty,uu____26713) ->
+                            match uu____26706 with
+                            | (uu____26717,ty,uu____26719) ->
                                 eta_expand_with_type env t ty))
-                | uu____26714 ->
-                    let uu____26715 =
+                | uu____26720 ->
+                    let uu____26721 =
                       env.FStar_TypeChecker_Env.type_of
-                        (let uu___3284_26723 = env  in
+                        (let uu___3286_26729 = env  in
                          {
                            FStar_TypeChecker_Env.solver =
-                             (uu___3284_26723.FStar_TypeChecker_Env.solver);
+                             (uu___3286_26729.FStar_TypeChecker_Env.solver);
                            FStar_TypeChecker_Env.range =
-                             (uu___3284_26723.FStar_TypeChecker_Env.range);
+                             (uu___3286_26729.FStar_TypeChecker_Env.range);
                            FStar_TypeChecker_Env.curmodule =
-                             (uu___3284_26723.FStar_TypeChecker_Env.curmodule);
+                             (uu___3286_26729.FStar_TypeChecker_Env.curmodule);
                            FStar_TypeChecker_Env.gamma =
-                             (uu___3284_26723.FStar_TypeChecker_Env.gamma);
+                             (uu___3286_26729.FStar_TypeChecker_Env.gamma);
                            FStar_TypeChecker_Env.gamma_sig =
-                             (uu___3284_26723.FStar_TypeChecker_Env.gamma_sig);
+                             (uu___3286_26729.FStar_TypeChecker_Env.gamma_sig);
                            FStar_TypeChecker_Env.gamma_cache =
-                             (uu___3284_26723.FStar_TypeChecker_Env.gamma_cache);
+                             (uu___3286_26729.FStar_TypeChecker_Env.gamma_cache);
                            FStar_TypeChecker_Env.modules =
-                             (uu___3284_26723.FStar_TypeChecker_Env.modules);
+                             (uu___3286_26729.FStar_TypeChecker_Env.modules);
                            FStar_TypeChecker_Env.expected_typ =
                              FStar_Pervasives_Native.None;
                            FStar_TypeChecker_Env.sigtab =
-                             (uu___3284_26723.FStar_TypeChecker_Env.sigtab);
+                             (uu___3286_26729.FStar_TypeChecker_Env.sigtab);
                            FStar_TypeChecker_Env.attrtab =
-                             (uu___3284_26723.FStar_TypeChecker_Env.attrtab);
+                             (uu___3286_26729.FStar_TypeChecker_Env.attrtab);
                            FStar_TypeChecker_Env.is_pattern =
-                             (uu___3284_26723.FStar_TypeChecker_Env.is_pattern);
+                             (uu___3286_26729.FStar_TypeChecker_Env.is_pattern);
                            FStar_TypeChecker_Env.instantiate_imp =
-                             (uu___3284_26723.FStar_TypeChecker_Env.instantiate_imp);
+                             (uu___3286_26729.FStar_TypeChecker_Env.instantiate_imp);
                            FStar_TypeChecker_Env.effects =
-                             (uu___3284_26723.FStar_TypeChecker_Env.effects);
+                             (uu___3286_26729.FStar_TypeChecker_Env.effects);
                            FStar_TypeChecker_Env.generalize =
-                             (uu___3284_26723.FStar_TypeChecker_Env.generalize);
+                             (uu___3286_26729.FStar_TypeChecker_Env.generalize);
                            FStar_TypeChecker_Env.letrecs =
-                             (uu___3284_26723.FStar_TypeChecker_Env.letrecs);
+                             (uu___3286_26729.FStar_TypeChecker_Env.letrecs);
                            FStar_TypeChecker_Env.top_level =
-                             (uu___3284_26723.FStar_TypeChecker_Env.top_level);
+                             (uu___3286_26729.FStar_TypeChecker_Env.top_level);
                            FStar_TypeChecker_Env.check_uvars =
-                             (uu___3284_26723.FStar_TypeChecker_Env.check_uvars);
+                             (uu___3286_26729.FStar_TypeChecker_Env.check_uvars);
                            FStar_TypeChecker_Env.use_eq =
-                             (uu___3284_26723.FStar_TypeChecker_Env.use_eq);
+                             (uu___3286_26729.FStar_TypeChecker_Env.use_eq);
                            FStar_TypeChecker_Env.is_iface =
-                             (uu___3284_26723.FStar_TypeChecker_Env.is_iface);
+                             (uu___3286_26729.FStar_TypeChecker_Env.is_iface);
                            FStar_TypeChecker_Env.admit =
-                             (uu___3284_26723.FStar_TypeChecker_Env.admit);
+                             (uu___3286_26729.FStar_TypeChecker_Env.admit);
                            FStar_TypeChecker_Env.lax = true;
                            FStar_TypeChecker_Env.lax_universes =
-                             (uu___3284_26723.FStar_TypeChecker_Env.lax_universes);
+                             (uu___3286_26729.FStar_TypeChecker_Env.lax_universes);
                            FStar_TypeChecker_Env.phase1 =
-                             (uu___3284_26723.FStar_TypeChecker_Env.phase1);
+                             (uu___3286_26729.FStar_TypeChecker_Env.phase1);
                            FStar_TypeChecker_Env.failhard =
-                             (uu___3284_26723.FStar_TypeChecker_Env.failhard);
+                             (uu___3286_26729.FStar_TypeChecker_Env.failhard);
                            FStar_TypeChecker_Env.nosynth =
-                             (uu___3284_26723.FStar_TypeChecker_Env.nosynth);
+                             (uu___3286_26729.FStar_TypeChecker_Env.nosynth);
                            FStar_TypeChecker_Env.uvar_subtyping =
-                             (uu___3284_26723.FStar_TypeChecker_Env.uvar_subtyping);
+                             (uu___3286_26729.FStar_TypeChecker_Env.uvar_subtyping);
                            FStar_TypeChecker_Env.tc_term =
-                             (uu___3284_26723.FStar_TypeChecker_Env.tc_term);
+                             (uu___3286_26729.FStar_TypeChecker_Env.tc_term);
                            FStar_TypeChecker_Env.type_of =
-                             (uu___3284_26723.FStar_TypeChecker_Env.type_of);
+                             (uu___3286_26729.FStar_TypeChecker_Env.type_of);
                            FStar_TypeChecker_Env.universe_of =
-                             (uu___3284_26723.FStar_TypeChecker_Env.universe_of);
+                             (uu___3286_26729.FStar_TypeChecker_Env.universe_of);
                            FStar_TypeChecker_Env.check_type_of =
-                             (uu___3284_26723.FStar_TypeChecker_Env.check_type_of);
+                             (uu___3286_26729.FStar_TypeChecker_Env.check_type_of);
                            FStar_TypeChecker_Env.use_bv_sorts = true;
                            FStar_TypeChecker_Env.qtbl_name_and_index =
-                             (uu___3284_26723.FStar_TypeChecker_Env.qtbl_name_and_index);
+                             (uu___3286_26729.FStar_TypeChecker_Env.qtbl_name_and_index);
                            FStar_TypeChecker_Env.normalized_eff_names =
-                             (uu___3284_26723.FStar_TypeChecker_Env.normalized_eff_names);
+                             (uu___3286_26729.FStar_TypeChecker_Env.normalized_eff_names);
                            FStar_TypeChecker_Env.fv_delta_depths =
-                             (uu___3284_26723.FStar_TypeChecker_Env.fv_delta_depths);
+                             (uu___3286_26729.FStar_TypeChecker_Env.fv_delta_depths);
                            FStar_TypeChecker_Env.proof_ns =
-                             (uu___3284_26723.FStar_TypeChecker_Env.proof_ns);
+                             (uu___3286_26729.FStar_TypeChecker_Env.proof_ns);
                            FStar_TypeChecker_Env.synth_hook =
-                             (uu___3284_26723.FStar_TypeChecker_Env.synth_hook);
+                             (uu___3286_26729.FStar_TypeChecker_Env.synth_hook);
                            FStar_TypeChecker_Env.splice =
-                             (uu___3284_26723.FStar_TypeChecker_Env.splice);
+                             (uu___3286_26729.FStar_TypeChecker_Env.splice);
                            FStar_TypeChecker_Env.postprocess =
-                             (uu___3284_26723.FStar_TypeChecker_Env.postprocess);
+                             (uu___3286_26729.FStar_TypeChecker_Env.postprocess);
                            FStar_TypeChecker_Env.is_native_tactic =
-                             (uu___3284_26723.FStar_TypeChecker_Env.is_native_tactic);
+                             (uu___3286_26729.FStar_TypeChecker_Env.is_native_tactic);
                            FStar_TypeChecker_Env.identifier_info =
-                             (uu___3284_26723.FStar_TypeChecker_Env.identifier_info);
+                             (uu___3286_26729.FStar_TypeChecker_Env.identifier_info);
                            FStar_TypeChecker_Env.tc_hooks =
-                             (uu___3284_26723.FStar_TypeChecker_Env.tc_hooks);
+                             (uu___3286_26729.FStar_TypeChecker_Env.tc_hooks);
                            FStar_TypeChecker_Env.dsenv =
-                             (uu___3284_26723.FStar_TypeChecker_Env.dsenv);
+                             (uu___3286_26729.FStar_TypeChecker_Env.dsenv);
                            FStar_TypeChecker_Env.nbe =
-                             (uu___3284_26723.FStar_TypeChecker_Env.nbe);
+                             (uu___3286_26729.FStar_TypeChecker_Env.nbe);
                            FStar_TypeChecker_Env.strict_args_tab =
-                             (uu___3284_26723.FStar_TypeChecker_Env.strict_args_tab);
+                             (uu___3286_26729.FStar_TypeChecker_Env.strict_args_tab);
                            FStar_TypeChecker_Env.erasable_types_tab =
-                             (uu___3284_26723.FStar_TypeChecker_Env.erasable_types_tab)
+                             (uu___3286_26729.FStar_TypeChecker_Env.erasable_types_tab)
                          }) t
                        in
-                    (match uu____26715 with
-                     | (uu____26726,ty,uu____26728) ->
+                    (match uu____26721 with
+                     | (uu____26732,ty,uu____26734) ->
                          eta_expand_with_type env t ty)))
   
 let rec (elim_delayed_subst_term :
@@ -8273,220 +8275,220 @@ let rec (elim_delayed_subst_term :
        in
     let t1 = FStar_Syntax_Subst.compress t  in
     let elim_bv x =
-      let uu___3296_26810 = x  in
-      let uu____26811 = elim_delayed_subst_term x.FStar_Syntax_Syntax.sort
+      let uu___3298_26816 = x  in
+      let uu____26817 = elim_delayed_subst_term x.FStar_Syntax_Syntax.sort
          in
       {
         FStar_Syntax_Syntax.ppname =
-          (uu___3296_26810.FStar_Syntax_Syntax.ppname);
+          (uu___3298_26816.FStar_Syntax_Syntax.ppname);
         FStar_Syntax_Syntax.index =
-          (uu___3296_26810.FStar_Syntax_Syntax.index);
-        FStar_Syntax_Syntax.sort = uu____26811
+          (uu___3298_26816.FStar_Syntax_Syntax.index);
+        FStar_Syntax_Syntax.sort = uu____26817
       }  in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____26814 -> failwith "Impossible"
-    | FStar_Syntax_Syntax.Tm_bvar uu____26838 -> t1
-    | FStar_Syntax_Syntax.Tm_name uu____26839 -> t1
-    | FStar_Syntax_Syntax.Tm_fvar uu____26840 -> t1
-    | FStar_Syntax_Syntax.Tm_uinst uu____26841 -> t1
-    | FStar_Syntax_Syntax.Tm_constant uu____26848 -> t1
-    | FStar_Syntax_Syntax.Tm_type uu____26849 -> t1
-    | FStar_Syntax_Syntax.Tm_lazy uu____26850 -> t1
+    | FStar_Syntax_Syntax.Tm_delayed uu____26820 -> failwith "Impossible"
+    | FStar_Syntax_Syntax.Tm_bvar uu____26844 -> t1
+    | FStar_Syntax_Syntax.Tm_name uu____26845 -> t1
+    | FStar_Syntax_Syntax.Tm_fvar uu____26846 -> t1
+    | FStar_Syntax_Syntax.Tm_uinst uu____26847 -> t1
+    | FStar_Syntax_Syntax.Tm_constant uu____26854 -> t1
+    | FStar_Syntax_Syntax.Tm_type uu____26855 -> t1
+    | FStar_Syntax_Syntax.Tm_lazy uu____26856 -> t1
     | FStar_Syntax_Syntax.Tm_unknown  -> t1
     | FStar_Syntax_Syntax.Tm_abs (bs,t2,rc_opt) ->
         let elim_rc rc =
-          let uu___3322_26884 = rc  in
-          let uu____26885 =
+          let uu___3324_26890 = rc  in
+          let uu____26891 =
             FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
               elim_delayed_subst_term
              in
-          let uu____26894 =
+          let uu____26900 =
             elim_delayed_subst_cflags rc.FStar_Syntax_Syntax.residual_flags
              in
           {
             FStar_Syntax_Syntax.residual_effect =
-              (uu___3322_26884.FStar_Syntax_Syntax.residual_effect);
-            FStar_Syntax_Syntax.residual_typ = uu____26885;
-            FStar_Syntax_Syntax.residual_flags = uu____26894
+              (uu___3324_26890.FStar_Syntax_Syntax.residual_effect);
+            FStar_Syntax_Syntax.residual_typ = uu____26891;
+            FStar_Syntax_Syntax.residual_flags = uu____26900
           }  in
-        let uu____26897 =
-          let uu____26898 =
-            let uu____26917 = elim_delayed_subst_binders bs  in
-            let uu____26926 = elim_delayed_subst_term t2  in
-            let uu____26929 = FStar_Util.map_opt rc_opt elim_rc  in
-            (uu____26917, uu____26926, uu____26929)  in
-          FStar_Syntax_Syntax.Tm_abs uu____26898  in
-        mk1 uu____26897
+        let uu____26903 =
+          let uu____26904 =
+            let uu____26923 = elim_delayed_subst_binders bs  in
+            let uu____26932 = elim_delayed_subst_term t2  in
+            let uu____26935 = FStar_Util.map_opt rc_opt elim_rc  in
+            (uu____26923, uu____26932, uu____26935)  in
+          FStar_Syntax_Syntax.Tm_abs uu____26904  in
+        mk1 uu____26903
     | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-        let uu____26966 =
-          let uu____26967 =
-            let uu____26982 = elim_delayed_subst_binders bs  in
-            let uu____26991 = elim_delayed_subst_comp c  in
-            (uu____26982, uu____26991)  in
-          FStar_Syntax_Syntax.Tm_arrow uu____26967  in
-        mk1 uu____26966
+        let uu____26972 =
+          let uu____26973 =
+            let uu____26988 = elim_delayed_subst_binders bs  in
+            let uu____26997 = elim_delayed_subst_comp c  in
+            (uu____26988, uu____26997)  in
+          FStar_Syntax_Syntax.Tm_arrow uu____26973  in
+        mk1 uu____26972
     | FStar_Syntax_Syntax.Tm_refine (bv,phi) ->
-        let uu____27010 =
-          let uu____27011 =
-            let uu____27018 = elim_bv bv  in
-            let uu____27019 = elim_delayed_subst_term phi  in
-            (uu____27018, uu____27019)  in
-          FStar_Syntax_Syntax.Tm_refine uu____27011  in
-        mk1 uu____27010
+        let uu____27016 =
+          let uu____27017 =
+            let uu____27024 = elim_bv bv  in
+            let uu____27025 = elim_delayed_subst_term phi  in
+            (uu____27024, uu____27025)  in
+          FStar_Syntax_Syntax.Tm_refine uu____27017  in
+        mk1 uu____27016
     | FStar_Syntax_Syntax.Tm_app (t2,args) ->
-        let uu____27050 =
-          let uu____27051 =
-            let uu____27068 = elim_delayed_subst_term t2  in
-            let uu____27071 = elim_delayed_subst_args args  in
-            (uu____27068, uu____27071)  in
-          FStar_Syntax_Syntax.Tm_app uu____27051  in
-        mk1 uu____27050
+        let uu____27056 =
+          let uu____27057 =
+            let uu____27074 = elim_delayed_subst_term t2  in
+            let uu____27077 = elim_delayed_subst_args args  in
+            (uu____27074, uu____27077)  in
+          FStar_Syntax_Syntax.Tm_app uu____27057  in
+        mk1 uu____27056
     | FStar_Syntax_Syntax.Tm_match (t2,branches) ->
         let rec elim_pat p =
           match p.FStar_Syntax_Syntax.v with
           | FStar_Syntax_Syntax.Pat_var x ->
-              let uu___3344_27143 = p  in
-              let uu____27144 =
-                let uu____27145 = elim_bv x  in
-                FStar_Syntax_Syntax.Pat_var uu____27145  in
+              let uu___3346_27149 = p  in
+              let uu____27150 =
+                let uu____27151 = elim_bv x  in
+                FStar_Syntax_Syntax.Pat_var uu____27151  in
               {
-                FStar_Syntax_Syntax.v = uu____27144;
+                FStar_Syntax_Syntax.v = uu____27150;
                 FStar_Syntax_Syntax.p =
-                  (uu___3344_27143.FStar_Syntax_Syntax.p)
+                  (uu___3346_27149.FStar_Syntax_Syntax.p)
               }
           | FStar_Syntax_Syntax.Pat_wild x ->
-              let uu___3348_27147 = p  in
-              let uu____27148 =
-                let uu____27149 = elim_bv x  in
-                FStar_Syntax_Syntax.Pat_wild uu____27149  in
+              let uu___3350_27153 = p  in
+              let uu____27154 =
+                let uu____27155 = elim_bv x  in
+                FStar_Syntax_Syntax.Pat_wild uu____27155  in
               {
-                FStar_Syntax_Syntax.v = uu____27148;
+                FStar_Syntax_Syntax.v = uu____27154;
                 FStar_Syntax_Syntax.p =
-                  (uu___3348_27147.FStar_Syntax_Syntax.p)
+                  (uu___3350_27153.FStar_Syntax_Syntax.p)
               }
           | FStar_Syntax_Syntax.Pat_dot_term (x,t0) ->
-              let uu___3354_27156 = p  in
-              let uu____27157 =
-                let uu____27158 =
-                  let uu____27165 = elim_bv x  in
-                  let uu____27166 = elim_delayed_subst_term t0  in
-                  (uu____27165, uu____27166)  in
-                FStar_Syntax_Syntax.Pat_dot_term uu____27158  in
+              let uu___3356_27162 = p  in
+              let uu____27163 =
+                let uu____27164 =
+                  let uu____27171 = elim_bv x  in
+                  let uu____27172 = elim_delayed_subst_term t0  in
+                  (uu____27171, uu____27172)  in
+                FStar_Syntax_Syntax.Pat_dot_term uu____27164  in
               {
-                FStar_Syntax_Syntax.v = uu____27157;
+                FStar_Syntax_Syntax.v = uu____27163;
                 FStar_Syntax_Syntax.p =
-                  (uu___3354_27156.FStar_Syntax_Syntax.p)
+                  (uu___3356_27162.FStar_Syntax_Syntax.p)
               }
           | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-              let uu___3360_27191 = p  in
-              let uu____27192 =
-                let uu____27193 =
-                  let uu____27207 =
+              let uu___3362_27197 = p  in
+              let uu____27198 =
+                let uu____27199 =
+                  let uu____27213 =
                     FStar_List.map
-                      (fun uu____27233  ->
-                         match uu____27233 with
+                      (fun uu____27239  ->
+                         match uu____27239 with
                          | (x,b) ->
-                             let uu____27250 = elim_pat x  in
-                             (uu____27250, b)) pats
+                             let uu____27256 = elim_pat x  in
+                             (uu____27256, b)) pats
                      in
-                  (fv, uu____27207)  in
-                FStar_Syntax_Syntax.Pat_cons uu____27193  in
+                  (fv, uu____27213)  in
+                FStar_Syntax_Syntax.Pat_cons uu____27199  in
               {
-                FStar_Syntax_Syntax.v = uu____27192;
+                FStar_Syntax_Syntax.v = uu____27198;
                 FStar_Syntax_Syntax.p =
-                  (uu___3360_27191.FStar_Syntax_Syntax.p)
+                  (uu___3362_27197.FStar_Syntax_Syntax.p)
               }
-          | uu____27265 -> p  in
-        let elim_branch uu____27289 =
-          match uu____27289 with
+          | uu____27271 -> p  in
+        let elim_branch uu____27295 =
+          match uu____27295 with
           | (pat,wopt,t3) ->
-              let uu____27315 = elim_pat pat  in
-              let uu____27318 =
+              let uu____27321 = elim_pat pat  in
+              let uu____27324 =
                 FStar_Util.map_opt wopt elim_delayed_subst_term  in
-              let uu____27321 = elim_delayed_subst_term t3  in
-              (uu____27315, uu____27318, uu____27321)
+              let uu____27327 = elim_delayed_subst_term t3  in
+              (uu____27321, uu____27324, uu____27327)
            in
-        let uu____27326 =
-          let uu____27327 =
-            let uu____27350 = elim_delayed_subst_term t2  in
-            let uu____27353 = FStar_List.map elim_branch branches  in
-            (uu____27350, uu____27353)  in
-          FStar_Syntax_Syntax.Tm_match uu____27327  in
-        mk1 uu____27326
+        let uu____27332 =
+          let uu____27333 =
+            let uu____27356 = elim_delayed_subst_term t2  in
+            let uu____27359 = FStar_List.map elim_branch branches  in
+            (uu____27356, uu____27359)  in
+          FStar_Syntax_Syntax.Tm_match uu____27333  in
+        mk1 uu____27332
     | FStar_Syntax_Syntax.Tm_ascribed (t2,a,lopt) ->
-        let elim_ascription uu____27484 =
-          match uu____27484 with
+        let elim_ascription uu____27490 =
+          match uu____27490 with
           | (tc,topt) ->
-              let uu____27519 =
+              let uu____27525 =
                 match tc with
                 | FStar_Util.Inl t3 ->
-                    let uu____27529 = elim_delayed_subst_term t3  in
-                    FStar_Util.Inl uu____27529
+                    let uu____27535 = elim_delayed_subst_term t3  in
+                    FStar_Util.Inl uu____27535
                 | FStar_Util.Inr c ->
-                    let uu____27531 = elim_delayed_subst_comp c  in
-                    FStar_Util.Inr uu____27531
+                    let uu____27537 = elim_delayed_subst_comp c  in
+                    FStar_Util.Inr uu____27537
                  in
-              let uu____27532 =
+              let uu____27538 =
                 FStar_Util.map_opt topt elim_delayed_subst_term  in
-              (uu____27519, uu____27532)
+              (uu____27525, uu____27538)
            in
-        let uu____27541 =
-          let uu____27542 =
-            let uu____27569 = elim_delayed_subst_term t2  in
-            let uu____27572 = elim_ascription a  in
-            (uu____27569, uu____27572, lopt)  in
-          FStar_Syntax_Syntax.Tm_ascribed uu____27542  in
-        mk1 uu____27541
+        let uu____27547 =
+          let uu____27548 =
+            let uu____27575 = elim_delayed_subst_term t2  in
+            let uu____27578 = elim_ascription a  in
+            (uu____27575, uu____27578, lopt)  in
+          FStar_Syntax_Syntax.Tm_ascribed uu____27548  in
+        mk1 uu____27547
     | FStar_Syntax_Syntax.Tm_let (lbs,t2) ->
         let elim_lb lb =
-          let uu___3390_27635 = lb  in
-          let uu____27636 =
+          let uu___3392_27641 = lb  in
+          let uu____27642 =
             elim_delayed_subst_term lb.FStar_Syntax_Syntax.lbtyp  in
-          let uu____27639 =
+          let uu____27645 =
             elim_delayed_subst_term lb.FStar_Syntax_Syntax.lbdef  in
           {
             FStar_Syntax_Syntax.lbname =
-              (uu___3390_27635.FStar_Syntax_Syntax.lbname);
+              (uu___3392_27641.FStar_Syntax_Syntax.lbname);
             FStar_Syntax_Syntax.lbunivs =
-              (uu___3390_27635.FStar_Syntax_Syntax.lbunivs);
-            FStar_Syntax_Syntax.lbtyp = uu____27636;
+              (uu___3392_27641.FStar_Syntax_Syntax.lbunivs);
+            FStar_Syntax_Syntax.lbtyp = uu____27642;
             FStar_Syntax_Syntax.lbeff =
-              (uu___3390_27635.FStar_Syntax_Syntax.lbeff);
-            FStar_Syntax_Syntax.lbdef = uu____27639;
+              (uu___3392_27641.FStar_Syntax_Syntax.lbeff);
+            FStar_Syntax_Syntax.lbdef = uu____27645;
             FStar_Syntax_Syntax.lbattrs =
-              (uu___3390_27635.FStar_Syntax_Syntax.lbattrs);
+              (uu___3392_27641.FStar_Syntax_Syntax.lbattrs);
             FStar_Syntax_Syntax.lbpos =
-              (uu___3390_27635.FStar_Syntax_Syntax.lbpos)
+              (uu___3392_27641.FStar_Syntax_Syntax.lbpos)
           }  in
-        let uu____27642 =
-          let uu____27643 =
-            let uu____27657 =
-              let uu____27665 =
+        let uu____27648 =
+          let uu____27649 =
+            let uu____27663 =
+              let uu____27671 =
                 FStar_List.map elim_lb (FStar_Pervasives_Native.snd lbs)  in
-              ((FStar_Pervasives_Native.fst lbs), uu____27665)  in
-            let uu____27677 = elim_delayed_subst_term t2  in
-            (uu____27657, uu____27677)  in
-          FStar_Syntax_Syntax.Tm_let uu____27643  in
-        mk1 uu____27642
+              ((FStar_Pervasives_Native.fst lbs), uu____27671)  in
+            let uu____27683 = elim_delayed_subst_term t2  in
+            (uu____27663, uu____27683)  in
+          FStar_Syntax_Syntax.Tm_let uu____27649  in
+        mk1 uu____27648
     | FStar_Syntax_Syntax.Tm_uvar (u,s) ->
         mk1 (FStar_Syntax_Syntax.Tm_uvar (u, s))
     | FStar_Syntax_Syntax.Tm_quoted (tm,qi) ->
         let qi1 =
           FStar_Syntax_Syntax.on_antiquoted elim_delayed_subst_term qi  in
-        let uu____27722 =
-          let uu____27723 =
-            let uu____27730 = elim_delayed_subst_term tm  in
-            (uu____27730, qi1)  in
-          FStar_Syntax_Syntax.Tm_quoted uu____27723  in
-        mk1 uu____27722
+        let uu____27728 =
+          let uu____27729 =
+            let uu____27736 = elim_delayed_subst_term tm  in
+            (uu____27736, qi1)  in
+          FStar_Syntax_Syntax.Tm_quoted uu____27729  in
+        mk1 uu____27728
     | FStar_Syntax_Syntax.Tm_meta (t2,md) ->
-        let uu____27741 =
-          let uu____27742 =
-            let uu____27749 = elim_delayed_subst_term t2  in
-            let uu____27752 = elim_delayed_subst_meta md  in
-            (uu____27749, uu____27752)  in
-          FStar_Syntax_Syntax.Tm_meta uu____27742  in
-        mk1 uu____27741
+        let uu____27747 =
+          let uu____27748 =
+            let uu____27755 = elim_delayed_subst_term t2  in
+            let uu____27758 = elim_delayed_subst_meta md  in
+            (uu____27755, uu____27758)  in
+          FStar_Syntax_Syntax.Tm_meta uu____27748  in
+        mk1 uu____27747
 
 and (elim_delayed_subst_cflags :
   FStar_Syntax_Syntax.cflag Prims.list ->
@@ -8494,11 +8496,11 @@ and (elim_delayed_subst_cflags :
   =
   fun flags  ->
     FStar_List.map
-      (fun uu___17_27761  ->
-         match uu___17_27761 with
+      (fun uu___17_27767  ->
+         match uu___17_27767 with
          | FStar_Syntax_Syntax.DECREASES t ->
-             let uu____27765 = elim_delayed_subst_term t  in
-             FStar_Syntax_Syntax.DECREASES uu____27765
+             let uu____27771 = elim_delayed_subst_term t  in
+             FStar_Syntax_Syntax.DECREASES uu____27771
          | f -> f) flags
 
 and (elim_delayed_subst_comp :
@@ -8510,59 +8512,59 @@ and (elim_delayed_subst_comp :
        in
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Total (t,uopt) ->
-        let uu____27788 =
-          let uu____27789 =
-            let uu____27798 = elim_delayed_subst_term t  in
-            (uu____27798, uopt)  in
-          FStar_Syntax_Syntax.Total uu____27789  in
-        mk1 uu____27788
+        let uu____27794 =
+          let uu____27795 =
+            let uu____27804 = elim_delayed_subst_term t  in
+            (uu____27804, uopt)  in
+          FStar_Syntax_Syntax.Total uu____27795  in
+        mk1 uu____27794
     | FStar_Syntax_Syntax.GTotal (t,uopt) ->
-        let uu____27815 =
-          let uu____27816 =
-            let uu____27825 = elim_delayed_subst_term t  in
-            (uu____27825, uopt)  in
-          FStar_Syntax_Syntax.GTotal uu____27816  in
-        mk1 uu____27815
+        let uu____27821 =
+          let uu____27822 =
+            let uu____27831 = elim_delayed_subst_term t  in
+            (uu____27831, uopt)  in
+          FStar_Syntax_Syntax.GTotal uu____27822  in
+        mk1 uu____27821
     | FStar_Syntax_Syntax.Comp ct ->
         let ct1 =
-          let uu___3423_27834 = ct  in
-          let uu____27835 =
+          let uu___3425_27840 = ct  in
+          let uu____27841 =
             elim_delayed_subst_term ct.FStar_Syntax_Syntax.result_typ  in
-          let uu____27838 =
+          let uu____27844 =
             elim_delayed_subst_args ct.FStar_Syntax_Syntax.effect_args  in
-          let uu____27849 =
+          let uu____27855 =
             elim_delayed_subst_cflags ct.FStar_Syntax_Syntax.flags  in
           {
             FStar_Syntax_Syntax.comp_univs =
-              (uu___3423_27834.FStar_Syntax_Syntax.comp_univs);
+              (uu___3425_27840.FStar_Syntax_Syntax.comp_univs);
             FStar_Syntax_Syntax.effect_name =
-              (uu___3423_27834.FStar_Syntax_Syntax.effect_name);
-            FStar_Syntax_Syntax.result_typ = uu____27835;
-            FStar_Syntax_Syntax.effect_args = uu____27838;
-            FStar_Syntax_Syntax.flags = uu____27849
+              (uu___3425_27840.FStar_Syntax_Syntax.effect_name);
+            FStar_Syntax_Syntax.result_typ = uu____27841;
+            FStar_Syntax_Syntax.effect_args = uu____27844;
+            FStar_Syntax_Syntax.flags = uu____27855
           }  in
         mk1 (FStar_Syntax_Syntax.Comp ct1)
 
 and (elim_delayed_subst_meta :
   FStar_Syntax_Syntax.metadata -> FStar_Syntax_Syntax.metadata) =
-  fun uu___18_27852  ->
-    match uu___18_27852 with
+  fun uu___18_27858  ->
+    match uu___18_27858 with
     | FStar_Syntax_Syntax.Meta_pattern (names1,args) ->
-        let uu____27887 =
-          let uu____27908 = FStar_List.map elim_delayed_subst_term names1  in
-          let uu____27917 = FStar_List.map elim_delayed_subst_args args  in
-          (uu____27908, uu____27917)  in
-        FStar_Syntax_Syntax.Meta_pattern uu____27887
+        let uu____27893 =
+          let uu____27914 = FStar_List.map elim_delayed_subst_term names1  in
+          let uu____27923 = FStar_List.map elim_delayed_subst_args args  in
+          (uu____27914, uu____27923)  in
+        FStar_Syntax_Syntax.Meta_pattern uu____27893
     | FStar_Syntax_Syntax.Meta_monadic (m,t) ->
-        let uu____27972 =
-          let uu____27979 = elim_delayed_subst_term t  in (m, uu____27979)
+        let uu____27978 =
+          let uu____27985 = elim_delayed_subst_term t  in (m, uu____27985)
            in
-        FStar_Syntax_Syntax.Meta_monadic uu____27972
+        FStar_Syntax_Syntax.Meta_monadic uu____27978
     | FStar_Syntax_Syntax.Meta_monadic_lift (m1,m2,t) ->
-        let uu____27991 =
-          let uu____28000 = elim_delayed_subst_term t  in
-          (m1, m2, uu____28000)  in
-        FStar_Syntax_Syntax.Meta_monadic_lift uu____27991
+        let uu____27997 =
+          let uu____28006 = elim_delayed_subst_term t  in
+          (m1, m2, uu____28006)  in
+        FStar_Syntax_Syntax.Meta_monadic_lift uu____27997
     | m -> m
 
 and (elim_delayed_subst_args :
@@ -8575,10 +8577,10 @@ and (elim_delayed_subst_args :
   =
   fun args  ->
     FStar_List.map
-      (fun uu____28033  ->
-         match uu____28033 with
+      (fun uu____28039  ->
+         match uu____28039 with
          | (t,q) ->
-             let uu____28052 = elim_delayed_subst_term t  in (uu____28052, q))
+             let uu____28058 = elim_delayed_subst_term t  in (uu____28058, q))
       args
 
 and (elim_delayed_subst_binders :
@@ -8589,21 +8591,21 @@ and (elim_delayed_subst_binders :
   =
   fun bs  ->
     FStar_List.map
-      (fun uu____28080  ->
-         match uu____28080 with
+      (fun uu____28086  ->
+         match uu____28086 with
          | (x,q) ->
-             let uu____28099 =
-               let uu___3449_28100 = x  in
-               let uu____28101 =
+             let uu____28105 =
+               let uu___3451_28106 = x  in
+               let uu____28107 =
                  elim_delayed_subst_term x.FStar_Syntax_Syntax.sort  in
                {
                  FStar_Syntax_Syntax.ppname =
-                   (uu___3449_28100.FStar_Syntax_Syntax.ppname);
+                   (uu___3451_28106.FStar_Syntax_Syntax.ppname);
                  FStar_Syntax_Syntax.index =
-                   (uu___3449_28100.FStar_Syntax_Syntax.index);
-                 FStar_Syntax_Syntax.sort = uu____28101
+                   (uu___3451_28106.FStar_Syntax_Syntax.index);
+                 FStar_Syntax_Syntax.sort = uu____28107
                }  in
-             (uu____28099, q)) bs
+             (uu____28105, q)) bs
 
 let (elim_uvars_aux_tc :
   FStar_TypeChecker_Env.env ->
@@ -8627,50 +8629,50 @@ let (elim_uvars_aux_tc :
             | ([],FStar_Util.Inl t) -> t
             | ([],FStar_Util.Inr c) ->
                 failwith "Impossible: empty bindes with a comp"
-            | (uu____28209,FStar_Util.Inr c) ->
+            | (uu____28215,FStar_Util.Inr c) ->
                 FStar_Syntax_Syntax.mk
                   (FStar_Syntax_Syntax.Tm_arrow (binders, c))
                   FStar_Pervasives_Native.None c.FStar_Syntax_Syntax.pos
-            | (uu____28241,FStar_Util.Inl t) ->
-                let uu____28263 =
-                  let uu____28270 =
-                    let uu____28271 =
-                      let uu____28286 = FStar_Syntax_Syntax.mk_Total t  in
-                      (binders, uu____28286)  in
-                    FStar_Syntax_Syntax.Tm_arrow uu____28271  in
-                  FStar_Syntax_Syntax.mk uu____28270  in
-                uu____28263 FStar_Pervasives_Native.None
+            | (uu____28247,FStar_Util.Inl t) ->
+                let uu____28269 =
+                  let uu____28276 =
+                    let uu____28277 =
+                      let uu____28292 = FStar_Syntax_Syntax.mk_Total t  in
+                      (binders, uu____28292)  in
+                    FStar_Syntax_Syntax.Tm_arrow uu____28277  in
+                  FStar_Syntax_Syntax.mk uu____28276  in
+                uu____28269 FStar_Pervasives_Native.None
                   t.FStar_Syntax_Syntax.pos
              in
-          let uu____28299 = FStar_Syntax_Subst.open_univ_vars univ_names t
+          let uu____28305 = FStar_Syntax_Subst.open_univ_vars univ_names t
              in
-          match uu____28299 with
+          match uu____28305 with
           | (univ_names1,t1) ->
               let t2 = remove_uvar_solutions env t1  in
               let t3 = FStar_Syntax_Subst.close_univ_vars univ_names1 t2  in
               let t4 = elim_delayed_subst_term t3  in
-              let uu____28331 =
+              let uu____28337 =
                 match binders with
                 | [] -> ([], (FStar_Util.Inl t4))
-                | uu____28404 ->
-                    let uu____28405 =
-                      let uu____28414 =
-                        let uu____28415 = FStar_Syntax_Subst.compress t4  in
-                        uu____28415.FStar_Syntax_Syntax.n  in
-                      (uu____28414, tc)  in
-                    (match uu____28405 with
+                | uu____28410 ->
+                    let uu____28411 =
+                      let uu____28420 =
+                        let uu____28421 = FStar_Syntax_Subst.compress t4  in
+                        uu____28421.FStar_Syntax_Syntax.n  in
+                      (uu____28420, tc)  in
+                    (match uu____28411 with
                      | (FStar_Syntax_Syntax.Tm_arrow
-                        (binders1,c),FStar_Util.Inr uu____28444) ->
+                        (binders1,c),FStar_Util.Inr uu____28450) ->
                          (binders1, (FStar_Util.Inr c))
                      | (FStar_Syntax_Syntax.Tm_arrow
-                        (binders1,c),FStar_Util.Inl uu____28491) ->
+                        (binders1,c),FStar_Util.Inl uu____28497) ->
                          (binders1,
                            (FStar_Util.Inl (FStar_Syntax_Util.comp_result c)))
-                     | (uu____28536,FStar_Util.Inl uu____28537) ->
+                     | (uu____28542,FStar_Util.Inl uu____28543) ->
                          ([], (FStar_Util.Inl t4))
-                     | uu____28568 -> failwith "Impossible")
+                     | uu____28574 -> failwith "Impossible")
                  in
-              (match uu____28331 with
+              (match uu____28337 with
                | (binders1,tc1) -> (univ_names1, binders1, tc1))
   
 let (elim_uvars_aux_t :
@@ -8687,12 +8689,12 @@ let (elim_uvars_aux_t :
     fun univ_names  ->
       fun binders  ->
         fun t  ->
-          let uu____28707 =
+          let uu____28713 =
             elim_uvars_aux_tc env univ_names binders (FStar_Util.Inl t)  in
-          match uu____28707 with
+          match uu____28713 with
           | (univ_names1,binders1,tc) ->
-              let uu____28781 = FStar_Util.left tc  in
-              (univ_names1, binders1, uu____28781)
+              let uu____28787 = FStar_Util.left tc  in
+              (univ_names1, binders1, uu____28787)
   
 let (elim_uvars_aux_c :
   FStar_TypeChecker_Env.env ->
@@ -8708,12 +8710,12 @@ let (elim_uvars_aux_c :
     fun univ_names  ->
       fun binders  ->
         fun c  ->
-          let uu____28835 =
+          let uu____28841 =
             elim_uvars_aux_tc env univ_names binders (FStar_Util.Inr c)  in
-          match uu____28835 with
+          match uu____28841 with
           | (univ_names1,binders1,tc) ->
-              let uu____28909 = FStar_Util.right tc  in
-              (univ_names1, binders1, uu____28909)
+              let uu____28915 = FStar_Util.right tc  in
+              (univ_names1, binders1, uu____28915)
   
 let rec (elim_uvars :
   FStar_TypeChecker_Env.env ->
@@ -8724,267 +8726,281 @@ let rec (elim_uvars :
       match s.FStar_Syntax_Syntax.sigel with
       | FStar_Syntax_Syntax.Sig_inductive_typ
           (lid,univ_names,binders,typ,lids,lids') ->
-          let uu____28951 = elim_uvars_aux_t env univ_names binders typ  in
-          (match uu____28951 with
+          let uu____28957 = elim_uvars_aux_t env univ_names binders typ  in
+          (match uu____28957 with
            | (univ_names1,binders1,typ1) ->
-               let uu___3532_28991 = s  in
+               let uu___3534_28997 = s  in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_inductive_typ
                       (lid, univ_names1, binders1, typ1, lids, lids'));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3532_28991.FStar_Syntax_Syntax.sigrng);
+                   (uu___3534_28997.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3532_28991.FStar_Syntax_Syntax.sigquals);
+                   (uu___3534_28997.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3532_28991.FStar_Syntax_Syntax.sigmeta);
+                   (uu___3534_28997.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3532_28991.FStar_Syntax_Syntax.sigattrs)
+                   (uu___3534_28997.FStar_Syntax_Syntax.sigattrs);
+                 FStar_Syntax_Syntax.sigopts =
+                   (uu___3534_28997.FStar_Syntax_Syntax.sigopts)
                })
       | FStar_Syntax_Syntax.Sig_bundle (sigs,lids) ->
-          let uu___3538_29006 = s  in
-          let uu____29007 =
-            let uu____29008 =
-              let uu____29017 = FStar_List.map (elim_uvars env) sigs  in
-              (uu____29017, lids)  in
-            FStar_Syntax_Syntax.Sig_bundle uu____29008  in
+          let uu___3540_29012 = s  in
+          let uu____29013 =
+            let uu____29014 =
+              let uu____29023 = FStar_List.map (elim_uvars env) sigs  in
+              (uu____29023, lids)  in
+            FStar_Syntax_Syntax.Sig_bundle uu____29014  in
           {
-            FStar_Syntax_Syntax.sigel = uu____29007;
+            FStar_Syntax_Syntax.sigel = uu____29013;
             FStar_Syntax_Syntax.sigrng =
-              (uu___3538_29006.FStar_Syntax_Syntax.sigrng);
+              (uu___3540_29012.FStar_Syntax_Syntax.sigrng);
             FStar_Syntax_Syntax.sigquals =
-              (uu___3538_29006.FStar_Syntax_Syntax.sigquals);
+              (uu___3540_29012.FStar_Syntax_Syntax.sigquals);
             FStar_Syntax_Syntax.sigmeta =
-              (uu___3538_29006.FStar_Syntax_Syntax.sigmeta);
+              (uu___3540_29012.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs =
-              (uu___3538_29006.FStar_Syntax_Syntax.sigattrs)
+              (uu___3540_29012.FStar_Syntax_Syntax.sigattrs);
+            FStar_Syntax_Syntax.sigopts =
+              (uu___3540_29012.FStar_Syntax_Syntax.sigopts)
           }
       | FStar_Syntax_Syntax.Sig_datacon (lid,univ_names,typ,lident,i,lids) ->
-          let uu____29036 = elim_uvars_aux_t env univ_names [] typ  in
-          (match uu____29036 with
-           | (univ_names1,uu____29060,typ1) ->
-               let uu___3552_29082 = s  in
+          let uu____29042 = elim_uvars_aux_t env univ_names [] typ  in
+          (match uu____29042 with
+           | (univ_names1,uu____29066,typ1) ->
+               let uu___3554_29088 = s  in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_datacon
                       (lid, univ_names1, typ1, lident, i, lids));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3552_29082.FStar_Syntax_Syntax.sigrng);
+                   (uu___3554_29088.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3552_29082.FStar_Syntax_Syntax.sigquals);
+                   (uu___3554_29088.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3552_29082.FStar_Syntax_Syntax.sigmeta);
+                   (uu___3554_29088.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3552_29082.FStar_Syntax_Syntax.sigattrs)
+                   (uu___3554_29088.FStar_Syntax_Syntax.sigattrs);
+                 FStar_Syntax_Syntax.sigopts =
+                   (uu___3554_29088.FStar_Syntax_Syntax.sigopts)
                })
       | FStar_Syntax_Syntax.Sig_declare_typ (lid,univ_names,typ) ->
-          let uu____29089 = elim_uvars_aux_t env univ_names [] typ  in
-          (match uu____29089 with
-           | (univ_names1,uu____29113,typ1) ->
-               let uu___3563_29135 = s  in
+          let uu____29095 = elim_uvars_aux_t env univ_names [] typ  in
+          (match uu____29095 with
+           | (univ_names1,uu____29119,typ1) ->
+               let uu___3565_29141 = s  in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_declare_typ
                       (lid, univ_names1, typ1));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3563_29135.FStar_Syntax_Syntax.sigrng);
+                   (uu___3565_29141.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3563_29135.FStar_Syntax_Syntax.sigquals);
+                   (uu___3565_29141.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3563_29135.FStar_Syntax_Syntax.sigmeta);
+                   (uu___3565_29141.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3563_29135.FStar_Syntax_Syntax.sigattrs)
+                   (uu___3565_29141.FStar_Syntax_Syntax.sigattrs);
+                 FStar_Syntax_Syntax.sigopts =
+                   (uu___3565_29141.FStar_Syntax_Syntax.sigopts)
                })
       | FStar_Syntax_Syntax.Sig_let ((b,lbs),lids) ->
           let lbs1 =
             FStar_All.pipe_right lbs
               (FStar_List.map
                  (fun lb  ->
-                    let uu____29165 =
+                    let uu____29171 =
                       FStar_Syntax_Subst.univ_var_opening
                         lb.FStar_Syntax_Syntax.lbunivs
                        in
-                    match uu____29165 with
+                    match uu____29171 with
                     | (opening,lbunivs) ->
                         let elim t =
-                          let uu____29190 =
-                            let uu____29191 =
-                              let uu____29192 =
+                          let uu____29196 =
+                            let uu____29197 =
+                              let uu____29198 =
                                 FStar_Syntax_Subst.subst opening t  in
-                              remove_uvar_solutions env uu____29192  in
+                              remove_uvar_solutions env uu____29198  in
                             FStar_Syntax_Subst.close_univ_vars lbunivs
-                              uu____29191
+                              uu____29197
                              in
-                          elim_delayed_subst_term uu____29190  in
+                          elim_delayed_subst_term uu____29196  in
                         let lbtyp = elim lb.FStar_Syntax_Syntax.lbtyp  in
                         let lbdef = elim lb.FStar_Syntax_Syntax.lbdef  in
-                        let uu___3579_29195 = lb  in
+                        let uu___3581_29201 = lb  in
                         {
                           FStar_Syntax_Syntax.lbname =
-                            (uu___3579_29195.FStar_Syntax_Syntax.lbname);
+                            (uu___3581_29201.FStar_Syntax_Syntax.lbname);
                           FStar_Syntax_Syntax.lbunivs = lbunivs;
                           FStar_Syntax_Syntax.lbtyp = lbtyp;
                           FStar_Syntax_Syntax.lbeff =
-                            (uu___3579_29195.FStar_Syntax_Syntax.lbeff);
+                            (uu___3581_29201.FStar_Syntax_Syntax.lbeff);
                           FStar_Syntax_Syntax.lbdef = lbdef;
                           FStar_Syntax_Syntax.lbattrs =
-                            (uu___3579_29195.FStar_Syntax_Syntax.lbattrs);
+                            (uu___3581_29201.FStar_Syntax_Syntax.lbattrs);
                           FStar_Syntax_Syntax.lbpos =
-                            (uu___3579_29195.FStar_Syntax_Syntax.lbpos)
+                            (uu___3581_29201.FStar_Syntax_Syntax.lbpos)
                         }))
              in
-          let uu___3582_29196 = s  in
+          let uu___3584_29202 = s  in
           {
             FStar_Syntax_Syntax.sigel =
               (FStar_Syntax_Syntax.Sig_let ((b, lbs1), lids));
             FStar_Syntax_Syntax.sigrng =
-              (uu___3582_29196.FStar_Syntax_Syntax.sigrng);
+              (uu___3584_29202.FStar_Syntax_Syntax.sigrng);
             FStar_Syntax_Syntax.sigquals =
-              (uu___3582_29196.FStar_Syntax_Syntax.sigquals);
+              (uu___3584_29202.FStar_Syntax_Syntax.sigquals);
             FStar_Syntax_Syntax.sigmeta =
-              (uu___3582_29196.FStar_Syntax_Syntax.sigmeta);
+              (uu___3584_29202.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs =
-              (uu___3582_29196.FStar_Syntax_Syntax.sigattrs)
+              (uu___3584_29202.FStar_Syntax_Syntax.sigattrs);
+            FStar_Syntax_Syntax.sigopts =
+              (uu___3584_29202.FStar_Syntax_Syntax.sigopts)
           }
       | FStar_Syntax_Syntax.Sig_main t ->
-          let uu___3586_29203 = s  in
-          let uu____29204 =
-            let uu____29205 = remove_uvar_solutions env t  in
-            FStar_Syntax_Syntax.Sig_main uu____29205  in
+          let uu___3588_29209 = s  in
+          let uu____29210 =
+            let uu____29211 = remove_uvar_solutions env t  in
+            FStar_Syntax_Syntax.Sig_main uu____29211  in
           {
-            FStar_Syntax_Syntax.sigel = uu____29204;
+            FStar_Syntax_Syntax.sigel = uu____29210;
             FStar_Syntax_Syntax.sigrng =
-              (uu___3586_29203.FStar_Syntax_Syntax.sigrng);
+              (uu___3588_29209.FStar_Syntax_Syntax.sigrng);
             FStar_Syntax_Syntax.sigquals =
-              (uu___3586_29203.FStar_Syntax_Syntax.sigquals);
+              (uu___3588_29209.FStar_Syntax_Syntax.sigquals);
             FStar_Syntax_Syntax.sigmeta =
-              (uu___3586_29203.FStar_Syntax_Syntax.sigmeta);
+              (uu___3588_29209.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs =
-              (uu___3586_29203.FStar_Syntax_Syntax.sigattrs)
+              (uu___3588_29209.FStar_Syntax_Syntax.sigattrs);
+            FStar_Syntax_Syntax.sigopts =
+              (uu___3588_29209.FStar_Syntax_Syntax.sigopts)
           }
       | FStar_Syntax_Syntax.Sig_assume (l,us,t) ->
-          let uu____29209 = elim_uvars_aux_t env us [] t  in
-          (match uu____29209 with
-           | (us1,uu____29233,t1) ->
-               let uu___3597_29255 = s  in
+          let uu____29215 = elim_uvars_aux_t env us [] t  in
+          (match uu____29215 with
+           | (us1,uu____29239,t1) ->
+               let uu___3599_29261 = s  in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_assume (l, us1, t1));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3597_29255.FStar_Syntax_Syntax.sigrng);
+                   (uu___3599_29261.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3597_29255.FStar_Syntax_Syntax.sigquals);
+                   (uu___3599_29261.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3597_29255.FStar_Syntax_Syntax.sigmeta);
+                   (uu___3599_29261.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3597_29255.FStar_Syntax_Syntax.sigattrs)
+                   (uu___3599_29261.FStar_Syntax_Syntax.sigattrs);
+                 FStar_Syntax_Syntax.sigopts =
+                   (uu___3599_29261.FStar_Syntax_Syntax.sigopts)
                })
-      | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____29256 ->
+      | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____29262 ->
           failwith "Impossible: should have been desugared already"
       | FStar_Syntax_Syntax.Sig_new_effect ed ->
-          let uu____29259 =
+          let uu____29265 =
             elim_uvars_aux_t env ed.FStar_Syntax_Syntax.univs
               ed.FStar_Syntax_Syntax.binders FStar_Syntax_Syntax.t_unit
              in
-          (match uu____29259 with
-           | (univs1,binders,uu____29278) ->
-               let uu____29299 =
-                 let uu____29304 = FStar_Syntax_Subst.univ_var_opening univs1
+          (match uu____29265 with
+           | (univs1,binders,uu____29284) ->
+               let uu____29305 =
+                 let uu____29310 = FStar_Syntax_Subst.univ_var_opening univs1
                     in
-                 match uu____29304 with
+                 match uu____29310 with
                  | (univs_opening,univs2) ->
-                     let uu____29327 =
+                     let uu____29333 =
                        FStar_Syntax_Subst.univ_var_closing univs2  in
-                     (univs_opening, uu____29327)
+                     (univs_opening, uu____29333)
                   in
-               (match uu____29299 with
+               (match uu____29305 with
                 | (univs_opening,univs_closing) ->
-                    let uu____29330 =
+                    let uu____29336 =
                       let binders1 = FStar_Syntax_Subst.open_binders binders
                          in
-                      let uu____29336 =
+                      let uu____29342 =
                         FStar_Syntax_Subst.opening_of_binders binders1  in
-                      let uu____29337 =
+                      let uu____29343 =
                         FStar_Syntax_Subst.closing_of_binders binders1  in
-                      (uu____29336, uu____29337)  in
-                    (match uu____29330 with
+                      (uu____29342, uu____29343)  in
+                    (match uu____29336 with
                      | (b_opening,b_closing) ->
                          let n1 = FStar_List.length univs1  in
                          let n_binders = FStar_List.length binders  in
-                         let elim_tscheme uu____29363 =
-                           match uu____29363 with
+                         let elim_tscheme uu____29369 =
+                           match uu____29369 with
                            | (us,t) ->
                                let n_us = FStar_List.length us  in
-                               let uu____29381 =
+                               let uu____29387 =
                                  FStar_Syntax_Subst.open_univ_vars us t  in
-                               (match uu____29381 with
+                               (match uu____29387 with
                                 | (us1,t1) ->
-                                    let uu____29392 =
-                                      let uu____29401 =
+                                    let uu____29398 =
+                                      let uu____29407 =
                                         FStar_All.pipe_right b_opening
                                           (FStar_Syntax_Subst.shift_subst
                                              n_us)
                                          in
-                                      let uu____29406 =
+                                      let uu____29412 =
                                         FStar_All.pipe_right b_closing
                                           (FStar_Syntax_Subst.shift_subst
                                              n_us)
                                          in
-                                      (uu____29401, uu____29406)  in
-                                    (match uu____29392 with
+                                      (uu____29407, uu____29412)  in
+                                    (match uu____29398 with
                                      | (b_opening1,b_closing1) ->
-                                         let uu____29429 =
-                                           let uu____29438 =
+                                         let uu____29435 =
+                                           let uu____29444 =
                                              FStar_All.pipe_right
                                                univs_opening
                                                (FStar_Syntax_Subst.shift_subst
                                                   (n_us + n_binders))
                                               in
-                                           let uu____29443 =
+                                           let uu____29449 =
                                              FStar_All.pipe_right
                                                univs_closing
                                                (FStar_Syntax_Subst.shift_subst
                                                   (n_us + n_binders))
                                               in
-                                           (uu____29438, uu____29443)  in
-                                         (match uu____29429 with
+                                           (uu____29444, uu____29449)  in
+                                         (match uu____29435 with
                                           | (univs_opening1,univs_closing1)
                                               ->
                                               let t2 =
-                                                let uu____29467 =
+                                                let uu____29473 =
                                                   FStar_Syntax_Subst.subst
                                                     b_opening1 t1
                                                    in
                                                 FStar_Syntax_Subst.subst
-                                                  univs_opening1 uu____29467
+                                                  univs_opening1 uu____29473
                                                  in
-                                              let uu____29468 =
+                                              let uu____29474 =
                                                 elim_uvars_aux_t env [] [] t2
                                                  in
-                                              (match uu____29468 with
-                                               | (uu____29495,uu____29496,t3)
+                                              (match uu____29474 with
+                                               | (uu____29501,uu____29502,t3)
                                                    ->
                                                    let t4 =
-                                                     let uu____29519 =
-                                                       let uu____29520 =
+                                                     let uu____29525 =
+                                                       let uu____29526 =
                                                          FStar_Syntax_Subst.close_univ_vars
                                                            us1 t3
                                                           in
                                                        FStar_Syntax_Subst.subst
                                                          b_closing1
-                                                         uu____29520
+                                                         uu____29526
                                                         in
                                                      FStar_Syntax_Subst.subst
                                                        univs_closing1
-                                                       uu____29519
+                                                       uu____29525
                                                       in
                                                    (us1, t4)))))
                             in
                          let elim_term t =
-                           let uu____29529 =
+                           let uu____29535 =
                              elim_uvars_aux_t env univs1 binders t  in
-                           match uu____29529 with
-                           | (uu____29548,uu____29549,t1) -> t1  in
+                           match uu____29535 with
+                           | (uu____29554,uu____29555,t1) -> t1  in
                          let elim_action a =
                            let action_typ_templ =
                              let body =
@@ -9000,7 +9016,7 @@ let rec (elim_uvars :
                                 in
                              match a.FStar_Syntax_Syntax.action_params with
                              | [] -> body
-                             | uu____29625 ->
+                             | uu____29631 ->
                                  FStar_Syntax_Syntax.mk
                                    (FStar_Syntax_Syntax.Tm_abs
                                       ((a.FStar_Syntax_Syntax.action_params),
@@ -9009,53 +9025,53 @@ let rec (elim_uvars :
                                    (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
                               in
                            let destruct_action_body body =
-                             let uu____29652 =
-                               let uu____29653 =
+                             let uu____29658 =
+                               let uu____29659 =
                                  FStar_Syntax_Subst.compress body  in
-                               uu____29653.FStar_Syntax_Syntax.n  in
-                             match uu____29652 with
+                               uu____29659.FStar_Syntax_Syntax.n  in
+                             match uu____29658 with
                              | FStar_Syntax_Syntax.Tm_ascribed
                                  (defn,(FStar_Util.Inl
                                         typ,FStar_Pervasives_Native.None ),FStar_Pervasives_Native.None
                                   )
                                  -> (defn, typ)
-                             | uu____29712 -> failwith "Impossible"  in
+                             | uu____29718 -> failwith "Impossible"  in
                            let destruct_action_typ_templ t =
-                             let uu____29746 =
-                               let uu____29747 =
+                             let uu____29752 =
+                               let uu____29753 =
                                  FStar_Syntax_Subst.compress t  in
-                               uu____29747.FStar_Syntax_Syntax.n  in
-                             match uu____29746 with
+                               uu____29753.FStar_Syntax_Syntax.n  in
+                             match uu____29752 with
                              | FStar_Syntax_Syntax.Tm_abs
-                                 (pars,body,uu____29770) ->
-                                 let uu____29795 = destruct_action_body body
+                                 (pars,body,uu____29776) ->
+                                 let uu____29801 = destruct_action_body body
                                     in
-                                 (match uu____29795 with
+                                 (match uu____29801 with
                                   | (defn,typ) -> (pars, defn, typ))
-                             | uu____29844 ->
-                                 let uu____29845 = destruct_action_body t  in
-                                 (match uu____29845 with
+                             | uu____29850 ->
+                                 let uu____29851 = destruct_action_body t  in
+                                 (match uu____29851 with
                                   | (defn,typ) -> ([], defn, typ))
                               in
-                           let uu____29900 =
+                           let uu____29906 =
                              elim_tscheme
                                ((a.FStar_Syntax_Syntax.action_univs),
                                  action_typ_templ)
                               in
-                           match uu____29900 with
+                           match uu____29906 with
                            | (action_univs,t) ->
-                               let uu____29909 = destruct_action_typ_templ t
+                               let uu____29915 = destruct_action_typ_templ t
                                   in
-                               (match uu____29909 with
+                               (match uu____29915 with
                                 | (action_params,action_defn,action_typ) ->
                                     let a' =
-                                      let uu___3683_29956 = a  in
+                                      let uu___3685_29962 = a  in
                                       {
                                         FStar_Syntax_Syntax.action_name =
-                                          (uu___3683_29956.FStar_Syntax_Syntax.action_name);
+                                          (uu___3685_29962.FStar_Syntax_Syntax.action_name);
                                         FStar_Syntax_Syntax.action_unqualified_name
                                           =
-                                          (uu___3683_29956.FStar_Syntax_Syntax.action_unqualified_name);
+                                          (uu___3685_29962.FStar_Syntax_Syntax.action_unqualified_name);
                                         FStar_Syntax_Syntax.action_univs =
                                           action_univs;
                                         FStar_Syntax_Syntax.action_params =
@@ -9068,130 +9084,136 @@ let rec (elim_uvars :
                                     a')
                             in
                          let ed1 =
-                           let uu___3686_29958 = ed  in
-                           let uu____29959 =
+                           let uu___3688_29964 = ed  in
+                           let uu____29965 =
                              elim_tscheme ed.FStar_Syntax_Syntax.signature
                               in
-                           let uu____29960 =
+                           let uu____29966 =
                              elim_tscheme ed.FStar_Syntax_Syntax.ret_wp  in
-                           let uu____29961 =
+                           let uu____29967 =
                              elim_tscheme ed.FStar_Syntax_Syntax.bind_wp  in
-                           let uu____29962 =
+                           let uu____29968 =
                              elim_tscheme ed.FStar_Syntax_Syntax.if_then_else
                               in
-                           let uu____29963 =
+                           let uu____29969 =
                              elim_tscheme ed.FStar_Syntax_Syntax.ite_wp  in
-                           let uu____29964 =
+                           let uu____29970 =
                              elim_tscheme ed.FStar_Syntax_Syntax.stronger  in
-                           let uu____29965 =
+                           let uu____29971 =
                              elim_tscheme ed.FStar_Syntax_Syntax.close_wp  in
-                           let uu____29966 =
+                           let uu____29972 =
                              elim_tscheme ed.FStar_Syntax_Syntax.trivial  in
-                           let uu____29967 =
+                           let uu____29973 =
                              elim_tscheme ed.FStar_Syntax_Syntax.repr  in
-                           let uu____29968 =
+                           let uu____29974 =
                              elim_tscheme ed.FStar_Syntax_Syntax.return_repr
                               in
-                           let uu____29969 =
+                           let uu____29975 =
                              elim_tscheme ed.FStar_Syntax_Syntax.bind_repr
                               in
-                           let uu____29970 =
+                           let uu____29976 =
                              FStar_List.map elim_action
                                ed.FStar_Syntax_Syntax.actions
                               in
                            {
                              FStar_Syntax_Syntax.cattributes =
-                               (uu___3686_29958.FStar_Syntax_Syntax.cattributes);
+                               (uu___3688_29964.FStar_Syntax_Syntax.cattributes);
                              FStar_Syntax_Syntax.mname =
-                               (uu___3686_29958.FStar_Syntax_Syntax.mname);
+                               (uu___3688_29964.FStar_Syntax_Syntax.mname);
                              FStar_Syntax_Syntax.univs = univs1;
                              FStar_Syntax_Syntax.binders = binders;
-                             FStar_Syntax_Syntax.signature = uu____29959;
-                             FStar_Syntax_Syntax.ret_wp = uu____29960;
-                             FStar_Syntax_Syntax.bind_wp = uu____29961;
-                             FStar_Syntax_Syntax.if_then_else = uu____29962;
-                             FStar_Syntax_Syntax.ite_wp = uu____29963;
-                             FStar_Syntax_Syntax.stronger = uu____29964;
-                             FStar_Syntax_Syntax.close_wp = uu____29965;
-                             FStar_Syntax_Syntax.trivial = uu____29966;
-                             FStar_Syntax_Syntax.repr = uu____29967;
-                             FStar_Syntax_Syntax.return_repr = uu____29968;
-                             FStar_Syntax_Syntax.bind_repr = uu____29969;
-                             FStar_Syntax_Syntax.actions = uu____29970;
+                             FStar_Syntax_Syntax.signature = uu____29965;
+                             FStar_Syntax_Syntax.ret_wp = uu____29966;
+                             FStar_Syntax_Syntax.bind_wp = uu____29967;
+                             FStar_Syntax_Syntax.if_then_else = uu____29968;
+                             FStar_Syntax_Syntax.ite_wp = uu____29969;
+                             FStar_Syntax_Syntax.stronger = uu____29970;
+                             FStar_Syntax_Syntax.close_wp = uu____29971;
+                             FStar_Syntax_Syntax.trivial = uu____29972;
+                             FStar_Syntax_Syntax.repr = uu____29973;
+                             FStar_Syntax_Syntax.return_repr = uu____29974;
+                             FStar_Syntax_Syntax.bind_repr = uu____29975;
+                             FStar_Syntax_Syntax.actions = uu____29976;
                              FStar_Syntax_Syntax.eff_attrs =
-                               (uu___3686_29958.FStar_Syntax_Syntax.eff_attrs)
+                               (uu___3688_29964.FStar_Syntax_Syntax.eff_attrs)
                            }  in
-                         let uu___3689_29973 = s  in
+                         let uu___3691_29979 = s  in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (FStar_Syntax_Syntax.Sig_new_effect ed1);
                            FStar_Syntax_Syntax.sigrng =
-                             (uu___3689_29973.FStar_Syntax_Syntax.sigrng);
+                             (uu___3691_29979.FStar_Syntax_Syntax.sigrng);
                            FStar_Syntax_Syntax.sigquals =
-                             (uu___3689_29973.FStar_Syntax_Syntax.sigquals);
+                             (uu___3691_29979.FStar_Syntax_Syntax.sigquals);
                            FStar_Syntax_Syntax.sigmeta =
-                             (uu___3689_29973.FStar_Syntax_Syntax.sigmeta);
+                             (uu___3691_29979.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs =
-                             (uu___3689_29973.FStar_Syntax_Syntax.sigattrs)
+                             (uu___3691_29979.FStar_Syntax_Syntax.sigattrs);
+                           FStar_Syntax_Syntax.sigopts =
+                             (uu___3691_29979.FStar_Syntax_Syntax.sigopts)
                          })))
       | FStar_Syntax_Syntax.Sig_sub_effect sub_eff ->
-          let elim_tscheme_opt uu___19_29994 =
-            match uu___19_29994 with
+          let elim_tscheme_opt uu___19_30000 =
+            match uu___19_30000 with
             | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
             | FStar_Pervasives_Native.Some (us,t) ->
-                let uu____30025 = elim_uvars_aux_t env us [] t  in
-                (match uu____30025 with
-                 | (us1,uu____30057,t1) ->
+                let uu____30031 = elim_uvars_aux_t env us [] t  in
+                (match uu____30031 with
+                 | (us1,uu____30063,t1) ->
                      FStar_Pervasives_Native.Some (us1, t1))
              in
           let sub_eff1 =
-            let uu___3704_30088 = sub_eff  in
-            let uu____30089 =
+            let uu___3706_30094 = sub_eff  in
+            let uu____30095 =
               elim_tscheme_opt sub_eff.FStar_Syntax_Syntax.lift_wp  in
-            let uu____30092 =
+            let uu____30098 =
               elim_tscheme_opt sub_eff.FStar_Syntax_Syntax.lift  in
             {
               FStar_Syntax_Syntax.source =
-                (uu___3704_30088.FStar_Syntax_Syntax.source);
+                (uu___3706_30094.FStar_Syntax_Syntax.source);
               FStar_Syntax_Syntax.target =
-                (uu___3704_30088.FStar_Syntax_Syntax.target);
-              FStar_Syntax_Syntax.lift_wp = uu____30089;
-              FStar_Syntax_Syntax.lift = uu____30092
+                (uu___3706_30094.FStar_Syntax_Syntax.target);
+              FStar_Syntax_Syntax.lift_wp = uu____30095;
+              FStar_Syntax_Syntax.lift = uu____30098
             }  in
-          let uu___3707_30095 = s  in
+          let uu___3709_30101 = s  in
           {
             FStar_Syntax_Syntax.sigel =
               (FStar_Syntax_Syntax.Sig_sub_effect sub_eff1);
             FStar_Syntax_Syntax.sigrng =
-              (uu___3707_30095.FStar_Syntax_Syntax.sigrng);
+              (uu___3709_30101.FStar_Syntax_Syntax.sigrng);
             FStar_Syntax_Syntax.sigquals =
-              (uu___3707_30095.FStar_Syntax_Syntax.sigquals);
+              (uu___3709_30101.FStar_Syntax_Syntax.sigquals);
             FStar_Syntax_Syntax.sigmeta =
-              (uu___3707_30095.FStar_Syntax_Syntax.sigmeta);
+              (uu___3709_30101.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs =
-              (uu___3707_30095.FStar_Syntax_Syntax.sigattrs)
+              (uu___3709_30101.FStar_Syntax_Syntax.sigattrs);
+            FStar_Syntax_Syntax.sigopts =
+              (uu___3709_30101.FStar_Syntax_Syntax.sigopts)
           }
       | FStar_Syntax_Syntax.Sig_effect_abbrev
           (lid,univ_names,binders,comp,flags) ->
-          let uu____30105 = elim_uvars_aux_c env univ_names binders comp  in
-          (match uu____30105 with
+          let uu____30111 = elim_uvars_aux_c env univ_names binders comp  in
+          (match uu____30111 with
            | (univ_names1,binders1,comp1) ->
-               let uu___3720_30145 = s  in
+               let uu___3722_30151 = s  in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_effect_abbrev
                       (lid, univ_names1, binders1, comp1, flags));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3720_30145.FStar_Syntax_Syntax.sigrng);
+                   (uu___3722_30151.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3720_30145.FStar_Syntax_Syntax.sigquals);
+                   (uu___3722_30151.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3720_30145.FStar_Syntax_Syntax.sigmeta);
+                   (uu___3722_30151.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3720_30145.FStar_Syntax_Syntax.sigattrs)
+                   (uu___3722_30151.FStar_Syntax_Syntax.sigattrs);
+                 FStar_Syntax_Syntax.sigopts =
+                   (uu___3722_30151.FStar_Syntax_Syntax.sigopts)
                })
-      | FStar_Syntax_Syntax.Sig_pragma uu____30148 -> s
-      | FStar_Syntax_Syntax.Sig_splice uu____30149 -> s
+      | FStar_Syntax_Syntax.Sig_pragma uu____30154 -> s
+      | FStar_Syntax_Syntax.Sig_splice uu____30155 -> s
   
 let (erase_universes :
   FStar_TypeChecker_Env.env ->
@@ -9211,18 +9233,18 @@ let (unfold_head_once :
   fun env  ->
     fun t  ->
       let aux f us args =
-        let uu____30198 =
+        let uu____30204 =
           FStar_TypeChecker_Env.lookup_nonrec_definition
             [FStar_TypeChecker_Env.Unfold FStar_Syntax_Syntax.delta_constant]
             env (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
            in
-        match uu____30198 with
+        match uu____30204 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some head_def_ts ->
-            let uu____30220 =
+            let uu____30226 =
               FStar_TypeChecker_Env.inst_tscheme_with head_def_ts us  in
-            (match uu____30220 with
-             | (uu____30227,head_def) ->
+            (match uu____30226 with
+             | (uu____30233,head_def) ->
                  let t' =
                    FStar_Syntax_Syntax.mk_Tm_app head_def args
                      FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
@@ -9234,18 +9256,18 @@ let (unfold_head_once :
                     in
                  FStar_Pervasives_Native.Some t'1)
          in
-      let uu____30233 = FStar_Syntax_Util.head_and_args t  in
-      match uu____30233 with
+      let uu____30239 = FStar_Syntax_Util.head_and_args t  in
+      match uu____30239 with
       | (head1,args) ->
-          let uu____30278 =
-            let uu____30279 = FStar_Syntax_Subst.compress head1  in
-            uu____30279.FStar_Syntax_Syntax.n  in
-          (match uu____30278 with
+          let uu____30284 =
+            let uu____30285 = FStar_Syntax_Subst.compress head1  in
+            uu____30285.FStar_Syntax_Syntax.n  in
+          (match uu____30284 with
            | FStar_Syntax_Syntax.Tm_fvar fv -> aux fv [] args
            | FStar_Syntax_Syntax.Tm_uinst
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-                  FStar_Syntax_Syntax.pos = uu____30286;
-                  FStar_Syntax_Syntax.vars = uu____30287;_},us)
+                  FStar_Syntax_Syntax.pos = uu____30292;
+                  FStar_Syntax_Syntax.vars = uu____30293;_},us)
                -> aux fv us args
-           | uu____30293 -> FStar_Pervasives_Native.None)
+           | uu____30299 -> FStar_Pervasives_Native.None)
   

--- a/src/ocaml-output/FStar_TypeChecker_Tc.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Tc.ml
@@ -3907,28 +3907,32 @@ let tc_lex_t :
                FStar_Syntax_Syntax.sigrng = r;
                FStar_Syntax_Syntax.sigquals = [];
                FStar_Syntax_Syntax.sigmeta = uu____6416;
-               FStar_Syntax_Syntax.sigattrs = uu____6417;_}::{
-                                                               FStar_Syntax_Syntax.sigel
-                                                                 =
-                                                                 FStar_Syntax_Syntax.Sig_datacon
-                                                                 (lex_top1,uu____6419,_t_top,_lex_t_top,_6453,uu____6422);
-                                                               FStar_Syntax_Syntax.sigrng
-                                                                 = r1;
-                                                               FStar_Syntax_Syntax.sigquals
-                                                                 = [];
-                                                               FStar_Syntax_Syntax.sigmeta
-                                                                 = uu____6424;
-                                                               FStar_Syntax_Syntax.sigattrs
-                                                                 = uu____6425;_}::
+               FStar_Syntax_Syntax.sigattrs = uu____6417;
+               FStar_Syntax_Syntax.sigopts = uu____6418;_}::{
+                                                              FStar_Syntax_Syntax.sigel
+                                                                =
+                                                                FStar_Syntax_Syntax.Sig_datacon
+                                                                (lex_top1,uu____6420,_t_top,_lex_t_top,_6458,uu____6423);
+                                                              FStar_Syntax_Syntax.sigrng
+                                                                = r1;
+                                                              FStar_Syntax_Syntax.sigquals
+                                                                = [];
+                                                              FStar_Syntax_Syntax.sigmeta
+                                                                = uu____6425;
+                                                              FStar_Syntax_Syntax.sigattrs
+                                                                = uu____6426;
+                                                              FStar_Syntax_Syntax.sigopts
+                                                                = uu____6427;_}::
                {
                  FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-                   (lex_cons,uu____6427,_t_cons,_lex_t_cons,_6461,uu____6430);
+                   (lex_cons,uu____6429,_t_cons,_lex_t_cons,_6468,uu____6432);
                  FStar_Syntax_Syntax.sigrng = r2;
                  FStar_Syntax_Syntax.sigquals = [];
-                 FStar_Syntax_Syntax.sigmeta = uu____6432;
-                 FStar_Syntax_Syntax.sigattrs = uu____6433;_}::[]
+                 FStar_Syntax_Syntax.sigmeta = uu____6434;
+                 FStar_Syntax_Syntax.sigattrs = uu____6435;
+                 FStar_Syntax_Syntax.sigopts = uu____6436;_}::[]
                when
-               ((_6453 = Prims.int_zero) && (_6461 = Prims.int_zero)) &&
+               ((_6458 = Prims.int_zero) && (_6468 = Prims.int_zero)) &&
                  (((FStar_Ident.lid_equals lex_t1
                       FStar_Parser_Const.lex_t_lid)
                      &&
@@ -3960,29 +3964,30 @@ let tc_lex_t :
                    FStar_Syntax_Syntax.sigquals = [];
                    FStar_Syntax_Syntax.sigmeta =
                      FStar_Syntax_Syntax.default_sigmeta;
-                   FStar_Syntax_Syntax.sigattrs = []
+                   FStar_Syntax_Syntax.sigattrs = [];
+                   FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                  }  in
                let utop =
                  FStar_Syntax_Syntax.new_univ_name
                    (FStar_Pervasives_Native.Some r1)
                   in
                let lex_top_t =
-                 let uu____6486 =
-                   let uu____6493 =
-                     let uu____6494 =
-                       let uu____6501 =
-                         let uu____6504 =
+                 let uu____6495 =
+                   let uu____6502 =
+                     let uu____6503 =
+                       let uu____6510 =
+                         let uu____6513 =
                            FStar_Ident.set_lid_range
                              FStar_Parser_Const.lex_t_lid r1
                             in
-                         FStar_Syntax_Syntax.fvar uu____6504
+                         FStar_Syntax_Syntax.fvar uu____6513
                            FStar_Syntax_Syntax.delta_constant
                            FStar_Pervasives_Native.None
                           in
-                       (uu____6501, [FStar_Syntax_Syntax.U_name utop])  in
-                     FStar_Syntax_Syntax.Tm_uinst uu____6494  in
-                   FStar_Syntax_Syntax.mk uu____6493  in
-                 uu____6486 FStar_Pervasives_Native.None r1  in
+                       (uu____6510, [FStar_Syntax_Syntax.U_name utop])  in
+                     FStar_Syntax_Syntax.Tm_uinst uu____6503  in
+                   FStar_Syntax_Syntax.mk uu____6502  in
+                 uu____6495 FStar_Pervasives_Native.None r1  in
                let lex_top_t1 =
                  FStar_Syntax_Subst.close_univ_vars [utop] lex_top_t  in
                let dc_lextop =
@@ -3995,7 +4000,8 @@ let tc_lex_t :
                    FStar_Syntax_Syntax.sigquals = [];
                    FStar_Syntax_Syntax.sigmeta =
                      FStar_Syntax_Syntax.default_sigmeta;
-                   FStar_Syntax_Syntax.sigattrs = []
+                   FStar_Syntax_Syntax.sigattrs = [];
+                   FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                  }  in
                let ucons1 =
                  FStar_Syntax_Syntax.new_univ_name
@@ -4007,70 +4013,70 @@ let tc_lex_t :
                   in
                let lex_cons_t =
                  let a =
-                   let uu____6519 =
+                   let uu____6528 =
                      FStar_Syntax_Syntax.mk
                        (FStar_Syntax_Syntax.Tm_type
                           (FStar_Syntax_Syntax.U_name ucons1))
                        FStar_Pervasives_Native.None r2
                       in
                    FStar_Syntax_Syntax.new_bv
-                     (FStar_Pervasives_Native.Some r2) uu____6519
+                     (FStar_Pervasives_Native.Some r2) uu____6528
                     in
                  let hd1 =
-                   let uu____6521 = FStar_Syntax_Syntax.bv_to_name a  in
+                   let uu____6530 = FStar_Syntax_Syntax.bv_to_name a  in
                    FStar_Syntax_Syntax.new_bv
-                     (FStar_Pervasives_Native.Some r2) uu____6521
+                     (FStar_Pervasives_Native.Some r2) uu____6530
                     in
                  let tl1 =
-                   let uu____6523 =
-                     let uu____6524 =
-                       let uu____6531 =
-                         let uu____6532 =
-                           let uu____6539 =
-                             let uu____6542 =
+                   let uu____6532 =
+                     let uu____6533 =
+                       let uu____6540 =
+                         let uu____6541 =
+                           let uu____6548 =
+                             let uu____6551 =
                                FStar_Ident.set_lid_range
                                  FStar_Parser_Const.lex_t_lid r2
                                 in
-                             FStar_Syntax_Syntax.fvar uu____6542
+                             FStar_Syntax_Syntax.fvar uu____6551
                                FStar_Syntax_Syntax.delta_constant
                                FStar_Pervasives_Native.None
                               in
-                           (uu____6539, [FStar_Syntax_Syntax.U_name ucons2])
+                           (uu____6548, [FStar_Syntax_Syntax.U_name ucons2])
                             in
-                         FStar_Syntax_Syntax.Tm_uinst uu____6532  in
-                       FStar_Syntax_Syntax.mk uu____6531  in
-                     uu____6524 FStar_Pervasives_Native.None r2  in
+                         FStar_Syntax_Syntax.Tm_uinst uu____6541  in
+                       FStar_Syntax_Syntax.mk uu____6540  in
+                     uu____6533 FStar_Pervasives_Native.None r2  in
                    FStar_Syntax_Syntax.new_bv
-                     (FStar_Pervasives_Native.Some r2) uu____6523
+                     (FStar_Pervasives_Native.Some r2) uu____6532
                     in
                  let res =
-                   let uu____6548 =
-                     let uu____6555 =
-                       let uu____6556 =
-                         let uu____6563 =
-                           let uu____6566 =
+                   let uu____6557 =
+                     let uu____6564 =
+                       let uu____6565 =
+                         let uu____6572 =
+                           let uu____6575 =
                              FStar_Ident.set_lid_range
                                FStar_Parser_Const.lex_t_lid r2
                               in
-                           FStar_Syntax_Syntax.fvar uu____6566
+                           FStar_Syntax_Syntax.fvar uu____6575
                              FStar_Syntax_Syntax.delta_constant
                              FStar_Pervasives_Native.None
                             in
-                         (uu____6563,
+                         (uu____6572,
                            [FStar_Syntax_Syntax.U_max
                               [FStar_Syntax_Syntax.U_name ucons1;
                               FStar_Syntax_Syntax.U_name ucons2]])
                           in
-                       FStar_Syntax_Syntax.Tm_uinst uu____6556  in
-                     FStar_Syntax_Syntax.mk uu____6555  in
-                   uu____6548 FStar_Pervasives_Native.None r2  in
-                 let uu____6569 = FStar_Syntax_Syntax.mk_Total res  in
+                       FStar_Syntax_Syntax.Tm_uinst uu____6565  in
+                     FStar_Syntax_Syntax.mk uu____6564  in
+                   uu____6557 FStar_Pervasives_Native.None r2  in
+                 let uu____6578 = FStar_Syntax_Syntax.mk_Total res  in
                  FStar_Syntax_Util.arrow
                    [(a,
                       (FStar_Pervasives_Native.Some
                          FStar_Syntax_Syntax.imp_tag));
                    (hd1, FStar_Pervasives_Native.None);
-                   (tl1, FStar_Pervasives_Native.None)] uu____6569
+                   (tl1, FStar_Pervasives_Native.None)] uu____6578
                   in
                let lex_cons_t1 =
                  FStar_Syntax_Subst.close_univ_vars [ucons1; ucons2]
@@ -4086,29 +4092,31 @@ let tc_lex_t :
                    FStar_Syntax_Syntax.sigquals = [];
                    FStar_Syntax_Syntax.sigmeta =
                      FStar_Syntax_Syntax.default_sigmeta;
-                   FStar_Syntax_Syntax.sigattrs = []
+                   FStar_Syntax_Syntax.sigattrs = [];
+                   FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                  }  in
-               let uu____6608 = FStar_TypeChecker_Env.get_range env  in
+               let uu____6617 = FStar_TypeChecker_Env.get_range env  in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_bundle
                       ([tc; dc_lextop; dc_lexcons], lids));
-                 FStar_Syntax_Syntax.sigrng = uu____6608;
+                 FStar_Syntax_Syntax.sigrng = uu____6617;
                  FStar_Syntax_Syntax.sigquals = [];
                  FStar_Syntax_Syntax.sigmeta =
                    FStar_Syntax_Syntax.default_sigmeta;
-                 FStar_Syntax_Syntax.sigattrs = []
+                 FStar_Syntax_Syntax.sigattrs = [];
+                 FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                }
-           | uu____6613 ->
+           | uu____6622 ->
                let err_msg =
-                 let uu____6618 =
-                   let uu____6620 =
+                 let uu____6627 =
+                   let uu____6629 =
                      FStar_Syntax_Syntax.mk_sigelt
                        (FStar_Syntax_Syntax.Sig_bundle (ses, lids))
                       in
-                   FStar_Syntax_Print.sigelt_to_string uu____6620  in
+                   FStar_Syntax_Print.sigelt_to_string uu____6629  in
                  FStar_Util.format1 "Invalid (re)definition of lex_t: %s\n"
-                   uu____6618
+                   uu____6627
                   in
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_InvalidRedefinitionOfLexT, err_msg)
@@ -4121,37 +4129,37 @@ let (tc_type_common :
         FStar_Range.range -> FStar_Syntax_Syntax.tscheme)
   =
   fun env  ->
-    fun uu____6645  ->
+    fun uu____6654  ->
       fun expected_typ1  ->
         fun r  ->
-          match uu____6645 with
+          match uu____6654 with
           | (uvs,t) ->
-              let uu____6658 = FStar_Syntax_Subst.open_univ_vars uvs t  in
-              (match uu____6658 with
+              let uu____6667 = FStar_Syntax_Subst.open_univ_vars uvs t  in
+              (match uu____6667 with
                | (uvs1,t1) ->
                    let env1 = FStar_TypeChecker_Env.push_univ_vars env uvs1
                       in
                    let t2 = tc_check_trivial_guard env1 t1 expected_typ1  in
                    if uvs1 = []
                    then
-                     let uu____6670 =
+                     let uu____6679 =
                        FStar_TypeChecker_Util.generalize_universes env1 t2
                         in
-                     (match uu____6670 with
+                     (match uu____6679 with
                       | (uvs2,t3) ->
                           (FStar_TypeChecker_Util.check_uvars r t3;
                            (uvs2, t3)))
                    else
-                     (let uu____6688 =
-                        let uu____6691 =
+                     (let uu____6697 =
+                        let uu____6700 =
                           FStar_All.pipe_right t2
                             (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                env1)
                            in
-                        FStar_All.pipe_right uu____6691
+                        FStar_All.pipe_right uu____6700
                           (FStar_Syntax_Subst.close_univ_vars uvs1)
                          in
-                      (uvs1, uu____6688)))
+                      (uvs1, uu____6697)))
   
 let (tc_declare_typ :
   FStar_TypeChecker_Env.env ->
@@ -4161,10 +4169,10 @@ let (tc_declare_typ :
   fun env  ->
     fun ts  ->
       fun r  ->
-        let uu____6714 =
-          let uu____6715 = FStar_Syntax_Util.type_u ()  in
-          FStar_All.pipe_right uu____6715 FStar_Pervasives_Native.fst  in
-        tc_type_common env ts uu____6714 r
+        let uu____6723 =
+          let uu____6724 = FStar_Syntax_Util.type_u ()  in
+          FStar_All.pipe_right uu____6724 FStar_Pervasives_Native.fst  in
+        tc_type_common env ts uu____6723 r
   
 let (tc_assume :
   FStar_TypeChecker_Env.env ->
@@ -4174,10 +4182,10 @@ let (tc_assume :
   fun env  ->
     fun ts  ->
       fun r  ->
-        let uu____6740 =
-          let uu____6741 = FStar_Syntax_Util.type_u ()  in
-          FStar_All.pipe_right uu____6741 FStar_Pervasives_Native.fst  in
-        tc_type_common env ts uu____6740 r
+        let uu____6749 =
+          let uu____6750 = FStar_Syntax_Util.type_u ()  in
+          FStar_All.pipe_right uu____6750 FStar_Pervasives_Native.fst  in
+        tc_type_common env ts uu____6749 r
   
 let (tc_inductive' :
   FStar_TypeChecker_Env.env ->
@@ -4191,36 +4199,36 @@ let (tc_inductive' :
     fun ses  ->
       fun quals  ->
         fun lids  ->
-          (let uu____6790 = FStar_TypeChecker_Env.debug env FStar_Options.Low
+          (let uu____6799 = FStar_TypeChecker_Env.debug env FStar_Options.Low
               in
-           if uu____6790
+           if uu____6799
            then
-             let uu____6793 =
+             let uu____6802 =
                FStar_Common.string_of_list
                  FStar_Syntax_Print.sigelt_to_string ses
                 in
-             FStar_Util.print1 ">>>>>>>>>>>>>>tc_inductive %s\n" uu____6793
+             FStar_Util.print1 ">>>>>>>>>>>>>>tc_inductive %s\n" uu____6802
            else ());
-          (let uu____6798 =
+          (let uu____6807 =
              FStar_TypeChecker_TcInductive.check_inductive_well_typedness env
                ses quals lids
               in
-           match uu____6798 with
+           match uu____6807 with
            | (sig_bndle,tcs,datas) ->
                let data_ops_ses =
-                 let uu____6829 =
+                 let uu____6838 =
                    FStar_List.map
                      (FStar_TypeChecker_TcInductive.mk_data_operations quals
                         env tcs) datas
                     in
-                 FStar_All.pipe_right uu____6829 FStar_List.flatten  in
-               ((let uu____6843 =
+                 FStar_All.pipe_right uu____6838 FStar_List.flatten  in
+               ((let uu____6852 =
                    (FStar_Options.no_positivity ()) ||
-                     (let uu____6846 =
+                     (let uu____6855 =
                         FStar_TypeChecker_Env.should_verify env  in
-                      Prims.op_Negation uu____6846)
+                      Prims.op_Negation uu____6855)
                     in
-                 if uu____6843
+                 if uu____6852
                  then ()
                  else
                    (let env1 =
@@ -4233,13 +4241,13 @@ let (tc_inductive' :
                             in
                          if Prims.op_Negation b
                          then
-                           let uu____6862 =
+                           let uu____6871 =
                              match ty.FStar_Syntax_Syntax.sigel with
                              | FStar_Syntax_Syntax.Sig_inductive_typ
-                                 (lid,uu____6872,uu____6873,uu____6874,uu____6875,uu____6876)
+                                 (lid,uu____6881,uu____6882,uu____6883,uu____6884,uu____6885)
                                  -> (lid, (ty.FStar_Syntax_Syntax.sigrng))
-                             | uu____6885 -> failwith "Impossible!"  in
-                           match uu____6862 with
+                             | uu____6894 -> failwith "Impossible!"  in
+                           match uu____6871 with
                            | (lid,r) ->
                                FStar_Errors.log_issue r
                                  (FStar_Errors.Error_InductiveTypeNotSatisfyPositivityCondition,
@@ -4249,25 +4257,25 @@ let (tc_inductive' :
                          else ()) tcs;
                     FStar_List.iter
                       (fun d  ->
-                         let uu____6904 =
+                         let uu____6913 =
                            match d.FStar_Syntax_Syntax.sigel with
                            | FStar_Syntax_Syntax.Sig_datacon
-                               (data_lid,uu____6914,uu____6915,ty_lid,uu____6917,uu____6918)
+                               (data_lid,uu____6923,uu____6924,ty_lid,uu____6926,uu____6927)
                                -> (data_lid, ty_lid)
-                           | uu____6925 -> failwith "Impossible"  in
-                         match uu____6904 with
+                           | uu____6934 -> failwith "Impossible"  in
+                         match uu____6913 with
                          | (data_lid,ty_lid) ->
-                             let uu____6933 =
+                             let uu____6942 =
                                (FStar_Ident.lid_equals ty_lid
                                   FStar_Parser_Const.exn_lid)
                                  &&
-                                 (let uu____6936 =
+                                 (let uu____6945 =
                                     FStar_TypeChecker_TcInductive.check_exn_positivity
                                       data_lid env1
                                      in
-                                  Prims.op_Negation uu____6936)
+                                  Prims.op_Negation uu____6945)
                                 in
-                             if uu____6933
+                             if uu____6942
                              then
                                FStar_Errors.log_issue
                                  d.FStar_Syntax_Syntax.sigrng
@@ -4277,14 +4285,14 @@ let (tc_inductive' :
                                          " does not satisfy the positivity condition")))
                              else ()) datas));
                 (let skip_haseq =
-                   let skip_prims_type uu____6952 =
+                   let skip_prims_type uu____6961 =
                      let lid =
                        let ty = FStar_List.hd tcs  in
                        match ty.FStar_Syntax_Syntax.sigel with
                        | FStar_Syntax_Syntax.Sig_inductive_typ
-                           (lid,uu____6957,uu____6958,uu____6959,uu____6960,uu____6961)
+                           (lid,uu____6966,uu____6967,uu____6968,uu____6969,uu____6970)
                            -> lid
-                       | uu____6970 -> failwith "Impossible"  in
+                       | uu____6979 -> failwith "Impossible"  in
                      FStar_List.existsb
                        (fun s  ->
                           s = (lid.FStar_Ident.ident).FStar_Ident.idText)
@@ -4294,11 +4302,11 @@ let (tc_inductive' :
                      FStar_List.existsb
                        (fun q  -> q = FStar_Syntax_Syntax.Noeq) quals
                       in
-                   let is_erasable uu____6987 =
-                     let uu____6988 =
-                       let uu____6991 = FStar_List.hd tcs  in
-                       uu____6991.FStar_Syntax_Syntax.sigattrs  in
-                     FStar_Syntax_Util.has_attribute uu____6988
+                   let is_erasable uu____6996 =
+                     let uu____6997 =
+                       let uu____7000 = FStar_List.hd tcs  in
+                       uu____7000.FStar_Syntax_Syntax.sigattrs  in
+                     FStar_Syntax_Util.has_attribute uu____6997
                        FStar_Parser_Const.erasable_attr
                       in
                    ((((FStar_List.length tcs) = Prims.int_zero) ||
@@ -4343,17 +4351,17 @@ let (tc_inductive :
       fun quals  ->
         fun lids  ->
           let env1 = FStar_TypeChecker_Env.push env "tc_inductive"  in
-          let pop1 uu____7072 =
-            let uu____7073 = FStar_TypeChecker_Env.pop env1 "tc_inductive"
+          let pop1 uu____7081 =
+            let uu____7082 = FStar_TypeChecker_Env.pop env1 "tc_inductive"
                in
             ()  in
           try
-            (fun uu___882_7083  ->
+            (fun uu___885_7092  ->
                match () with
                | () ->
-                   let uu____7090 = tc_inductive' env1 ses quals lids  in
-                   FStar_All.pipe_right uu____7090 (fun r  -> pop1 (); r)) ()
-          with | uu___881_7121 -> (pop1 (); FStar_Exn.raise uu___881_7121)
+                   let uu____7099 = tc_inductive' env1 ses quals lids  in
+                   FStar_All.pipe_right uu____7099 (fun r  -> pop1 (); r)) ()
+          with | uu___884_7130 -> (pop1 (); FStar_Exn.raise uu___884_7130)
   
 let (get_fail_se :
   FStar_Syntax_Syntax.sigelt ->
@@ -4370,20 +4378,20 @@ let (get_fail_se :
           FStar_Pervasives_Native.Some (e, l)
       | (FStar_Pervasives_Native.None ,FStar_Pervasives_Native.Some (e,l)) ->
           FStar_Pervasives_Native.Some (e, l)
-      | uu____7437 -> FStar_Pervasives_Native.None  in
+      | uu____7446 -> FStar_Pervasives_Native.None  in
     FStar_List.fold_right
       (fun at  ->
          fun acc  ->
-           let uu____7495 = FStar_ToSyntax_ToSyntax.get_fail_attr true at  in
-           comb uu____7495 acc) se.FStar_Syntax_Syntax.sigattrs
+           let uu____7504 = FStar_ToSyntax_ToSyntax.get_fail_attr true at  in
+           comb uu____7504 acc) se.FStar_Syntax_Syntax.sigattrs
       FStar_Pervasives_Native.None
   
 let list_of_option :
-  'Auu____7520 .
-    'Auu____7520 FStar_Pervasives_Native.option -> 'Auu____7520 Prims.list
+  'Auu____7529 .
+    'Auu____7529 FStar_Pervasives_Native.option -> 'Auu____7529 Prims.list
   =
-  fun uu___0_7529  ->
-    match uu___0_7529 with
+  fun uu___0_7538  ->
+    match uu___0_7538 with
     | FStar_Pervasives_Native.None  -> []
     | FStar_Pervasives_Native.Some x -> [x]
   
@@ -4398,8 +4406,8 @@ let (check_multi_eq :
         match l with
         | [] -> []
         | hd1::tl1 ->
-            let uu____7609 = collect1 tl1  in
-            (match uu____7609 with
+            let uu____7618 = collect1 tl1  in
+            (match uu____7618 with
              | [] -> [(hd1, Prims.int_one)]
              | (h,n1)::t ->
                  if h = hd1
@@ -4412,9 +4420,9 @@ let (check_multi_eq :
       let rec aux l12 l22 =
         match (l12, l22) with
         | ([],[]) -> FStar_Pervasives_Native.None
-        | ((e,n1)::uu____7847,[]) ->
+        | ((e,n1)::uu____7856,[]) ->
             FStar_Pervasives_Native.Some (e, n1, Prims.int_zero)
-        | ([],(e,n1)::uu____7903) ->
+        | ([],(e,n1)::uu____7912) ->
             FStar_Pervasives_Native.Some (e, Prims.int_zero, n1)
         | ((hd1,n1)::tl1,(hd2,n2)::tl2) ->
             if hd1 < hd2
@@ -4435,16 +4443,16 @@ let (check_must_erase_attribute :
     fun se  ->
       match se.FStar_Syntax_Syntax.sigel with
       | FStar_Syntax_Syntax.Sig_let (lbs,l) ->
-          let uu____8113 =
-            let uu____8115 = FStar_Options.ide ()  in
-            Prims.op_Negation uu____8115  in
-          if uu____8113
+          let uu____8122 =
+            let uu____8124 = FStar_Options.ide ()  in
+            Prims.op_Negation uu____8124  in
+          if uu____8122
           then
-            let uu____8118 =
-              let uu____8123 = FStar_TypeChecker_Env.dsenv env  in
-              let uu____8124 = FStar_TypeChecker_Env.current_module env  in
-              FStar_Syntax_DsEnv.iface_decls uu____8123 uu____8124  in
-            (match uu____8118 with
+            let uu____8127 =
+              let uu____8132 = FStar_TypeChecker_Env.dsenv env  in
+              let uu____8133 = FStar_TypeChecker_Env.current_module env  in
+              FStar_Syntax_DsEnv.iface_decls uu____8132 uu____8133  in
+            (match uu____8127 with
              | FStar_Pervasives_Native.None  -> ()
              | FStar_Pervasives_Native.Some iface_decls1 ->
                  FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
@@ -4470,46 +4478,83 @@ let (check_must_erase_attribute :
                               in
                            (if must_erase && (Prims.op_Negation has_attr)
                             then
-                              let uu____8157 =
+                              let uu____8166 =
                                 FStar_Syntax_Syntax.range_of_fv lbname  in
-                              let uu____8158 =
-                                let uu____8164 =
-                                  let uu____8166 =
+                              let uu____8167 =
+                                let uu____8173 =
+                                  let uu____8175 =
                                     FStar_Syntax_Print.fv_to_string lbname
                                      in
-                                  let uu____8168 =
+                                  let uu____8177 =
                                     FStar_Syntax_Print.fv_to_string lbname
                                      in
                                   FStar_Util.format2
                                     "Values of type `%s` will be erased during extraction, but its interface hides this fact. Add the `must_erase_for_extraction` attribute to the `val %s` declaration for this symbol in the interface"
-                                    uu____8166 uu____8168
+                                    uu____8175 uu____8177
                                    in
                                 (FStar_Errors.Error_MustEraseMissing,
-                                  uu____8164)
+                                  uu____8173)
                                  in
-                              FStar_Errors.log_issue uu____8157 uu____8158
+                              FStar_Errors.log_issue uu____8166 uu____8167
                             else
                               if has_attr && (Prims.op_Negation must_erase)
                               then
-                                (let uu____8175 =
+                                (let uu____8184 =
                                    FStar_Syntax_Syntax.range_of_fv lbname  in
-                                 let uu____8176 =
-                                   let uu____8182 =
-                                     let uu____8184 =
+                                 let uu____8185 =
+                                   let uu____8191 =
+                                     let uu____8193 =
                                        FStar_Syntax_Print.fv_to_string lbname
                                         in
                                      FStar_Util.format1
                                        "Values of type `%s` cannot be erased during extraction, but the `must_erase_for_extraction` attribute claims that it can. Please remove the attribute."
-                                       uu____8184
+                                       uu____8193
                                       in
                                    (FStar_Errors.Error_MustEraseMissing,
-                                     uu____8182)
+                                     uu____8191)
                                     in
-                                 FStar_Errors.log_issue uu____8175 uu____8176)
+                                 FStar_Errors.log_issue uu____8184 uu____8185)
                               else ())
                          else ())))
           else ()
-      | uu____8194 -> ()
+      | uu____8203 -> ()
+  
+let (unembed_optionstate_knot :
+  FStar_Options.optionstate FStar_Syntax_Embeddings.embedding
+    FStar_Pervasives_Native.option FStar_ST.ref)
+  = FStar_Util.mk_ref FStar_Pervasives_Native.None 
+let (unembed_optionstate :
+  FStar_Syntax_Syntax.term ->
+    FStar_Options.optionstate FStar_Pervasives_Native.option)
+  =
+  fun t  ->
+    let uu____8233 =
+      let uu____8240 =
+        let uu____8243 = FStar_ST.op_Bang unembed_optionstate_knot  in
+        FStar_Util.must uu____8243  in
+      FStar_Syntax_Embeddings.unembed uu____8240 t  in
+    uu____8233 true FStar_Syntax_Embeddings.id_norm_cb
+  
+let proc_check_with :
+  'a . FStar_Syntax_Syntax.attribute Prims.list -> (unit -> 'a) -> 'a =
+  fun attrs  ->
+    fun kont  ->
+      let uu____8305 =
+        FStar_Syntax_Util.get_attribute FStar_Parser_Const.check_with_lid
+          attrs
+         in
+      match uu____8305 with
+      | FStar_Pervasives_Native.None  -> kont ()
+      | FStar_Pervasives_Native.Some ((a,FStar_Pervasives_Native.None )::[])
+          ->
+          FStar_Options.with_saved_options
+            (fun uu____8333  ->
+               (let uu____8335 =
+                  let uu____8336 = unembed_optionstate a  in
+                  FStar_All.pipe_right uu____8336 FStar_Util.must  in
+                FStar_Options.set uu____8335);
+               kont ())
+      | uu____8341 -> failwith "huh?"
   
 let (tc_decl' :
   FStar_TypeChecker_Env.env ->
@@ -4521,2429 +4566,2554 @@ let (tc_decl' :
     fun se  ->
       let env = env0  in
       FStar_TypeChecker_Util.check_sigelt_quals env se;
-      (let r = se.FStar_Syntax_Syntax.sigrng  in
-       match se.FStar_Syntax_Syntax.sigel with
-       | FStar_Syntax_Syntax.Sig_inductive_typ uu____8239 ->
-           failwith "Impossible bare data-constructor"
-       | FStar_Syntax_Syntax.Sig_datacon uu____8267 ->
-           failwith "Impossible bare data-constructor"
-       | FStar_Syntax_Syntax.Sig_bundle (ses,lids) when
-           FStar_All.pipe_right lids
-             (FStar_Util.for_some
-                (FStar_Ident.lid_equals FStar_Parser_Const.lex_t_lid))
-           ->
-           let env1 = FStar_TypeChecker_Env.set_range env r  in
-           let se1 = tc_lex_t env1 ses se.FStar_Syntax_Syntax.sigquals lids
-              in
-           ([se1], [], env0)
-       | FStar_Syntax_Syntax.Sig_bundle (ses,lids) ->
-           let env1 = FStar_TypeChecker_Env.set_range env r  in
-           let ses1 =
-             FStar_All.pipe_right ses
-               (FStar_List.map
-                  (fun e  ->
-                     let uu___1014_8334 = e  in
-                     {
-                       FStar_Syntax_Syntax.sigel =
-                         (uu___1014_8334.FStar_Syntax_Syntax.sigel);
-                       FStar_Syntax_Syntax.sigrng =
-                         (uu___1014_8334.FStar_Syntax_Syntax.sigrng);
-                       FStar_Syntax_Syntax.sigquals =
-                         (uu___1014_8334.FStar_Syntax_Syntax.sigquals);
-                       FStar_Syntax_Syntax.sigmeta =
-                         (uu___1014_8334.FStar_Syntax_Syntax.sigmeta);
-                       FStar_Syntax_Syntax.sigattrs =
-                         (FStar_List.append e.FStar_Syntax_Syntax.sigattrs
-                            se.FStar_Syntax_Syntax.sigattrs)
-                     }))
-              in
-           let ses2 =
-             let uu____8338 =
-               (FStar_Options.use_two_phase_tc ()) &&
-                 (FStar_TypeChecker_Env.should_verify env1)
-                in
-             if uu____8338
-             then
-               let ses2 =
-                 let uu____8346 =
-                   let uu____8347 =
-                     let uu____8348 =
-                       tc_inductive
-                         (let uu___1018_8357 = env1  in
-                          {
-                            FStar_TypeChecker_Env.solver =
-                              (uu___1018_8357.FStar_TypeChecker_Env.solver);
-                            FStar_TypeChecker_Env.range =
-                              (uu___1018_8357.FStar_TypeChecker_Env.range);
-                            FStar_TypeChecker_Env.curmodule =
-                              (uu___1018_8357.FStar_TypeChecker_Env.curmodule);
-                            FStar_TypeChecker_Env.gamma =
-                              (uu___1018_8357.FStar_TypeChecker_Env.gamma);
-                            FStar_TypeChecker_Env.gamma_sig =
-                              (uu___1018_8357.FStar_TypeChecker_Env.gamma_sig);
-                            FStar_TypeChecker_Env.gamma_cache =
-                              (uu___1018_8357.FStar_TypeChecker_Env.gamma_cache);
-                            FStar_TypeChecker_Env.modules =
-                              (uu___1018_8357.FStar_TypeChecker_Env.modules);
-                            FStar_TypeChecker_Env.expected_typ =
-                              (uu___1018_8357.FStar_TypeChecker_Env.expected_typ);
-                            FStar_TypeChecker_Env.sigtab =
-                              (uu___1018_8357.FStar_TypeChecker_Env.sigtab);
-                            FStar_TypeChecker_Env.attrtab =
-                              (uu___1018_8357.FStar_TypeChecker_Env.attrtab);
-                            FStar_TypeChecker_Env.is_pattern =
-                              (uu___1018_8357.FStar_TypeChecker_Env.is_pattern);
-                            FStar_TypeChecker_Env.instantiate_imp =
-                              (uu___1018_8357.FStar_TypeChecker_Env.instantiate_imp);
-                            FStar_TypeChecker_Env.effects =
-                              (uu___1018_8357.FStar_TypeChecker_Env.effects);
-                            FStar_TypeChecker_Env.generalize =
-                              (uu___1018_8357.FStar_TypeChecker_Env.generalize);
-                            FStar_TypeChecker_Env.letrecs =
-                              (uu___1018_8357.FStar_TypeChecker_Env.letrecs);
-                            FStar_TypeChecker_Env.top_level =
-                              (uu___1018_8357.FStar_TypeChecker_Env.top_level);
-                            FStar_TypeChecker_Env.check_uvars =
-                              (uu___1018_8357.FStar_TypeChecker_Env.check_uvars);
-                            FStar_TypeChecker_Env.use_eq =
-                              (uu___1018_8357.FStar_TypeChecker_Env.use_eq);
-                            FStar_TypeChecker_Env.is_iface =
-                              (uu___1018_8357.FStar_TypeChecker_Env.is_iface);
-                            FStar_TypeChecker_Env.admit =
-                              (uu___1018_8357.FStar_TypeChecker_Env.admit);
-                            FStar_TypeChecker_Env.lax = true;
-                            FStar_TypeChecker_Env.lax_universes =
-                              (uu___1018_8357.FStar_TypeChecker_Env.lax_universes);
-                            FStar_TypeChecker_Env.phase1 = true;
-                            FStar_TypeChecker_Env.failhard =
-                              (uu___1018_8357.FStar_TypeChecker_Env.failhard);
-                            FStar_TypeChecker_Env.nosynth =
-                              (uu___1018_8357.FStar_TypeChecker_Env.nosynth);
-                            FStar_TypeChecker_Env.uvar_subtyping =
-                              (uu___1018_8357.FStar_TypeChecker_Env.uvar_subtyping);
-                            FStar_TypeChecker_Env.tc_term =
-                              (uu___1018_8357.FStar_TypeChecker_Env.tc_term);
-                            FStar_TypeChecker_Env.type_of =
-                              (uu___1018_8357.FStar_TypeChecker_Env.type_of);
-                            FStar_TypeChecker_Env.universe_of =
-                              (uu___1018_8357.FStar_TypeChecker_Env.universe_of);
-                            FStar_TypeChecker_Env.check_type_of =
-                              (uu___1018_8357.FStar_TypeChecker_Env.check_type_of);
-                            FStar_TypeChecker_Env.use_bv_sorts =
-                              (uu___1018_8357.FStar_TypeChecker_Env.use_bv_sorts);
-                            FStar_TypeChecker_Env.qtbl_name_and_index =
-                              (uu___1018_8357.FStar_TypeChecker_Env.qtbl_name_and_index);
-                            FStar_TypeChecker_Env.normalized_eff_names =
-                              (uu___1018_8357.FStar_TypeChecker_Env.normalized_eff_names);
-                            FStar_TypeChecker_Env.fv_delta_depths =
-                              (uu___1018_8357.FStar_TypeChecker_Env.fv_delta_depths);
-                            FStar_TypeChecker_Env.proof_ns =
-                              (uu___1018_8357.FStar_TypeChecker_Env.proof_ns);
-                            FStar_TypeChecker_Env.synth_hook =
-                              (uu___1018_8357.FStar_TypeChecker_Env.synth_hook);
-                            FStar_TypeChecker_Env.splice =
-                              (uu___1018_8357.FStar_TypeChecker_Env.splice);
-                            FStar_TypeChecker_Env.postprocess =
-                              (uu___1018_8357.FStar_TypeChecker_Env.postprocess);
-                            FStar_TypeChecker_Env.is_native_tactic =
-                              (uu___1018_8357.FStar_TypeChecker_Env.is_native_tactic);
-                            FStar_TypeChecker_Env.identifier_info =
-                              (uu___1018_8357.FStar_TypeChecker_Env.identifier_info);
-                            FStar_TypeChecker_Env.tc_hooks =
-                              (uu___1018_8357.FStar_TypeChecker_Env.tc_hooks);
-                            FStar_TypeChecker_Env.dsenv =
-                              (uu___1018_8357.FStar_TypeChecker_Env.dsenv);
-                            FStar_TypeChecker_Env.nbe =
-                              (uu___1018_8357.FStar_TypeChecker_Env.nbe);
-                            FStar_TypeChecker_Env.strict_args_tab =
-                              (uu___1018_8357.FStar_TypeChecker_Env.strict_args_tab);
-                            FStar_TypeChecker_Env.erasable_types_tab =
-                              (uu___1018_8357.FStar_TypeChecker_Env.erasable_types_tab)
-                          }) ses1 se.FStar_Syntax_Syntax.sigquals lids
-                        in
-                     FStar_All.pipe_right uu____8348
-                       FStar_Pervasives_Native.fst
-                      in
-                   FStar_All.pipe_right uu____8347
-                     (FStar_TypeChecker_Normalize.elim_uvars env1)
-                    in
-                 FStar_All.pipe_right uu____8346
-                   FStar_Syntax_Util.ses_of_sigbundle
-                  in
-               ((let uu____8371 =
-                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
-                     (FStar_Options.Other "TwoPhases")
-                    in
-                 if uu____8371
-                 then
-                   let uu____8376 =
-                     FStar_Syntax_Print.sigelt_to_string
-                       (let uu___1022_8380 = se  in
-                        {
-                          FStar_Syntax_Syntax.sigel =
-                            (FStar_Syntax_Syntax.Sig_bundle (ses2, lids));
-                          FStar_Syntax_Syntax.sigrng =
-                            (uu___1022_8380.FStar_Syntax_Syntax.sigrng);
-                          FStar_Syntax_Syntax.sigquals =
-                            (uu___1022_8380.FStar_Syntax_Syntax.sigquals);
-                          FStar_Syntax_Syntax.sigmeta =
-                            (uu___1022_8380.FStar_Syntax_Syntax.sigmeta);
-                          FStar_Syntax_Syntax.sigattrs =
-                            (uu___1022_8380.FStar_Syntax_Syntax.sigattrs)
-                        })
-                      in
-                   FStar_Util.print1 "Inductive after phase 1: %s\n"
-                     uu____8376
-                 else ());
-                ses2)
-             else ses1  in
-           let uu____8390 =
-             tc_inductive env1 ses2 se.FStar_Syntax_Syntax.sigquals lids  in
-           (match uu____8390 with
-            | (sigbndle,projectors_ses) ->
-                let sigbndle1 =
-                  let uu___1029_8414 = sigbndle  in
-                  {
-                    FStar_Syntax_Syntax.sigel =
-                      (uu___1029_8414.FStar_Syntax_Syntax.sigel);
-                    FStar_Syntax_Syntax.sigrng =
-                      (uu___1029_8414.FStar_Syntax_Syntax.sigrng);
-                    FStar_Syntax_Syntax.sigquals =
-                      (uu___1029_8414.FStar_Syntax_Syntax.sigquals);
-                    FStar_Syntax_Syntax.sigmeta =
-                      (uu___1029_8414.FStar_Syntax_Syntax.sigmeta);
-                    FStar_Syntax_Syntax.sigattrs =
-                      (se.FStar_Syntax_Syntax.sigattrs)
-                  }  in
-                ([sigbndle1], projectors_ses, env0))
-       | FStar_Syntax_Syntax.Sig_pragma p ->
-           (FStar_Syntax_Util.process_pragma p r; ([se], [], env0))
-       | FStar_Syntax_Syntax.Sig_new_effect_for_free ne ->
-           let uu____8426 = cps_and_elaborate env ne  in
-           (match uu____8426 with
-            | (ses,ne1,lift_from_pure_opt) ->
-                let effect_and_lift_ses =
-                  match lift_from_pure_opt with
-                  | FStar_Pervasives_Native.Some lift ->
-                      [(let uu___1043_8465 = se  in
-                        {
-                          FStar_Syntax_Syntax.sigel =
-                            (FStar_Syntax_Syntax.Sig_new_effect ne1);
-                          FStar_Syntax_Syntax.sigrng =
-                            (uu___1043_8465.FStar_Syntax_Syntax.sigrng);
-                          FStar_Syntax_Syntax.sigquals =
-                            (uu___1043_8465.FStar_Syntax_Syntax.sigquals);
-                          FStar_Syntax_Syntax.sigmeta =
-                            (uu___1043_8465.FStar_Syntax_Syntax.sigmeta);
-                          FStar_Syntax_Syntax.sigattrs =
-                            (uu___1043_8465.FStar_Syntax_Syntax.sigattrs)
-                        });
-                      lift]
-                  | FStar_Pervasives_Native.None  ->
-                      [(let uu___1046_8467 = se  in
-                        {
-                          FStar_Syntax_Syntax.sigel =
-                            (FStar_Syntax_Syntax.Sig_new_effect ne1);
-                          FStar_Syntax_Syntax.sigrng =
-                            (uu___1046_8467.FStar_Syntax_Syntax.sigrng);
-                          FStar_Syntax_Syntax.sigquals =
-                            (uu___1046_8467.FStar_Syntax_Syntax.sigquals);
-                          FStar_Syntax_Syntax.sigmeta =
-                            (uu___1046_8467.FStar_Syntax_Syntax.sigmeta);
-                          FStar_Syntax_Syntax.sigattrs =
-                            (uu___1046_8467.FStar_Syntax_Syntax.sigattrs)
-                        })]
-                   in
-                ([], (FStar_List.append ses effect_and_lift_ses), env0))
-       | FStar_Syntax_Syntax.Sig_new_effect ne ->
-           let ne1 =
-             let uu____8474 =
-               (FStar_Options.use_two_phase_tc ()) &&
-                 (FStar_TypeChecker_Env.should_verify env)
-                in
-             if uu____8474
-             then
-               let ne1 =
-                 let uu____8478 =
-                   let uu____8479 =
-                     let uu____8480 =
-                       tc_eff_decl
-                         (let uu___1052_8483 = env  in
-                          {
-                            FStar_TypeChecker_Env.solver =
-                              (uu___1052_8483.FStar_TypeChecker_Env.solver);
-                            FStar_TypeChecker_Env.range =
-                              (uu___1052_8483.FStar_TypeChecker_Env.range);
-                            FStar_TypeChecker_Env.curmodule =
-                              (uu___1052_8483.FStar_TypeChecker_Env.curmodule);
-                            FStar_TypeChecker_Env.gamma =
-                              (uu___1052_8483.FStar_TypeChecker_Env.gamma);
-                            FStar_TypeChecker_Env.gamma_sig =
-                              (uu___1052_8483.FStar_TypeChecker_Env.gamma_sig);
-                            FStar_TypeChecker_Env.gamma_cache =
-                              (uu___1052_8483.FStar_TypeChecker_Env.gamma_cache);
-                            FStar_TypeChecker_Env.modules =
-                              (uu___1052_8483.FStar_TypeChecker_Env.modules);
-                            FStar_TypeChecker_Env.expected_typ =
-                              (uu___1052_8483.FStar_TypeChecker_Env.expected_typ);
-                            FStar_TypeChecker_Env.sigtab =
-                              (uu___1052_8483.FStar_TypeChecker_Env.sigtab);
-                            FStar_TypeChecker_Env.attrtab =
-                              (uu___1052_8483.FStar_TypeChecker_Env.attrtab);
-                            FStar_TypeChecker_Env.is_pattern =
-                              (uu___1052_8483.FStar_TypeChecker_Env.is_pattern);
-                            FStar_TypeChecker_Env.instantiate_imp =
-                              (uu___1052_8483.FStar_TypeChecker_Env.instantiate_imp);
-                            FStar_TypeChecker_Env.effects =
-                              (uu___1052_8483.FStar_TypeChecker_Env.effects);
-                            FStar_TypeChecker_Env.generalize =
-                              (uu___1052_8483.FStar_TypeChecker_Env.generalize);
-                            FStar_TypeChecker_Env.letrecs =
-                              (uu___1052_8483.FStar_TypeChecker_Env.letrecs);
-                            FStar_TypeChecker_Env.top_level =
-                              (uu___1052_8483.FStar_TypeChecker_Env.top_level);
-                            FStar_TypeChecker_Env.check_uvars =
-                              (uu___1052_8483.FStar_TypeChecker_Env.check_uvars);
-                            FStar_TypeChecker_Env.use_eq =
-                              (uu___1052_8483.FStar_TypeChecker_Env.use_eq);
-                            FStar_TypeChecker_Env.is_iface =
-                              (uu___1052_8483.FStar_TypeChecker_Env.is_iface);
-                            FStar_TypeChecker_Env.admit =
-                              (uu___1052_8483.FStar_TypeChecker_Env.admit);
-                            FStar_TypeChecker_Env.lax = true;
-                            FStar_TypeChecker_Env.lax_universes =
-                              (uu___1052_8483.FStar_TypeChecker_Env.lax_universes);
-                            FStar_TypeChecker_Env.phase1 = true;
-                            FStar_TypeChecker_Env.failhard =
-                              (uu___1052_8483.FStar_TypeChecker_Env.failhard);
-                            FStar_TypeChecker_Env.nosynth =
-                              (uu___1052_8483.FStar_TypeChecker_Env.nosynth);
-                            FStar_TypeChecker_Env.uvar_subtyping =
-                              (uu___1052_8483.FStar_TypeChecker_Env.uvar_subtyping);
-                            FStar_TypeChecker_Env.tc_term =
-                              (uu___1052_8483.FStar_TypeChecker_Env.tc_term);
-                            FStar_TypeChecker_Env.type_of =
-                              (uu___1052_8483.FStar_TypeChecker_Env.type_of);
-                            FStar_TypeChecker_Env.universe_of =
-                              (uu___1052_8483.FStar_TypeChecker_Env.universe_of);
-                            FStar_TypeChecker_Env.check_type_of =
-                              (uu___1052_8483.FStar_TypeChecker_Env.check_type_of);
-                            FStar_TypeChecker_Env.use_bv_sorts =
-                              (uu___1052_8483.FStar_TypeChecker_Env.use_bv_sorts);
-                            FStar_TypeChecker_Env.qtbl_name_and_index =
-                              (uu___1052_8483.FStar_TypeChecker_Env.qtbl_name_and_index);
-                            FStar_TypeChecker_Env.normalized_eff_names =
-                              (uu___1052_8483.FStar_TypeChecker_Env.normalized_eff_names);
-                            FStar_TypeChecker_Env.fv_delta_depths =
-                              (uu___1052_8483.FStar_TypeChecker_Env.fv_delta_depths);
-                            FStar_TypeChecker_Env.proof_ns =
-                              (uu___1052_8483.FStar_TypeChecker_Env.proof_ns);
-                            FStar_TypeChecker_Env.synth_hook =
-                              (uu___1052_8483.FStar_TypeChecker_Env.synth_hook);
-                            FStar_TypeChecker_Env.splice =
-                              (uu___1052_8483.FStar_TypeChecker_Env.splice);
-                            FStar_TypeChecker_Env.postprocess =
-                              (uu___1052_8483.FStar_TypeChecker_Env.postprocess);
-                            FStar_TypeChecker_Env.is_native_tactic =
-                              (uu___1052_8483.FStar_TypeChecker_Env.is_native_tactic);
-                            FStar_TypeChecker_Env.identifier_info =
-                              (uu___1052_8483.FStar_TypeChecker_Env.identifier_info);
-                            FStar_TypeChecker_Env.tc_hooks =
-                              (uu___1052_8483.FStar_TypeChecker_Env.tc_hooks);
-                            FStar_TypeChecker_Env.dsenv =
-                              (uu___1052_8483.FStar_TypeChecker_Env.dsenv);
-                            FStar_TypeChecker_Env.nbe =
-                              (uu___1052_8483.FStar_TypeChecker_Env.nbe);
-                            FStar_TypeChecker_Env.strict_args_tab =
-                              (uu___1052_8483.FStar_TypeChecker_Env.strict_args_tab);
-                            FStar_TypeChecker_Env.erasable_types_tab =
-                              (uu___1052_8483.FStar_TypeChecker_Env.erasable_types_tab)
-                          }) ne
-                        in
-                     FStar_All.pipe_right uu____8480
-                       (fun ne1  ->
-                          let uu___1055_8489 = se  in
-                          {
-                            FStar_Syntax_Syntax.sigel =
-                              (FStar_Syntax_Syntax.Sig_new_effect ne1);
-                            FStar_Syntax_Syntax.sigrng =
-                              (uu___1055_8489.FStar_Syntax_Syntax.sigrng);
-                            FStar_Syntax_Syntax.sigquals =
-                              (uu___1055_8489.FStar_Syntax_Syntax.sigquals);
-                            FStar_Syntax_Syntax.sigmeta =
-                              (uu___1055_8489.FStar_Syntax_Syntax.sigmeta);
-                            FStar_Syntax_Syntax.sigattrs =
-                              (uu___1055_8489.FStar_Syntax_Syntax.sigattrs)
-                          })
-                      in
-                   FStar_All.pipe_right uu____8479
-                     (FStar_TypeChecker_Normalize.elim_uvars env)
-                    in
-                 FStar_All.pipe_right uu____8478
-                   FStar_Syntax_Util.eff_decl_of_new_effect
-                  in
-               ((let uu____8491 =
-                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                     (FStar_Options.Other "TwoPhases")
-                    in
-                 if uu____8491
-                 then
-                   let uu____8496 =
-                     FStar_Syntax_Print.sigelt_to_string
-                       (let uu___1059_8500 = se  in
-                        {
-                          FStar_Syntax_Syntax.sigel =
-                            (FStar_Syntax_Syntax.Sig_new_effect ne1);
-                          FStar_Syntax_Syntax.sigrng =
-                            (uu___1059_8500.FStar_Syntax_Syntax.sigrng);
-                          FStar_Syntax_Syntax.sigquals =
-                            (uu___1059_8500.FStar_Syntax_Syntax.sigquals);
-                          FStar_Syntax_Syntax.sigmeta =
-                            (uu___1059_8500.FStar_Syntax_Syntax.sigmeta);
-                          FStar_Syntax_Syntax.sigattrs =
-                            (uu___1059_8500.FStar_Syntax_Syntax.sigattrs)
-                        })
-                      in
-                   FStar_Util.print1 "Effect decl after phase 1: %s\n"
-                     uu____8496
-                 else ());
-                ne1)
-             else ne  in
-           let ne2 = tc_eff_decl env ne1  in
+      proc_check_with se.FStar_Syntax_Syntax.sigattrs
+        (fun uu____8392  ->
+           let r = se.FStar_Syntax_Syntax.sigrng  in
            let se1 =
-             let uu___1064_8508 = se  in
+             let uu___1015_8395 = se  in
+             let uu____8396 =
+               let uu____8399 = FStar_Options.peek ()  in
+               FStar_Pervasives_Native.Some uu____8399  in
              {
                FStar_Syntax_Syntax.sigel =
-                 (FStar_Syntax_Syntax.Sig_new_effect ne2);
+                 (uu___1015_8395.FStar_Syntax_Syntax.sigel);
                FStar_Syntax_Syntax.sigrng =
-                 (uu___1064_8508.FStar_Syntax_Syntax.sigrng);
+                 (uu___1015_8395.FStar_Syntax_Syntax.sigrng);
                FStar_Syntax_Syntax.sigquals =
-                 (uu___1064_8508.FStar_Syntax_Syntax.sigquals);
+                 (uu___1015_8395.FStar_Syntax_Syntax.sigquals);
                FStar_Syntax_Syntax.sigmeta =
-                 (uu___1064_8508.FStar_Syntax_Syntax.sigmeta);
+                 (uu___1015_8395.FStar_Syntax_Syntax.sigmeta);
                FStar_Syntax_Syntax.sigattrs =
-                 (uu___1064_8508.FStar_Syntax_Syntax.sigattrs)
+                 (uu___1015_8395.FStar_Syntax_Syntax.sigattrs);
+               FStar_Syntax_Syntax.sigopts = uu____8396
              }  in
-           ([se1], [], env0)
-       | FStar_Syntax_Syntax.Sig_sub_effect sub1 ->
-           let ed_src =
-             FStar_TypeChecker_Env.get_effect_decl env
-               sub1.FStar_Syntax_Syntax.source
-              in
-           let ed_tgt =
-             FStar_TypeChecker_Env.get_effect_decl env
-               sub1.FStar_Syntax_Syntax.target
-              in
-           let uu____8516 =
-             let uu____8523 =
-               FStar_TypeChecker_Env.lookup_effect_lid env
-                 sub1.FStar_Syntax_Syntax.source
-                in
-             monad_signature env sub1.FStar_Syntax_Syntax.source uu____8523
-              in
-           (match uu____8516 with
-            | (a,wp_a_src) ->
-                let uu____8540 =
-                  let uu____8547 =
-                    FStar_TypeChecker_Env.lookup_effect_lid env
-                      sub1.FStar_Syntax_Syntax.target
-                     in
-                  monad_signature env sub1.FStar_Syntax_Syntax.target
-                    uu____8547
-                   in
-                (match uu____8540 with
-                 | (b,wp_b_tgt) ->
-                     let wp_a_tgt =
-                       let uu____8565 =
-                         let uu____8568 =
-                           let uu____8569 =
-                             let uu____8576 =
-                               FStar_Syntax_Syntax.bv_to_name a  in
-                             (b, uu____8576)  in
-                           FStar_Syntax_Syntax.NT uu____8569  in
-                         [uu____8568]  in
-                       FStar_Syntax_Subst.subst uu____8565 wp_b_tgt  in
-                     let expected_k =
-                       let uu____8584 =
-                         let uu____8593 = FStar_Syntax_Syntax.mk_binder a  in
-                         let uu____8600 =
-                           let uu____8609 =
-                             FStar_Syntax_Syntax.null_binder wp_a_src  in
-                           [uu____8609]  in
-                         uu____8593 :: uu____8600  in
-                       let uu____8634 = FStar_Syntax_Syntax.mk_Total wp_a_tgt
-                          in
-                       FStar_Syntax_Util.arrow uu____8584 uu____8634  in
-                     let repr_type eff_name a1 wp =
-                       (let uu____8656 =
-                          let uu____8658 =
-                            FStar_TypeChecker_Env.is_reifiable_effect env
-                              eff_name
-                             in
-                          Prims.op_Negation uu____8658  in
-                        if uu____8656
-                        then
-                          let uu____8661 =
-                            let uu____8667 =
-                              FStar_Util.format1
-                                "Effect %s cannot be reified"
-                                eff_name.FStar_Ident.str
-                               in
-                            (FStar_Errors.Fatal_EffectCannotBeReified,
-                              uu____8667)
-                             in
-                          let uu____8671 =
-                            FStar_TypeChecker_Env.get_range env  in
-                          FStar_Errors.raise_error uu____8661 uu____8671
-                        else ());
-                       (let uu____8674 =
-                          FStar_TypeChecker_Env.effect_decl_opt env eff_name
-                           in
-                        match uu____8674 with
-                        | FStar_Pervasives_Native.None  ->
-                            failwith
-                              "internal error: reifiable effect has no decl?"
-                        | FStar_Pervasives_Native.Some (ed,qualifiers) ->
-                            let repr =
-                              FStar_TypeChecker_Env.inst_effect_fun_with
-                                [FStar_Syntax_Syntax.U_unknown] env ed
-                                ed.FStar_Syntax_Syntax.repr
-                               in
-                            let uu____8707 =
-                              FStar_TypeChecker_Env.get_range env  in
-                            let uu____8708 =
-                              let uu____8715 =
-                                let uu____8716 =
-                                  let uu____8733 =
-                                    let uu____8744 =
-                                      FStar_Syntax_Syntax.as_arg a1  in
-                                    let uu____8753 =
-                                      let uu____8764 =
-                                        FStar_Syntax_Syntax.as_arg wp  in
-                                      [uu____8764]  in
-                                    uu____8744 :: uu____8753  in
-                                  (repr, uu____8733)  in
-                                FStar_Syntax_Syntax.Tm_app uu____8716  in
-                              FStar_Syntax_Syntax.mk uu____8715  in
-                            uu____8708 FStar_Pervasives_Native.None
-                              uu____8707)
-                        in
-                     let uu____8809 =
-                       match ((sub1.FStar_Syntax_Syntax.lift),
-                               (sub1.FStar_Syntax_Syntax.lift_wp))
-                       with
-                       | (FStar_Pervasives_Native.None
-                          ,FStar_Pervasives_Native.None ) ->
-                           failwith "Impossible (parser)"
-                       | (lift,FStar_Pervasives_Native.Some (uvs,lift_wp)) ->
-                           let uu____8982 =
-                             if (FStar_List.length uvs) > Prims.int_zero
-                             then
-                               let uu____8993 =
-                                 FStar_Syntax_Subst.univ_var_opening uvs  in
-                               match uu____8993 with
-                               | (usubst,uvs1) ->
-                                   let uu____9016 =
-                                     FStar_TypeChecker_Env.push_univ_vars env
-                                       uvs1
-                                      in
-                                   let uu____9017 =
-                                     FStar_Syntax_Subst.subst usubst lift_wp
-                                      in
-                                   (uu____9016, uu____9017)
-                             else (env, lift_wp)  in
-                           (match uu____8982 with
-                            | (env1,lift_wp1) ->
-                                let lift_wp2 =
-                                  if (FStar_List.length uvs) = Prims.int_zero
-                                  then check_and_gen env1 lift_wp1 expected_k
-                                  else
-                                    (let lift_wp2 =
-                                       tc_check_trivial_guard env1 lift_wp1
-                                         expected_k
-                                        in
-                                     let uu____9067 =
-                                       FStar_Syntax_Subst.close_univ_vars uvs
-                                         lift_wp2
-                                        in
-                                     (uvs, uu____9067))
-                                   in
-                                (lift, lift_wp2))
-                       | (FStar_Pervasives_Native.Some
-                          (what,lift),FStar_Pervasives_Native.None ) ->
-                           let uu____9138 =
-                             if (FStar_List.length what) > Prims.int_zero
-                             then
-                               let uu____9153 =
-                                 FStar_Syntax_Subst.univ_var_opening what  in
-                               match uu____9153 with
-                               | (usubst,uvs) ->
-                                   let uu____9178 =
-                                     FStar_Syntax_Subst.subst usubst lift  in
-                                   (uvs, uu____9178)
-                             else ([], lift)  in
-                           (match uu____9138 with
-                            | (uvs,lift1) ->
-                                ((let uu____9214 =
-                                    FStar_TypeChecker_Env.debug env
-                                      (FStar_Options.Other "ED")
-                                     in
-                                  if uu____9214
-                                  then
-                                    let uu____9218 =
-                                      FStar_Syntax_Print.term_to_string lift1
-                                       in
-                                    FStar_Util.print1 "Lift for free : %s\n"
-                                      uu____9218
-                                  else ());
-                                 (let dmff_env =
-                                    FStar_TypeChecker_DMFF.empty env
-                                      (FStar_TypeChecker_TcTerm.tc_constant
-                                         env FStar_Range.dummyRange)
-                                     in
-                                  let uu____9224 =
-                                    let uu____9231 =
-                                      FStar_TypeChecker_Env.push_univ_vars
-                                        env uvs
-                                       in
-                                    FStar_TypeChecker_TcTerm.tc_term
-                                      uu____9231 lift1
-                                     in
-                                  match uu____9224 with
-                                  | (lift2,comp,uu____9256) ->
-                                      let uu____9257 =
-                                        FStar_TypeChecker_DMFF.star_expr
-                                          dmff_env lift2
-                                         in
-                                      (match uu____9257 with
-                                       | (uu____9286,lift_wp,lift_elab) ->
-                                           let lift_wp1 =
-                                             recheck_debug "lift-wp" env
-                                               lift_wp
-                                              in
-                                           let lift_elab1 =
-                                             recheck_debug "lift-elab" env
-                                               lift_elab
-                                              in
-                                           if
-                                             (FStar_List.length uvs) =
-                                               Prims.int_zero
-                                           then
-                                             let uu____9318 =
-                                               let uu____9329 =
-                                                 FStar_TypeChecker_Util.generalize_universes
-                                                   env lift_elab1
-                                                  in
-                                               FStar_Pervasives_Native.Some
-                                                 uu____9329
-                                                in
-                                             let uu____9346 =
-                                               FStar_TypeChecker_Util.generalize_universes
-                                                 env lift_wp1
-                                                in
-                                             (uu____9318, uu____9346)
-                                           else
-                                             (let uu____9375 =
-                                                let uu____9386 =
-                                                  let uu____9395 =
-                                                    FStar_Syntax_Subst.close_univ_vars
-                                                      uvs lift_elab1
-                                                     in
-                                                  (uvs, uu____9395)  in
-                                                FStar_Pervasives_Native.Some
-                                                  uu____9386
-                                                 in
-                                              let uu____9410 =
-                                                let uu____9419 =
-                                                  FStar_Syntax_Subst.close_univ_vars
-                                                    uvs lift_wp1
-                                                   in
-                                                (uvs, uu____9419)  in
-                                              (uu____9375, uu____9410))))))
-                        in
-                     (match uu____8809 with
-                      | (lift,lift_wp) ->
-                          let env1 =
-                            let uu___1140_9493 = env  in
-                            {
-                              FStar_TypeChecker_Env.solver =
-                                (uu___1140_9493.FStar_TypeChecker_Env.solver);
-                              FStar_TypeChecker_Env.range =
-                                (uu___1140_9493.FStar_TypeChecker_Env.range);
-                              FStar_TypeChecker_Env.curmodule =
-                                (uu___1140_9493.FStar_TypeChecker_Env.curmodule);
-                              FStar_TypeChecker_Env.gamma =
-                                (uu___1140_9493.FStar_TypeChecker_Env.gamma);
-                              FStar_TypeChecker_Env.gamma_sig =
-                                (uu___1140_9493.FStar_TypeChecker_Env.gamma_sig);
-                              FStar_TypeChecker_Env.gamma_cache =
-                                (uu___1140_9493.FStar_TypeChecker_Env.gamma_cache);
-                              FStar_TypeChecker_Env.modules =
-                                (uu___1140_9493.FStar_TypeChecker_Env.modules);
-                              FStar_TypeChecker_Env.expected_typ =
-                                (uu___1140_9493.FStar_TypeChecker_Env.expected_typ);
-                              FStar_TypeChecker_Env.sigtab =
-                                (uu___1140_9493.FStar_TypeChecker_Env.sigtab);
-                              FStar_TypeChecker_Env.attrtab =
-                                (uu___1140_9493.FStar_TypeChecker_Env.attrtab);
-                              FStar_TypeChecker_Env.is_pattern =
-                                (uu___1140_9493.FStar_TypeChecker_Env.is_pattern);
-                              FStar_TypeChecker_Env.instantiate_imp =
-                                (uu___1140_9493.FStar_TypeChecker_Env.instantiate_imp);
-                              FStar_TypeChecker_Env.effects =
-                                (uu___1140_9493.FStar_TypeChecker_Env.effects);
-                              FStar_TypeChecker_Env.generalize =
-                                (uu___1140_9493.FStar_TypeChecker_Env.generalize);
-                              FStar_TypeChecker_Env.letrecs =
-                                (uu___1140_9493.FStar_TypeChecker_Env.letrecs);
-                              FStar_TypeChecker_Env.top_level =
-                                (uu___1140_9493.FStar_TypeChecker_Env.top_level);
-                              FStar_TypeChecker_Env.check_uvars =
-                                (uu___1140_9493.FStar_TypeChecker_Env.check_uvars);
-                              FStar_TypeChecker_Env.use_eq =
-                                (uu___1140_9493.FStar_TypeChecker_Env.use_eq);
-                              FStar_TypeChecker_Env.is_iface =
-                                (uu___1140_9493.FStar_TypeChecker_Env.is_iface);
-                              FStar_TypeChecker_Env.admit =
-                                (uu___1140_9493.FStar_TypeChecker_Env.admit);
-                              FStar_TypeChecker_Env.lax = true;
-                              FStar_TypeChecker_Env.lax_universes =
-                                (uu___1140_9493.FStar_TypeChecker_Env.lax_universes);
-                              FStar_TypeChecker_Env.phase1 =
-                                (uu___1140_9493.FStar_TypeChecker_Env.phase1);
-                              FStar_TypeChecker_Env.failhard =
-                                (uu___1140_9493.FStar_TypeChecker_Env.failhard);
-                              FStar_TypeChecker_Env.nosynth =
-                                (uu___1140_9493.FStar_TypeChecker_Env.nosynth);
-                              FStar_TypeChecker_Env.uvar_subtyping =
-                                (uu___1140_9493.FStar_TypeChecker_Env.uvar_subtyping);
-                              FStar_TypeChecker_Env.tc_term =
-                                (uu___1140_9493.FStar_TypeChecker_Env.tc_term);
-                              FStar_TypeChecker_Env.type_of =
-                                (uu___1140_9493.FStar_TypeChecker_Env.type_of);
-                              FStar_TypeChecker_Env.universe_of =
-                                (uu___1140_9493.FStar_TypeChecker_Env.universe_of);
-                              FStar_TypeChecker_Env.check_type_of =
-                                (uu___1140_9493.FStar_TypeChecker_Env.check_type_of);
-                              FStar_TypeChecker_Env.use_bv_sorts =
-                                (uu___1140_9493.FStar_TypeChecker_Env.use_bv_sorts);
-                              FStar_TypeChecker_Env.qtbl_name_and_index =
-                                (uu___1140_9493.FStar_TypeChecker_Env.qtbl_name_and_index);
-                              FStar_TypeChecker_Env.normalized_eff_names =
-                                (uu___1140_9493.FStar_TypeChecker_Env.normalized_eff_names);
-                              FStar_TypeChecker_Env.fv_delta_depths =
-                                (uu___1140_9493.FStar_TypeChecker_Env.fv_delta_depths);
-                              FStar_TypeChecker_Env.proof_ns =
-                                (uu___1140_9493.FStar_TypeChecker_Env.proof_ns);
-                              FStar_TypeChecker_Env.synth_hook =
-                                (uu___1140_9493.FStar_TypeChecker_Env.synth_hook);
-                              FStar_TypeChecker_Env.splice =
-                                (uu___1140_9493.FStar_TypeChecker_Env.splice);
-                              FStar_TypeChecker_Env.postprocess =
-                                (uu___1140_9493.FStar_TypeChecker_Env.postprocess);
-                              FStar_TypeChecker_Env.is_native_tactic =
-                                (uu___1140_9493.FStar_TypeChecker_Env.is_native_tactic);
-                              FStar_TypeChecker_Env.identifier_info =
-                                (uu___1140_9493.FStar_TypeChecker_Env.identifier_info);
-                              FStar_TypeChecker_Env.tc_hooks =
-                                (uu___1140_9493.FStar_TypeChecker_Env.tc_hooks);
-                              FStar_TypeChecker_Env.dsenv =
-                                (uu___1140_9493.FStar_TypeChecker_Env.dsenv);
-                              FStar_TypeChecker_Env.nbe =
-                                (uu___1140_9493.FStar_TypeChecker_Env.nbe);
-                              FStar_TypeChecker_Env.strict_args_tab =
-                                (uu___1140_9493.FStar_TypeChecker_Env.strict_args_tab);
-                              FStar_TypeChecker_Env.erasable_types_tab =
-                                (uu___1140_9493.FStar_TypeChecker_Env.erasable_types_tab)
-                            }  in
-                          let lift1 =
-                            match lift with
-                            | FStar_Pervasives_Native.None  ->
-                                FStar_Pervasives_Native.None
-                            | FStar_Pervasives_Native.Some (uvs,lift1) ->
-                                let uu____9550 =
-                                  let uu____9555 =
-                                    FStar_Syntax_Subst.univ_var_opening uvs
-                                     in
-                                  match uu____9555 with
-                                  | (usubst,uvs1) ->
-                                      let uu____9578 =
-                                        FStar_TypeChecker_Env.push_univ_vars
-                                          env1 uvs1
-                                         in
-                                      let uu____9579 =
-                                        FStar_Syntax_Subst.subst usubst lift1
-                                         in
-                                      (uu____9578, uu____9579)
-                                   in
-                                (match uu____9550 with
-                                 | (env2,lift2) ->
-                                     let uu____9592 =
-                                       let uu____9599 =
-                                         FStar_TypeChecker_Env.lookup_effect_lid
-                                           env2
-                                           sub1.FStar_Syntax_Syntax.source
-                                          in
-                                       monad_signature env2
-                                         sub1.FStar_Syntax_Syntax.source
-                                         uu____9599
-                                        in
-                                     (match uu____9592 with
-                                      | (a1,wp_a_src1) ->
-                                          let wp_a =
-                                            FStar_Syntax_Syntax.new_bv
-                                              FStar_Pervasives_Native.None
-                                              wp_a_src1
-                                             in
-                                          let a_typ =
-                                            FStar_Syntax_Syntax.bv_to_name a1
-                                             in
-                                          let wp_a_typ =
-                                            FStar_Syntax_Syntax.bv_to_name
-                                              wp_a
-                                             in
-                                          let repr_f =
-                                            repr_type
-                                              sub1.FStar_Syntax_Syntax.source
-                                              a_typ wp_a_typ
-                                             in
-                                          let repr_result =
-                                            let lift_wp1 =
-                                              FStar_TypeChecker_Normalize.normalize
-                                                [FStar_TypeChecker_Env.EraseUniverses;
-                                                FStar_TypeChecker_Env.AllowUnboundUniverses]
-                                                env2
-                                                (FStar_Pervasives_Native.snd
-                                                   lift_wp)
-                                               in
-                                            let lift_wp_a =
-                                              let uu____9633 =
-                                                FStar_TypeChecker_Env.get_range
-                                                  env2
-                                                 in
-                                              let uu____9634 =
-                                                let uu____9641 =
-                                                  let uu____9642 =
-                                                    let uu____9659 =
-                                                      let uu____9670 =
-                                                        FStar_Syntax_Syntax.as_arg
-                                                          a_typ
-                                                         in
-                                                      let uu____9679 =
-                                                        let uu____9690 =
-                                                          FStar_Syntax_Syntax.as_arg
-                                                            wp_a_typ
-                                                           in
-                                                        [uu____9690]  in
-                                                      uu____9670 ::
-                                                        uu____9679
-                                                       in
-                                                    (lift_wp1, uu____9659)
-                                                     in
-                                                  FStar_Syntax_Syntax.Tm_app
-                                                    uu____9642
-                                                   in
-                                                FStar_Syntax_Syntax.mk
-                                                  uu____9641
-                                                 in
-                                              uu____9634
-                                                FStar_Pervasives_Native.None
-                                                uu____9633
-                                               in
-                                            repr_type
-                                              sub1.FStar_Syntax_Syntax.target
-                                              a_typ lift_wp_a
-                                             in
-                                          let expected_k1 =
-                                            let uu____9738 =
-                                              let uu____9747 =
-                                                FStar_Syntax_Syntax.mk_binder
-                                                  a1
-                                                 in
-                                              let uu____9754 =
-                                                let uu____9763 =
-                                                  FStar_Syntax_Syntax.mk_binder
-                                                    wp_a
-                                                   in
-                                                let uu____9770 =
-                                                  let uu____9779 =
-                                                    FStar_Syntax_Syntax.null_binder
-                                                      repr_f
-                                                     in
-                                                  [uu____9779]  in
-                                                uu____9763 :: uu____9770  in
-                                              uu____9747 :: uu____9754  in
-                                            let uu____9810 =
-                                              FStar_Syntax_Syntax.mk_Total
-                                                repr_result
-                                               in
-                                            FStar_Syntax_Util.arrow
-                                              uu____9738 uu____9810
-                                             in
-                                          let uu____9813 =
-                                            FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                              env2 expected_k1
-                                             in
-                                          (match uu____9813 with
-                                           | (expected_k2,uu____9831,uu____9832)
-                                               ->
-                                               let lift3 =
-                                                 if
-                                                   (FStar_List.length uvs) =
-                                                     Prims.int_zero
-                                                 then
-                                                   check_and_gen env2 lift2
-                                                     expected_k2
-                                                 else
-                                                   (let lift3 =
-                                                      tc_check_trivial_guard
-                                                        env2 lift2
-                                                        expected_k2
-                                                       in
-                                                    let uu____9856 =
-                                                      FStar_Syntax_Subst.close_univ_vars
-                                                        uvs lift3
-                                                       in
-                                                    (uvs, uu____9856))
-                                                  in
-                                               FStar_Pervasives_Native.Some
-                                                 lift3)))
-                             in
-                          ((let uu____9872 =
-                              let uu____9874 =
-                                let uu____9876 =
-                                  FStar_All.pipe_right lift_wp
-                                    FStar_Pervasives_Native.fst
-                                   in
-                                FStar_All.pipe_right uu____9876
-                                  FStar_List.length
-                                 in
-                              uu____9874 <> Prims.int_one  in
-                            if uu____9872
-                            then
-                              let uu____9899 =
-                                let uu____9905 =
-                                  let uu____9907 =
-                                    FStar_Syntax_Print.lid_to_string
-                                      sub1.FStar_Syntax_Syntax.source
-                                     in
-                                  let uu____9909 =
-                                    FStar_Syntax_Print.lid_to_string
-                                      sub1.FStar_Syntax_Syntax.target
-                                     in
-                                  let uu____9911 =
-                                    let uu____9913 =
-                                      let uu____9915 =
-                                        FStar_All.pipe_right lift_wp
-                                          FStar_Pervasives_Native.fst
-                                         in
-                                      FStar_All.pipe_right uu____9915
-                                        FStar_List.length
-                                       in
-                                    FStar_All.pipe_right uu____9913
-                                      FStar_Util.string_of_int
-                                     in
-                                  FStar_Util.format3
-                                    "Sub effect wp must be polymorphic in exactly 1 universe; %s ~> %s has %s universes"
-                                    uu____9907 uu____9909 uu____9911
-                                   in
-                                (FStar_Errors.Fatal_TooManyUniverse,
-                                  uu____9905)
-                                 in
-                              FStar_Errors.raise_error uu____9899 r
-                            else ());
-                           (let uu____9942 =
-                              (FStar_Util.is_some lift1) &&
-                                (let uu____9953 =
-                                   let uu____9955 =
-                                     let uu____9958 =
-                                       FStar_All.pipe_right lift1
-                                         FStar_Util.must
-                                        in
-                                     FStar_All.pipe_right uu____9958
-                                       FStar_Pervasives_Native.fst
-                                      in
-                                   FStar_All.pipe_right uu____9955
-                                     FStar_List.length
-                                    in
-                                 uu____9953 <> Prims.int_one)
-                               in
-                            if uu____9942
-                            then
-                              let uu____10012 =
-                                let uu____10018 =
-                                  let uu____10020 =
-                                    FStar_Syntax_Print.lid_to_string
-                                      sub1.FStar_Syntax_Syntax.source
-                                     in
-                                  let uu____10022 =
-                                    FStar_Syntax_Print.lid_to_string
-                                      sub1.FStar_Syntax_Syntax.target
-                                     in
-                                  let uu____10024 =
-                                    let uu____10026 =
-                                      let uu____10028 =
-                                        let uu____10031 =
-                                          FStar_All.pipe_right lift1
-                                            FStar_Util.must
-                                           in
-                                        FStar_All.pipe_right uu____10031
-                                          FStar_Pervasives_Native.fst
-                                         in
-                                      FStar_All.pipe_right uu____10028
-                                        FStar_List.length
-                                       in
-                                    FStar_All.pipe_right uu____10026
-                                      FStar_Util.string_of_int
-                                     in
-                                  FStar_Util.format3
-                                    "Sub effect lift must be polymorphic in exactly 1 universe; %s ~> %s has %s universes"
-                                    uu____10020 uu____10022 uu____10024
-                                   in
-                                (FStar_Errors.Fatal_TooManyUniverse,
-                                  uu____10018)
-                                 in
-                              FStar_Errors.raise_error uu____10012 r
-                            else ());
-                           (let sub2 =
-                              let uu___1177_10090 = sub1  in
-                              {
-                                FStar_Syntax_Syntax.source =
-                                  (uu___1177_10090.FStar_Syntax_Syntax.source);
-                                FStar_Syntax_Syntax.target =
-                                  (uu___1177_10090.FStar_Syntax_Syntax.target);
-                                FStar_Syntax_Syntax.lift_wp =
-                                  (FStar_Pervasives_Native.Some lift_wp);
-                                FStar_Syntax_Syntax.lift = lift1
-                              }  in
-                            let se1 =
-                              let uu___1180_10092 = se  in
-                              {
-                                FStar_Syntax_Syntax.sigel =
-                                  (FStar_Syntax_Syntax.Sig_sub_effect sub2);
-                                FStar_Syntax_Syntax.sigrng =
-                                  (uu___1180_10092.FStar_Syntax_Syntax.sigrng);
-                                FStar_Syntax_Syntax.sigquals =
-                                  (uu___1180_10092.FStar_Syntax_Syntax.sigquals);
-                                FStar_Syntax_Syntax.sigmeta =
-                                  (uu___1180_10092.FStar_Syntax_Syntax.sigmeta);
-                                FStar_Syntax_Syntax.sigattrs =
-                                  (uu___1180_10092.FStar_Syntax_Syntax.sigattrs)
-                              }  in
-                            ([se1], [], env0))))))
-       | FStar_Syntax_Syntax.Sig_effect_abbrev (lid,uvs,tps,c,flags) ->
-           let uu____10106 =
-             if (FStar_List.length uvs) = Prims.int_zero
-             then (env, uvs, tps, c)
-             else
-               (let uu____10134 = FStar_Syntax_Subst.univ_var_opening uvs  in
-                match uu____10134 with
-                | (usubst,uvs1) ->
-                    let tps1 = FStar_Syntax_Subst.subst_binders usubst tps
-                       in
-                    let c1 =
-                      let uu____10165 =
-                        FStar_Syntax_Subst.shift_subst
-                          (FStar_List.length tps1) usubst
-                         in
-                      FStar_Syntax_Subst.subst_comp uu____10165 c  in
-                    let uu____10174 =
-                      FStar_TypeChecker_Env.push_univ_vars env uvs1  in
-                    (uu____10174, uvs1, tps1, c1))
-              in
-           (match uu____10106 with
-            | (env1,uvs1,tps1,c1) ->
-                let env2 = FStar_TypeChecker_Env.set_range env1 r  in
-                let uu____10196 = FStar_Syntax_Subst.open_comp tps1 c1  in
-                (match uu____10196 with
-                 | (tps2,c2) ->
-                     let uu____10213 =
-                       FStar_TypeChecker_TcTerm.tc_tparams env2 tps2  in
-                     (match uu____10213 with
-                      | (tps3,env3,us) ->
-                          let uu____10233 =
-                            FStar_TypeChecker_TcTerm.tc_comp env3 c2  in
-                          (match uu____10233 with
-                           | (c3,u,g) ->
-                               (FStar_TypeChecker_Rel.force_trivial_guard
-                                  env3 g;
-                                (let expected_result_typ =
-                                   match tps3 with
-                                   | (x,uu____10261)::uu____10262 ->
-                                       FStar_Syntax_Syntax.bv_to_name x
-                                   | uu____10281 ->
-                                       FStar_Errors.raise_error
-                                         (FStar_Errors.Fatal_NotEnoughArgumentsForEffect,
-                                           "Effect abbreviations must bind at least the result type")
-                                         r
-                                    in
-                                 let def_result_typ =
-                                   FStar_Syntax_Util.comp_result c3  in
-                                 let uu____10289 =
-                                   let uu____10291 =
-                                     FStar_TypeChecker_Rel.teq_nosmt_force
-                                       env3 expected_result_typ
-                                       def_result_typ
-                                      in
-                                   Prims.op_Negation uu____10291  in
-                                 if uu____10289
-                                 then
-                                   let uu____10294 =
-                                     let uu____10300 =
-                                       let uu____10302 =
-                                         FStar_Syntax_Print.term_to_string
-                                           expected_result_typ
-                                          in
-                                       let uu____10304 =
-                                         FStar_Syntax_Print.term_to_string
-                                           def_result_typ
-                                          in
-                                       FStar_Util.format2
-                                         "Result type of effect abbreviation `%s` does not match the result type of its definition `%s`"
-                                         uu____10302 uu____10304
-                                        in
-                                     (FStar_Errors.Fatal_EffectAbbreviationResultTypeMismatch,
-                                       uu____10300)
-                                      in
-                                   FStar_Errors.raise_error uu____10294 r
-                                 else ());
-                                (let tps4 =
-                                   FStar_Syntax_Subst.close_binders tps3  in
-                                 let c4 =
-                                   FStar_Syntax_Subst.close_comp tps4 c3  in
-                                 let uu____10312 =
-                                   let uu____10313 =
-                                     FStar_Syntax_Syntax.mk
-                                       (FStar_Syntax_Syntax.Tm_arrow
-                                          (tps4, c4))
-                                       FStar_Pervasives_Native.None r
-                                      in
-                                   FStar_TypeChecker_Util.generalize_universes
-                                     env0 uu____10313
-                                    in
-                                 match uu____10312 with
-                                 | (uvs2,t) ->
-                                     let uu____10344 =
-                                       let uu____10349 =
-                                         let uu____10362 =
-                                           let uu____10363 =
-                                             FStar_Syntax_Subst.compress t
-                                              in
-                                           uu____10363.FStar_Syntax_Syntax.n
-                                            in
-                                         (tps4, uu____10362)  in
-                                       match uu____10349 with
-                                       | ([],FStar_Syntax_Syntax.Tm_arrow
-                                          (uu____10378,c5)) -> ([], c5)
-                                       | (uu____10420,FStar_Syntax_Syntax.Tm_arrow
-                                          (tps5,c5)) -> (tps5, c5)
-                                       | uu____10459 ->
-                                           failwith
-                                             "Impossible (t is an arrow)"
-                                        in
-                                     (match uu____10344 with
-                                      | (tps5,c5) ->
-                                          (if
-                                             (FStar_List.length uvs2) <>
-                                               Prims.int_one
-                                           then
-                                             (let uu____10493 =
-                                                FStar_Syntax_Subst.open_univ_vars
-                                                  uvs2 t
-                                                 in
-                                              match uu____10493 with
-                                              | (uu____10498,t1) ->
-                                                  let uu____10500 =
-                                                    let uu____10506 =
-                                                      let uu____10508 =
-                                                        FStar_Syntax_Print.lid_to_string
-                                                          lid
-                                                         in
-                                                      let uu____10510 =
-                                                        FStar_All.pipe_right
-                                                          (FStar_List.length
-                                                             uvs2)
-                                                          FStar_Util.string_of_int
-                                                         in
-                                                      let uu____10514 =
-                                                        FStar_Syntax_Print.term_to_string
-                                                          t1
-                                                         in
-                                                      FStar_Util.format3
-                                                        "Effect abbreviations must be polymorphic in exactly 1 universe; %s has %s universes (%s)"
-                                                        uu____10508
-                                                        uu____10510
-                                                        uu____10514
-                                                       in
-                                                    (FStar_Errors.Fatal_TooManyUniverse,
-                                                      uu____10506)
-                                                     in
-                                                  FStar_Errors.raise_error
-                                                    uu____10500 r)
-                                           else ();
-                                           (let se1 =
-                                              let uu___1250_10521 = se  in
-                                              {
-                                                FStar_Syntax_Syntax.sigel =
-                                                  (FStar_Syntax_Syntax.Sig_effect_abbrev
-                                                     (lid, uvs2, tps5, c5,
-                                                       flags));
-                                                FStar_Syntax_Syntax.sigrng =
-                                                  (uu___1250_10521.FStar_Syntax_Syntax.sigrng);
-                                                FStar_Syntax_Syntax.sigquals
-                                                  =
-                                                  (uu___1250_10521.FStar_Syntax_Syntax.sigquals);
-                                                FStar_Syntax_Syntax.sigmeta =
-                                                  (uu___1250_10521.FStar_Syntax_Syntax.sigmeta);
-                                                FStar_Syntax_Syntax.sigattrs
-                                                  =
-                                                  (uu___1250_10521.FStar_Syntax_Syntax.sigattrs)
-                                              }  in
-                                            ([se1], [], env0))))))))))
-       | FStar_Syntax_Syntax.Sig_declare_typ
-           (uu____10528,uu____10529,uu____10530) when
-           FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
-             (FStar_Util.for_some
-                (fun uu___1_10535  ->
-                   match uu___1_10535 with
-                   | FStar_Syntax_Syntax.OnlyName  -> true
-                   | uu____10538 -> false))
-           -> ([], [], env0)
-       | FStar_Syntax_Syntax.Sig_let (uu____10544,uu____10545) when
-           FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
-             (FStar_Util.for_some
-                (fun uu___1_10554  ->
-                   match uu___1_10554 with
-                   | FStar_Syntax_Syntax.OnlyName  -> true
-                   | uu____10557 -> false))
-           -> ([], [], env0)
-       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uvs,t) ->
-           let env1 = FStar_TypeChecker_Env.set_range env r  in
-           ((let uu____10568 = FStar_TypeChecker_Env.lid_exists env1 lid  in
-             if uu____10568
-             then
-               let uu____10571 =
-                 let uu____10577 =
-                   let uu____10579 = FStar_Ident.text_of_lid lid  in
-                   FStar_Util.format1
-                     "Top-level declaration %s for a name that is already used in this module; top-level declarations must be unique in their module"
-                     uu____10579
-                    in
-                 (FStar_Errors.Fatal_AlreadyDefinedTopLevelDeclaration,
-                   uu____10577)
-                  in
-               FStar_Errors.raise_error uu____10571 r
-             else ());
-            (let uu____10585 =
-               let uu____10594 =
-                 (FStar_Options.use_two_phase_tc ()) &&
-                   (FStar_TypeChecker_Env.should_verify env1)
-                  in
-               if uu____10594
-               then
-                 let uu____10605 =
-                   tc_declare_typ
-                     (let uu___1274_10608 = env1  in
-                      {
-                        FStar_TypeChecker_Env.solver =
-                          (uu___1274_10608.FStar_TypeChecker_Env.solver);
-                        FStar_TypeChecker_Env.range =
-                          (uu___1274_10608.FStar_TypeChecker_Env.range);
-                        FStar_TypeChecker_Env.curmodule =
-                          (uu___1274_10608.FStar_TypeChecker_Env.curmodule);
-                        FStar_TypeChecker_Env.gamma =
-                          (uu___1274_10608.FStar_TypeChecker_Env.gamma);
-                        FStar_TypeChecker_Env.gamma_sig =
-                          (uu___1274_10608.FStar_TypeChecker_Env.gamma_sig);
-                        FStar_TypeChecker_Env.gamma_cache =
-                          (uu___1274_10608.FStar_TypeChecker_Env.gamma_cache);
-                        FStar_TypeChecker_Env.modules =
-                          (uu___1274_10608.FStar_TypeChecker_Env.modules);
-                        FStar_TypeChecker_Env.expected_typ =
-                          (uu___1274_10608.FStar_TypeChecker_Env.expected_typ);
-                        FStar_TypeChecker_Env.sigtab =
-                          (uu___1274_10608.FStar_TypeChecker_Env.sigtab);
-                        FStar_TypeChecker_Env.attrtab =
-                          (uu___1274_10608.FStar_TypeChecker_Env.attrtab);
-                        FStar_TypeChecker_Env.is_pattern =
-                          (uu___1274_10608.FStar_TypeChecker_Env.is_pattern);
-                        FStar_TypeChecker_Env.instantiate_imp =
-                          (uu___1274_10608.FStar_TypeChecker_Env.instantiate_imp);
-                        FStar_TypeChecker_Env.effects =
-                          (uu___1274_10608.FStar_TypeChecker_Env.effects);
-                        FStar_TypeChecker_Env.generalize =
-                          (uu___1274_10608.FStar_TypeChecker_Env.generalize);
-                        FStar_TypeChecker_Env.letrecs =
-                          (uu___1274_10608.FStar_TypeChecker_Env.letrecs);
-                        FStar_TypeChecker_Env.top_level =
-                          (uu___1274_10608.FStar_TypeChecker_Env.top_level);
-                        FStar_TypeChecker_Env.check_uvars =
-                          (uu___1274_10608.FStar_TypeChecker_Env.check_uvars);
-                        FStar_TypeChecker_Env.use_eq =
-                          (uu___1274_10608.FStar_TypeChecker_Env.use_eq);
-                        FStar_TypeChecker_Env.is_iface =
-                          (uu___1274_10608.FStar_TypeChecker_Env.is_iface);
-                        FStar_TypeChecker_Env.admit =
-                          (uu___1274_10608.FStar_TypeChecker_Env.admit);
-                        FStar_TypeChecker_Env.lax = true;
-                        FStar_TypeChecker_Env.lax_universes =
-                          (uu___1274_10608.FStar_TypeChecker_Env.lax_universes);
-                        FStar_TypeChecker_Env.phase1 =
-                          (uu___1274_10608.FStar_TypeChecker_Env.phase1);
-                        FStar_TypeChecker_Env.failhard =
-                          (uu___1274_10608.FStar_TypeChecker_Env.failhard);
-                        FStar_TypeChecker_Env.nosynth =
-                          (uu___1274_10608.FStar_TypeChecker_Env.nosynth);
-                        FStar_TypeChecker_Env.uvar_subtyping =
-                          (uu___1274_10608.FStar_TypeChecker_Env.uvar_subtyping);
-                        FStar_TypeChecker_Env.tc_term =
-                          (uu___1274_10608.FStar_TypeChecker_Env.tc_term);
-                        FStar_TypeChecker_Env.type_of =
-                          (uu___1274_10608.FStar_TypeChecker_Env.type_of);
-                        FStar_TypeChecker_Env.universe_of =
-                          (uu___1274_10608.FStar_TypeChecker_Env.universe_of);
-                        FStar_TypeChecker_Env.check_type_of =
-                          (uu___1274_10608.FStar_TypeChecker_Env.check_type_of);
-                        FStar_TypeChecker_Env.use_bv_sorts =
-                          (uu___1274_10608.FStar_TypeChecker_Env.use_bv_sorts);
-                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                          (uu___1274_10608.FStar_TypeChecker_Env.qtbl_name_and_index);
-                        FStar_TypeChecker_Env.normalized_eff_names =
-                          (uu___1274_10608.FStar_TypeChecker_Env.normalized_eff_names);
-                        FStar_TypeChecker_Env.fv_delta_depths =
-                          (uu___1274_10608.FStar_TypeChecker_Env.fv_delta_depths);
-                        FStar_TypeChecker_Env.proof_ns =
-                          (uu___1274_10608.FStar_TypeChecker_Env.proof_ns);
-                        FStar_TypeChecker_Env.synth_hook =
-                          (uu___1274_10608.FStar_TypeChecker_Env.synth_hook);
-                        FStar_TypeChecker_Env.splice =
-                          (uu___1274_10608.FStar_TypeChecker_Env.splice);
-                        FStar_TypeChecker_Env.postprocess =
-                          (uu___1274_10608.FStar_TypeChecker_Env.postprocess);
-                        FStar_TypeChecker_Env.is_native_tactic =
-                          (uu___1274_10608.FStar_TypeChecker_Env.is_native_tactic);
-                        FStar_TypeChecker_Env.identifier_info =
-                          (uu___1274_10608.FStar_TypeChecker_Env.identifier_info);
-                        FStar_TypeChecker_Env.tc_hooks =
-                          (uu___1274_10608.FStar_TypeChecker_Env.tc_hooks);
-                        FStar_TypeChecker_Env.dsenv =
-                          (uu___1274_10608.FStar_TypeChecker_Env.dsenv);
-                        FStar_TypeChecker_Env.nbe =
-                          (uu___1274_10608.FStar_TypeChecker_Env.nbe);
-                        FStar_TypeChecker_Env.strict_args_tab =
-                          (uu___1274_10608.FStar_TypeChecker_Env.strict_args_tab);
-                        FStar_TypeChecker_Env.erasable_types_tab =
-                          (uu___1274_10608.FStar_TypeChecker_Env.erasable_types_tab)
-                      }) (uvs, t) se.FStar_Syntax_Syntax.sigrng
-                    in
-                 match uu____10605 with
-                 | (uvs1,t1) ->
-                     ((let uu____10633 =
-                         FStar_All.pipe_left
-                           (FStar_TypeChecker_Env.debug env1)
-                           (FStar_Options.Other "TwoPhases")
-                          in
-                       if uu____10633
-                       then
-                         let uu____10638 =
-                           FStar_Syntax_Print.term_to_string t1  in
-                         let uu____10640 =
-                           FStar_Syntax_Print.univ_names_to_string uvs1  in
-                         FStar_Util.print2
-                           "Val declaration after phase 1: %s and uvs: %s\n"
-                           uu____10638 uu____10640
-                       else ());
-                      (uvs1, t1))
-               else (uvs, t)  in
-             match uu____10585 with
-             | (uvs1,t1) ->
-                 let uu____10675 =
-                   tc_declare_typ env1 (uvs1, t1)
-                     se.FStar_Syntax_Syntax.sigrng
-                    in
-                 (match uu____10675 with
-                  | (uvs2,t2) ->
-                      ([(let uu___1287_10705 = se  in
+           match se1.FStar_Syntax_Syntax.sigel with
+           | FStar_Syntax_Syntax.Sig_inductive_typ uu____8410 ->
+               failwith "Impossible bare data-constructor"
+           | FStar_Syntax_Syntax.Sig_datacon uu____8438 ->
+               failwith "Impossible bare data-constructor"
+           | FStar_Syntax_Syntax.Sig_bundle (ses,lids) when
+               FStar_All.pipe_right lids
+                 (FStar_Util.for_some
+                    (FStar_Ident.lid_equals FStar_Parser_Const.lex_t_lid))
+               ->
+               let env1 = FStar_TypeChecker_Env.set_range env r  in
+               let se2 =
+                 tc_lex_t env1 ses se1.FStar_Syntax_Syntax.sigquals lids  in
+               ([se2], [], env0)
+           | FStar_Syntax_Syntax.Sig_bundle (ses,lids) ->
+               let env1 = FStar_TypeChecker_Env.set_range env r  in
+               let ses1 =
+                 FStar_All.pipe_right ses
+                   (FStar_List.map
+                      (fun e  ->
+                         let uu___1034_8505 = e  in
                          {
                            FStar_Syntax_Syntax.sigel =
-                             (FStar_Syntax_Syntax.Sig_declare_typ
-                                (lid, uvs2, t2));
+                             (uu___1034_8505.FStar_Syntax_Syntax.sigel);
                            FStar_Syntax_Syntax.sigrng =
-                             (uu___1287_10705.FStar_Syntax_Syntax.sigrng);
+                             (uu___1034_8505.FStar_Syntax_Syntax.sigrng);
                            FStar_Syntax_Syntax.sigquals =
-                             (uu___1287_10705.FStar_Syntax_Syntax.sigquals);
+                             (uu___1034_8505.FStar_Syntax_Syntax.sigquals);
                            FStar_Syntax_Syntax.sigmeta =
-                             (uu___1287_10705.FStar_Syntax_Syntax.sigmeta);
+                             (uu___1034_8505.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs =
-                             (uu___1287_10705.FStar_Syntax_Syntax.sigattrs)
-                         })], [], env0))))
-       | FStar_Syntax_Syntax.Sig_assume (lid,uvs,t) ->
-           let env1 = FStar_TypeChecker_Env.set_range env r  in
-           let uu____10710 =
-             let uu____10719 =
-               (FStar_Options.use_two_phase_tc ()) &&
-                 (FStar_TypeChecker_Env.should_verify env1)
-                in
-             if uu____10719
-             then
-               let uu____10730 =
-                 tc_assume
-                   (let uu___1296_10733 = env1  in
-                    {
-                      FStar_TypeChecker_Env.solver =
-                        (uu___1296_10733.FStar_TypeChecker_Env.solver);
-                      FStar_TypeChecker_Env.range =
-                        (uu___1296_10733.FStar_TypeChecker_Env.range);
-                      FStar_TypeChecker_Env.curmodule =
-                        (uu___1296_10733.FStar_TypeChecker_Env.curmodule);
-                      FStar_TypeChecker_Env.gamma =
-                        (uu___1296_10733.FStar_TypeChecker_Env.gamma);
-                      FStar_TypeChecker_Env.gamma_sig =
-                        (uu___1296_10733.FStar_TypeChecker_Env.gamma_sig);
-                      FStar_TypeChecker_Env.gamma_cache =
-                        (uu___1296_10733.FStar_TypeChecker_Env.gamma_cache);
-                      FStar_TypeChecker_Env.modules =
-                        (uu___1296_10733.FStar_TypeChecker_Env.modules);
-                      FStar_TypeChecker_Env.expected_typ =
-                        (uu___1296_10733.FStar_TypeChecker_Env.expected_typ);
-                      FStar_TypeChecker_Env.sigtab =
-                        (uu___1296_10733.FStar_TypeChecker_Env.sigtab);
-                      FStar_TypeChecker_Env.attrtab =
-                        (uu___1296_10733.FStar_TypeChecker_Env.attrtab);
-                      FStar_TypeChecker_Env.is_pattern =
-                        (uu___1296_10733.FStar_TypeChecker_Env.is_pattern);
-                      FStar_TypeChecker_Env.instantiate_imp =
-                        (uu___1296_10733.FStar_TypeChecker_Env.instantiate_imp);
-                      FStar_TypeChecker_Env.effects =
-                        (uu___1296_10733.FStar_TypeChecker_Env.effects);
-                      FStar_TypeChecker_Env.generalize =
-                        (uu___1296_10733.FStar_TypeChecker_Env.generalize);
-                      FStar_TypeChecker_Env.letrecs =
-                        (uu___1296_10733.FStar_TypeChecker_Env.letrecs);
-                      FStar_TypeChecker_Env.top_level =
-                        (uu___1296_10733.FStar_TypeChecker_Env.top_level);
-                      FStar_TypeChecker_Env.check_uvars =
-                        (uu___1296_10733.FStar_TypeChecker_Env.check_uvars);
-                      FStar_TypeChecker_Env.use_eq =
-                        (uu___1296_10733.FStar_TypeChecker_Env.use_eq);
-                      FStar_TypeChecker_Env.is_iface =
-                        (uu___1296_10733.FStar_TypeChecker_Env.is_iface);
-                      FStar_TypeChecker_Env.admit =
-                        (uu___1296_10733.FStar_TypeChecker_Env.admit);
-                      FStar_TypeChecker_Env.lax = true;
-                      FStar_TypeChecker_Env.lax_universes =
-                        (uu___1296_10733.FStar_TypeChecker_Env.lax_universes);
-                      FStar_TypeChecker_Env.phase1 = true;
-                      FStar_TypeChecker_Env.failhard =
-                        (uu___1296_10733.FStar_TypeChecker_Env.failhard);
-                      FStar_TypeChecker_Env.nosynth =
-                        (uu___1296_10733.FStar_TypeChecker_Env.nosynth);
-                      FStar_TypeChecker_Env.uvar_subtyping =
-                        (uu___1296_10733.FStar_TypeChecker_Env.uvar_subtyping);
-                      FStar_TypeChecker_Env.tc_term =
-                        (uu___1296_10733.FStar_TypeChecker_Env.tc_term);
-                      FStar_TypeChecker_Env.type_of =
-                        (uu___1296_10733.FStar_TypeChecker_Env.type_of);
-                      FStar_TypeChecker_Env.universe_of =
-                        (uu___1296_10733.FStar_TypeChecker_Env.universe_of);
-                      FStar_TypeChecker_Env.check_type_of =
-                        (uu___1296_10733.FStar_TypeChecker_Env.check_type_of);
-                      FStar_TypeChecker_Env.use_bv_sorts =
-                        (uu___1296_10733.FStar_TypeChecker_Env.use_bv_sorts);
-                      FStar_TypeChecker_Env.qtbl_name_and_index =
-                        (uu___1296_10733.FStar_TypeChecker_Env.qtbl_name_and_index);
-                      FStar_TypeChecker_Env.normalized_eff_names =
-                        (uu___1296_10733.FStar_TypeChecker_Env.normalized_eff_names);
-                      FStar_TypeChecker_Env.fv_delta_depths =
-                        (uu___1296_10733.FStar_TypeChecker_Env.fv_delta_depths);
-                      FStar_TypeChecker_Env.proof_ns =
-                        (uu___1296_10733.FStar_TypeChecker_Env.proof_ns);
-                      FStar_TypeChecker_Env.synth_hook =
-                        (uu___1296_10733.FStar_TypeChecker_Env.synth_hook);
-                      FStar_TypeChecker_Env.splice =
-                        (uu___1296_10733.FStar_TypeChecker_Env.splice);
-                      FStar_TypeChecker_Env.postprocess =
-                        (uu___1296_10733.FStar_TypeChecker_Env.postprocess);
-                      FStar_TypeChecker_Env.is_native_tactic =
-                        (uu___1296_10733.FStar_TypeChecker_Env.is_native_tactic);
-                      FStar_TypeChecker_Env.identifier_info =
-                        (uu___1296_10733.FStar_TypeChecker_Env.identifier_info);
-                      FStar_TypeChecker_Env.tc_hooks =
-                        (uu___1296_10733.FStar_TypeChecker_Env.tc_hooks);
-                      FStar_TypeChecker_Env.dsenv =
-                        (uu___1296_10733.FStar_TypeChecker_Env.dsenv);
-                      FStar_TypeChecker_Env.nbe =
-                        (uu___1296_10733.FStar_TypeChecker_Env.nbe);
-                      FStar_TypeChecker_Env.strict_args_tab =
-                        (uu___1296_10733.FStar_TypeChecker_Env.strict_args_tab);
-                      FStar_TypeChecker_Env.erasable_types_tab =
-                        (uu___1296_10733.FStar_TypeChecker_Env.erasable_types_tab)
-                    }) (uvs, t) se.FStar_Syntax_Syntax.sigrng
+                             (FStar_List.append
+                                e.FStar_Syntax_Syntax.sigattrs
+                                se1.FStar_Syntax_Syntax.sigattrs);
+                           FStar_Syntax_Syntax.sigopts =
+                             (uu___1034_8505.FStar_Syntax_Syntax.sigopts)
+                         }))
                   in
-               match uu____10730 with
-               | (uvs1,t1) ->
-                   ((let uu____10759 =
+               let ses2 =
+                 let uu____8509 =
+                   (FStar_Options.use_two_phase_tc ()) &&
+                     (FStar_TypeChecker_Env.should_verify env1)
+                    in
+                 if uu____8509
+                 then
+                   let ses2 =
+                     let uu____8517 =
+                       let uu____8518 =
+                         let uu____8519 =
+                           tc_inductive
+                             (let uu___1038_8528 = env1  in
+                              {
+                                FStar_TypeChecker_Env.solver =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.solver);
+                                FStar_TypeChecker_Env.range =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.range);
+                                FStar_TypeChecker_Env.curmodule =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.curmodule);
+                                FStar_TypeChecker_Env.gamma =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.gamma);
+                                FStar_TypeChecker_Env.gamma_sig =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.gamma_sig);
+                                FStar_TypeChecker_Env.gamma_cache =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.gamma_cache);
+                                FStar_TypeChecker_Env.modules =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.modules);
+                                FStar_TypeChecker_Env.expected_typ =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.expected_typ);
+                                FStar_TypeChecker_Env.sigtab =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.sigtab);
+                                FStar_TypeChecker_Env.attrtab =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.attrtab);
+                                FStar_TypeChecker_Env.is_pattern =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.is_pattern);
+                                FStar_TypeChecker_Env.instantiate_imp =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.instantiate_imp);
+                                FStar_TypeChecker_Env.effects =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.effects);
+                                FStar_TypeChecker_Env.generalize =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.generalize);
+                                FStar_TypeChecker_Env.letrecs =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.letrecs);
+                                FStar_TypeChecker_Env.top_level =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.top_level);
+                                FStar_TypeChecker_Env.check_uvars =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.check_uvars);
+                                FStar_TypeChecker_Env.use_eq =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.use_eq);
+                                FStar_TypeChecker_Env.is_iface =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.is_iface);
+                                FStar_TypeChecker_Env.admit =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.admit);
+                                FStar_TypeChecker_Env.lax = true;
+                                FStar_TypeChecker_Env.lax_universes =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.lax_universes);
+                                FStar_TypeChecker_Env.phase1 = true;
+                                FStar_TypeChecker_Env.failhard =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.failhard);
+                                FStar_TypeChecker_Env.nosynth =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.nosynth);
+                                FStar_TypeChecker_Env.uvar_subtyping =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.uvar_subtyping);
+                                FStar_TypeChecker_Env.tc_term =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.tc_term);
+                                FStar_TypeChecker_Env.type_of =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.type_of);
+                                FStar_TypeChecker_Env.universe_of =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.universe_of);
+                                FStar_TypeChecker_Env.check_type_of =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.check_type_of);
+                                FStar_TypeChecker_Env.use_bv_sorts =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.use_bv_sorts);
+                                FStar_TypeChecker_Env.qtbl_name_and_index =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                FStar_TypeChecker_Env.normalized_eff_names =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.normalized_eff_names);
+                                FStar_TypeChecker_Env.fv_delta_depths =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.fv_delta_depths);
+                                FStar_TypeChecker_Env.proof_ns =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.proof_ns);
+                                FStar_TypeChecker_Env.synth_hook =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.synth_hook);
+                                FStar_TypeChecker_Env.splice =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.splice);
+                                FStar_TypeChecker_Env.postprocess =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.postprocess);
+                                FStar_TypeChecker_Env.is_native_tactic =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.is_native_tactic);
+                                FStar_TypeChecker_Env.identifier_info =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.identifier_info);
+                                FStar_TypeChecker_Env.tc_hooks =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.tc_hooks);
+                                FStar_TypeChecker_Env.dsenv =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.dsenv);
+                                FStar_TypeChecker_Env.nbe =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.nbe);
+                                FStar_TypeChecker_Env.strict_args_tab =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.strict_args_tab);
+                                FStar_TypeChecker_Env.erasable_types_tab =
+                                  (uu___1038_8528.FStar_TypeChecker_Env.erasable_types_tab)
+                              }) ses1 se1.FStar_Syntax_Syntax.sigquals lids
+                            in
+                         FStar_All.pipe_right uu____8519
+                           FStar_Pervasives_Native.fst
+                          in
+                       FStar_All.pipe_right uu____8518
+                         (FStar_TypeChecker_Normalize.elim_uvars env1)
+                        in
+                     FStar_All.pipe_right uu____8517
+                       FStar_Syntax_Util.ses_of_sigbundle
+                      in
+                   ((let uu____8542 =
                        FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                          (FStar_Options.Other "TwoPhases")
                         in
-                     if uu____10759
+                     if uu____8542
                      then
-                       let uu____10764 = FStar_Syntax_Print.term_to_string t1
+                       let uu____8547 =
+                         FStar_Syntax_Print.sigelt_to_string
+                           (let uu___1042_8551 = se1  in
+                            {
+                              FStar_Syntax_Syntax.sigel =
+                                (FStar_Syntax_Syntax.Sig_bundle (ses2, lids));
+                              FStar_Syntax_Syntax.sigrng =
+                                (uu___1042_8551.FStar_Syntax_Syntax.sigrng);
+                              FStar_Syntax_Syntax.sigquals =
+                                (uu___1042_8551.FStar_Syntax_Syntax.sigquals);
+                              FStar_Syntax_Syntax.sigmeta =
+                                (uu___1042_8551.FStar_Syntax_Syntax.sigmeta);
+                              FStar_Syntax_Syntax.sigattrs =
+                                (uu___1042_8551.FStar_Syntax_Syntax.sigattrs);
+                              FStar_Syntax_Syntax.sigopts =
+                                (uu___1042_8551.FStar_Syntax_Syntax.sigopts)
+                            })
                           in
-                       let uu____10766 =
-                         FStar_Syntax_Print.univ_names_to_string uvs1  in
-                       FStar_Util.print2
-                         "Assume after phase 1: %s and uvs: %s\n" uu____10764
-                         uu____10766
+                       FStar_Util.print1 "Inductive after phase 1: %s\n"
+                         uu____8547
                      else ());
-                    (uvs1, t1))
-             else (uvs, t)  in
-           (match uu____10710 with
-            | (uvs1,t1) ->
-                let uu____10801 =
-                  tc_assume env1 (uvs1, t1) se.FStar_Syntax_Syntax.sigrng  in
-                (match uu____10801 with
-                 | (uvs2,t2) ->
-                     ([(let uu___1309_10831 = se  in
-                        {
-                          FStar_Syntax_Syntax.sigel =
-                            (FStar_Syntax_Syntax.Sig_assume (lid, uvs2, t2));
-                          FStar_Syntax_Syntax.sigrng =
-                            (uu___1309_10831.FStar_Syntax_Syntax.sigrng);
-                          FStar_Syntax_Syntax.sigquals =
-                            (uu___1309_10831.FStar_Syntax_Syntax.sigquals);
-                          FStar_Syntax_Syntax.sigmeta =
-                            (uu___1309_10831.FStar_Syntax_Syntax.sigmeta);
-                          FStar_Syntax_Syntax.sigattrs =
-                            (uu___1309_10831.FStar_Syntax_Syntax.sigattrs)
-                        })], [], env0)))
-       | FStar_Syntax_Syntax.Sig_main e ->
-           let env1 = FStar_TypeChecker_Env.set_range env r  in
-           let env2 =
-             FStar_TypeChecker_Env.set_expected_typ env1
-               FStar_Syntax_Syntax.t_unit
-              in
-           let uu____10835 = FStar_TypeChecker_TcTerm.tc_term env2 e  in
-           (match uu____10835 with
-            | (e1,c,g1) ->
-                let uu____10855 =
-                  let uu____10862 =
-                    let uu____10865 =
-                      FStar_Syntax_Util.ml_comp FStar_Syntax_Syntax.t_unit r
-                       in
-                    FStar_Pervasives_Native.Some uu____10865  in
-                  let uu____10866 =
-                    let uu____10871 = FStar_Syntax_Syntax.lcomp_comp c  in
-                    (e1, uu____10871)  in
-                  FStar_TypeChecker_TcTerm.check_expected_effect env2
-                    uu____10862 uu____10866
-                   in
-                (match uu____10855 with
-                 | (e2,uu____10883,g) ->
-                     ((let uu____10886 =
-                         FStar_TypeChecker_Env.conj_guard g1 g  in
-                       FStar_TypeChecker_Rel.force_trivial_guard env2
-                         uu____10886);
-                      (let se1 =
-                         let uu___1324_10888 = se  in
-                         {
-                           FStar_Syntax_Syntax.sigel =
-                             (FStar_Syntax_Syntax.Sig_main e2);
-                           FStar_Syntax_Syntax.sigrng =
-                             (uu___1324_10888.FStar_Syntax_Syntax.sigrng);
-                           FStar_Syntax_Syntax.sigquals =
-                             (uu___1324_10888.FStar_Syntax_Syntax.sigquals);
-                           FStar_Syntax_Syntax.sigmeta =
-                             (uu___1324_10888.FStar_Syntax_Syntax.sigmeta);
-                           FStar_Syntax_Syntax.sigattrs =
-                             (uu___1324_10888.FStar_Syntax_Syntax.sigattrs)
-                         }  in
-                       ([se1], [], env0)))))
-       | FStar_Syntax_Syntax.Sig_splice (lids,t) ->
-           ((let uu____10900 = FStar_Options.debug_any ()  in
-             if uu____10900
-             then
-               let uu____10903 =
-                 FStar_Ident.string_of_lid
-                   env.FStar_TypeChecker_Env.curmodule
+                    ses2)
+                 else ses1  in
+               let uu____8561 =
+                 tc_inductive env1 ses2 se1.FStar_Syntax_Syntax.sigquals lids
                   in
-               let uu____10905 = FStar_Syntax_Print.term_to_string t  in
-               FStar_Util.print2 "%s: Found splice of (%s)\n" uu____10903
-                 uu____10905
-             else ());
-            (let uu____10910 = FStar_TypeChecker_TcTerm.tc_tactic env t  in
-             match uu____10910 with
-             | (t1,uu____10928,g) ->
-                 (FStar_TypeChecker_Rel.force_trivial_guard env g;
-                  (let ses = env.FStar_TypeChecker_Env.splice env t1  in
-                   let lids' =
-                     FStar_List.collect FStar_Syntax_Util.lids_of_sigelt ses
-                      in
-                   FStar_List.iter
-                     (fun lid  ->
-                        let uu____10942 =
-                          FStar_List.tryFind (FStar_Ident.lid_equals lid)
-                            lids'
-                           in
-                        match uu____10942 with
-                        | FStar_Pervasives_Native.None  when
-                            Prims.op_Negation
-                              env.FStar_TypeChecker_Env.nosynth
-                            ->
-                            let uu____10945 =
-                              let uu____10951 =
-                                let uu____10953 =
-                                  FStar_Ident.string_of_lid lid  in
-                                let uu____10955 =
-                                  let uu____10957 =
-                                    FStar_List.map FStar_Ident.string_of_lid
-                                      lids'
-                                     in
-                                  FStar_All.pipe_left
-                                    (FStar_String.concat ", ") uu____10957
-                                   in
-                                FStar_Util.format2
-                                  "Splice declared the name %s but it was not defined.\nThose defined were: %s"
-                                  uu____10953 uu____10955
-                                 in
-                              (FStar_Errors.Fatal_SplicedUndef, uu____10951)
-                               in
-                            FStar_Errors.raise_error uu____10945 r
-                        | uu____10969 -> ()) lids;
-                   (let dsenv1 =
-                      FStar_List.fold_left
-                        FStar_Syntax_DsEnv.push_sigelt_force
-                        env.FStar_TypeChecker_Env.dsenv ses
+               (match uu____8561 with
+                | (sigbndle,projectors_ses) ->
+                    let sigbndle1 =
+                      let uu___1049_8585 = sigbndle  in
+                      {
+                        FStar_Syntax_Syntax.sigel =
+                          (uu___1049_8585.FStar_Syntax_Syntax.sigel);
+                        FStar_Syntax_Syntax.sigrng =
+                          (uu___1049_8585.FStar_Syntax_Syntax.sigrng);
+                        FStar_Syntax_Syntax.sigquals =
+                          (uu___1049_8585.FStar_Syntax_Syntax.sigquals);
+                        FStar_Syntax_Syntax.sigmeta =
+                          (uu___1049_8585.FStar_Syntax_Syntax.sigmeta);
+                        FStar_Syntax_Syntax.sigattrs =
+                          (se1.FStar_Syntax_Syntax.sigattrs);
+                        FStar_Syntax_Syntax.sigopts =
+                          (uu___1049_8585.FStar_Syntax_Syntax.sigopts)
+                      }  in
+                    ([sigbndle1], projectors_ses, env0))
+           | FStar_Syntax_Syntax.Sig_pragma p ->
+               (FStar_Syntax_Util.process_pragma p r; ([se1], [], env0))
+           | FStar_Syntax_Syntax.Sig_new_effect_for_free ne ->
+               let uu____8597 = cps_and_elaborate env ne  in
+               (match uu____8597 with
+                | (ses,ne1,lift_from_pure_opt) ->
+                    let effect_and_lift_ses =
+                      match lift_from_pure_opt with
+                      | FStar_Pervasives_Native.Some lift ->
+                          [(let uu___1063_8636 = se1  in
+                            {
+                              FStar_Syntax_Syntax.sigel =
+                                (FStar_Syntax_Syntax.Sig_new_effect ne1);
+                              FStar_Syntax_Syntax.sigrng =
+                                (uu___1063_8636.FStar_Syntax_Syntax.sigrng);
+                              FStar_Syntax_Syntax.sigquals =
+                                (uu___1063_8636.FStar_Syntax_Syntax.sigquals);
+                              FStar_Syntax_Syntax.sigmeta =
+                                (uu___1063_8636.FStar_Syntax_Syntax.sigmeta);
+                              FStar_Syntax_Syntax.sigattrs =
+                                (uu___1063_8636.FStar_Syntax_Syntax.sigattrs);
+                              FStar_Syntax_Syntax.sigopts =
+                                (uu___1063_8636.FStar_Syntax_Syntax.sigopts)
+                            });
+                          lift]
+                      | FStar_Pervasives_Native.None  ->
+                          [(let uu___1066_8638 = se1  in
+                            {
+                              FStar_Syntax_Syntax.sigel =
+                                (FStar_Syntax_Syntax.Sig_new_effect ne1);
+                              FStar_Syntax_Syntax.sigrng =
+                                (uu___1066_8638.FStar_Syntax_Syntax.sigrng);
+                              FStar_Syntax_Syntax.sigquals =
+                                (uu___1066_8638.FStar_Syntax_Syntax.sigquals);
+                              FStar_Syntax_Syntax.sigmeta =
+                                (uu___1066_8638.FStar_Syntax_Syntax.sigmeta);
+                              FStar_Syntax_Syntax.sigattrs =
+                                (uu___1066_8638.FStar_Syntax_Syntax.sigattrs);
+                              FStar_Syntax_Syntax.sigopts =
+                                (uu___1066_8638.FStar_Syntax_Syntax.sigopts)
+                            })]
                        in
-                    let env1 =
-                      let uu___1345_10974 = env  in
+                    ([], (FStar_List.append ses effect_and_lift_ses), env0))
+           | FStar_Syntax_Syntax.Sig_new_effect ne ->
+               let ne1 =
+                 let uu____8645 =
+                   (FStar_Options.use_two_phase_tc ()) &&
+                     (FStar_TypeChecker_Env.should_verify env)
+                    in
+                 if uu____8645
+                 then
+                   let ne1 =
+                     let uu____8649 =
+                       let uu____8650 =
+                         let uu____8651 =
+                           tc_eff_decl
+                             (let uu___1072_8654 = env  in
+                              {
+                                FStar_TypeChecker_Env.solver =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.solver);
+                                FStar_TypeChecker_Env.range =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.range);
+                                FStar_TypeChecker_Env.curmodule =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.curmodule);
+                                FStar_TypeChecker_Env.gamma =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.gamma);
+                                FStar_TypeChecker_Env.gamma_sig =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.gamma_sig);
+                                FStar_TypeChecker_Env.gamma_cache =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.gamma_cache);
+                                FStar_TypeChecker_Env.modules =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.modules);
+                                FStar_TypeChecker_Env.expected_typ =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.expected_typ);
+                                FStar_TypeChecker_Env.sigtab =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.sigtab);
+                                FStar_TypeChecker_Env.attrtab =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.attrtab);
+                                FStar_TypeChecker_Env.is_pattern =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.is_pattern);
+                                FStar_TypeChecker_Env.instantiate_imp =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.instantiate_imp);
+                                FStar_TypeChecker_Env.effects =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.effects);
+                                FStar_TypeChecker_Env.generalize =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.generalize);
+                                FStar_TypeChecker_Env.letrecs =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.letrecs);
+                                FStar_TypeChecker_Env.top_level =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.top_level);
+                                FStar_TypeChecker_Env.check_uvars =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.check_uvars);
+                                FStar_TypeChecker_Env.use_eq =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.use_eq);
+                                FStar_TypeChecker_Env.is_iface =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.is_iface);
+                                FStar_TypeChecker_Env.admit =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.admit);
+                                FStar_TypeChecker_Env.lax = true;
+                                FStar_TypeChecker_Env.lax_universes =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.lax_universes);
+                                FStar_TypeChecker_Env.phase1 = true;
+                                FStar_TypeChecker_Env.failhard =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.failhard);
+                                FStar_TypeChecker_Env.nosynth =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.nosynth);
+                                FStar_TypeChecker_Env.uvar_subtyping =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.uvar_subtyping);
+                                FStar_TypeChecker_Env.tc_term =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.tc_term);
+                                FStar_TypeChecker_Env.type_of =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.type_of);
+                                FStar_TypeChecker_Env.universe_of =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.universe_of);
+                                FStar_TypeChecker_Env.check_type_of =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.check_type_of);
+                                FStar_TypeChecker_Env.use_bv_sorts =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.use_bv_sorts);
+                                FStar_TypeChecker_Env.qtbl_name_and_index =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                FStar_TypeChecker_Env.normalized_eff_names =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.normalized_eff_names);
+                                FStar_TypeChecker_Env.fv_delta_depths =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.fv_delta_depths);
+                                FStar_TypeChecker_Env.proof_ns =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.proof_ns);
+                                FStar_TypeChecker_Env.synth_hook =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.synth_hook);
+                                FStar_TypeChecker_Env.splice =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.splice);
+                                FStar_TypeChecker_Env.postprocess =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.postprocess);
+                                FStar_TypeChecker_Env.is_native_tactic =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.is_native_tactic);
+                                FStar_TypeChecker_Env.identifier_info =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.identifier_info);
+                                FStar_TypeChecker_Env.tc_hooks =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.tc_hooks);
+                                FStar_TypeChecker_Env.dsenv =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.dsenv);
+                                FStar_TypeChecker_Env.nbe =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.nbe);
+                                FStar_TypeChecker_Env.strict_args_tab =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.strict_args_tab);
+                                FStar_TypeChecker_Env.erasable_types_tab =
+                                  (uu___1072_8654.FStar_TypeChecker_Env.erasable_types_tab)
+                              }) ne
+                            in
+                         FStar_All.pipe_right uu____8651
+                           (fun ne1  ->
+                              let uu___1075_8660 = se1  in
+                              {
+                                FStar_Syntax_Syntax.sigel =
+                                  (FStar_Syntax_Syntax.Sig_new_effect ne1);
+                                FStar_Syntax_Syntax.sigrng =
+                                  (uu___1075_8660.FStar_Syntax_Syntax.sigrng);
+                                FStar_Syntax_Syntax.sigquals =
+                                  (uu___1075_8660.FStar_Syntax_Syntax.sigquals);
+                                FStar_Syntax_Syntax.sigmeta =
+                                  (uu___1075_8660.FStar_Syntax_Syntax.sigmeta);
+                                FStar_Syntax_Syntax.sigattrs =
+                                  (uu___1075_8660.FStar_Syntax_Syntax.sigattrs);
+                                FStar_Syntax_Syntax.sigopts =
+                                  (uu___1075_8660.FStar_Syntax_Syntax.sigopts)
+                              })
+                          in
+                       FStar_All.pipe_right uu____8650
+                         (FStar_TypeChecker_Normalize.elim_uvars env)
+                        in
+                     FStar_All.pipe_right uu____8649
+                       FStar_Syntax_Util.eff_decl_of_new_effect
+                      in
+                   ((let uu____8662 =
+                       FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
+                         (FStar_Options.Other "TwoPhases")
+                        in
+                     if uu____8662
+                     then
+                       let uu____8667 =
+                         FStar_Syntax_Print.sigelt_to_string
+                           (let uu___1079_8671 = se1  in
+                            {
+                              FStar_Syntax_Syntax.sigel =
+                                (FStar_Syntax_Syntax.Sig_new_effect ne1);
+                              FStar_Syntax_Syntax.sigrng =
+                                (uu___1079_8671.FStar_Syntax_Syntax.sigrng);
+                              FStar_Syntax_Syntax.sigquals =
+                                (uu___1079_8671.FStar_Syntax_Syntax.sigquals);
+                              FStar_Syntax_Syntax.sigmeta =
+                                (uu___1079_8671.FStar_Syntax_Syntax.sigmeta);
+                              FStar_Syntax_Syntax.sigattrs =
+                                (uu___1079_8671.FStar_Syntax_Syntax.sigattrs);
+                              FStar_Syntax_Syntax.sigopts =
+                                (uu___1079_8671.FStar_Syntax_Syntax.sigopts)
+                            })
+                          in
+                       FStar_Util.print1 "Effect decl after phase 1: %s\n"
+                         uu____8667
+                     else ());
+                    ne1)
+                 else ne  in
+               let ne2 = tc_eff_decl env ne1  in
+               let se2 =
+                 let uu___1084_8679 = se1  in
+                 {
+                   FStar_Syntax_Syntax.sigel =
+                     (FStar_Syntax_Syntax.Sig_new_effect ne2);
+                   FStar_Syntax_Syntax.sigrng =
+                     (uu___1084_8679.FStar_Syntax_Syntax.sigrng);
+                   FStar_Syntax_Syntax.sigquals =
+                     (uu___1084_8679.FStar_Syntax_Syntax.sigquals);
+                   FStar_Syntax_Syntax.sigmeta =
+                     (uu___1084_8679.FStar_Syntax_Syntax.sigmeta);
+                   FStar_Syntax_Syntax.sigattrs =
+                     (uu___1084_8679.FStar_Syntax_Syntax.sigattrs);
+                   FStar_Syntax_Syntax.sigopts =
+                     (uu___1084_8679.FStar_Syntax_Syntax.sigopts)
+                 }  in
+               ([se2], [], env0)
+           | FStar_Syntax_Syntax.Sig_sub_effect sub1 ->
+               let ed_src =
+                 FStar_TypeChecker_Env.get_effect_decl env
+                   sub1.FStar_Syntax_Syntax.source
+                  in
+               let ed_tgt =
+                 FStar_TypeChecker_Env.get_effect_decl env
+                   sub1.FStar_Syntax_Syntax.target
+                  in
+               let uu____8687 =
+                 let uu____8694 =
+                   FStar_TypeChecker_Env.lookup_effect_lid env
+                     sub1.FStar_Syntax_Syntax.source
+                    in
+                 monad_signature env sub1.FStar_Syntax_Syntax.source
+                   uu____8694
+                  in
+               (match uu____8687 with
+                | (a,wp_a_src) ->
+                    let uu____8711 =
+                      let uu____8718 =
+                        FStar_TypeChecker_Env.lookup_effect_lid env
+                          sub1.FStar_Syntax_Syntax.target
+                         in
+                      monad_signature env sub1.FStar_Syntax_Syntax.target
+                        uu____8718
+                       in
+                    (match uu____8711 with
+                     | (b,wp_b_tgt) ->
+                         let wp_a_tgt =
+                           let uu____8736 =
+                             let uu____8739 =
+                               let uu____8740 =
+                                 let uu____8747 =
+                                   FStar_Syntax_Syntax.bv_to_name a  in
+                                 (b, uu____8747)  in
+                               FStar_Syntax_Syntax.NT uu____8740  in
+                             [uu____8739]  in
+                           FStar_Syntax_Subst.subst uu____8736 wp_b_tgt  in
+                         let expected_k =
+                           let uu____8755 =
+                             let uu____8764 = FStar_Syntax_Syntax.mk_binder a
+                                in
+                             let uu____8771 =
+                               let uu____8780 =
+                                 FStar_Syntax_Syntax.null_binder wp_a_src  in
+                               [uu____8780]  in
+                             uu____8764 :: uu____8771  in
+                           let uu____8805 =
+                             FStar_Syntax_Syntax.mk_Total wp_a_tgt  in
+                           FStar_Syntax_Util.arrow uu____8755 uu____8805  in
+                         let repr_type eff_name a1 wp =
+                           (let uu____8827 =
+                              let uu____8829 =
+                                FStar_TypeChecker_Env.is_reifiable_effect env
+                                  eff_name
+                                 in
+                              Prims.op_Negation uu____8829  in
+                            if uu____8827
+                            then
+                              let uu____8832 =
+                                let uu____8838 =
+                                  FStar_Util.format1
+                                    "Effect %s cannot be reified"
+                                    eff_name.FStar_Ident.str
+                                   in
+                                (FStar_Errors.Fatal_EffectCannotBeReified,
+                                  uu____8838)
+                                 in
+                              let uu____8842 =
+                                FStar_TypeChecker_Env.get_range env  in
+                              FStar_Errors.raise_error uu____8832 uu____8842
+                            else ());
+                           (let uu____8845 =
+                              FStar_TypeChecker_Env.effect_decl_opt env
+                                eff_name
+                               in
+                            match uu____8845 with
+                            | FStar_Pervasives_Native.None  ->
+                                failwith
+                                  "internal error: reifiable effect has no decl?"
+                            | FStar_Pervasives_Native.Some (ed,qualifiers) ->
+                                let repr =
+                                  FStar_TypeChecker_Env.inst_effect_fun_with
+                                    [FStar_Syntax_Syntax.U_unknown] env ed
+                                    ed.FStar_Syntax_Syntax.repr
+                                   in
+                                let uu____8878 =
+                                  FStar_TypeChecker_Env.get_range env  in
+                                let uu____8879 =
+                                  let uu____8886 =
+                                    let uu____8887 =
+                                      let uu____8904 =
+                                        let uu____8915 =
+                                          FStar_Syntax_Syntax.as_arg a1  in
+                                        let uu____8924 =
+                                          let uu____8935 =
+                                            FStar_Syntax_Syntax.as_arg wp  in
+                                          [uu____8935]  in
+                                        uu____8915 :: uu____8924  in
+                                      (repr, uu____8904)  in
+                                    FStar_Syntax_Syntax.Tm_app uu____8887  in
+                                  FStar_Syntax_Syntax.mk uu____8886  in
+                                uu____8879 FStar_Pervasives_Native.None
+                                  uu____8878)
+                            in
+                         let uu____8980 =
+                           match ((sub1.FStar_Syntax_Syntax.lift),
+                                   (sub1.FStar_Syntax_Syntax.lift_wp))
+                           with
+                           | (FStar_Pervasives_Native.None
+                              ,FStar_Pervasives_Native.None ) ->
+                               failwith "Impossible (parser)"
+                           | (lift,FStar_Pervasives_Native.Some
+                              (uvs,lift_wp)) ->
+                               let uu____9147 =
+                                 if (FStar_List.length uvs) > Prims.int_zero
+                                 then
+                                   let uu____9158 =
+                                     FStar_Syntax_Subst.univ_var_opening uvs
+                                      in
+                                   match uu____9158 with
+                                   | (usubst,uvs1) ->
+                                       let uu____9181 =
+                                         FStar_TypeChecker_Env.push_univ_vars
+                                           env uvs1
+                                          in
+                                       let uu____9182 =
+                                         FStar_Syntax_Subst.subst usubst
+                                           lift_wp
+                                          in
+                                       (uu____9181, uu____9182)
+                                 else (env, lift_wp)  in
+                               (match uu____9147 with
+                                | (env1,lift_wp1) ->
+                                    let lift_wp2 =
+                                      if
+                                        (FStar_List.length uvs) =
+                                          Prims.int_zero
+                                      then
+                                        check_and_gen env1 lift_wp1
+                                          expected_k
+                                      else
+                                        (let lift_wp2 =
+                                           tc_check_trivial_guard env1
+                                             lift_wp1 expected_k
+                                            in
+                                         let uu____9226 =
+                                           FStar_Syntax_Subst.close_univ_vars
+                                             uvs lift_wp2
+                                            in
+                                         (uvs, uu____9226))
+                                       in
+                                    (lift, lift_wp2))
+                           | (FStar_Pervasives_Native.Some
+                              (what,lift),FStar_Pervasives_Native.None ) ->
+                               let uu____9291 =
+                                 if (FStar_List.length what) > Prims.int_zero
+                                 then
+                                   let uu____9306 =
+                                     FStar_Syntax_Subst.univ_var_opening what
+                                      in
+                                   match uu____9306 with
+                                   | (usubst,uvs) ->
+                                       let uu____9331 =
+                                         FStar_Syntax_Subst.subst usubst lift
+                                          in
+                                       (uvs, uu____9331)
+                                 else ([], lift)  in
+                               (match uu____9291 with
+                                | (uvs,lift1) ->
+                                    ((let uu____9365 =
+                                        FStar_TypeChecker_Env.debug env
+                                          (FStar_Options.Other "ED")
+                                         in
+                                      if uu____9365
+                                      then
+                                        let uu____9369 =
+                                          FStar_Syntax_Print.term_to_string
+                                            lift1
+                                           in
+                                        FStar_Util.print1
+                                          "Lift for free : %s\n" uu____9369
+                                      else ());
+                                     (let dmff_env =
+                                        FStar_TypeChecker_DMFF.empty env
+                                          (FStar_TypeChecker_TcTerm.tc_constant
+                                             env FStar_Range.dummyRange)
+                                         in
+                                      let uu____9375 =
+                                        let uu____9382 =
+                                          FStar_TypeChecker_Env.push_univ_vars
+                                            env uvs
+                                           in
+                                        FStar_TypeChecker_TcTerm.tc_term
+                                          uu____9382 lift1
+                                         in
+                                      match uu____9375 with
+                                      | (lift2,comp,uu____9405) ->
+                                          let uu____9406 =
+                                            FStar_TypeChecker_DMFF.star_expr
+                                              dmff_env lift2
+                                             in
+                                          (match uu____9406 with
+                                           | (uu____9433,lift_wp,lift_elab)
+                                               ->
+                                               let lift_wp1 =
+                                                 recheck_debug "lift-wp" env
+                                                   lift_wp
+                                                  in
+                                               let lift_elab1 =
+                                                 recheck_debug "lift-elab"
+                                                   env lift_elab
+                                                  in
+                                               if
+                                                 (FStar_List.length uvs) =
+                                                   Prims.int_zero
+                                               then
+                                                 let uu____9463 =
+                                                   let uu____9474 =
+                                                     FStar_TypeChecker_Util.generalize_universes
+                                                       env lift_elab1
+                                                      in
+                                                   FStar_Pervasives_Native.Some
+                                                     uu____9474
+                                                    in
+                                                 let uu____9491 =
+                                                   FStar_TypeChecker_Util.generalize_universes
+                                                     env lift_wp1
+                                                    in
+                                                 (uu____9463, uu____9491)
+                                               else
+                                                 (let uu____9516 =
+                                                    let uu____9527 =
+                                                      let uu____9536 =
+                                                        FStar_Syntax_Subst.close_univ_vars
+                                                          uvs lift_elab1
+                                                         in
+                                                      (uvs, uu____9536)  in
+                                                    FStar_Pervasives_Native.Some
+                                                      uu____9527
+                                                     in
+                                                  let uu____9551 =
+                                                    let uu____9558 =
+                                                      FStar_Syntax_Subst.close_univ_vars
+                                                        uvs lift_wp1
+                                                       in
+                                                    (uvs, uu____9558)  in
+                                                  (uu____9516, uu____9551))))))
+                            in
+                         (match uu____8980 with
+                          | (lift,lift_wp) ->
+                              let env1 =
+                                let uu___1160_9622 = env  in
+                                {
+                                  FStar_TypeChecker_Env.solver =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.solver);
+                                  FStar_TypeChecker_Env.range =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.range);
+                                  FStar_TypeChecker_Env.curmodule =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.curmodule);
+                                  FStar_TypeChecker_Env.gamma =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.gamma);
+                                  FStar_TypeChecker_Env.gamma_sig =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.gamma_sig);
+                                  FStar_TypeChecker_Env.gamma_cache =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.gamma_cache);
+                                  FStar_TypeChecker_Env.modules =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.modules);
+                                  FStar_TypeChecker_Env.expected_typ =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.expected_typ);
+                                  FStar_TypeChecker_Env.sigtab =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.sigtab);
+                                  FStar_TypeChecker_Env.attrtab =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.attrtab);
+                                  FStar_TypeChecker_Env.is_pattern =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.is_pattern);
+                                  FStar_TypeChecker_Env.instantiate_imp =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.instantiate_imp);
+                                  FStar_TypeChecker_Env.effects =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.effects);
+                                  FStar_TypeChecker_Env.generalize =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.generalize);
+                                  FStar_TypeChecker_Env.letrecs =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.letrecs);
+                                  FStar_TypeChecker_Env.top_level =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.top_level);
+                                  FStar_TypeChecker_Env.check_uvars =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.check_uvars);
+                                  FStar_TypeChecker_Env.use_eq =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.use_eq);
+                                  FStar_TypeChecker_Env.is_iface =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.is_iface);
+                                  FStar_TypeChecker_Env.admit =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.admit);
+                                  FStar_TypeChecker_Env.lax = true;
+                                  FStar_TypeChecker_Env.lax_universes =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.lax_universes);
+                                  FStar_TypeChecker_Env.phase1 =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.phase1);
+                                  FStar_TypeChecker_Env.failhard =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.failhard);
+                                  FStar_TypeChecker_Env.nosynth =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.nosynth);
+                                  FStar_TypeChecker_Env.uvar_subtyping =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.uvar_subtyping);
+                                  FStar_TypeChecker_Env.tc_term =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.tc_term);
+                                  FStar_TypeChecker_Env.type_of =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.type_of);
+                                  FStar_TypeChecker_Env.universe_of =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.universe_of);
+                                  FStar_TypeChecker_Env.check_type_of =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.check_type_of);
+                                  FStar_TypeChecker_Env.use_bv_sorts =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.use_bv_sorts);
+                                  FStar_TypeChecker_Env.qtbl_name_and_index =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                  FStar_TypeChecker_Env.normalized_eff_names
+                                    =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.normalized_eff_names);
+                                  FStar_TypeChecker_Env.fv_delta_depths =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.fv_delta_depths);
+                                  FStar_TypeChecker_Env.proof_ns =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.proof_ns);
+                                  FStar_TypeChecker_Env.synth_hook =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.synth_hook);
+                                  FStar_TypeChecker_Env.splice =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.splice);
+                                  FStar_TypeChecker_Env.postprocess =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.postprocess);
+                                  FStar_TypeChecker_Env.is_native_tactic =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.is_native_tactic);
+                                  FStar_TypeChecker_Env.identifier_info =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.identifier_info);
+                                  FStar_TypeChecker_Env.tc_hooks =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.tc_hooks);
+                                  FStar_TypeChecker_Env.dsenv =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.dsenv);
+                                  FStar_TypeChecker_Env.nbe =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.nbe);
+                                  FStar_TypeChecker_Env.strict_args_tab =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.strict_args_tab);
+                                  FStar_TypeChecker_Env.erasable_types_tab =
+                                    (uu___1160_9622.FStar_TypeChecker_Env.erasable_types_tab)
+                                }  in
+                              let lift1 =
+                                match lift with
+                                | FStar_Pervasives_Native.None  ->
+                                    FStar_Pervasives_Native.None
+                                | FStar_Pervasives_Native.Some (uvs,lift1) ->
+                                    let uu____9679 =
+                                      let uu____9684 =
+                                        FStar_Syntax_Subst.univ_var_opening
+                                          uvs
+                                         in
+                                      match uu____9684 with
+                                      | (usubst,uvs1) ->
+                                          let uu____9707 =
+                                            FStar_TypeChecker_Env.push_univ_vars
+                                              env1 uvs1
+                                             in
+                                          let uu____9708 =
+                                            FStar_Syntax_Subst.subst usubst
+                                              lift1
+                                             in
+                                          (uu____9707, uu____9708)
+                                       in
+                                    (match uu____9679 with
+                                     | (env2,lift2) ->
+                                         let uu____9721 =
+                                           let uu____9728 =
+                                             FStar_TypeChecker_Env.lookup_effect_lid
+                                               env2
+                                               sub1.FStar_Syntax_Syntax.source
+                                              in
+                                           monad_signature env2
+                                             sub1.FStar_Syntax_Syntax.source
+                                             uu____9728
+                                            in
+                                         (match uu____9721 with
+                                          | (a1,wp_a_src1) ->
+                                              let wp_a =
+                                                FStar_Syntax_Syntax.new_bv
+                                                  FStar_Pervasives_Native.None
+                                                  wp_a_src1
+                                                 in
+                                              let a_typ =
+                                                FStar_Syntax_Syntax.bv_to_name
+                                                  a1
+                                                 in
+                                              let wp_a_typ =
+                                                FStar_Syntax_Syntax.bv_to_name
+                                                  wp_a
+                                                 in
+                                              let repr_f =
+                                                repr_type
+                                                  sub1.FStar_Syntax_Syntax.source
+                                                  a_typ wp_a_typ
+                                                 in
+                                              let repr_result =
+                                                let lift_wp1 =
+                                                  FStar_TypeChecker_Normalize.normalize
+                                                    [FStar_TypeChecker_Env.EraseUniverses;
+                                                    FStar_TypeChecker_Env.AllowUnboundUniverses]
+                                                    env2
+                                                    (FStar_Pervasives_Native.snd
+                                                       lift_wp)
+                                                   in
+                                                let lift_wp_a =
+                                                  let uu____9760 =
+                                                    FStar_TypeChecker_Env.get_range
+                                                      env2
+                                                     in
+                                                  let uu____9761 =
+                                                    let uu____9768 =
+                                                      let uu____9769 =
+                                                        let uu____9786 =
+                                                          let uu____9797 =
+                                                            FStar_Syntax_Syntax.as_arg
+                                                              a_typ
+                                                             in
+                                                          let uu____9806 =
+                                                            let uu____9817 =
+                                                              FStar_Syntax_Syntax.as_arg
+                                                                wp_a_typ
+                                                               in
+                                                            [uu____9817]  in
+                                                          uu____9797 ::
+                                                            uu____9806
+                                                           in
+                                                        (lift_wp1,
+                                                          uu____9786)
+                                                         in
+                                                      FStar_Syntax_Syntax.Tm_app
+                                                        uu____9769
+                                                       in
+                                                    FStar_Syntax_Syntax.mk
+                                                      uu____9768
+                                                     in
+                                                  uu____9761
+                                                    FStar_Pervasives_Native.None
+                                                    uu____9760
+                                                   in
+                                                repr_type
+                                                  sub1.FStar_Syntax_Syntax.target
+                                                  a_typ lift_wp_a
+                                                 in
+                                              let expected_k1 =
+                                                let uu____9865 =
+                                                  let uu____9874 =
+                                                    FStar_Syntax_Syntax.mk_binder
+                                                      a1
+                                                     in
+                                                  let uu____9881 =
+                                                    let uu____9890 =
+                                                      FStar_Syntax_Syntax.mk_binder
+                                                        wp_a
+                                                       in
+                                                    let uu____9897 =
+                                                      let uu____9906 =
+                                                        FStar_Syntax_Syntax.null_binder
+                                                          repr_f
+                                                         in
+                                                      [uu____9906]  in
+                                                    uu____9890 :: uu____9897
+                                                     in
+                                                  uu____9874 :: uu____9881
+                                                   in
+                                                let uu____9937 =
+                                                  FStar_Syntax_Syntax.mk_Total
+                                                    repr_result
+                                                   in
+                                                FStar_Syntax_Util.arrow
+                                                  uu____9865 uu____9937
+                                                 in
+                                              let uu____9940 =
+                                                FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
+                                                  env2 expected_k1
+                                                 in
+                                              (match uu____9940 with
+                                               | (expected_k2,uu____9958,uu____9959)
+                                                   ->
+                                                   let lift3 =
+                                                     if
+                                                       (FStar_List.length uvs)
+                                                         = Prims.int_zero
+                                                     then
+                                                       check_and_gen env2
+                                                         lift2 expected_k2
+                                                     else
+                                                       (let lift3 =
+                                                          tc_check_trivial_guard
+                                                            env2 lift2
+                                                            expected_k2
+                                                           in
+                                                        let uu____9983 =
+                                                          FStar_Syntax_Subst.close_univ_vars
+                                                            uvs lift3
+                                                           in
+                                                        (uvs, uu____9983))
+                                                      in
+                                                   FStar_Pervasives_Native.Some
+                                                     lift3)))
+                                 in
+                              ((let uu____9999 =
+                                  let uu____10001 =
+                                    let uu____10003 =
+                                      FStar_All.pipe_right lift_wp
+                                        FStar_Pervasives_Native.fst
+                                       in
+                                    FStar_All.pipe_right uu____10003
+                                      FStar_List.length
+                                     in
+                                  uu____10001 <> Prims.int_one  in
+                                if uu____9999
+                                then
+                                  let uu____10022 =
+                                    let uu____10028 =
+                                      let uu____10030 =
+                                        FStar_Syntax_Print.lid_to_string
+                                          sub1.FStar_Syntax_Syntax.source
+                                         in
+                                      let uu____10032 =
+                                        FStar_Syntax_Print.lid_to_string
+                                          sub1.FStar_Syntax_Syntax.target
+                                         in
+                                      let uu____10034 =
+                                        let uu____10036 =
+                                          let uu____10038 =
+                                            FStar_All.pipe_right lift_wp
+                                              FStar_Pervasives_Native.fst
+                                             in
+                                          FStar_All.pipe_right uu____10038
+                                            FStar_List.length
+                                           in
+                                        FStar_All.pipe_right uu____10036
+                                          FStar_Util.string_of_int
+                                         in
+                                      FStar_Util.format3
+                                        "Sub effect wp must be polymorphic in exactly 1 universe; %s ~> %s has %s universes"
+                                        uu____10030 uu____10032 uu____10034
+                                       in
+                                    (FStar_Errors.Fatal_TooManyUniverse,
+                                      uu____10028)
+                                     in
+                                  FStar_Errors.raise_error uu____10022 r
+                                else ());
+                               (let uu____10061 =
+                                  (FStar_Util.is_some lift1) &&
+                                    (let uu____10072 =
+                                       let uu____10074 =
+                                         let uu____10077 =
+                                           FStar_All.pipe_right lift1
+                                             FStar_Util.must
+                                            in
+                                         FStar_All.pipe_right uu____10077
+                                           FStar_Pervasives_Native.fst
+                                          in
+                                       FStar_All.pipe_right uu____10074
+                                         FStar_List.length
+                                        in
+                                     uu____10072 <> Prims.int_one)
+                                   in
+                                if uu____10061
+                                then
+                                  let uu____10131 =
+                                    let uu____10137 =
+                                      let uu____10139 =
+                                        FStar_Syntax_Print.lid_to_string
+                                          sub1.FStar_Syntax_Syntax.source
+                                         in
+                                      let uu____10141 =
+                                        FStar_Syntax_Print.lid_to_string
+                                          sub1.FStar_Syntax_Syntax.target
+                                         in
+                                      let uu____10143 =
+                                        let uu____10145 =
+                                          let uu____10147 =
+                                            let uu____10150 =
+                                              FStar_All.pipe_right lift1
+                                                FStar_Util.must
+                                               in
+                                            FStar_All.pipe_right uu____10150
+                                              FStar_Pervasives_Native.fst
+                                             in
+                                          FStar_All.pipe_right uu____10147
+                                            FStar_List.length
+                                           in
+                                        FStar_All.pipe_right uu____10145
+                                          FStar_Util.string_of_int
+                                         in
+                                      FStar_Util.format3
+                                        "Sub effect lift must be polymorphic in exactly 1 universe; %s ~> %s has %s universes"
+                                        uu____10139 uu____10141 uu____10143
+                                       in
+                                    (FStar_Errors.Fatal_TooManyUniverse,
+                                      uu____10137)
+                                     in
+                                  FStar_Errors.raise_error uu____10131 r
+                                else ());
+                               (let sub2 =
+                                  let uu___1197_10209 = sub1  in
+                                  {
+                                    FStar_Syntax_Syntax.source =
+                                      (uu___1197_10209.FStar_Syntax_Syntax.source);
+                                    FStar_Syntax_Syntax.target =
+                                      (uu___1197_10209.FStar_Syntax_Syntax.target);
+                                    FStar_Syntax_Syntax.lift_wp =
+                                      (FStar_Pervasives_Native.Some lift_wp);
+                                    FStar_Syntax_Syntax.lift = lift1
+                                  }  in
+                                let se2 =
+                                  let uu___1200_10211 = se1  in
+                                  {
+                                    FStar_Syntax_Syntax.sigel =
+                                      (FStar_Syntax_Syntax.Sig_sub_effect
+                                         sub2);
+                                    FStar_Syntax_Syntax.sigrng =
+                                      (uu___1200_10211.FStar_Syntax_Syntax.sigrng);
+                                    FStar_Syntax_Syntax.sigquals =
+                                      (uu___1200_10211.FStar_Syntax_Syntax.sigquals);
+                                    FStar_Syntax_Syntax.sigmeta =
+                                      (uu___1200_10211.FStar_Syntax_Syntax.sigmeta);
+                                    FStar_Syntax_Syntax.sigattrs =
+                                      (uu___1200_10211.FStar_Syntax_Syntax.sigattrs);
+                                    FStar_Syntax_Syntax.sigopts =
+                                      (uu___1200_10211.FStar_Syntax_Syntax.sigopts)
+                                  }  in
+                                ([se2], [], env0))))))
+           | FStar_Syntax_Syntax.Sig_effect_abbrev (lid,uvs,tps,c,flags) ->
+               let uu____10225 =
+                 if (FStar_List.length uvs) = Prims.int_zero
+                 then (env, uvs, tps, c)
+                 else
+                   (let uu____10253 = FStar_Syntax_Subst.univ_var_opening uvs
+                       in
+                    match uu____10253 with
+                    | (usubst,uvs1) ->
+                        let tps1 =
+                          FStar_Syntax_Subst.subst_binders usubst tps  in
+                        let c1 =
+                          let uu____10284 =
+                            FStar_Syntax_Subst.shift_subst
+                              (FStar_List.length tps1) usubst
+                             in
+                          FStar_Syntax_Subst.subst_comp uu____10284 c  in
+                        let uu____10293 =
+                          FStar_TypeChecker_Env.push_univ_vars env uvs1  in
+                        (uu____10293, uvs1, tps1, c1))
+                  in
+               (match uu____10225 with
+                | (env1,uvs1,tps1,c1) ->
+                    let env2 = FStar_TypeChecker_Env.set_range env1 r  in
+                    let uu____10315 = FStar_Syntax_Subst.open_comp tps1 c1
+                       in
+                    (match uu____10315 with
+                     | (tps2,c2) ->
+                         let uu____10332 =
+                           FStar_TypeChecker_TcTerm.tc_tparams env2 tps2  in
+                         (match uu____10332 with
+                          | (tps3,env3,us) ->
+                              let uu____10352 =
+                                FStar_TypeChecker_TcTerm.tc_comp env3 c2  in
+                              (match uu____10352 with
+                               | (c3,u,g) ->
+                                   (FStar_TypeChecker_Rel.force_trivial_guard
+                                      env3 g;
+                                    (let expected_result_typ =
+                                       match tps3 with
+                                       | (x,uu____10380)::uu____10381 ->
+                                           FStar_Syntax_Syntax.bv_to_name x
+                                       | uu____10400 ->
+                                           FStar_Errors.raise_error
+                                             (FStar_Errors.Fatal_NotEnoughArgumentsForEffect,
+                                               "Effect abbreviations must bind at least the result type")
+                                             r
+                                        in
+                                     let def_result_typ =
+                                       FStar_Syntax_Util.comp_result c3  in
+                                     let uu____10408 =
+                                       let uu____10410 =
+                                         FStar_TypeChecker_Rel.teq_nosmt_force
+                                           env3 expected_result_typ
+                                           def_result_typ
+                                          in
+                                       Prims.op_Negation uu____10410  in
+                                     if uu____10408
+                                     then
+                                       let uu____10413 =
+                                         let uu____10419 =
+                                           let uu____10421 =
+                                             FStar_Syntax_Print.term_to_string
+                                               expected_result_typ
+                                              in
+                                           let uu____10423 =
+                                             FStar_Syntax_Print.term_to_string
+                                               def_result_typ
+                                              in
+                                           FStar_Util.format2
+                                             "Result type of effect abbreviation `%s` does not match the result type of its definition `%s`"
+                                             uu____10421 uu____10423
+                                            in
+                                         (FStar_Errors.Fatal_EffectAbbreviationResultTypeMismatch,
+                                           uu____10419)
+                                          in
+                                       FStar_Errors.raise_error uu____10413 r
+                                     else ());
+                                    (let tps4 =
+                                       FStar_Syntax_Subst.close_binders tps3
+                                        in
+                                     let c4 =
+                                       FStar_Syntax_Subst.close_comp tps4 c3
+                                        in
+                                     let uu____10431 =
+                                       let uu____10432 =
+                                         FStar_Syntax_Syntax.mk
+                                           (FStar_Syntax_Syntax.Tm_arrow
+                                              (tps4, c4))
+                                           FStar_Pervasives_Native.None r
+                                          in
+                                       FStar_TypeChecker_Util.generalize_universes
+                                         env0 uu____10432
+                                        in
+                                     match uu____10431 with
+                                     | (uvs2,t) ->
+                                         let uu____10463 =
+                                           let uu____10468 =
+                                             let uu____10481 =
+                                               let uu____10482 =
+                                                 FStar_Syntax_Subst.compress
+                                                   t
+                                                  in
+                                               uu____10482.FStar_Syntax_Syntax.n
+                                                in
+                                             (tps4, uu____10481)  in
+                                           match uu____10468 with
+                                           | ([],FStar_Syntax_Syntax.Tm_arrow
+                                              (uu____10497,c5)) -> ([], c5)
+                                           | (uu____10539,FStar_Syntax_Syntax.Tm_arrow
+                                              (tps5,c5)) -> (tps5, c5)
+                                           | uu____10578 ->
+                                               failwith
+                                                 "Impossible (t is an arrow)"
+                                            in
+                                         (match uu____10463 with
+                                          | (tps5,c5) ->
+                                              (if
+                                                 (FStar_List.length uvs2) <>
+                                                   Prims.int_one
+                                               then
+                                                 (let uu____10612 =
+                                                    FStar_Syntax_Subst.open_univ_vars
+                                                      uvs2 t
+                                                     in
+                                                  match uu____10612 with
+                                                  | (uu____10617,t1) ->
+                                                      let uu____10619 =
+                                                        let uu____10625 =
+                                                          let uu____10627 =
+                                                            FStar_Syntax_Print.lid_to_string
+                                                              lid
+                                                             in
+                                                          let uu____10629 =
+                                                            FStar_All.pipe_right
+                                                              (FStar_List.length
+                                                                 uvs2)
+                                                              FStar_Util.string_of_int
+                                                             in
+                                                          let uu____10633 =
+                                                            FStar_Syntax_Print.term_to_string
+                                                              t1
+                                                             in
+                                                          FStar_Util.format3
+                                                            "Effect abbreviations must be polymorphic in exactly 1 universe; %s has %s universes (%s)"
+                                                            uu____10627
+                                                            uu____10629
+                                                            uu____10633
+                                                           in
+                                                        (FStar_Errors.Fatal_TooManyUniverse,
+                                                          uu____10625)
+                                                         in
+                                                      FStar_Errors.raise_error
+                                                        uu____10619 r)
+                                               else ();
+                                               (let se2 =
+                                                  let uu___1270_10640 = se1
+                                                     in
+                                                  {
+                                                    FStar_Syntax_Syntax.sigel
+                                                      =
+                                                      (FStar_Syntax_Syntax.Sig_effect_abbrev
+                                                         (lid, uvs2, tps5,
+                                                           c5, flags));
+                                                    FStar_Syntax_Syntax.sigrng
+                                                      =
+                                                      (uu___1270_10640.FStar_Syntax_Syntax.sigrng);
+                                                    FStar_Syntax_Syntax.sigquals
+                                                      =
+                                                      (uu___1270_10640.FStar_Syntax_Syntax.sigquals);
+                                                    FStar_Syntax_Syntax.sigmeta
+                                                      =
+                                                      (uu___1270_10640.FStar_Syntax_Syntax.sigmeta);
+                                                    FStar_Syntax_Syntax.sigattrs
+                                                      =
+                                                      (uu___1270_10640.FStar_Syntax_Syntax.sigattrs);
+                                                    FStar_Syntax_Syntax.sigopts
+                                                      =
+                                                      (uu___1270_10640.FStar_Syntax_Syntax.sigopts)
+                                                  }  in
+                                                ([se2], [], env0))))))))))
+           | FStar_Syntax_Syntax.Sig_declare_typ
+               (uu____10647,uu____10648,uu____10649) when
+               FStar_All.pipe_right se1.FStar_Syntax_Syntax.sigquals
+                 (FStar_Util.for_some
+                    (fun uu___1_10654  ->
+                       match uu___1_10654 with
+                       | FStar_Syntax_Syntax.OnlyName  -> true
+                       | uu____10657 -> false))
+               -> ([], [], env0)
+           | FStar_Syntax_Syntax.Sig_let (uu____10663,uu____10664) when
+               FStar_All.pipe_right se1.FStar_Syntax_Syntax.sigquals
+                 (FStar_Util.for_some
+                    (fun uu___1_10673  ->
+                       match uu___1_10673 with
+                       | FStar_Syntax_Syntax.OnlyName  -> true
+                       | uu____10676 -> false))
+               -> ([], [], env0)
+           | FStar_Syntax_Syntax.Sig_declare_typ (lid,uvs,t) ->
+               let env1 = FStar_TypeChecker_Env.set_range env r  in
+               ((let uu____10687 = FStar_TypeChecker_Env.lid_exists env1 lid
+                    in
+                 if uu____10687
+                 then
+                   let uu____10690 =
+                     let uu____10696 =
+                       let uu____10698 = FStar_Ident.text_of_lid lid  in
+                       FStar_Util.format1
+                         "Top-level declaration %s for a name that is already used in this module; top-level declarations must be unique in their module"
+                         uu____10698
+                        in
+                     (FStar_Errors.Fatal_AlreadyDefinedTopLevelDeclaration,
+                       uu____10696)
+                      in
+                   FStar_Errors.raise_error uu____10690 r
+                 else ());
+                (let uu____10704 =
+                   let uu____10713 =
+                     (FStar_Options.use_two_phase_tc ()) &&
+                       (FStar_TypeChecker_Env.should_verify env1)
+                      in
+                   if uu____10713
+                   then
+                     let uu____10724 =
+                       tc_declare_typ
+                         (let uu___1294_10727 = env1  in
+                          {
+                            FStar_TypeChecker_Env.solver =
+                              (uu___1294_10727.FStar_TypeChecker_Env.solver);
+                            FStar_TypeChecker_Env.range =
+                              (uu___1294_10727.FStar_TypeChecker_Env.range);
+                            FStar_TypeChecker_Env.curmodule =
+                              (uu___1294_10727.FStar_TypeChecker_Env.curmodule);
+                            FStar_TypeChecker_Env.gamma =
+                              (uu___1294_10727.FStar_TypeChecker_Env.gamma);
+                            FStar_TypeChecker_Env.gamma_sig =
+                              (uu___1294_10727.FStar_TypeChecker_Env.gamma_sig);
+                            FStar_TypeChecker_Env.gamma_cache =
+                              (uu___1294_10727.FStar_TypeChecker_Env.gamma_cache);
+                            FStar_TypeChecker_Env.modules =
+                              (uu___1294_10727.FStar_TypeChecker_Env.modules);
+                            FStar_TypeChecker_Env.expected_typ =
+                              (uu___1294_10727.FStar_TypeChecker_Env.expected_typ);
+                            FStar_TypeChecker_Env.sigtab =
+                              (uu___1294_10727.FStar_TypeChecker_Env.sigtab);
+                            FStar_TypeChecker_Env.attrtab =
+                              (uu___1294_10727.FStar_TypeChecker_Env.attrtab);
+                            FStar_TypeChecker_Env.is_pattern =
+                              (uu___1294_10727.FStar_TypeChecker_Env.is_pattern);
+                            FStar_TypeChecker_Env.instantiate_imp =
+                              (uu___1294_10727.FStar_TypeChecker_Env.instantiate_imp);
+                            FStar_TypeChecker_Env.effects =
+                              (uu___1294_10727.FStar_TypeChecker_Env.effects);
+                            FStar_TypeChecker_Env.generalize =
+                              (uu___1294_10727.FStar_TypeChecker_Env.generalize);
+                            FStar_TypeChecker_Env.letrecs =
+                              (uu___1294_10727.FStar_TypeChecker_Env.letrecs);
+                            FStar_TypeChecker_Env.top_level =
+                              (uu___1294_10727.FStar_TypeChecker_Env.top_level);
+                            FStar_TypeChecker_Env.check_uvars =
+                              (uu___1294_10727.FStar_TypeChecker_Env.check_uvars);
+                            FStar_TypeChecker_Env.use_eq =
+                              (uu___1294_10727.FStar_TypeChecker_Env.use_eq);
+                            FStar_TypeChecker_Env.is_iface =
+                              (uu___1294_10727.FStar_TypeChecker_Env.is_iface);
+                            FStar_TypeChecker_Env.admit =
+                              (uu___1294_10727.FStar_TypeChecker_Env.admit);
+                            FStar_TypeChecker_Env.lax = true;
+                            FStar_TypeChecker_Env.lax_universes =
+                              (uu___1294_10727.FStar_TypeChecker_Env.lax_universes);
+                            FStar_TypeChecker_Env.phase1 =
+                              (uu___1294_10727.FStar_TypeChecker_Env.phase1);
+                            FStar_TypeChecker_Env.failhard =
+                              (uu___1294_10727.FStar_TypeChecker_Env.failhard);
+                            FStar_TypeChecker_Env.nosynth =
+                              (uu___1294_10727.FStar_TypeChecker_Env.nosynth);
+                            FStar_TypeChecker_Env.uvar_subtyping =
+                              (uu___1294_10727.FStar_TypeChecker_Env.uvar_subtyping);
+                            FStar_TypeChecker_Env.tc_term =
+                              (uu___1294_10727.FStar_TypeChecker_Env.tc_term);
+                            FStar_TypeChecker_Env.type_of =
+                              (uu___1294_10727.FStar_TypeChecker_Env.type_of);
+                            FStar_TypeChecker_Env.universe_of =
+                              (uu___1294_10727.FStar_TypeChecker_Env.universe_of);
+                            FStar_TypeChecker_Env.check_type_of =
+                              (uu___1294_10727.FStar_TypeChecker_Env.check_type_of);
+                            FStar_TypeChecker_Env.use_bv_sorts =
+                              (uu___1294_10727.FStar_TypeChecker_Env.use_bv_sorts);
+                            FStar_TypeChecker_Env.qtbl_name_and_index =
+                              (uu___1294_10727.FStar_TypeChecker_Env.qtbl_name_and_index);
+                            FStar_TypeChecker_Env.normalized_eff_names =
+                              (uu___1294_10727.FStar_TypeChecker_Env.normalized_eff_names);
+                            FStar_TypeChecker_Env.fv_delta_depths =
+                              (uu___1294_10727.FStar_TypeChecker_Env.fv_delta_depths);
+                            FStar_TypeChecker_Env.proof_ns =
+                              (uu___1294_10727.FStar_TypeChecker_Env.proof_ns);
+                            FStar_TypeChecker_Env.synth_hook =
+                              (uu___1294_10727.FStar_TypeChecker_Env.synth_hook);
+                            FStar_TypeChecker_Env.splice =
+                              (uu___1294_10727.FStar_TypeChecker_Env.splice);
+                            FStar_TypeChecker_Env.postprocess =
+                              (uu___1294_10727.FStar_TypeChecker_Env.postprocess);
+                            FStar_TypeChecker_Env.is_native_tactic =
+                              (uu___1294_10727.FStar_TypeChecker_Env.is_native_tactic);
+                            FStar_TypeChecker_Env.identifier_info =
+                              (uu___1294_10727.FStar_TypeChecker_Env.identifier_info);
+                            FStar_TypeChecker_Env.tc_hooks =
+                              (uu___1294_10727.FStar_TypeChecker_Env.tc_hooks);
+                            FStar_TypeChecker_Env.dsenv =
+                              (uu___1294_10727.FStar_TypeChecker_Env.dsenv);
+                            FStar_TypeChecker_Env.nbe =
+                              (uu___1294_10727.FStar_TypeChecker_Env.nbe);
+                            FStar_TypeChecker_Env.strict_args_tab =
+                              (uu___1294_10727.FStar_TypeChecker_Env.strict_args_tab);
+                            FStar_TypeChecker_Env.erasable_types_tab =
+                              (uu___1294_10727.FStar_TypeChecker_Env.erasable_types_tab)
+                          }) (uvs, t) se1.FStar_Syntax_Syntax.sigrng
+                        in
+                     match uu____10724 with
+                     | (uvs1,t1) ->
+                         ((let uu____10752 =
+                             FStar_All.pipe_left
+                               (FStar_TypeChecker_Env.debug env1)
+                               (FStar_Options.Other "TwoPhases")
+                              in
+                           if uu____10752
+                           then
+                             let uu____10757 =
+                               FStar_Syntax_Print.term_to_string t1  in
+                             let uu____10759 =
+                               FStar_Syntax_Print.univ_names_to_string uvs1
+                                in
+                             FStar_Util.print2
+                               "Val declaration after phase 1: %s and uvs: %s\n"
+                               uu____10757 uu____10759
+                           else ());
+                          (uvs1, t1))
+                   else (uvs, t)  in
+                 match uu____10704 with
+                 | (uvs1,t1) ->
+                     let uu____10794 =
+                       tc_declare_typ env1 (uvs1, t1)
+                         se1.FStar_Syntax_Syntax.sigrng
+                        in
+                     (match uu____10794 with
+                      | (uvs2,t2) ->
+                          ([(let uu___1307_10824 = se1  in
+                             {
+                               FStar_Syntax_Syntax.sigel =
+                                 (FStar_Syntax_Syntax.Sig_declare_typ
+                                    (lid, uvs2, t2));
+                               FStar_Syntax_Syntax.sigrng =
+                                 (uu___1307_10824.FStar_Syntax_Syntax.sigrng);
+                               FStar_Syntax_Syntax.sigquals =
+                                 (uu___1307_10824.FStar_Syntax_Syntax.sigquals);
+                               FStar_Syntax_Syntax.sigmeta =
+                                 (uu___1307_10824.FStar_Syntax_Syntax.sigmeta);
+                               FStar_Syntax_Syntax.sigattrs =
+                                 (uu___1307_10824.FStar_Syntax_Syntax.sigattrs);
+                               FStar_Syntax_Syntax.sigopts =
+                                 (uu___1307_10824.FStar_Syntax_Syntax.sigopts)
+                             })], [], env0))))
+           | FStar_Syntax_Syntax.Sig_assume (lid,uvs,t) ->
+               let env1 = FStar_TypeChecker_Env.set_range env r  in
+               let uu____10829 =
+                 let uu____10838 =
+                   (FStar_Options.use_two_phase_tc ()) &&
+                     (FStar_TypeChecker_Env.should_verify env1)
+                    in
+                 if uu____10838
+                 then
+                   let uu____10849 =
+                     tc_assume
+                       (let uu___1316_10852 = env1  in
+                        {
+                          FStar_TypeChecker_Env.solver =
+                            (uu___1316_10852.FStar_TypeChecker_Env.solver);
+                          FStar_TypeChecker_Env.range =
+                            (uu___1316_10852.FStar_TypeChecker_Env.range);
+                          FStar_TypeChecker_Env.curmodule =
+                            (uu___1316_10852.FStar_TypeChecker_Env.curmodule);
+                          FStar_TypeChecker_Env.gamma =
+                            (uu___1316_10852.FStar_TypeChecker_Env.gamma);
+                          FStar_TypeChecker_Env.gamma_sig =
+                            (uu___1316_10852.FStar_TypeChecker_Env.gamma_sig);
+                          FStar_TypeChecker_Env.gamma_cache =
+                            (uu___1316_10852.FStar_TypeChecker_Env.gamma_cache);
+                          FStar_TypeChecker_Env.modules =
+                            (uu___1316_10852.FStar_TypeChecker_Env.modules);
+                          FStar_TypeChecker_Env.expected_typ =
+                            (uu___1316_10852.FStar_TypeChecker_Env.expected_typ);
+                          FStar_TypeChecker_Env.sigtab =
+                            (uu___1316_10852.FStar_TypeChecker_Env.sigtab);
+                          FStar_TypeChecker_Env.attrtab =
+                            (uu___1316_10852.FStar_TypeChecker_Env.attrtab);
+                          FStar_TypeChecker_Env.is_pattern =
+                            (uu___1316_10852.FStar_TypeChecker_Env.is_pattern);
+                          FStar_TypeChecker_Env.instantiate_imp =
+                            (uu___1316_10852.FStar_TypeChecker_Env.instantiate_imp);
+                          FStar_TypeChecker_Env.effects =
+                            (uu___1316_10852.FStar_TypeChecker_Env.effects);
+                          FStar_TypeChecker_Env.generalize =
+                            (uu___1316_10852.FStar_TypeChecker_Env.generalize);
+                          FStar_TypeChecker_Env.letrecs =
+                            (uu___1316_10852.FStar_TypeChecker_Env.letrecs);
+                          FStar_TypeChecker_Env.top_level =
+                            (uu___1316_10852.FStar_TypeChecker_Env.top_level);
+                          FStar_TypeChecker_Env.check_uvars =
+                            (uu___1316_10852.FStar_TypeChecker_Env.check_uvars);
+                          FStar_TypeChecker_Env.use_eq =
+                            (uu___1316_10852.FStar_TypeChecker_Env.use_eq);
+                          FStar_TypeChecker_Env.is_iface =
+                            (uu___1316_10852.FStar_TypeChecker_Env.is_iface);
+                          FStar_TypeChecker_Env.admit =
+                            (uu___1316_10852.FStar_TypeChecker_Env.admit);
+                          FStar_TypeChecker_Env.lax = true;
+                          FStar_TypeChecker_Env.lax_universes =
+                            (uu___1316_10852.FStar_TypeChecker_Env.lax_universes);
+                          FStar_TypeChecker_Env.phase1 = true;
+                          FStar_TypeChecker_Env.failhard =
+                            (uu___1316_10852.FStar_TypeChecker_Env.failhard);
+                          FStar_TypeChecker_Env.nosynth =
+                            (uu___1316_10852.FStar_TypeChecker_Env.nosynth);
+                          FStar_TypeChecker_Env.uvar_subtyping =
+                            (uu___1316_10852.FStar_TypeChecker_Env.uvar_subtyping);
+                          FStar_TypeChecker_Env.tc_term =
+                            (uu___1316_10852.FStar_TypeChecker_Env.tc_term);
+                          FStar_TypeChecker_Env.type_of =
+                            (uu___1316_10852.FStar_TypeChecker_Env.type_of);
+                          FStar_TypeChecker_Env.universe_of =
+                            (uu___1316_10852.FStar_TypeChecker_Env.universe_of);
+                          FStar_TypeChecker_Env.check_type_of =
+                            (uu___1316_10852.FStar_TypeChecker_Env.check_type_of);
+                          FStar_TypeChecker_Env.use_bv_sorts =
+                            (uu___1316_10852.FStar_TypeChecker_Env.use_bv_sorts);
+                          FStar_TypeChecker_Env.qtbl_name_and_index =
+                            (uu___1316_10852.FStar_TypeChecker_Env.qtbl_name_and_index);
+                          FStar_TypeChecker_Env.normalized_eff_names =
+                            (uu___1316_10852.FStar_TypeChecker_Env.normalized_eff_names);
+                          FStar_TypeChecker_Env.fv_delta_depths =
+                            (uu___1316_10852.FStar_TypeChecker_Env.fv_delta_depths);
+                          FStar_TypeChecker_Env.proof_ns =
+                            (uu___1316_10852.FStar_TypeChecker_Env.proof_ns);
+                          FStar_TypeChecker_Env.synth_hook =
+                            (uu___1316_10852.FStar_TypeChecker_Env.synth_hook);
+                          FStar_TypeChecker_Env.splice =
+                            (uu___1316_10852.FStar_TypeChecker_Env.splice);
+                          FStar_TypeChecker_Env.postprocess =
+                            (uu___1316_10852.FStar_TypeChecker_Env.postprocess);
+                          FStar_TypeChecker_Env.is_native_tactic =
+                            (uu___1316_10852.FStar_TypeChecker_Env.is_native_tactic);
+                          FStar_TypeChecker_Env.identifier_info =
+                            (uu___1316_10852.FStar_TypeChecker_Env.identifier_info);
+                          FStar_TypeChecker_Env.tc_hooks =
+                            (uu___1316_10852.FStar_TypeChecker_Env.tc_hooks);
+                          FStar_TypeChecker_Env.dsenv =
+                            (uu___1316_10852.FStar_TypeChecker_Env.dsenv);
+                          FStar_TypeChecker_Env.nbe =
+                            (uu___1316_10852.FStar_TypeChecker_Env.nbe);
+                          FStar_TypeChecker_Env.strict_args_tab =
+                            (uu___1316_10852.FStar_TypeChecker_Env.strict_args_tab);
+                          FStar_TypeChecker_Env.erasable_types_tab =
+                            (uu___1316_10852.FStar_TypeChecker_Env.erasable_types_tab)
+                        }) (uvs, t) se1.FStar_Syntax_Syntax.sigrng
+                      in
+                   match uu____10849 with
+                   | (uvs1,t1) ->
+                       ((let uu____10878 =
+                           FStar_All.pipe_left
+                             (FStar_TypeChecker_Env.debug env1)
+                             (FStar_Options.Other "TwoPhases")
+                            in
+                         if uu____10878
+                         then
+                           let uu____10883 =
+                             FStar_Syntax_Print.term_to_string t1  in
+                           let uu____10885 =
+                             FStar_Syntax_Print.univ_names_to_string uvs1  in
+                           FStar_Util.print2
+                             "Assume after phase 1: %s and uvs: %s\n"
+                             uu____10883 uu____10885
+                         else ());
+                        (uvs1, t1))
+                 else (uvs, t)  in
+               (match uu____10829 with
+                | (uvs1,t1) ->
+                    let uu____10920 =
+                      tc_assume env1 (uvs1, t1)
+                        se1.FStar_Syntax_Syntax.sigrng
+                       in
+                    (match uu____10920 with
+                     | (uvs2,t2) ->
+                         ([(let uu___1329_10950 = se1  in
+                            {
+                              FStar_Syntax_Syntax.sigel =
+                                (FStar_Syntax_Syntax.Sig_assume
+                                   (lid, uvs2, t2));
+                              FStar_Syntax_Syntax.sigrng =
+                                (uu___1329_10950.FStar_Syntax_Syntax.sigrng);
+                              FStar_Syntax_Syntax.sigquals =
+                                (uu___1329_10950.FStar_Syntax_Syntax.sigquals);
+                              FStar_Syntax_Syntax.sigmeta =
+                                (uu___1329_10950.FStar_Syntax_Syntax.sigmeta);
+                              FStar_Syntax_Syntax.sigattrs =
+                                (uu___1329_10950.FStar_Syntax_Syntax.sigattrs);
+                              FStar_Syntax_Syntax.sigopts =
+                                (uu___1329_10950.FStar_Syntax_Syntax.sigopts)
+                            })], [], env0)))
+           | FStar_Syntax_Syntax.Sig_main e ->
+               let env1 = FStar_TypeChecker_Env.set_range env r  in
+               let env2 =
+                 FStar_TypeChecker_Env.set_expected_typ env1
+                   FStar_Syntax_Syntax.t_unit
+                  in
+               let uu____10954 = FStar_TypeChecker_TcTerm.tc_term env2 e  in
+               (match uu____10954 with
+                | (e1,c,g1) ->
+                    let uu____10974 =
+                      let uu____10981 =
+                        let uu____10984 =
+                          FStar_Syntax_Util.ml_comp
+                            FStar_Syntax_Syntax.t_unit r
+                           in
+                        FStar_Pervasives_Native.Some uu____10984  in
+                      let uu____10985 =
+                        let uu____10990 = FStar_Syntax_Syntax.lcomp_comp c
+                           in
+                        (e1, uu____10990)  in
+                      FStar_TypeChecker_TcTerm.check_expected_effect env2
+                        uu____10981 uu____10985
+                       in
+                    (match uu____10974 with
+                     | (e2,uu____11002,g) ->
+                         ((let uu____11005 =
+                             FStar_TypeChecker_Env.conj_guard g1 g  in
+                           FStar_TypeChecker_Rel.force_trivial_guard env2
+                             uu____11005);
+                          (let se2 =
+                             let uu___1344_11007 = se1  in
+                             {
+                               FStar_Syntax_Syntax.sigel =
+                                 (FStar_Syntax_Syntax.Sig_main e2);
+                               FStar_Syntax_Syntax.sigrng =
+                                 (uu___1344_11007.FStar_Syntax_Syntax.sigrng);
+                               FStar_Syntax_Syntax.sigquals =
+                                 (uu___1344_11007.FStar_Syntax_Syntax.sigquals);
+                               FStar_Syntax_Syntax.sigmeta =
+                                 (uu___1344_11007.FStar_Syntax_Syntax.sigmeta);
+                               FStar_Syntax_Syntax.sigattrs =
+                                 (uu___1344_11007.FStar_Syntax_Syntax.sigattrs);
+                               FStar_Syntax_Syntax.sigopts =
+                                 (uu___1344_11007.FStar_Syntax_Syntax.sigopts)
+                             }  in
+                           ([se2], [], env0)))))
+           | FStar_Syntax_Syntax.Sig_splice (lids,t) ->
+               ((let uu____11019 = FStar_Options.debug_any ()  in
+                 if uu____11019
+                 then
+                   let uu____11022 =
+                     FStar_Ident.string_of_lid
+                       env.FStar_TypeChecker_Env.curmodule
+                      in
+                   let uu____11024 = FStar_Syntax_Print.term_to_string t  in
+                   FStar_Util.print2 "%s: Found splice of (%s)\n" uu____11022
+                     uu____11024
+                 else ());
+                (let uu____11029 = FStar_TypeChecker_TcTerm.tc_tactic env t
+                    in
+                 match uu____11029 with
+                 | (t1,uu____11047,g) ->
+                     (FStar_TypeChecker_Rel.force_trivial_guard env g;
+                      (let ses = env.FStar_TypeChecker_Env.splice env t1  in
+                       let lids' =
+                         FStar_List.collect FStar_Syntax_Util.lids_of_sigelt
+                           ses
+                          in
+                       FStar_List.iter
+                         (fun lid  ->
+                            let uu____11061 =
+                              FStar_List.tryFind (FStar_Ident.lid_equals lid)
+                                lids'
+                               in
+                            match uu____11061 with
+                            | FStar_Pervasives_Native.None  when
+                                Prims.op_Negation
+                                  env.FStar_TypeChecker_Env.nosynth
+                                ->
+                                let uu____11064 =
+                                  let uu____11070 =
+                                    let uu____11072 =
+                                      FStar_Ident.string_of_lid lid  in
+                                    let uu____11074 =
+                                      let uu____11076 =
+                                        FStar_List.map
+                                          FStar_Ident.string_of_lid lids'
+                                         in
+                                      FStar_All.pipe_left
+                                        (FStar_String.concat ", ")
+                                        uu____11076
+                                       in
+                                    FStar_Util.format2
+                                      "Splice declared the name %s but it was not defined.\nThose defined were: %s"
+                                      uu____11072 uu____11074
+                                     in
+                                  (FStar_Errors.Fatal_SplicedUndef,
+                                    uu____11070)
+                                   in
+                                FStar_Errors.raise_error uu____11064 r
+                            | uu____11088 -> ()) lids;
+                       (let dsenv1 =
+                          FStar_List.fold_left
+                            FStar_Syntax_DsEnv.push_sigelt_force
+                            env.FStar_TypeChecker_Env.dsenv ses
+                           in
+                        let env1 =
+                          let uu___1365_11093 = env  in
+                          {
+                            FStar_TypeChecker_Env.solver =
+                              (uu___1365_11093.FStar_TypeChecker_Env.solver);
+                            FStar_TypeChecker_Env.range =
+                              (uu___1365_11093.FStar_TypeChecker_Env.range);
+                            FStar_TypeChecker_Env.curmodule =
+                              (uu___1365_11093.FStar_TypeChecker_Env.curmodule);
+                            FStar_TypeChecker_Env.gamma =
+                              (uu___1365_11093.FStar_TypeChecker_Env.gamma);
+                            FStar_TypeChecker_Env.gamma_sig =
+                              (uu___1365_11093.FStar_TypeChecker_Env.gamma_sig);
+                            FStar_TypeChecker_Env.gamma_cache =
+                              (uu___1365_11093.FStar_TypeChecker_Env.gamma_cache);
+                            FStar_TypeChecker_Env.modules =
+                              (uu___1365_11093.FStar_TypeChecker_Env.modules);
+                            FStar_TypeChecker_Env.expected_typ =
+                              (uu___1365_11093.FStar_TypeChecker_Env.expected_typ);
+                            FStar_TypeChecker_Env.sigtab =
+                              (uu___1365_11093.FStar_TypeChecker_Env.sigtab);
+                            FStar_TypeChecker_Env.attrtab =
+                              (uu___1365_11093.FStar_TypeChecker_Env.attrtab);
+                            FStar_TypeChecker_Env.is_pattern =
+                              (uu___1365_11093.FStar_TypeChecker_Env.is_pattern);
+                            FStar_TypeChecker_Env.instantiate_imp =
+                              (uu___1365_11093.FStar_TypeChecker_Env.instantiate_imp);
+                            FStar_TypeChecker_Env.effects =
+                              (uu___1365_11093.FStar_TypeChecker_Env.effects);
+                            FStar_TypeChecker_Env.generalize =
+                              (uu___1365_11093.FStar_TypeChecker_Env.generalize);
+                            FStar_TypeChecker_Env.letrecs =
+                              (uu___1365_11093.FStar_TypeChecker_Env.letrecs);
+                            FStar_TypeChecker_Env.top_level =
+                              (uu___1365_11093.FStar_TypeChecker_Env.top_level);
+                            FStar_TypeChecker_Env.check_uvars =
+                              (uu___1365_11093.FStar_TypeChecker_Env.check_uvars);
+                            FStar_TypeChecker_Env.use_eq =
+                              (uu___1365_11093.FStar_TypeChecker_Env.use_eq);
+                            FStar_TypeChecker_Env.is_iface =
+                              (uu___1365_11093.FStar_TypeChecker_Env.is_iface);
+                            FStar_TypeChecker_Env.admit =
+                              (uu___1365_11093.FStar_TypeChecker_Env.admit);
+                            FStar_TypeChecker_Env.lax =
+                              (uu___1365_11093.FStar_TypeChecker_Env.lax);
+                            FStar_TypeChecker_Env.lax_universes =
+                              (uu___1365_11093.FStar_TypeChecker_Env.lax_universes);
+                            FStar_TypeChecker_Env.phase1 =
+                              (uu___1365_11093.FStar_TypeChecker_Env.phase1);
+                            FStar_TypeChecker_Env.failhard =
+                              (uu___1365_11093.FStar_TypeChecker_Env.failhard);
+                            FStar_TypeChecker_Env.nosynth =
+                              (uu___1365_11093.FStar_TypeChecker_Env.nosynth);
+                            FStar_TypeChecker_Env.uvar_subtyping =
+                              (uu___1365_11093.FStar_TypeChecker_Env.uvar_subtyping);
+                            FStar_TypeChecker_Env.tc_term =
+                              (uu___1365_11093.FStar_TypeChecker_Env.tc_term);
+                            FStar_TypeChecker_Env.type_of =
+                              (uu___1365_11093.FStar_TypeChecker_Env.type_of);
+                            FStar_TypeChecker_Env.universe_of =
+                              (uu___1365_11093.FStar_TypeChecker_Env.universe_of);
+                            FStar_TypeChecker_Env.check_type_of =
+                              (uu___1365_11093.FStar_TypeChecker_Env.check_type_of);
+                            FStar_TypeChecker_Env.use_bv_sorts =
+                              (uu___1365_11093.FStar_TypeChecker_Env.use_bv_sorts);
+                            FStar_TypeChecker_Env.qtbl_name_and_index =
+                              (uu___1365_11093.FStar_TypeChecker_Env.qtbl_name_and_index);
+                            FStar_TypeChecker_Env.normalized_eff_names =
+                              (uu___1365_11093.FStar_TypeChecker_Env.normalized_eff_names);
+                            FStar_TypeChecker_Env.fv_delta_depths =
+                              (uu___1365_11093.FStar_TypeChecker_Env.fv_delta_depths);
+                            FStar_TypeChecker_Env.proof_ns =
+                              (uu___1365_11093.FStar_TypeChecker_Env.proof_ns);
+                            FStar_TypeChecker_Env.synth_hook =
+                              (uu___1365_11093.FStar_TypeChecker_Env.synth_hook);
+                            FStar_TypeChecker_Env.splice =
+                              (uu___1365_11093.FStar_TypeChecker_Env.splice);
+                            FStar_TypeChecker_Env.postprocess =
+                              (uu___1365_11093.FStar_TypeChecker_Env.postprocess);
+                            FStar_TypeChecker_Env.is_native_tactic =
+                              (uu___1365_11093.FStar_TypeChecker_Env.is_native_tactic);
+                            FStar_TypeChecker_Env.identifier_info =
+                              (uu___1365_11093.FStar_TypeChecker_Env.identifier_info);
+                            FStar_TypeChecker_Env.tc_hooks =
+                              (uu___1365_11093.FStar_TypeChecker_Env.tc_hooks);
+                            FStar_TypeChecker_Env.dsenv = dsenv1;
+                            FStar_TypeChecker_Env.nbe =
+                              (uu___1365_11093.FStar_TypeChecker_Env.nbe);
+                            FStar_TypeChecker_Env.strict_args_tab =
+                              (uu___1365_11093.FStar_TypeChecker_Env.strict_args_tab);
+                            FStar_TypeChecker_Env.erasable_types_tab =
+                              (uu___1365_11093.FStar_TypeChecker_Env.erasable_types_tab)
+                          }  in
+                        ([], ses, env1))))))
+           | FStar_Syntax_Syntax.Sig_let (lbs,lids) ->
+               let env1 = FStar_TypeChecker_Env.set_range env r  in
+               let check_quals_eq l qopt val_q =
+                 match qopt with
+                 | FStar_Pervasives_Native.None  ->
+                     FStar_Pervasives_Native.Some val_q
+                 | FStar_Pervasives_Native.Some q' ->
+                     let drop_logic =
+                       FStar_List.filter
+                         (fun x  ->
+                            Prims.op_Negation (x = FStar_Syntax_Syntax.Logic))
+                        in
+                     let uu____11161 =
+                       let uu____11163 =
+                         let uu____11172 = drop_logic val_q  in
+                         let uu____11175 = drop_logic q'  in
+                         (uu____11172, uu____11175)  in
+                       match uu____11163 with
+                       | (val_q1,q'1) ->
+                           ((FStar_List.length val_q1) =
+                              (FStar_List.length q'1))
+                             &&
+                             (FStar_List.forall2
+                                FStar_Syntax_Util.qualifier_equal val_q1 q'1)
+                        in
+                     if uu____11161
+                     then FStar_Pervasives_Native.Some q'
+                     else
+                       (let uu____11202 =
+                          let uu____11208 =
+                            let uu____11210 =
+                              FStar_Syntax_Print.lid_to_string l  in
+                            let uu____11212 =
+                              FStar_Syntax_Print.quals_to_string val_q  in
+                            let uu____11214 =
+                              FStar_Syntax_Print.quals_to_string q'  in
+                            FStar_Util.format3
+                              "Inconsistent qualifier annotations on %s; Expected {%s}, got {%s}"
+                              uu____11210 uu____11212 uu____11214
+                             in
+                          (FStar_Errors.Fatal_InconsistentQualifierAnnotation,
+                            uu____11208)
+                           in
+                        FStar_Errors.raise_error uu____11202 r)
+                  in
+               let rename_parameters lb =
+                 let rename_in_typ def typ =
+                   let typ1 = FStar_Syntax_Subst.compress typ  in
+                   let def_bs =
+                     let uu____11251 =
+                       let uu____11252 = FStar_Syntax_Subst.compress def  in
+                       uu____11252.FStar_Syntax_Syntax.n  in
+                     match uu____11251 with
+                     | FStar_Syntax_Syntax.Tm_abs
+                         (binders,uu____11264,uu____11265) -> binders
+                     | uu____11290 -> []  in
+                   match typ1 with
+                   | {
+                       FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_arrow
+                         (val_bs,c);
+                       FStar_Syntax_Syntax.pos = r1;
+                       FStar_Syntax_Syntax.vars = uu____11302;_} ->
+                       let has_auto_name bv =
+                         FStar_Util.starts_with
+                           (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
+                           FStar_Ident.reserved_prefix
+                          in
+                       let rec rename_binders1 def_bs1 val_bs1 =
+                         match (def_bs1, val_bs1) with
+                         | ([],uu____11407) -> val_bs1
+                         | (uu____11438,[]) -> val_bs1
+                         | ((body_bv,uu____11470)::bt,(val_bv,aqual)::vt) ->
+                             let uu____11527 = rename_binders1 bt vt  in
+                             ((match ((has_auto_name body_bv),
+                                       (has_auto_name val_bv))
+                               with
+                               | (true ,uu____11551) -> (val_bv, aqual)
+                               | (false ,true ) ->
+                                   ((let uu___1434_11565 = val_bv  in
+                                     {
+                                       FStar_Syntax_Syntax.ppname =
+                                         (let uu___1436_11568 =
+                                            val_bv.FStar_Syntax_Syntax.ppname
+                                             in
+                                          {
+                                            FStar_Ident.idText =
+                                              ((body_bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText);
+                                            FStar_Ident.idRange =
+                                              (uu___1436_11568.FStar_Ident.idRange)
+                                          });
+                                       FStar_Syntax_Syntax.index =
+                                         (uu___1434_11565.FStar_Syntax_Syntax.index);
+                                       FStar_Syntax_Syntax.sort =
+                                         (uu___1434_11565.FStar_Syntax_Syntax.sort)
+                                     }), aqual)
+                               | (false ,false ) -> (val_bv, aqual))) ::
+                               uu____11527
+                          in
+                       let uu____11575 =
+                         let uu____11582 =
+                           let uu____11583 =
+                             let uu____11598 = rename_binders1 def_bs val_bs
+                                in
+                             (uu____11598, c)  in
+                           FStar_Syntax_Syntax.Tm_arrow uu____11583  in
+                         FStar_Syntax_Syntax.mk uu____11582  in
+                       uu____11575 FStar_Pervasives_Native.None r1
+                   | uu____11617 -> typ1  in
+                 let uu___1442_11618 = lb  in
+                 let uu____11619 =
+                   rename_in_typ lb.FStar_Syntax_Syntax.lbdef
+                     lb.FStar_Syntax_Syntax.lbtyp
+                    in
+                 {
+                   FStar_Syntax_Syntax.lbname =
+                     (uu___1442_11618.FStar_Syntax_Syntax.lbname);
+                   FStar_Syntax_Syntax.lbunivs =
+                     (uu___1442_11618.FStar_Syntax_Syntax.lbunivs);
+                   FStar_Syntax_Syntax.lbtyp = uu____11619;
+                   FStar_Syntax_Syntax.lbeff =
+                     (uu___1442_11618.FStar_Syntax_Syntax.lbeff);
+                   FStar_Syntax_Syntax.lbdef =
+                     (uu___1442_11618.FStar_Syntax_Syntax.lbdef);
+                   FStar_Syntax_Syntax.lbattrs =
+                     (uu___1442_11618.FStar_Syntax_Syntax.lbattrs);
+                   FStar_Syntax_Syntax.lbpos =
+                     (uu___1442_11618.FStar_Syntax_Syntax.lbpos)
+                 }  in
+               let uu____11622 =
+                 FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
+                   (FStar_List.fold_left
+                      (fun uu____11677  ->
+                         fun lb  ->
+                           match uu____11677 with
+                           | (gen1,lbs1,quals_opt) ->
+                               let lbname =
+                                 FStar_Util.right
+                                   lb.FStar_Syntax_Syntax.lbname
+                                  in
+                               let uu____11723 =
+                                 let uu____11735 =
+                                   FStar_TypeChecker_Env.try_lookup_val_decl
+                                     env1
+                                     (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                                    in
+                                 match uu____11735 with
+                                 | FStar_Pervasives_Native.None  ->
+                                     if lb.FStar_Syntax_Syntax.lbunivs <> []
+                                     then (false, lb, quals_opt)
+                                     else (gen1, lb, quals_opt)
+                                 | FStar_Pervasives_Native.Some
+                                     ((uvs,tval),quals) ->
+                                     let quals_opt1 =
+                                       check_quals_eq
+                                         (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                                         quals_opt quals
+                                        in
+                                     let def =
+                                       match (lb.FStar_Syntax_Syntax.lbtyp).FStar_Syntax_Syntax.n
+                                       with
+                                       | FStar_Syntax_Syntax.Tm_unknown  ->
+                                           lb.FStar_Syntax_Syntax.lbdef
+                                       | uu____11815 ->
+                                           FStar_Syntax_Syntax.mk
+                                             (FStar_Syntax_Syntax.Tm_ascribed
+                                                ((lb.FStar_Syntax_Syntax.lbdef),
+                                                  ((FStar_Util.Inl
+                                                      (lb.FStar_Syntax_Syntax.lbtyp)),
+                                                    FStar_Pervasives_Native.None),
+                                                  FStar_Pervasives_Native.None))
+                                             FStar_Pervasives_Native.None
+                                             (lb.FStar_Syntax_Syntax.lbdef).FStar_Syntax_Syntax.pos
+                                        in
+                                     (if
+                                        (lb.FStar_Syntax_Syntax.lbunivs <> [])
+                                          &&
+                                          ((FStar_List.length
+                                              lb.FStar_Syntax_Syntax.lbunivs)
+                                             <> (FStar_List.length uvs))
+                                      then
+                                        FStar_Errors.raise_error
+                                          (FStar_Errors.Fatal_IncoherentInlineUniverse,
+                                            "Inline universes are incoherent with annotation from val declaration")
+                                          r
+                                      else ();
+                                      (let uu____11862 =
+                                         FStar_Syntax_Syntax.mk_lb
+                                           ((FStar_Util.Inr lbname), uvs,
+                                             FStar_Parser_Const.effect_ALL_lid,
+                                             tval, def, [],
+                                             (lb.FStar_Syntax_Syntax.lbpos))
+                                          in
+                                       (false, uu____11862, quals_opt1)))
+                                  in
+                               (match uu____11723 with
+                                | (gen2,lb1,quals_opt1) ->
+                                    (gen2, (lb1 :: lbs1), quals_opt1)))
+                      (true, [],
+                        (if se1.FStar_Syntax_Syntax.sigquals = []
+                         then FStar_Pervasives_Native.None
+                         else
+                           FStar_Pervasives_Native.Some
+                             (se1.FStar_Syntax_Syntax.sigquals))))
+                  in
+               (match uu____11622 with
+                | (should_generalize,lbs',quals_opt) ->
+                    let quals =
+                      match quals_opt with
+                      | FStar_Pervasives_Native.None  ->
+                          [FStar_Syntax_Syntax.Visible_default]
+                      | FStar_Pervasives_Native.Some q ->
+                          let uu____11966 =
+                            FStar_All.pipe_right q
+                              (FStar_Util.for_some
+                                 (fun uu___2_11972  ->
+                                    match uu___2_11972 with
+                                    | FStar_Syntax_Syntax.Irreducible  ->
+                                        true
+                                    | FStar_Syntax_Syntax.Visible_default  ->
+                                        true
+                                    | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen
+                                         -> true
+                                    | uu____11977 -> false))
+                             in
+                          if uu____11966
+                          then q
+                          else FStar_Syntax_Syntax.Visible_default :: q
+                       in
+                    let lbs'1 = FStar_List.rev lbs'  in
+                    let e =
+                      let uu____11990 =
+                        let uu____11997 =
+                          let uu____11998 =
+                            let uu____12012 =
+                              FStar_Syntax_Syntax.mk
+                                (FStar_Syntax_Syntax.Tm_constant
+                                   FStar_Const.Const_unit)
+                                FStar_Pervasives_Native.None r
+                               in
+                            (((FStar_Pervasives_Native.fst lbs), lbs'1),
+                              uu____12012)
+                             in
+                          FStar_Syntax_Syntax.Tm_let uu____11998  in
+                        FStar_Syntax_Syntax.mk uu____11997  in
+                      uu____11990 FStar_Pervasives_Native.None r  in
+                    let env' =
+                      let uu___1485_12031 = env1  in
                       {
                         FStar_TypeChecker_Env.solver =
-                          (uu___1345_10974.FStar_TypeChecker_Env.solver);
+                          (uu___1485_12031.FStar_TypeChecker_Env.solver);
                         FStar_TypeChecker_Env.range =
-                          (uu___1345_10974.FStar_TypeChecker_Env.range);
+                          (uu___1485_12031.FStar_TypeChecker_Env.range);
                         FStar_TypeChecker_Env.curmodule =
-                          (uu___1345_10974.FStar_TypeChecker_Env.curmodule);
+                          (uu___1485_12031.FStar_TypeChecker_Env.curmodule);
                         FStar_TypeChecker_Env.gamma =
-                          (uu___1345_10974.FStar_TypeChecker_Env.gamma);
+                          (uu___1485_12031.FStar_TypeChecker_Env.gamma);
                         FStar_TypeChecker_Env.gamma_sig =
-                          (uu___1345_10974.FStar_TypeChecker_Env.gamma_sig);
+                          (uu___1485_12031.FStar_TypeChecker_Env.gamma_sig);
                         FStar_TypeChecker_Env.gamma_cache =
-                          (uu___1345_10974.FStar_TypeChecker_Env.gamma_cache);
+                          (uu___1485_12031.FStar_TypeChecker_Env.gamma_cache);
                         FStar_TypeChecker_Env.modules =
-                          (uu___1345_10974.FStar_TypeChecker_Env.modules);
+                          (uu___1485_12031.FStar_TypeChecker_Env.modules);
                         FStar_TypeChecker_Env.expected_typ =
-                          (uu___1345_10974.FStar_TypeChecker_Env.expected_typ);
+                          (uu___1485_12031.FStar_TypeChecker_Env.expected_typ);
                         FStar_TypeChecker_Env.sigtab =
-                          (uu___1345_10974.FStar_TypeChecker_Env.sigtab);
+                          (uu___1485_12031.FStar_TypeChecker_Env.sigtab);
                         FStar_TypeChecker_Env.attrtab =
-                          (uu___1345_10974.FStar_TypeChecker_Env.attrtab);
+                          (uu___1485_12031.FStar_TypeChecker_Env.attrtab);
                         FStar_TypeChecker_Env.is_pattern =
-                          (uu___1345_10974.FStar_TypeChecker_Env.is_pattern);
+                          (uu___1485_12031.FStar_TypeChecker_Env.is_pattern);
                         FStar_TypeChecker_Env.instantiate_imp =
-                          (uu___1345_10974.FStar_TypeChecker_Env.instantiate_imp);
+                          (uu___1485_12031.FStar_TypeChecker_Env.instantiate_imp);
                         FStar_TypeChecker_Env.effects =
-                          (uu___1345_10974.FStar_TypeChecker_Env.effects);
-                        FStar_TypeChecker_Env.generalize =
-                          (uu___1345_10974.FStar_TypeChecker_Env.generalize);
+                          (uu___1485_12031.FStar_TypeChecker_Env.effects);
+                        FStar_TypeChecker_Env.generalize = should_generalize;
                         FStar_TypeChecker_Env.letrecs =
-                          (uu___1345_10974.FStar_TypeChecker_Env.letrecs);
-                        FStar_TypeChecker_Env.top_level =
-                          (uu___1345_10974.FStar_TypeChecker_Env.top_level);
+                          (uu___1485_12031.FStar_TypeChecker_Env.letrecs);
+                        FStar_TypeChecker_Env.top_level = true;
                         FStar_TypeChecker_Env.check_uvars =
-                          (uu___1345_10974.FStar_TypeChecker_Env.check_uvars);
+                          (uu___1485_12031.FStar_TypeChecker_Env.check_uvars);
                         FStar_TypeChecker_Env.use_eq =
-                          (uu___1345_10974.FStar_TypeChecker_Env.use_eq);
+                          (uu___1485_12031.FStar_TypeChecker_Env.use_eq);
                         FStar_TypeChecker_Env.is_iface =
-                          (uu___1345_10974.FStar_TypeChecker_Env.is_iface);
+                          (uu___1485_12031.FStar_TypeChecker_Env.is_iface);
                         FStar_TypeChecker_Env.admit =
-                          (uu___1345_10974.FStar_TypeChecker_Env.admit);
+                          (uu___1485_12031.FStar_TypeChecker_Env.admit);
                         FStar_TypeChecker_Env.lax =
-                          (uu___1345_10974.FStar_TypeChecker_Env.lax);
+                          (uu___1485_12031.FStar_TypeChecker_Env.lax);
                         FStar_TypeChecker_Env.lax_universes =
-                          (uu___1345_10974.FStar_TypeChecker_Env.lax_universes);
+                          (uu___1485_12031.FStar_TypeChecker_Env.lax_universes);
                         FStar_TypeChecker_Env.phase1 =
-                          (uu___1345_10974.FStar_TypeChecker_Env.phase1);
+                          (uu___1485_12031.FStar_TypeChecker_Env.phase1);
                         FStar_TypeChecker_Env.failhard =
-                          (uu___1345_10974.FStar_TypeChecker_Env.failhard);
+                          (uu___1485_12031.FStar_TypeChecker_Env.failhard);
                         FStar_TypeChecker_Env.nosynth =
-                          (uu___1345_10974.FStar_TypeChecker_Env.nosynth);
+                          (uu___1485_12031.FStar_TypeChecker_Env.nosynth);
                         FStar_TypeChecker_Env.uvar_subtyping =
-                          (uu___1345_10974.FStar_TypeChecker_Env.uvar_subtyping);
+                          (uu___1485_12031.FStar_TypeChecker_Env.uvar_subtyping);
                         FStar_TypeChecker_Env.tc_term =
-                          (uu___1345_10974.FStar_TypeChecker_Env.tc_term);
+                          (uu___1485_12031.FStar_TypeChecker_Env.tc_term);
                         FStar_TypeChecker_Env.type_of =
-                          (uu___1345_10974.FStar_TypeChecker_Env.type_of);
+                          (uu___1485_12031.FStar_TypeChecker_Env.type_of);
                         FStar_TypeChecker_Env.universe_of =
-                          (uu___1345_10974.FStar_TypeChecker_Env.universe_of);
+                          (uu___1485_12031.FStar_TypeChecker_Env.universe_of);
                         FStar_TypeChecker_Env.check_type_of =
-                          (uu___1345_10974.FStar_TypeChecker_Env.check_type_of);
+                          (uu___1485_12031.FStar_TypeChecker_Env.check_type_of);
                         FStar_TypeChecker_Env.use_bv_sorts =
-                          (uu___1345_10974.FStar_TypeChecker_Env.use_bv_sorts);
+                          (uu___1485_12031.FStar_TypeChecker_Env.use_bv_sorts);
                         FStar_TypeChecker_Env.qtbl_name_and_index =
-                          (uu___1345_10974.FStar_TypeChecker_Env.qtbl_name_and_index);
+                          (uu___1485_12031.FStar_TypeChecker_Env.qtbl_name_and_index);
                         FStar_TypeChecker_Env.normalized_eff_names =
-                          (uu___1345_10974.FStar_TypeChecker_Env.normalized_eff_names);
+                          (uu___1485_12031.FStar_TypeChecker_Env.normalized_eff_names);
                         FStar_TypeChecker_Env.fv_delta_depths =
-                          (uu___1345_10974.FStar_TypeChecker_Env.fv_delta_depths);
+                          (uu___1485_12031.FStar_TypeChecker_Env.fv_delta_depths);
                         FStar_TypeChecker_Env.proof_ns =
-                          (uu___1345_10974.FStar_TypeChecker_Env.proof_ns);
+                          (uu___1485_12031.FStar_TypeChecker_Env.proof_ns);
                         FStar_TypeChecker_Env.synth_hook =
-                          (uu___1345_10974.FStar_TypeChecker_Env.synth_hook);
+                          (uu___1485_12031.FStar_TypeChecker_Env.synth_hook);
                         FStar_TypeChecker_Env.splice =
-                          (uu___1345_10974.FStar_TypeChecker_Env.splice);
+                          (uu___1485_12031.FStar_TypeChecker_Env.splice);
                         FStar_TypeChecker_Env.postprocess =
-                          (uu___1345_10974.FStar_TypeChecker_Env.postprocess);
+                          (uu___1485_12031.FStar_TypeChecker_Env.postprocess);
                         FStar_TypeChecker_Env.is_native_tactic =
-                          (uu___1345_10974.FStar_TypeChecker_Env.is_native_tactic);
+                          (uu___1485_12031.FStar_TypeChecker_Env.is_native_tactic);
                         FStar_TypeChecker_Env.identifier_info =
-                          (uu___1345_10974.FStar_TypeChecker_Env.identifier_info);
+                          (uu___1485_12031.FStar_TypeChecker_Env.identifier_info);
                         FStar_TypeChecker_Env.tc_hooks =
-                          (uu___1345_10974.FStar_TypeChecker_Env.tc_hooks);
-                        FStar_TypeChecker_Env.dsenv = dsenv1;
+                          (uu___1485_12031.FStar_TypeChecker_Env.tc_hooks);
+                        FStar_TypeChecker_Env.dsenv =
+                          (uu___1485_12031.FStar_TypeChecker_Env.dsenv);
                         FStar_TypeChecker_Env.nbe =
-                          (uu___1345_10974.FStar_TypeChecker_Env.nbe);
+                          (uu___1485_12031.FStar_TypeChecker_Env.nbe);
                         FStar_TypeChecker_Env.strict_args_tab =
-                          (uu___1345_10974.FStar_TypeChecker_Env.strict_args_tab);
+                          (uu___1485_12031.FStar_TypeChecker_Env.strict_args_tab);
                         FStar_TypeChecker_Env.erasable_types_tab =
-                          (uu___1345_10974.FStar_TypeChecker_Env.erasable_types_tab)
+                          (uu___1485_12031.FStar_TypeChecker_Env.erasable_types_tab)
                       }  in
-                    ([], ses, env1))))))
-       | FStar_Syntax_Syntax.Sig_let (lbs,lids) ->
-           let env1 = FStar_TypeChecker_Env.set_range env r  in
-           let check_quals_eq l qopt val_q =
-             match qopt with
-             | FStar_Pervasives_Native.None  ->
-                 FStar_Pervasives_Native.Some val_q
-             | FStar_Pervasives_Native.Some q' ->
-                 let drop_logic =
-                   FStar_List.filter
-                     (fun x  ->
-                        Prims.op_Negation (x = FStar_Syntax_Syntax.Logic))
-                    in
-                 let uu____11042 =
-                   let uu____11044 =
-                     let uu____11053 = drop_logic val_q  in
-                     let uu____11056 = drop_logic q'  in
-                     (uu____11053, uu____11056)  in
-                   match uu____11044 with
-                   | (val_q1,q'1) ->
-                       ((FStar_List.length val_q1) = (FStar_List.length q'1))
-                         &&
-                         (FStar_List.forall2
-                            FStar_Syntax_Util.qualifier_equal val_q1 q'1)
-                    in
-                 if uu____11042
-                 then FStar_Pervasives_Native.Some q'
-                 else
-                   (let uu____11083 =
-                      let uu____11089 =
-                        let uu____11091 = FStar_Syntax_Print.lid_to_string l
-                           in
-                        let uu____11093 =
-                          FStar_Syntax_Print.quals_to_string val_q  in
-                        let uu____11095 =
-                          FStar_Syntax_Print.quals_to_string q'  in
-                        FStar_Util.format3
-                          "Inconsistent qualifier annotations on %s; Expected {%s}, got {%s}"
-                          uu____11091 uu____11093 uu____11095
+                    let e1 =
+                      let uu____12034 =
+                        (FStar_Options.use_two_phase_tc ()) &&
+                          (FStar_TypeChecker_Env.should_verify env')
                          in
-                      (FStar_Errors.Fatal_InconsistentQualifierAnnotation,
-                        uu____11089)
-                       in
-                    FStar_Errors.raise_error uu____11083 r)
-              in
-           let rename_parameters lb =
-             let rename_in_typ def typ =
-               let typ1 = FStar_Syntax_Subst.compress typ  in
-               let def_bs =
-                 let uu____11132 =
-                   let uu____11133 = FStar_Syntax_Subst.compress def  in
-                   uu____11133.FStar_Syntax_Syntax.n  in
-                 match uu____11132 with
-                 | FStar_Syntax_Syntax.Tm_abs
-                     (binders,uu____11145,uu____11146) -> binders
-                 | uu____11171 -> []  in
-               match typ1 with
-               | {
-                   FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_arrow
-                     (val_bs,c);
-                   FStar_Syntax_Syntax.pos = r1;
-                   FStar_Syntax_Syntax.vars = uu____11183;_} ->
-                   let has_auto_name bv =
-                     FStar_Util.starts_with
-                       (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                       FStar_Ident.reserved_prefix
-                      in
-                   let rec rename_binders1 def_bs1 val_bs1 =
-                     match (def_bs1, val_bs1) with
-                     | ([],uu____11288) -> val_bs1
-                     | (uu____11319,[]) -> val_bs1
-                     | ((body_bv,uu____11351)::bt,(val_bv,aqual)::vt) ->
-                         let uu____11408 = rename_binders1 bt vt  in
-                         ((match ((has_auto_name body_bv),
-                                   (has_auto_name val_bv))
-                           with
-                           | (true ,uu____11432) -> (val_bv, aqual)
-                           | (false ,true ) ->
-                               ((let uu___1414_11446 = val_bv  in
-                                 {
-                                   FStar_Syntax_Syntax.ppname =
-                                     (let uu___1416_11449 =
-                                        val_bv.FStar_Syntax_Syntax.ppname  in
-                                      {
-                                        FStar_Ident.idText =
-                                          ((body_bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText);
-                                        FStar_Ident.idRange =
-                                          (uu___1416_11449.FStar_Ident.idRange)
-                                      });
-                                   FStar_Syntax_Syntax.index =
-                                     (uu___1414_11446.FStar_Syntax_Syntax.index);
-                                   FStar_Syntax_Syntax.sort =
-                                     (uu___1414_11446.FStar_Syntax_Syntax.sort)
-                                 }), aqual)
-                           | (false ,false ) -> (val_bv, aqual))) ::
-                           uu____11408
-                      in
-                   let uu____11456 =
-                     let uu____11463 =
-                       let uu____11464 =
-                         let uu____11479 = rename_binders1 def_bs val_bs  in
-                         (uu____11479, c)  in
-                       FStar_Syntax_Syntax.Tm_arrow uu____11464  in
-                     FStar_Syntax_Syntax.mk uu____11463  in
-                   uu____11456 FStar_Pervasives_Native.None r1
-               | uu____11498 -> typ1  in
-             let uu___1422_11499 = lb  in
-             let uu____11500 =
-               rename_in_typ lb.FStar_Syntax_Syntax.lbdef
-                 lb.FStar_Syntax_Syntax.lbtyp
-                in
-             {
-               FStar_Syntax_Syntax.lbname =
-                 (uu___1422_11499.FStar_Syntax_Syntax.lbname);
-               FStar_Syntax_Syntax.lbunivs =
-                 (uu___1422_11499.FStar_Syntax_Syntax.lbunivs);
-               FStar_Syntax_Syntax.lbtyp = uu____11500;
-               FStar_Syntax_Syntax.lbeff =
-                 (uu___1422_11499.FStar_Syntax_Syntax.lbeff);
-               FStar_Syntax_Syntax.lbdef =
-                 (uu___1422_11499.FStar_Syntax_Syntax.lbdef);
-               FStar_Syntax_Syntax.lbattrs =
-                 (uu___1422_11499.FStar_Syntax_Syntax.lbattrs);
-               FStar_Syntax_Syntax.lbpos =
-                 (uu___1422_11499.FStar_Syntax_Syntax.lbpos)
-             }  in
-           let uu____11503 =
-             FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
-               (FStar_List.fold_left
-                  (fun uu____11558  ->
-                     fun lb  ->
-                       match uu____11558 with
-                       | (gen1,lbs1,quals_opt) ->
-                           let lbname =
-                             FStar_Util.right lb.FStar_Syntax_Syntax.lbname
-                              in
-                           let uu____11604 =
-                             let uu____11616 =
-                               FStar_TypeChecker_Env.try_lookup_val_decl env1
-                                 (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                                in
-                             match uu____11616 with
-                             | FStar_Pervasives_Native.None  ->
-                                 if lb.FStar_Syntax_Syntax.lbunivs <> []
-                                 then (false, lb, quals_opt)
-                                 else (gen1, lb, quals_opt)
-                             | FStar_Pervasives_Native.Some
-                                 ((uvs,tval),quals) ->
-                                 let quals_opt1 =
-                                   check_quals_eq
-                                     (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                                     quals_opt quals
-                                    in
-                                 let def =
-                                   match (lb.FStar_Syntax_Syntax.lbtyp).FStar_Syntax_Syntax.n
-                                   with
-                                   | FStar_Syntax_Syntax.Tm_unknown  ->
-                                       lb.FStar_Syntax_Syntax.lbdef
-                                   | uu____11696 ->
-                                       FStar_Syntax_Syntax.mk
-                                         (FStar_Syntax_Syntax.Tm_ascribed
-                                            ((lb.FStar_Syntax_Syntax.lbdef),
-                                              ((FStar_Util.Inl
-                                                  (lb.FStar_Syntax_Syntax.lbtyp)),
-                                                FStar_Pervasives_Native.None),
-                                              FStar_Pervasives_Native.None))
-                                         FStar_Pervasives_Native.None
-                                         (lb.FStar_Syntax_Syntax.lbdef).FStar_Syntax_Syntax.pos
-                                    in
-                                 (if
-                                    (lb.FStar_Syntax_Syntax.lbunivs <> []) &&
-                                      ((FStar_List.length
-                                          lb.FStar_Syntax_Syntax.lbunivs)
-                                         <> (FStar_List.length uvs))
-                                  then
-                                    FStar_Errors.raise_error
-                                      (FStar_Errors.Fatal_IncoherentInlineUniverse,
-                                        "Inline universes are incoherent with annotation from val declaration")
-                                      r
-                                  else ();
-                                  (let uu____11743 =
-                                     FStar_Syntax_Syntax.mk_lb
-                                       ((FStar_Util.Inr lbname), uvs,
-                                         FStar_Parser_Const.effect_ALL_lid,
-                                         tval, def, [],
-                                         (lb.FStar_Syntax_Syntax.lbpos))
-                                      in
-                                   (false, uu____11743, quals_opt1)))
-                              in
-                           (match uu____11604 with
-                            | (gen2,lb1,quals_opt1) ->
-                                (gen2, (lb1 :: lbs1), quals_opt1)))
-                  (true, [],
-                    (if se.FStar_Syntax_Syntax.sigquals = []
-                     then FStar_Pervasives_Native.None
-                     else
-                       FStar_Pervasives_Native.Some
-                         (se.FStar_Syntax_Syntax.sigquals))))
-              in
-           (match uu____11503 with
-            | (should_generalize,lbs',quals_opt) ->
-                let quals =
-                  match quals_opt with
-                  | FStar_Pervasives_Native.None  ->
-                      [FStar_Syntax_Syntax.Visible_default]
-                  | FStar_Pervasives_Native.Some q ->
-                      let uu____11847 =
-                        FStar_All.pipe_right q
-                          (FStar_Util.for_some
-                             (fun uu___2_11853  ->
-                                match uu___2_11853 with
-                                | FStar_Syntax_Syntax.Irreducible  -> true
-                                | FStar_Syntax_Syntax.Visible_default  ->
-                                    true
-                                | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen
-                                     -> true
-                                | uu____11858 -> false))
-                         in
-                      if uu____11847
-                      then q
-                      else FStar_Syntax_Syntax.Visible_default :: q
-                   in
-                let lbs'1 = FStar_List.rev lbs'  in
-                let e =
-                  let uu____11871 =
-                    let uu____11878 =
-                      let uu____11879 =
-                        let uu____11893 =
-                          FStar_Syntax_Syntax.mk
-                            (FStar_Syntax_Syntax.Tm_constant
-                               FStar_Const.Const_unit)
-                            FStar_Pervasives_Native.None r
-                           in
-                        (((FStar_Pervasives_Native.fst lbs), lbs'1),
-                          uu____11893)
-                         in
-                      FStar_Syntax_Syntax.Tm_let uu____11879  in
-                    FStar_Syntax_Syntax.mk uu____11878  in
-                  uu____11871 FStar_Pervasives_Native.None r  in
-                let env' =
-                  let uu___1465_11912 = env1  in
-                  {
-                    FStar_TypeChecker_Env.solver =
-                      (uu___1465_11912.FStar_TypeChecker_Env.solver);
-                    FStar_TypeChecker_Env.range =
-                      (uu___1465_11912.FStar_TypeChecker_Env.range);
-                    FStar_TypeChecker_Env.curmodule =
-                      (uu___1465_11912.FStar_TypeChecker_Env.curmodule);
-                    FStar_TypeChecker_Env.gamma =
-                      (uu___1465_11912.FStar_TypeChecker_Env.gamma);
-                    FStar_TypeChecker_Env.gamma_sig =
-                      (uu___1465_11912.FStar_TypeChecker_Env.gamma_sig);
-                    FStar_TypeChecker_Env.gamma_cache =
-                      (uu___1465_11912.FStar_TypeChecker_Env.gamma_cache);
-                    FStar_TypeChecker_Env.modules =
-                      (uu___1465_11912.FStar_TypeChecker_Env.modules);
-                    FStar_TypeChecker_Env.expected_typ =
-                      (uu___1465_11912.FStar_TypeChecker_Env.expected_typ);
-                    FStar_TypeChecker_Env.sigtab =
-                      (uu___1465_11912.FStar_TypeChecker_Env.sigtab);
-                    FStar_TypeChecker_Env.attrtab =
-                      (uu___1465_11912.FStar_TypeChecker_Env.attrtab);
-                    FStar_TypeChecker_Env.is_pattern =
-                      (uu___1465_11912.FStar_TypeChecker_Env.is_pattern);
-                    FStar_TypeChecker_Env.instantiate_imp =
-                      (uu___1465_11912.FStar_TypeChecker_Env.instantiate_imp);
-                    FStar_TypeChecker_Env.effects =
-                      (uu___1465_11912.FStar_TypeChecker_Env.effects);
-                    FStar_TypeChecker_Env.generalize = should_generalize;
-                    FStar_TypeChecker_Env.letrecs =
-                      (uu___1465_11912.FStar_TypeChecker_Env.letrecs);
-                    FStar_TypeChecker_Env.top_level = true;
-                    FStar_TypeChecker_Env.check_uvars =
-                      (uu___1465_11912.FStar_TypeChecker_Env.check_uvars);
-                    FStar_TypeChecker_Env.use_eq =
-                      (uu___1465_11912.FStar_TypeChecker_Env.use_eq);
-                    FStar_TypeChecker_Env.is_iface =
-                      (uu___1465_11912.FStar_TypeChecker_Env.is_iface);
-                    FStar_TypeChecker_Env.admit =
-                      (uu___1465_11912.FStar_TypeChecker_Env.admit);
-                    FStar_TypeChecker_Env.lax =
-                      (uu___1465_11912.FStar_TypeChecker_Env.lax);
-                    FStar_TypeChecker_Env.lax_universes =
-                      (uu___1465_11912.FStar_TypeChecker_Env.lax_universes);
-                    FStar_TypeChecker_Env.phase1 =
-                      (uu___1465_11912.FStar_TypeChecker_Env.phase1);
-                    FStar_TypeChecker_Env.failhard =
-                      (uu___1465_11912.FStar_TypeChecker_Env.failhard);
-                    FStar_TypeChecker_Env.nosynth =
-                      (uu___1465_11912.FStar_TypeChecker_Env.nosynth);
-                    FStar_TypeChecker_Env.uvar_subtyping =
-                      (uu___1465_11912.FStar_TypeChecker_Env.uvar_subtyping);
-                    FStar_TypeChecker_Env.tc_term =
-                      (uu___1465_11912.FStar_TypeChecker_Env.tc_term);
-                    FStar_TypeChecker_Env.type_of =
-                      (uu___1465_11912.FStar_TypeChecker_Env.type_of);
-                    FStar_TypeChecker_Env.universe_of =
-                      (uu___1465_11912.FStar_TypeChecker_Env.universe_of);
-                    FStar_TypeChecker_Env.check_type_of =
-                      (uu___1465_11912.FStar_TypeChecker_Env.check_type_of);
-                    FStar_TypeChecker_Env.use_bv_sorts =
-                      (uu___1465_11912.FStar_TypeChecker_Env.use_bv_sorts);
-                    FStar_TypeChecker_Env.qtbl_name_and_index =
-                      (uu___1465_11912.FStar_TypeChecker_Env.qtbl_name_and_index);
-                    FStar_TypeChecker_Env.normalized_eff_names =
-                      (uu___1465_11912.FStar_TypeChecker_Env.normalized_eff_names);
-                    FStar_TypeChecker_Env.fv_delta_depths =
-                      (uu___1465_11912.FStar_TypeChecker_Env.fv_delta_depths);
-                    FStar_TypeChecker_Env.proof_ns =
-                      (uu___1465_11912.FStar_TypeChecker_Env.proof_ns);
-                    FStar_TypeChecker_Env.synth_hook =
-                      (uu___1465_11912.FStar_TypeChecker_Env.synth_hook);
-                    FStar_TypeChecker_Env.splice =
-                      (uu___1465_11912.FStar_TypeChecker_Env.splice);
-                    FStar_TypeChecker_Env.postprocess =
-                      (uu___1465_11912.FStar_TypeChecker_Env.postprocess);
-                    FStar_TypeChecker_Env.is_native_tactic =
-                      (uu___1465_11912.FStar_TypeChecker_Env.is_native_tactic);
-                    FStar_TypeChecker_Env.identifier_info =
-                      (uu___1465_11912.FStar_TypeChecker_Env.identifier_info);
-                    FStar_TypeChecker_Env.tc_hooks =
-                      (uu___1465_11912.FStar_TypeChecker_Env.tc_hooks);
-                    FStar_TypeChecker_Env.dsenv =
-                      (uu___1465_11912.FStar_TypeChecker_Env.dsenv);
-                    FStar_TypeChecker_Env.nbe =
-                      (uu___1465_11912.FStar_TypeChecker_Env.nbe);
-                    FStar_TypeChecker_Env.strict_args_tab =
-                      (uu___1465_11912.FStar_TypeChecker_Env.strict_args_tab);
-                    FStar_TypeChecker_Env.erasable_types_tab =
-                      (uu___1465_11912.FStar_TypeChecker_Env.erasable_types_tab)
-                  }  in
-                let e1 =
-                  let uu____11915 =
-                    (FStar_Options.use_two_phase_tc ()) &&
-                      (FStar_TypeChecker_Env.should_verify env')
-                     in
-                  if uu____11915
-                  then
-                    let drop_lbtyp e_lax =
-                      let uu____11924 =
-                        let uu____11925 = FStar_Syntax_Subst.compress e_lax
-                           in
-                        uu____11925.FStar_Syntax_Syntax.n  in
-                      match uu____11924 with
-                      | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),e2) ->
-                          let lb_unannotated =
-                            let uu____11947 =
-                              let uu____11948 = FStar_Syntax_Subst.compress e
-                                 in
-                              uu____11948.FStar_Syntax_Syntax.n  in
-                            match uu____11947 with
-                            | FStar_Syntax_Syntax.Tm_let
-                                ((uu____11952,lb1::[]),uu____11954) ->
-                                let uu____11970 =
-                                  let uu____11971 =
-                                    FStar_Syntax_Subst.compress
-                                      lb1.FStar_Syntax_Syntax.lbtyp
-                                     in
-                                  uu____11971.FStar_Syntax_Syntax.n  in
-                                (match uu____11970 with
-                                 | FStar_Syntax_Syntax.Tm_unknown  -> true
-                                 | uu____11976 -> false)
-                            | uu____11978 ->
-                                failwith
-                                  "Impossible: first phase lb and second phase lb differ in structure!"
-                             in
-                          if lb_unannotated
-                          then
-                            let uu___1490_11982 = e_lax  in
-                            {
-                              FStar_Syntax_Syntax.n =
-                                (FStar_Syntax_Syntax.Tm_let
-                                   ((false,
-                                      [(let uu___1492_11997 = lb  in
-                                        {
-                                          FStar_Syntax_Syntax.lbname =
-                                            (uu___1492_11997.FStar_Syntax_Syntax.lbname);
-                                          FStar_Syntax_Syntax.lbunivs =
-                                            (uu___1492_11997.FStar_Syntax_Syntax.lbunivs);
-                                          FStar_Syntax_Syntax.lbtyp =
-                                            FStar_Syntax_Syntax.tun;
-                                          FStar_Syntax_Syntax.lbeff =
-                                            (uu___1492_11997.FStar_Syntax_Syntax.lbeff);
-                                          FStar_Syntax_Syntax.lbdef =
-                                            (uu___1492_11997.FStar_Syntax_Syntax.lbdef);
-                                          FStar_Syntax_Syntax.lbattrs =
-                                            (uu___1492_11997.FStar_Syntax_Syntax.lbattrs);
-                                          FStar_Syntax_Syntax.lbpos =
-                                            (uu___1492_11997.FStar_Syntax_Syntax.lbpos)
-                                        })]), e2));
-                              FStar_Syntax_Syntax.pos =
-                                (uu___1490_11982.FStar_Syntax_Syntax.pos);
-                              FStar_Syntax_Syntax.vars =
-                                (uu___1490_11982.FStar_Syntax_Syntax.vars)
-                            }
-                          else e_lax
-                      | uu____12000 -> e_lax  in
-                    let uu____12001 =
-                      FStar_Util.record_time
-                        (fun uu____12009  ->
-                           let uu____12010 =
-                             let uu____12011 =
-                               let uu____12012 =
-                                 FStar_TypeChecker_TcTerm.tc_maybe_toplevel_term
-                                   (let uu___1496_12021 = env'  in
-                                    {
-                                      FStar_TypeChecker_Env.solver =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.solver);
-                                      FStar_TypeChecker_Env.range =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.range);
-                                      FStar_TypeChecker_Env.curmodule =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.curmodule);
-                                      FStar_TypeChecker_Env.gamma =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.gamma);
-                                      FStar_TypeChecker_Env.gamma_sig =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.gamma_sig);
-                                      FStar_TypeChecker_Env.gamma_cache =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.gamma_cache);
-                                      FStar_TypeChecker_Env.modules =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.modules);
-                                      FStar_TypeChecker_Env.expected_typ =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.expected_typ);
-                                      FStar_TypeChecker_Env.sigtab =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.sigtab);
-                                      FStar_TypeChecker_Env.attrtab =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.attrtab);
-                                      FStar_TypeChecker_Env.is_pattern =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.is_pattern);
-                                      FStar_TypeChecker_Env.instantiate_imp =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.instantiate_imp);
-                                      FStar_TypeChecker_Env.effects =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.effects);
-                                      FStar_TypeChecker_Env.generalize =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.generalize);
-                                      FStar_TypeChecker_Env.letrecs =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.letrecs);
-                                      FStar_TypeChecker_Env.top_level =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.top_level);
-                                      FStar_TypeChecker_Env.check_uvars =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.check_uvars);
-                                      FStar_TypeChecker_Env.use_eq =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.use_eq);
-                                      FStar_TypeChecker_Env.is_iface =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.is_iface);
-                                      FStar_TypeChecker_Env.admit =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.admit);
-                                      FStar_TypeChecker_Env.lax = true;
-                                      FStar_TypeChecker_Env.lax_universes =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.lax_universes);
-                                      FStar_TypeChecker_Env.phase1 = true;
-                                      FStar_TypeChecker_Env.failhard =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.failhard);
-                                      FStar_TypeChecker_Env.nosynth =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.nosynth);
-                                      FStar_TypeChecker_Env.uvar_subtyping =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.uvar_subtyping);
-                                      FStar_TypeChecker_Env.tc_term =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.tc_term);
-                                      FStar_TypeChecker_Env.type_of =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.type_of);
-                                      FStar_TypeChecker_Env.universe_of =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.universe_of);
-                                      FStar_TypeChecker_Env.check_type_of =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.check_type_of);
-                                      FStar_TypeChecker_Env.use_bv_sorts =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.use_bv_sorts);
-                                      FStar_TypeChecker_Env.qtbl_name_and_index
-                                        =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.qtbl_name_and_index);
-                                      FStar_TypeChecker_Env.normalized_eff_names
-                                        =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.normalized_eff_names);
-                                      FStar_TypeChecker_Env.fv_delta_depths =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.fv_delta_depths);
-                                      FStar_TypeChecker_Env.proof_ns =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.proof_ns);
-                                      FStar_TypeChecker_Env.synth_hook =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.synth_hook);
-                                      FStar_TypeChecker_Env.splice =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.splice);
-                                      FStar_TypeChecker_Env.postprocess =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.postprocess);
-                                      FStar_TypeChecker_Env.is_native_tactic
-                                        =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.is_native_tactic);
-                                      FStar_TypeChecker_Env.identifier_info =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.identifier_info);
-                                      FStar_TypeChecker_Env.tc_hooks =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.tc_hooks);
-                                      FStar_TypeChecker_Env.dsenv =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.dsenv);
-                                      FStar_TypeChecker_Env.nbe =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.nbe);
-                                      FStar_TypeChecker_Env.strict_args_tab =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.strict_args_tab);
-                                      FStar_TypeChecker_Env.erasable_types_tab
-                                        =
-                                        (uu___1496_12021.FStar_TypeChecker_Env.erasable_types_tab)
-                                    }) e
-                                  in
-                               FStar_All.pipe_right uu____12012
-                                 (fun uu____12034  ->
-                                    match uu____12034 with
-                                    | (e1,uu____12042,uu____12043) -> e1)
-                                in
-                             FStar_All.pipe_right uu____12011
-                               (FStar_TypeChecker_Normalize.remove_uvar_solutions
-                                  env')
-                              in
-                           FStar_All.pipe_right uu____12010 drop_lbtyp)
-                       in
-                    match uu____12001 with
-                    | (e1,ms) ->
-                        ((let uu____12049 =
-                            FStar_All.pipe_left
-                              (FStar_TypeChecker_Env.debug env1)
-                              (FStar_Options.Other "TwoPhases")
-                             in
-                          if uu____12049
-                          then
-                            let uu____12054 =
-                              FStar_Syntax_Print.term_to_string e1  in
-                            FStar_Util.print1
-                              "Let binding after phase 1: %s\n" uu____12054
-                          else ());
-                         (let uu____12060 =
-                            FStar_All.pipe_left
-                              (FStar_TypeChecker_Env.debug env1)
-                              (FStar_Options.Other "TCDeclTime")
-                             in
-                          if uu____12060
-                          then
-                            let uu____12065 = FStar_Util.string_of_int ms  in
-                            FStar_Util.print1
-                              "Let binding elaborated (phase 1) in %s milliseconds\n"
-                              uu____12065
-                          else ());
-                         e1)
-                  else e  in
-                let uu____12072 =
-                  let uu____12081 =
-                    FStar_Syntax_Util.extract_attr'
-                      FStar_Parser_Const.postprocess_with
-                      se.FStar_Syntax_Syntax.sigattrs
-                     in
-                  match uu____12081 with
-                  | FStar_Pervasives_Native.None  ->
-                      ((se.FStar_Syntax_Syntax.sigattrs),
-                        FStar_Pervasives_Native.None)
-                  | FStar_Pervasives_Native.Some
-                      (ats,(tau,FStar_Pervasives_Native.None )::[]) ->
-                      (ats, (FStar_Pervasives_Native.Some tau))
-                  | FStar_Pervasives_Native.Some (ats,args) ->
-                      (FStar_Errors.log_issue r
-                         (FStar_Errors.Warning_UnrecognizedAttribute,
-                           "Ill-formed application of `postprocess_with`");
-                       ((se.FStar_Syntax_Syntax.sigattrs),
-                         FStar_Pervasives_Native.None))
-                   in
-                (match uu____12072 with
-                 | (attrs,post_tau) ->
-                     let se1 =
-                       let uu___1526_12186 = se  in
-                       {
-                         FStar_Syntax_Syntax.sigel =
-                           (uu___1526_12186.FStar_Syntax_Syntax.sigel);
-                         FStar_Syntax_Syntax.sigrng =
-                           (uu___1526_12186.FStar_Syntax_Syntax.sigrng);
-                         FStar_Syntax_Syntax.sigquals =
-                           (uu___1526_12186.FStar_Syntax_Syntax.sigquals);
-                         FStar_Syntax_Syntax.sigmeta =
-                           (uu___1526_12186.FStar_Syntax_Syntax.sigmeta);
-                         FStar_Syntax_Syntax.sigattrs = attrs
-                       }  in
-                     let postprocess_lb tau lb =
-                       let lbdef =
-                         env1.FStar_TypeChecker_Env.postprocess env1 tau
-                           lb.FStar_Syntax_Syntax.lbtyp
-                           lb.FStar_Syntax_Syntax.lbdef
-                          in
-                       let uu___1533_12199 = lb  in
-                       {
-                         FStar_Syntax_Syntax.lbname =
-                           (uu___1533_12199.FStar_Syntax_Syntax.lbname);
-                         FStar_Syntax_Syntax.lbunivs =
-                           (uu___1533_12199.FStar_Syntax_Syntax.lbunivs);
-                         FStar_Syntax_Syntax.lbtyp =
-                           (uu___1533_12199.FStar_Syntax_Syntax.lbtyp);
-                         FStar_Syntax_Syntax.lbeff =
-                           (uu___1533_12199.FStar_Syntax_Syntax.lbeff);
-                         FStar_Syntax_Syntax.lbdef = lbdef;
-                         FStar_Syntax_Syntax.lbattrs =
-                           (uu___1533_12199.FStar_Syntax_Syntax.lbattrs);
-                         FStar_Syntax_Syntax.lbpos =
-                           (uu___1533_12199.FStar_Syntax_Syntax.lbpos)
-                       }  in
-                     let uu____12200 =
-                       FStar_Util.record_time
-                         (fun uu____12219  ->
-                            FStar_TypeChecker_TcTerm.tc_maybe_toplevel_term
-                              env' e1)
-                        in
-                     (match uu____12200 with
-                      | (r1,ms) ->
-                          ((let uu____12247 =
-                              FStar_All.pipe_left
-                                (FStar_TypeChecker_Env.debug env1)
-                                (FStar_Options.Other "TCDeclTime")
-                               in
-                            if uu____12247
-                            then
-                              let uu____12252 = FStar_Util.string_of_int ms
-                                 in
-                              FStar_Util.print1
-                                "Let binding typechecked in phase 2 in %s milliseconds\n"
-                                uu____12252
-                            else ());
-                           (let uu____12257 =
-                              match r1 with
-                              | ({
-                                   FStar_Syntax_Syntax.n =
-                                     FStar_Syntax_Syntax.Tm_let (lbs1,e2);
-                                   FStar_Syntax_Syntax.pos = uu____12282;
-                                   FStar_Syntax_Syntax.vars = uu____12283;_},uu____12284,g)
-                                  when FStar_TypeChecker_Env.is_trivial g ->
-                                  let lbs2 =
-                                    let uu____12314 =
-                                      FStar_All.pipe_right
-                                        (FStar_Pervasives_Native.snd lbs1)
-                                        (FStar_List.map rename_parameters)
-                                       in
-                                    ((FStar_Pervasives_Native.fst lbs1),
-                                      uu____12314)
-                                     in
-                                  let lbs3 =
-                                    let uu____12338 =
-                                      match post_tau with
-                                      | FStar_Pervasives_Native.Some tau ->
-                                          FStar_List.map (postprocess_lb tau)
-                                            (FStar_Pervasives_Native.snd lbs2)
-                                      | FStar_Pervasives_Native.None  ->
-                                          FStar_Pervasives_Native.snd lbs2
-                                       in
-                                    ((FStar_Pervasives_Native.fst lbs2),
-                                      uu____12338)
-                                     in
-                                  let quals1 =
-                                    match e2.FStar_Syntax_Syntax.n with
-                                    | FStar_Syntax_Syntax.Tm_meta
-                                        (uu____12361,FStar_Syntax_Syntax.Meta_desugared
-                                         (FStar_Syntax_Syntax.Masked_effect
-                                         ))
-                                        ->
-                                        FStar_Syntax_Syntax.HasMaskedEffect
-                                        :: quals
-                                    | uu____12366 -> quals  in
-                                  ((let uu___1563_12375 = se1  in
-                                    {
-                                      FStar_Syntax_Syntax.sigel =
-                                        (FStar_Syntax_Syntax.Sig_let
-                                           (lbs3, lids));
-                                      FStar_Syntax_Syntax.sigrng =
-                                        (uu___1563_12375.FStar_Syntax_Syntax.sigrng);
-                                      FStar_Syntax_Syntax.sigquals = quals1;
-                                      FStar_Syntax_Syntax.sigmeta =
-                                        (uu___1563_12375.FStar_Syntax_Syntax.sigmeta);
-                                      FStar_Syntax_Syntax.sigattrs =
-                                        (uu___1563_12375.FStar_Syntax_Syntax.sigattrs)
-                                    }), lbs3)
-                              | uu____12378 ->
-                                  failwith
-                                    "impossible (typechecking should preserve Tm_let)"
-                               in
-                            match uu____12257 with
-                            | (se2,lbs1) ->
-                                (FStar_All.pipe_right
-                                   (FStar_Pervasives_Native.snd lbs1)
-                                   (FStar_List.iter
-                                      (fun lb  ->
-                                         let fv =
-                                           FStar_Util.right
-                                             lb.FStar_Syntax_Syntax.lbname
-                                            in
-                                         FStar_TypeChecker_Env.insert_fv_info
-                                           env1 fv
-                                           lb.FStar_Syntax_Syntax.lbtyp));
-                                 (let uu____12434 = log env1  in
-                                  if uu____12434
-                                  then
-                                    let uu____12437 =
-                                      let uu____12439 =
-                                        FStar_All.pipe_right
-                                          (FStar_Pervasives_Native.snd lbs1)
-                                          (FStar_List.map
-                                             (fun lb  ->
-                                                let should_log =
-                                                  let uu____12459 =
-                                                    let uu____12468 =
-                                                      let uu____12469 =
-                                                        let uu____12472 =
-                                                          FStar_Util.right
-                                                            lb.FStar_Syntax_Syntax.lbname
-                                                           in
-                                                        uu____12472.FStar_Syntax_Syntax.fv_name
-                                                         in
-                                                      uu____12469.FStar_Syntax_Syntax.v
-                                                       in
-                                                    FStar_TypeChecker_Env.try_lookup_val_decl
-                                                      env1 uu____12468
-                                                     in
-                                                  match uu____12459 with
-                                                  | FStar_Pervasives_Native.None
-                                                       -> true
-                                                  | uu____12481 -> false  in
-                                                if should_log
-                                                then
-                                                  let uu____12493 =
-                                                    FStar_Syntax_Print.lbname_to_string
-                                                      lb.FStar_Syntax_Syntax.lbname
-                                                     in
-                                                  let uu____12495 =
-                                                    FStar_Syntax_Print.term_to_string
-                                                      lb.FStar_Syntax_Syntax.lbtyp
-                                                     in
-                                                  FStar_Util.format2
-                                                    "let %s : %s" uu____12493
-                                                    uu____12495
-                                                else ""))
+                      if uu____12034
+                      then
+                        let drop_lbtyp e_lax =
+                          let uu____12043 =
+                            let uu____12044 =
+                              FStar_Syntax_Subst.compress e_lax  in
+                            uu____12044.FStar_Syntax_Syntax.n  in
+                          match uu____12043 with
+                          | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),e2)
+                              ->
+                              let lb_unannotated =
+                                let uu____12066 =
+                                  let uu____12067 =
+                                    FStar_Syntax_Subst.compress e  in
+                                  uu____12067.FStar_Syntax_Syntax.n  in
+                                match uu____12066 with
+                                | FStar_Syntax_Syntax.Tm_let
+                                    ((uu____12071,lb1::[]),uu____12073) ->
+                                    let uu____12089 =
+                                      let uu____12090 =
+                                        FStar_Syntax_Subst.compress
+                                          lb1.FStar_Syntax_Syntax.lbtyp
                                          in
-                                      FStar_All.pipe_right uu____12439
-                                        (FStar_String.concat "\n")
-                                       in
-                                    FStar_Util.print1 "%s\n" uu____12437
-                                  else ());
-                                 check_must_erase_attribute env0 se2;
-                                 ([se2], [], env0))))))))
+                                      uu____12090.FStar_Syntax_Syntax.n  in
+                                    (match uu____12089 with
+                                     | FStar_Syntax_Syntax.Tm_unknown  ->
+                                         true
+                                     | uu____12095 -> false)
+                                | uu____12097 ->
+                                    failwith
+                                      "Impossible: first phase lb and second phase lb differ in structure!"
+                                 in
+                              if lb_unannotated
+                              then
+                                let uu___1510_12101 = e_lax  in
+                                {
+                                  FStar_Syntax_Syntax.n =
+                                    (FStar_Syntax_Syntax.Tm_let
+                                       ((false,
+                                          [(let uu___1512_12116 = lb  in
+                                            {
+                                              FStar_Syntax_Syntax.lbname =
+                                                (uu___1512_12116.FStar_Syntax_Syntax.lbname);
+                                              FStar_Syntax_Syntax.lbunivs =
+                                                (uu___1512_12116.FStar_Syntax_Syntax.lbunivs);
+                                              FStar_Syntax_Syntax.lbtyp =
+                                                FStar_Syntax_Syntax.tun;
+                                              FStar_Syntax_Syntax.lbeff =
+                                                (uu___1512_12116.FStar_Syntax_Syntax.lbeff);
+                                              FStar_Syntax_Syntax.lbdef =
+                                                (uu___1512_12116.FStar_Syntax_Syntax.lbdef);
+                                              FStar_Syntax_Syntax.lbattrs =
+                                                (uu___1512_12116.FStar_Syntax_Syntax.lbattrs);
+                                              FStar_Syntax_Syntax.lbpos =
+                                                (uu___1512_12116.FStar_Syntax_Syntax.lbpos)
+                                            })]), e2));
+                                  FStar_Syntax_Syntax.pos =
+                                    (uu___1510_12101.FStar_Syntax_Syntax.pos);
+                                  FStar_Syntax_Syntax.vars =
+                                    (uu___1510_12101.FStar_Syntax_Syntax.vars)
+                                }
+                              else e_lax
+                          | uu____12119 -> e_lax  in
+                        let uu____12120 =
+                          FStar_Util.record_time
+                            (fun uu____12128  ->
+                               let uu____12129 =
+                                 let uu____12130 =
+                                   let uu____12131 =
+                                     FStar_TypeChecker_TcTerm.tc_maybe_toplevel_term
+                                       (let uu___1516_12140 = env'  in
+                                        {
+                                          FStar_TypeChecker_Env.solver =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.solver);
+                                          FStar_TypeChecker_Env.range =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.range);
+                                          FStar_TypeChecker_Env.curmodule =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.curmodule);
+                                          FStar_TypeChecker_Env.gamma =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.gamma);
+                                          FStar_TypeChecker_Env.gamma_sig =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.gamma_sig);
+                                          FStar_TypeChecker_Env.gamma_cache =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.gamma_cache);
+                                          FStar_TypeChecker_Env.modules =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.modules);
+                                          FStar_TypeChecker_Env.expected_typ
+                                            =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.expected_typ);
+                                          FStar_TypeChecker_Env.sigtab =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.sigtab);
+                                          FStar_TypeChecker_Env.attrtab =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.attrtab);
+                                          FStar_TypeChecker_Env.is_pattern =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.is_pattern);
+                                          FStar_TypeChecker_Env.instantiate_imp
+                                            =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.instantiate_imp);
+                                          FStar_TypeChecker_Env.effects =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.effects);
+                                          FStar_TypeChecker_Env.generalize =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.generalize);
+                                          FStar_TypeChecker_Env.letrecs =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.letrecs);
+                                          FStar_TypeChecker_Env.top_level =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.top_level);
+                                          FStar_TypeChecker_Env.check_uvars =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.check_uvars);
+                                          FStar_TypeChecker_Env.use_eq =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.use_eq);
+                                          FStar_TypeChecker_Env.is_iface =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.is_iface);
+                                          FStar_TypeChecker_Env.admit =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.admit);
+                                          FStar_TypeChecker_Env.lax = true;
+                                          FStar_TypeChecker_Env.lax_universes
+                                            =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.lax_universes);
+                                          FStar_TypeChecker_Env.phase1 = true;
+                                          FStar_TypeChecker_Env.failhard =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.failhard);
+                                          FStar_TypeChecker_Env.nosynth =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.nosynth);
+                                          FStar_TypeChecker_Env.uvar_subtyping
+                                            =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.uvar_subtyping);
+                                          FStar_TypeChecker_Env.tc_term =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.tc_term);
+                                          FStar_TypeChecker_Env.type_of =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.type_of);
+                                          FStar_TypeChecker_Env.universe_of =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.universe_of);
+                                          FStar_TypeChecker_Env.check_type_of
+                                            =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.check_type_of);
+                                          FStar_TypeChecker_Env.use_bv_sorts
+                                            =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.use_bv_sorts);
+                                          FStar_TypeChecker_Env.qtbl_name_and_index
+                                            =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                          FStar_TypeChecker_Env.normalized_eff_names
+                                            =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.normalized_eff_names);
+                                          FStar_TypeChecker_Env.fv_delta_depths
+                                            =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.fv_delta_depths);
+                                          FStar_TypeChecker_Env.proof_ns =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.proof_ns);
+                                          FStar_TypeChecker_Env.synth_hook =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.synth_hook);
+                                          FStar_TypeChecker_Env.splice =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.splice);
+                                          FStar_TypeChecker_Env.postprocess =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.postprocess);
+                                          FStar_TypeChecker_Env.is_native_tactic
+                                            =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.is_native_tactic);
+                                          FStar_TypeChecker_Env.identifier_info
+                                            =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.identifier_info);
+                                          FStar_TypeChecker_Env.tc_hooks =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.tc_hooks);
+                                          FStar_TypeChecker_Env.dsenv =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.dsenv);
+                                          FStar_TypeChecker_Env.nbe =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.nbe);
+                                          FStar_TypeChecker_Env.strict_args_tab
+                                            =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.strict_args_tab);
+                                          FStar_TypeChecker_Env.erasable_types_tab
+                                            =
+                                            (uu___1516_12140.FStar_TypeChecker_Env.erasable_types_tab)
+                                        }) e
+                                      in
+                                   FStar_All.pipe_right uu____12131
+                                     (fun uu____12153  ->
+                                        match uu____12153 with
+                                        | (e1,uu____12161,uu____12162) -> e1)
+                                    in
+                                 FStar_All.pipe_right uu____12130
+                                   (FStar_TypeChecker_Normalize.remove_uvar_solutions
+                                      env')
+                                  in
+                               FStar_All.pipe_right uu____12129 drop_lbtyp)
+                           in
+                        match uu____12120 with
+                        | (e1,ms) ->
+                            ((let uu____12168 =
+                                FStar_All.pipe_left
+                                  (FStar_TypeChecker_Env.debug env1)
+                                  (FStar_Options.Other "TwoPhases")
+                                 in
+                              if uu____12168
+                              then
+                                let uu____12173 =
+                                  FStar_Syntax_Print.term_to_string e1  in
+                                FStar_Util.print1
+                                  "Let binding after phase 1: %s\n"
+                                  uu____12173
+                              else ());
+                             (let uu____12179 =
+                                FStar_All.pipe_left
+                                  (FStar_TypeChecker_Env.debug env1)
+                                  (FStar_Options.Other "TCDeclTime")
+                                 in
+                              if uu____12179
+                              then
+                                let uu____12184 = FStar_Util.string_of_int ms
+                                   in
+                                FStar_Util.print1
+                                  "Let binding elaborated (phase 1) in %s milliseconds\n"
+                                  uu____12184
+                              else ());
+                             e1)
+                      else e  in
+                    let uu____12191 =
+                      let uu____12200 =
+                        FStar_Syntax_Util.extract_attr'
+                          FStar_Parser_Const.postprocess_with
+                          se1.FStar_Syntax_Syntax.sigattrs
+                         in
+                      match uu____12200 with
+                      | FStar_Pervasives_Native.None  ->
+                          ((se1.FStar_Syntax_Syntax.sigattrs),
+                            FStar_Pervasives_Native.None)
+                      | FStar_Pervasives_Native.Some
+                          (ats,(tau,FStar_Pervasives_Native.None )::[]) ->
+                          (ats, (FStar_Pervasives_Native.Some tau))
+                      | FStar_Pervasives_Native.Some (ats,args) ->
+                          (FStar_Errors.log_issue r
+                             (FStar_Errors.Warning_UnrecognizedAttribute,
+                               "Ill-formed application of `postprocess_with`");
+                           ((se1.FStar_Syntax_Syntax.sigattrs),
+                             FStar_Pervasives_Native.None))
+                       in
+                    (match uu____12191 with
+                     | (attrs,post_tau) ->
+                         let se2 =
+                           let uu___1546_12305 = se1  in
+                           {
+                             FStar_Syntax_Syntax.sigel =
+                               (uu___1546_12305.FStar_Syntax_Syntax.sigel);
+                             FStar_Syntax_Syntax.sigrng =
+                               (uu___1546_12305.FStar_Syntax_Syntax.sigrng);
+                             FStar_Syntax_Syntax.sigquals =
+                               (uu___1546_12305.FStar_Syntax_Syntax.sigquals);
+                             FStar_Syntax_Syntax.sigmeta =
+                               (uu___1546_12305.FStar_Syntax_Syntax.sigmeta);
+                             FStar_Syntax_Syntax.sigattrs = attrs;
+                             FStar_Syntax_Syntax.sigopts =
+                               (uu___1546_12305.FStar_Syntax_Syntax.sigopts)
+                           }  in
+                         let postprocess_lb tau lb =
+                           let lbdef =
+                             env1.FStar_TypeChecker_Env.postprocess env1 tau
+                               lb.FStar_Syntax_Syntax.lbtyp
+                               lb.FStar_Syntax_Syntax.lbdef
+                              in
+                           let uu___1553_12318 = lb  in
+                           {
+                             FStar_Syntax_Syntax.lbname =
+                               (uu___1553_12318.FStar_Syntax_Syntax.lbname);
+                             FStar_Syntax_Syntax.lbunivs =
+                               (uu___1553_12318.FStar_Syntax_Syntax.lbunivs);
+                             FStar_Syntax_Syntax.lbtyp =
+                               (uu___1553_12318.FStar_Syntax_Syntax.lbtyp);
+                             FStar_Syntax_Syntax.lbeff =
+                               (uu___1553_12318.FStar_Syntax_Syntax.lbeff);
+                             FStar_Syntax_Syntax.lbdef = lbdef;
+                             FStar_Syntax_Syntax.lbattrs =
+                               (uu___1553_12318.FStar_Syntax_Syntax.lbattrs);
+                             FStar_Syntax_Syntax.lbpos =
+                               (uu___1553_12318.FStar_Syntax_Syntax.lbpos)
+                           }  in
+                         let uu____12319 =
+                           FStar_Util.record_time
+                             (fun uu____12338  ->
+                                FStar_TypeChecker_TcTerm.tc_maybe_toplevel_term
+                                  env' e1)
+                            in
+                         (match uu____12319 with
+                          | (r1,ms) ->
+                              ((let uu____12366 =
+                                  FStar_All.pipe_left
+                                    (FStar_TypeChecker_Env.debug env1)
+                                    (FStar_Options.Other "TCDeclTime")
+                                   in
+                                if uu____12366
+                                then
+                                  let uu____12371 =
+                                    FStar_Util.string_of_int ms  in
+                                  FStar_Util.print1
+                                    "Let binding typechecked in phase 2 in %s milliseconds\n"
+                                    uu____12371
+                                else ());
+                               (let uu____12376 =
+                                  match r1 with
+                                  | ({
+                                       FStar_Syntax_Syntax.n =
+                                         FStar_Syntax_Syntax.Tm_let (lbs1,e2);
+                                       FStar_Syntax_Syntax.pos = uu____12401;
+                                       FStar_Syntax_Syntax.vars = uu____12402;_},uu____12403,g)
+                                      when FStar_TypeChecker_Env.is_trivial g
+                                      ->
+                                      let lbs2 =
+                                        let uu____12433 =
+                                          FStar_All.pipe_right
+                                            (FStar_Pervasives_Native.snd lbs1)
+                                            (FStar_List.map rename_parameters)
+                                           in
+                                        ((FStar_Pervasives_Native.fst lbs1),
+                                          uu____12433)
+                                         in
+                                      let lbs3 =
+                                        let uu____12457 =
+                                          match post_tau with
+                                          | FStar_Pervasives_Native.Some tau
+                                              ->
+                                              FStar_List.map
+                                                (postprocess_lb tau)
+                                                (FStar_Pervasives_Native.snd
+                                                   lbs2)
+                                          | FStar_Pervasives_Native.None  ->
+                                              FStar_Pervasives_Native.snd
+                                                lbs2
+                                           in
+                                        ((FStar_Pervasives_Native.fst lbs2),
+                                          uu____12457)
+                                         in
+                                      let quals1 =
+                                        match e2.FStar_Syntax_Syntax.n with
+                                        | FStar_Syntax_Syntax.Tm_meta
+                                            (uu____12480,FStar_Syntax_Syntax.Meta_desugared
+                                             (FStar_Syntax_Syntax.Masked_effect
+                                             ))
+                                            ->
+                                            FStar_Syntax_Syntax.HasMaskedEffect
+                                            :: quals
+                                        | uu____12485 -> quals  in
+                                      ((let uu___1583_12494 = se2  in
+                                        {
+                                          FStar_Syntax_Syntax.sigel =
+                                            (FStar_Syntax_Syntax.Sig_let
+                                               (lbs3, lids));
+                                          FStar_Syntax_Syntax.sigrng =
+                                            (uu___1583_12494.FStar_Syntax_Syntax.sigrng);
+                                          FStar_Syntax_Syntax.sigquals =
+                                            quals1;
+                                          FStar_Syntax_Syntax.sigmeta =
+                                            (uu___1583_12494.FStar_Syntax_Syntax.sigmeta);
+                                          FStar_Syntax_Syntax.sigattrs =
+                                            (uu___1583_12494.FStar_Syntax_Syntax.sigattrs);
+                                          FStar_Syntax_Syntax.sigopts =
+                                            (uu___1583_12494.FStar_Syntax_Syntax.sigopts)
+                                        }), lbs3)
+                                  | uu____12497 ->
+                                      failwith
+                                        "impossible (typechecking should preserve Tm_let)"
+                                   in
+                                match uu____12376 with
+                                | (se3,lbs1) ->
+                                    (FStar_All.pipe_right
+                                       (FStar_Pervasives_Native.snd lbs1)
+                                       (FStar_List.iter
+                                          (fun lb  ->
+                                             let fv =
+                                               FStar_Util.right
+                                                 lb.FStar_Syntax_Syntax.lbname
+                                                in
+                                             FStar_TypeChecker_Env.insert_fv_info
+                                               env1 fv
+                                               lb.FStar_Syntax_Syntax.lbtyp));
+                                     (let uu____12553 = log env1  in
+                                      if uu____12553
+                                      then
+                                        let uu____12556 =
+                                          let uu____12558 =
+                                            FStar_All.pipe_right
+                                              (FStar_Pervasives_Native.snd
+                                                 lbs1)
+                                              (FStar_List.map
+                                                 (fun lb  ->
+                                                    let should_log =
+                                                      let uu____12578 =
+                                                        let uu____12587 =
+                                                          let uu____12588 =
+                                                            let uu____12591 =
+                                                              FStar_Util.right
+                                                                lb.FStar_Syntax_Syntax.lbname
+                                                               in
+                                                            uu____12591.FStar_Syntax_Syntax.fv_name
+                                                             in
+                                                          uu____12588.FStar_Syntax_Syntax.v
+                                                           in
+                                                        FStar_TypeChecker_Env.try_lookup_val_decl
+                                                          env1 uu____12587
+                                                         in
+                                                      match uu____12578 with
+                                                      | FStar_Pervasives_Native.None
+                                                           -> true
+                                                      | uu____12600 -> false
+                                                       in
+                                                    if should_log
+                                                    then
+                                                      let uu____12612 =
+                                                        FStar_Syntax_Print.lbname_to_string
+                                                          lb.FStar_Syntax_Syntax.lbname
+                                                         in
+                                                      let uu____12614 =
+                                                        FStar_Syntax_Print.term_to_string
+                                                          lb.FStar_Syntax_Syntax.lbtyp
+                                                         in
+                                                      FStar_Util.format2
+                                                        "let %s : %s"
+                                                        uu____12612
+                                                        uu____12614
+                                                    else ""))
+                                             in
+                                          FStar_All.pipe_right uu____12558
+                                            (FStar_String.concat "\n")
+                                           in
+                                        FStar_Util.print1 "%s\n" uu____12556
+                                      else ());
+                                     check_must_erase_attribute env0 se3;
+                                     ([se3], [], env0))))))))
   
 let (tc_decl :
   FStar_TypeChecker_Env.env ->
@@ -6954,137 +7124,137 @@ let (tc_decl :
   fun env  ->
     fun se  ->
       let env1 = set_hint_correlator env se  in
-      (let uu____12547 = FStar_TypeChecker_Env.debug env1 FStar_Options.Low
+      (let uu____12666 = FStar_TypeChecker_Env.debug env1 FStar_Options.Low
           in
-       if uu____12547
+       if uu____12666
        then
-         let uu____12550 = FStar_Syntax_Print.sigelt_to_string se  in
-         FStar_Util.print1 ">>>>>>>>>>>>>>tc_decl %s\n" uu____12550
+         let uu____12669 = FStar_Syntax_Print.sigelt_to_string se  in
+         FStar_Util.print1 ">>>>>>>>>>>>>>tc_decl %s\n" uu____12669
        else ());
-      (let uu____12555 = get_fail_se se  in
-       match uu____12555 with
-       | FStar_Pervasives_Native.Some (uu____12576,false ) when
-           let uu____12593 = FStar_TypeChecker_Env.should_verify env1  in
-           Prims.op_Negation uu____12593 -> ([], [], env1)
+      (let uu____12674 = get_fail_se se  in
+       match uu____12674 with
+       | FStar_Pervasives_Native.Some (uu____12695,false ) when
+           let uu____12712 = FStar_TypeChecker_Env.should_verify env1  in
+           Prims.op_Negation uu____12712 -> ([], [], env1)
        | FStar_Pervasives_Native.Some (errnos,lax1) ->
            let env' =
              if lax1
              then
-               let uu___1594_12619 = env1  in
+               let uu___1614_12738 = env1  in
                {
                  FStar_TypeChecker_Env.solver =
-                   (uu___1594_12619.FStar_TypeChecker_Env.solver);
+                   (uu___1614_12738.FStar_TypeChecker_Env.solver);
                  FStar_TypeChecker_Env.range =
-                   (uu___1594_12619.FStar_TypeChecker_Env.range);
+                   (uu___1614_12738.FStar_TypeChecker_Env.range);
                  FStar_TypeChecker_Env.curmodule =
-                   (uu___1594_12619.FStar_TypeChecker_Env.curmodule);
+                   (uu___1614_12738.FStar_TypeChecker_Env.curmodule);
                  FStar_TypeChecker_Env.gamma =
-                   (uu___1594_12619.FStar_TypeChecker_Env.gamma);
+                   (uu___1614_12738.FStar_TypeChecker_Env.gamma);
                  FStar_TypeChecker_Env.gamma_sig =
-                   (uu___1594_12619.FStar_TypeChecker_Env.gamma_sig);
+                   (uu___1614_12738.FStar_TypeChecker_Env.gamma_sig);
                  FStar_TypeChecker_Env.gamma_cache =
-                   (uu___1594_12619.FStar_TypeChecker_Env.gamma_cache);
+                   (uu___1614_12738.FStar_TypeChecker_Env.gamma_cache);
                  FStar_TypeChecker_Env.modules =
-                   (uu___1594_12619.FStar_TypeChecker_Env.modules);
+                   (uu___1614_12738.FStar_TypeChecker_Env.modules);
                  FStar_TypeChecker_Env.expected_typ =
-                   (uu___1594_12619.FStar_TypeChecker_Env.expected_typ);
+                   (uu___1614_12738.FStar_TypeChecker_Env.expected_typ);
                  FStar_TypeChecker_Env.sigtab =
-                   (uu___1594_12619.FStar_TypeChecker_Env.sigtab);
+                   (uu___1614_12738.FStar_TypeChecker_Env.sigtab);
                  FStar_TypeChecker_Env.attrtab =
-                   (uu___1594_12619.FStar_TypeChecker_Env.attrtab);
+                   (uu___1614_12738.FStar_TypeChecker_Env.attrtab);
                  FStar_TypeChecker_Env.is_pattern =
-                   (uu___1594_12619.FStar_TypeChecker_Env.is_pattern);
+                   (uu___1614_12738.FStar_TypeChecker_Env.is_pattern);
                  FStar_TypeChecker_Env.instantiate_imp =
-                   (uu___1594_12619.FStar_TypeChecker_Env.instantiate_imp);
+                   (uu___1614_12738.FStar_TypeChecker_Env.instantiate_imp);
                  FStar_TypeChecker_Env.effects =
-                   (uu___1594_12619.FStar_TypeChecker_Env.effects);
+                   (uu___1614_12738.FStar_TypeChecker_Env.effects);
                  FStar_TypeChecker_Env.generalize =
-                   (uu___1594_12619.FStar_TypeChecker_Env.generalize);
+                   (uu___1614_12738.FStar_TypeChecker_Env.generalize);
                  FStar_TypeChecker_Env.letrecs =
-                   (uu___1594_12619.FStar_TypeChecker_Env.letrecs);
+                   (uu___1614_12738.FStar_TypeChecker_Env.letrecs);
                  FStar_TypeChecker_Env.top_level =
-                   (uu___1594_12619.FStar_TypeChecker_Env.top_level);
+                   (uu___1614_12738.FStar_TypeChecker_Env.top_level);
                  FStar_TypeChecker_Env.check_uvars =
-                   (uu___1594_12619.FStar_TypeChecker_Env.check_uvars);
+                   (uu___1614_12738.FStar_TypeChecker_Env.check_uvars);
                  FStar_TypeChecker_Env.use_eq =
-                   (uu___1594_12619.FStar_TypeChecker_Env.use_eq);
+                   (uu___1614_12738.FStar_TypeChecker_Env.use_eq);
                  FStar_TypeChecker_Env.is_iface =
-                   (uu___1594_12619.FStar_TypeChecker_Env.is_iface);
+                   (uu___1614_12738.FStar_TypeChecker_Env.is_iface);
                  FStar_TypeChecker_Env.admit =
-                   (uu___1594_12619.FStar_TypeChecker_Env.admit);
+                   (uu___1614_12738.FStar_TypeChecker_Env.admit);
                  FStar_TypeChecker_Env.lax = true;
                  FStar_TypeChecker_Env.lax_universes =
-                   (uu___1594_12619.FStar_TypeChecker_Env.lax_universes);
+                   (uu___1614_12738.FStar_TypeChecker_Env.lax_universes);
                  FStar_TypeChecker_Env.phase1 =
-                   (uu___1594_12619.FStar_TypeChecker_Env.phase1);
+                   (uu___1614_12738.FStar_TypeChecker_Env.phase1);
                  FStar_TypeChecker_Env.failhard =
-                   (uu___1594_12619.FStar_TypeChecker_Env.failhard);
+                   (uu___1614_12738.FStar_TypeChecker_Env.failhard);
                  FStar_TypeChecker_Env.nosynth =
-                   (uu___1594_12619.FStar_TypeChecker_Env.nosynth);
+                   (uu___1614_12738.FStar_TypeChecker_Env.nosynth);
                  FStar_TypeChecker_Env.uvar_subtyping =
-                   (uu___1594_12619.FStar_TypeChecker_Env.uvar_subtyping);
+                   (uu___1614_12738.FStar_TypeChecker_Env.uvar_subtyping);
                  FStar_TypeChecker_Env.tc_term =
-                   (uu___1594_12619.FStar_TypeChecker_Env.tc_term);
+                   (uu___1614_12738.FStar_TypeChecker_Env.tc_term);
                  FStar_TypeChecker_Env.type_of =
-                   (uu___1594_12619.FStar_TypeChecker_Env.type_of);
+                   (uu___1614_12738.FStar_TypeChecker_Env.type_of);
                  FStar_TypeChecker_Env.universe_of =
-                   (uu___1594_12619.FStar_TypeChecker_Env.universe_of);
+                   (uu___1614_12738.FStar_TypeChecker_Env.universe_of);
                  FStar_TypeChecker_Env.check_type_of =
-                   (uu___1594_12619.FStar_TypeChecker_Env.check_type_of);
+                   (uu___1614_12738.FStar_TypeChecker_Env.check_type_of);
                  FStar_TypeChecker_Env.use_bv_sorts =
-                   (uu___1594_12619.FStar_TypeChecker_Env.use_bv_sorts);
+                   (uu___1614_12738.FStar_TypeChecker_Env.use_bv_sorts);
                  FStar_TypeChecker_Env.qtbl_name_and_index =
-                   (uu___1594_12619.FStar_TypeChecker_Env.qtbl_name_and_index);
+                   (uu___1614_12738.FStar_TypeChecker_Env.qtbl_name_and_index);
                  FStar_TypeChecker_Env.normalized_eff_names =
-                   (uu___1594_12619.FStar_TypeChecker_Env.normalized_eff_names);
+                   (uu___1614_12738.FStar_TypeChecker_Env.normalized_eff_names);
                  FStar_TypeChecker_Env.fv_delta_depths =
-                   (uu___1594_12619.FStar_TypeChecker_Env.fv_delta_depths);
+                   (uu___1614_12738.FStar_TypeChecker_Env.fv_delta_depths);
                  FStar_TypeChecker_Env.proof_ns =
-                   (uu___1594_12619.FStar_TypeChecker_Env.proof_ns);
+                   (uu___1614_12738.FStar_TypeChecker_Env.proof_ns);
                  FStar_TypeChecker_Env.synth_hook =
-                   (uu___1594_12619.FStar_TypeChecker_Env.synth_hook);
+                   (uu___1614_12738.FStar_TypeChecker_Env.synth_hook);
                  FStar_TypeChecker_Env.splice =
-                   (uu___1594_12619.FStar_TypeChecker_Env.splice);
+                   (uu___1614_12738.FStar_TypeChecker_Env.splice);
                  FStar_TypeChecker_Env.postprocess =
-                   (uu___1594_12619.FStar_TypeChecker_Env.postprocess);
+                   (uu___1614_12738.FStar_TypeChecker_Env.postprocess);
                  FStar_TypeChecker_Env.is_native_tactic =
-                   (uu___1594_12619.FStar_TypeChecker_Env.is_native_tactic);
+                   (uu___1614_12738.FStar_TypeChecker_Env.is_native_tactic);
                  FStar_TypeChecker_Env.identifier_info =
-                   (uu___1594_12619.FStar_TypeChecker_Env.identifier_info);
+                   (uu___1614_12738.FStar_TypeChecker_Env.identifier_info);
                  FStar_TypeChecker_Env.tc_hooks =
-                   (uu___1594_12619.FStar_TypeChecker_Env.tc_hooks);
+                   (uu___1614_12738.FStar_TypeChecker_Env.tc_hooks);
                  FStar_TypeChecker_Env.dsenv =
-                   (uu___1594_12619.FStar_TypeChecker_Env.dsenv);
+                   (uu___1614_12738.FStar_TypeChecker_Env.dsenv);
                  FStar_TypeChecker_Env.nbe =
-                   (uu___1594_12619.FStar_TypeChecker_Env.nbe);
+                   (uu___1614_12738.FStar_TypeChecker_Env.nbe);
                  FStar_TypeChecker_Env.strict_args_tab =
-                   (uu___1594_12619.FStar_TypeChecker_Env.strict_args_tab);
+                   (uu___1614_12738.FStar_TypeChecker_Env.strict_args_tab);
                  FStar_TypeChecker_Env.erasable_types_tab =
-                   (uu___1594_12619.FStar_TypeChecker_Env.erasable_types_tab)
+                   (uu___1614_12738.FStar_TypeChecker_Env.erasable_types_tab)
                }
              else env1  in
-           ((let uu____12624 =
+           ((let uu____12743 =
                FStar_TypeChecker_Env.debug env1 FStar_Options.Low  in
-             if uu____12624
+             if uu____12743
              then
-               let uu____12627 =
-                 let uu____12629 =
+               let uu____12746 =
+                 let uu____12748 =
                    FStar_List.map FStar_Util.string_of_int errnos  in
-                 FStar_All.pipe_left (FStar_String.concat "; ") uu____12629
+                 FStar_All.pipe_left (FStar_String.concat "; ") uu____12748
                   in
-               FStar_Util.print1 ">> Expecting errors: [%s]\n" uu____12627
+               FStar_Util.print1 ">> Expecting errors: [%s]\n" uu____12746
              else ());
-            (let uu____12643 =
+            (let uu____12762 =
                FStar_Errors.catch_errors
-                 (fun uu____12673  ->
+                 (fun uu____12792  ->
                     FStar_Options.with_saved_options
-                      (fun uu____12685  -> tc_decl' env' se))
+                      (fun uu____12804  -> tc_decl' env' se))
                 in
-             match uu____12643 with
-             | (errs,uu____12697) ->
-                 ((let uu____12727 =
+             match uu____12762 with
+             | (errs,uu____12816) ->
+                 ((let uu____12846 =
                      FStar_TypeChecker_Env.debug env1 FStar_Options.Low  in
-                   if uu____12727
+                   if uu____12846
                    then
                      (FStar_Util.print_string ">> Got issues: [\n";
                       FStar_List.iter FStar_Errors.print_issue errs;
@@ -7094,66 +7264,66 @@ let (tc_decl :
                       in
                    let errnos1 = sort errnos  in
                    let actual =
-                     let uu____12762 =
+                     let uu____12881 =
                        FStar_List.concatMap
                          (fun i  ->
                             list_of_option i.FStar_Errors.issue_number) errs
                         in
-                     sort uu____12762  in
+                     sort uu____12881  in
                    (match errs with
                     | [] ->
                         (FStar_List.iter FStar_Errors.print_issue errs;
                          FStar_Errors.log_issue se.FStar_Syntax_Syntax.sigrng
                            (FStar_Errors.Error_DidNotFail,
                              "This top-level definition was expected to fail, but it succeeded"))
-                    | uu____12774 ->
+                    | uu____12893 ->
                         if (errnos1 <> []) && (errnos1 <> actual)
                         then
-                          let uu____12785 =
-                            let uu____12795 = check_multi_eq errnos1 actual
+                          let uu____12904 =
+                            let uu____12914 = check_multi_eq errnos1 actual
                                in
-                            match uu____12795 with
+                            match uu____12914 with
                             | FStar_Pervasives_Native.Some r -> r
                             | FStar_Pervasives_Native.None  ->
                                 ((~- Prims.int_one), (~- Prims.int_one),
                                   (~- Prims.int_one))
                              in
-                          (match uu____12785 with
+                          (match uu____12904 with
                            | (e,n1,n2) ->
                                (FStar_List.iter FStar_Errors.print_issue errs;
-                                (let uu____12860 =
-                                   let uu____12866 =
-                                     let uu____12868 =
+                                (let uu____12979 =
+                                   let uu____12985 =
+                                     let uu____12987 =
                                        FStar_Common.string_of_list
                                          FStar_Util.string_of_int errnos1
                                         in
-                                     let uu____12871 =
+                                     let uu____12990 =
                                        FStar_Common.string_of_list
                                          FStar_Util.string_of_int actual
                                         in
-                                     let uu____12874 =
+                                     let uu____12993 =
                                        FStar_Util.string_of_int e  in
-                                     let uu____12876 =
+                                     let uu____12995 =
                                        FStar_Util.string_of_int n2  in
-                                     let uu____12878 =
+                                     let uu____12997 =
                                        FStar_Util.string_of_int n1  in
                                      FStar_Util.format5
                                        "This top-level definition was expected to raise error codes %s, but it raised %s. Error #%s was raised %s times, instead of %s."
-                                       uu____12868 uu____12871 uu____12874
-                                       uu____12876 uu____12878
+                                       uu____12987 uu____12990 uu____12993
+                                       uu____12995 uu____12997
                                       in
                                    (FStar_Errors.Error_DidNotFail,
-                                     uu____12866)
+                                     uu____12985)
                                     in
                                  FStar_Errors.log_issue
-                                   se.FStar_Syntax_Syntax.sigrng uu____12860)))
+                                   se.FStar_Syntax_Syntax.sigrng uu____12979)))
                         else ());
                    ([], [], env1)))))
        | FStar_Pervasives_Native.None  -> tc_decl' env1 se)
   
 let for_export :
-  'Auu____12905 .
-    'Auu____12905 ->
+  'Auu____13024 .
+    'Auu____13024 ->
       FStar_Ident.lident Prims.list ->
         FStar_Syntax_Syntax.sigelt ->
           (FStar_Syntax_Syntax.sigelt Prims.list * FStar_Ident.lident
@@ -7165,195 +7335,204 @@ let for_export :
         let is_abstract quals =
           FStar_All.pipe_right quals
             (FStar_Util.for_some
-               (fun uu___3_12948  ->
-                  match uu___3_12948 with
+               (fun uu___3_13067  ->
+                  match uu___3_13067 with
                   | FStar_Syntax_Syntax.Abstract  -> true
-                  | uu____12951 -> false))
+                  | uu____13070 -> false))
            in
         let is_hidden_proj_or_disc q =
           match q with
-          | FStar_Syntax_Syntax.Projector (l,uu____12962) ->
+          | FStar_Syntax_Syntax.Projector (l,uu____13081) ->
               FStar_All.pipe_right hidden
                 (FStar_Util.for_some (FStar_Ident.lid_equals l))
           | FStar_Syntax_Syntax.Discriminator l ->
               FStar_All.pipe_right hidden
                 (FStar_Util.for_some (FStar_Ident.lid_equals l))
-          | uu____12970 -> false  in
+          | uu____13089 -> false  in
         match se.FStar_Syntax_Syntax.sigel with
-        | FStar_Syntax_Syntax.Sig_pragma uu____12980 -> ([], hidden)
-        | FStar_Syntax_Syntax.Sig_splice uu____12985 ->
+        | FStar_Syntax_Syntax.Sig_pragma uu____13099 -> ([], hidden)
+        | FStar_Syntax_Syntax.Sig_splice uu____13104 ->
             failwith "Impossible (Already handled)"
-        | FStar_Syntax_Syntax.Sig_inductive_typ uu____13001 ->
+        | FStar_Syntax_Syntax.Sig_inductive_typ uu____13120 ->
             failwith "Impossible (Already handled)"
-        | FStar_Syntax_Syntax.Sig_datacon uu____13027 ->
+        | FStar_Syntax_Syntax.Sig_datacon uu____13146 ->
             failwith "Impossible (Already handled)"
-        | FStar_Syntax_Syntax.Sig_bundle (ses,uu____13053) ->
-            let uu____13062 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
-            if uu____13062
+        | FStar_Syntax_Syntax.Sig_bundle (ses,uu____13172) ->
+            let uu____13181 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
+            if uu____13181
             then
-              let for_export_bundle se1 uu____13099 =
-                match uu____13099 with
+              let for_export_bundle se1 uu____13218 =
+                match uu____13218 with
                 | (out,hidden1) ->
                     (match se1.FStar_Syntax_Syntax.sigel with
                      | FStar_Syntax_Syntax.Sig_inductive_typ
-                         (l,us,bs,t,uu____13138,uu____13139) ->
+                         (l,us,bs,t,uu____13257,uu____13258) ->
                          let dec =
-                           let uu___1670_13149 = se1  in
-                           let uu____13150 =
-                             let uu____13151 =
-                               let uu____13158 =
-                                 let uu____13159 =
+                           let uu___1690_13268 = se1  in
+                           let uu____13269 =
+                             let uu____13270 =
+                               let uu____13277 =
+                                 let uu____13278 =
                                    FStar_Syntax_Syntax.mk_Total t  in
-                                 FStar_Syntax_Util.arrow bs uu____13159  in
-                               (l, us, uu____13158)  in
-                             FStar_Syntax_Syntax.Sig_declare_typ uu____13151
+                                 FStar_Syntax_Util.arrow bs uu____13278  in
+                               (l, us, uu____13277)  in
+                             FStar_Syntax_Syntax.Sig_declare_typ uu____13270
                               in
                            {
-                             FStar_Syntax_Syntax.sigel = uu____13150;
+                             FStar_Syntax_Syntax.sigel = uu____13269;
                              FStar_Syntax_Syntax.sigrng =
-                               (uu___1670_13149.FStar_Syntax_Syntax.sigrng);
+                               (uu___1690_13268.FStar_Syntax_Syntax.sigrng);
                              FStar_Syntax_Syntax.sigquals =
                                (FStar_Syntax_Syntax.Assumption ::
                                FStar_Syntax_Syntax.New ::
                                (se1.FStar_Syntax_Syntax.sigquals));
                              FStar_Syntax_Syntax.sigmeta =
-                               (uu___1670_13149.FStar_Syntax_Syntax.sigmeta);
+                               (uu___1690_13268.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs =
-                               (uu___1670_13149.FStar_Syntax_Syntax.sigattrs)
+                               (uu___1690_13268.FStar_Syntax_Syntax.sigattrs);
+                             FStar_Syntax_Syntax.sigopts =
+                               (uu___1690_13268.FStar_Syntax_Syntax.sigopts)
                            }  in
                          ((dec :: out), hidden1)
                      | FStar_Syntax_Syntax.Sig_datacon
-                         (l,us,t,uu____13169,uu____13170,uu____13171) ->
+                         (l,us,t,uu____13288,uu____13289,uu____13290) ->
                          let dec =
-                           let uu___1681_13179 = se1  in
+                           let uu___1701_13298 = se1  in
                            {
                              FStar_Syntax_Syntax.sigel =
                                (FStar_Syntax_Syntax.Sig_declare_typ
                                   (l, us, t));
                              FStar_Syntax_Syntax.sigrng =
-                               (uu___1681_13179.FStar_Syntax_Syntax.sigrng);
+                               (uu___1701_13298.FStar_Syntax_Syntax.sigrng);
                              FStar_Syntax_Syntax.sigquals =
                                [FStar_Syntax_Syntax.Assumption];
                              FStar_Syntax_Syntax.sigmeta =
-                               (uu___1681_13179.FStar_Syntax_Syntax.sigmeta);
+                               (uu___1701_13298.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs =
-                               (uu___1681_13179.FStar_Syntax_Syntax.sigattrs)
+                               (uu___1701_13298.FStar_Syntax_Syntax.sigattrs);
+                             FStar_Syntax_Syntax.sigopts =
+                               (uu___1701_13298.FStar_Syntax_Syntax.sigopts)
                            }  in
                          ((dec :: out), (l :: hidden1))
-                     | uu____13184 -> (out, hidden1))
+                     | uu____13303 -> (out, hidden1))
                  in
               FStar_List.fold_right for_export_bundle ses ([], hidden)
             else ([se], hidden)
         | FStar_Syntax_Syntax.Sig_assume
-            (uu____13207,uu____13208,uu____13209) ->
-            let uu____13210 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
-            if uu____13210 then ([], hidden) else ([se], hidden)
+            (uu____13326,uu____13327,uu____13328) ->
+            let uu____13329 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
+            if uu____13329 then ([], hidden) else ([se], hidden)
         | FStar_Syntax_Syntax.Sig_declare_typ (l,us,t) ->
-            let uu____13234 =
+            let uu____13353 =
               FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                 (FStar_Util.for_some is_hidden_proj_or_disc)
                in
-            if uu____13234
+            if uu____13353
             then
-              ([(let uu___1697_13253 = se  in
+              ([(let uu___1717_13372 = se  in
                  {
                    FStar_Syntax_Syntax.sigel =
                      (FStar_Syntax_Syntax.Sig_declare_typ (l, us, t));
                    FStar_Syntax_Syntax.sigrng =
-                     (uu___1697_13253.FStar_Syntax_Syntax.sigrng);
+                     (uu___1717_13372.FStar_Syntax_Syntax.sigrng);
                    FStar_Syntax_Syntax.sigquals =
                      [FStar_Syntax_Syntax.Assumption];
                    FStar_Syntax_Syntax.sigmeta =
-                     (uu___1697_13253.FStar_Syntax_Syntax.sigmeta);
+                     (uu___1717_13372.FStar_Syntax_Syntax.sigmeta);
                    FStar_Syntax_Syntax.sigattrs =
-                     (uu___1697_13253.FStar_Syntax_Syntax.sigattrs)
+                     (uu___1717_13372.FStar_Syntax_Syntax.sigattrs);
+                   FStar_Syntax_Syntax.sigopts =
+                     (uu___1717_13372.FStar_Syntax_Syntax.sigopts)
                  })], (l :: hidden))
             else
-              (let uu____13256 =
+              (let uu____13375 =
                  FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                    (FStar_Util.for_some
-                      (fun uu___4_13262  ->
-                         match uu___4_13262 with
+                      (fun uu___4_13381  ->
+                         match uu___4_13381 with
                          | FStar_Syntax_Syntax.Assumption  -> true
-                         | FStar_Syntax_Syntax.Projector uu____13265 -> true
-                         | FStar_Syntax_Syntax.Discriminator uu____13271 ->
+                         | FStar_Syntax_Syntax.Projector uu____13384 -> true
+                         | FStar_Syntax_Syntax.Discriminator uu____13390 ->
                              true
-                         | uu____13273 -> false))
+                         | uu____13392 -> false))
                   in
-               if uu____13256 then ([se], hidden) else ([], hidden))
-        | FStar_Syntax_Syntax.Sig_main uu____13294 -> ([], hidden)
-        | FStar_Syntax_Syntax.Sig_new_effect uu____13299 -> ([se], hidden)
-        | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____13304 ->
+               if uu____13375 then ([se], hidden) else ([], hidden))
+        | FStar_Syntax_Syntax.Sig_main uu____13413 -> ([], hidden)
+        | FStar_Syntax_Syntax.Sig_new_effect uu____13418 -> ([se], hidden)
+        | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____13423 ->
             ([se], hidden)
-        | FStar_Syntax_Syntax.Sig_sub_effect uu____13309 -> ([se], hidden)
-        | FStar_Syntax_Syntax.Sig_effect_abbrev uu____13314 -> ([se], hidden)
-        | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____13332) when
+        | FStar_Syntax_Syntax.Sig_sub_effect uu____13428 -> ([se], hidden)
+        | FStar_Syntax_Syntax.Sig_effect_abbrev uu____13433 -> ([se], hidden)
+        | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____13451) when
             FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
               (FStar_Util.for_some is_hidden_proj_or_disc)
             ->
             let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
             let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                in
-            let uu____13346 =
+            let uu____13465 =
               FStar_All.pipe_right hidden
                 (FStar_Util.for_some (FStar_Syntax_Syntax.fv_eq_lid fv))
                in
-            if uu____13346
+            if uu____13465
             then ([], hidden)
             else
               (let dec =
-                 let uu____13367 = FStar_Ident.range_of_lid lid  in
+                 let uu____13486 = FStar_Ident.range_of_lid lid  in
                  {
                    FStar_Syntax_Syntax.sigel =
                      (FStar_Syntax_Syntax.Sig_declare_typ
                         (((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v),
                           (lb.FStar_Syntax_Syntax.lbunivs),
                           (lb.FStar_Syntax_Syntax.lbtyp)));
-                   FStar_Syntax_Syntax.sigrng = uu____13367;
+                   FStar_Syntax_Syntax.sigrng = uu____13486;
                    FStar_Syntax_Syntax.sigquals =
                      [FStar_Syntax_Syntax.Assumption];
                    FStar_Syntax_Syntax.sigmeta =
                      FStar_Syntax_Syntax.default_sigmeta;
-                   FStar_Syntax_Syntax.sigattrs = []
+                   FStar_Syntax_Syntax.sigattrs = [];
+                   FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                  }  in
                ([dec], (lid :: hidden)))
         | FStar_Syntax_Syntax.Sig_let (lbs,l) ->
-            let uu____13378 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
-            if uu____13378
+            let uu____13497 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
+            if uu____13497
             then
-              let uu____13389 =
+              let uu____13508 =
                 FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
                   (FStar_List.map
                      (fun lb  ->
-                        let uu___1734_13403 = se  in
-                        let uu____13404 =
-                          let uu____13405 =
-                            let uu____13412 =
-                              let uu____13413 =
-                                let uu____13416 =
+                        let uu___1754_13522 = se  in
+                        let uu____13523 =
+                          let uu____13524 =
+                            let uu____13531 =
+                              let uu____13532 =
+                                let uu____13535 =
                                   FStar_Util.right
                                     lb.FStar_Syntax_Syntax.lbname
                                    in
-                                uu____13416.FStar_Syntax_Syntax.fv_name  in
-                              uu____13413.FStar_Syntax_Syntax.v  in
-                            (uu____13412, (lb.FStar_Syntax_Syntax.lbunivs),
+                                uu____13535.FStar_Syntax_Syntax.fv_name  in
+                              uu____13532.FStar_Syntax_Syntax.v  in
+                            (uu____13531, (lb.FStar_Syntax_Syntax.lbunivs),
                               (lb.FStar_Syntax_Syntax.lbtyp))
                              in
-                          FStar_Syntax_Syntax.Sig_declare_typ uu____13405  in
+                          FStar_Syntax_Syntax.Sig_declare_typ uu____13524  in
                         {
-                          FStar_Syntax_Syntax.sigel = uu____13404;
+                          FStar_Syntax_Syntax.sigel = uu____13523;
                           FStar_Syntax_Syntax.sigrng =
-                            (uu___1734_13403.FStar_Syntax_Syntax.sigrng);
+                            (uu___1754_13522.FStar_Syntax_Syntax.sigrng);
                           FStar_Syntax_Syntax.sigquals =
                             (FStar_Syntax_Syntax.Assumption ::
                             (se.FStar_Syntax_Syntax.sigquals));
                           FStar_Syntax_Syntax.sigmeta =
-                            (uu___1734_13403.FStar_Syntax_Syntax.sigmeta);
+                            (uu___1754_13522.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (uu___1734_13403.FStar_Syntax_Syntax.sigattrs)
+                            (uu___1754_13522.FStar_Syntax_Syntax.sigattrs);
+                          FStar_Syntax_Syntax.sigopts =
+                            (uu___1754_13522.FStar_Syntax_Syntax.sigopts)
                         }))
                  in
-              (uu____13389, hidden)
+              (uu____13508, hidden)
             else ([se], hidden)
   
 let (add_sigelt_to_env :
@@ -7363,450 +7542,450 @@ let (add_sigelt_to_env :
   fun env  ->
     fun se  ->
       fun from_cache  ->
-        (let uu____13446 = FStar_TypeChecker_Env.debug env FStar_Options.Low
+        (let uu____13565 = FStar_TypeChecker_Env.debug env FStar_Options.Low
             in
-         if uu____13446
+         if uu____13565
          then
-           let uu____13449 = FStar_Syntax_Print.sigelt_to_string se  in
-           let uu____13451 = FStar_Util.string_of_bool from_cache  in
+           let uu____13568 = FStar_Syntax_Print.sigelt_to_string se  in
+           let uu____13570 = FStar_Util.string_of_bool from_cache  in
            FStar_Util.print2
              ">>>>>>>>>>>>>>Adding top-level decl to environment: %s (from_cache:%s)\n"
-             uu____13449 uu____13451
+             uu____13568 uu____13570
          else ());
         (match se.FStar_Syntax_Syntax.sigel with
-         | FStar_Syntax_Syntax.Sig_inductive_typ uu____13456 ->
-             let uu____13473 =
-               let uu____13479 =
-                 let uu____13481 = FStar_Syntax_Print.sigelt_to_string se  in
+         | FStar_Syntax_Syntax.Sig_inductive_typ uu____13575 ->
+             let uu____13592 =
+               let uu____13598 =
+                 let uu____13600 = FStar_Syntax_Print.sigelt_to_string se  in
                  FStar_Util.format1
                    "add_sigelt_to_env: unexpected bare type/data constructor: %s"
-                   uu____13481
+                   uu____13600
                   in
-               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____13479)  in
-             FStar_Errors.raise_error uu____13473
+               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____13598)  in
+             FStar_Errors.raise_error uu____13592
                se.FStar_Syntax_Syntax.sigrng
-         | FStar_Syntax_Syntax.Sig_datacon uu____13485 ->
-             let uu____13501 =
-               let uu____13507 =
-                 let uu____13509 = FStar_Syntax_Print.sigelt_to_string se  in
+         | FStar_Syntax_Syntax.Sig_datacon uu____13604 ->
+             let uu____13620 =
+               let uu____13626 =
+                 let uu____13628 = FStar_Syntax_Print.sigelt_to_string se  in
                  FStar_Util.format1
                    "add_sigelt_to_env: unexpected bare type/data constructor: %s"
-                   uu____13509
+                   uu____13628
                   in
-               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____13507)  in
-             FStar_Errors.raise_error uu____13501
+               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____13626)  in
+             FStar_Errors.raise_error uu____13620
                se.FStar_Syntax_Syntax.sigrng
          | FStar_Syntax_Syntax.Sig_declare_typ
-             (uu____13513,uu____13514,uu____13515) when
+             (uu____13632,uu____13633,uu____13634) when
              FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                (FStar_Util.for_some
-                  (fun uu___5_13520  ->
-                     match uu___5_13520 with
+                  (fun uu___5_13639  ->
+                     match uu___5_13639 with
                      | FStar_Syntax_Syntax.OnlyName  -> true
-                     | uu____13523 -> false))
+                     | uu____13642 -> false))
              -> env
-         | FStar_Syntax_Syntax.Sig_let (uu____13525,uu____13526) when
+         | FStar_Syntax_Syntax.Sig_let (uu____13644,uu____13645) when
              FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                (FStar_Util.for_some
-                  (fun uu___5_13535  ->
-                     match uu___5_13535 with
+                  (fun uu___5_13654  ->
+                     match uu___5_13654 with
                      | FStar_Syntax_Syntax.OnlyName  -> true
-                     | uu____13538 -> false))
+                     | uu____13657 -> false))
              -> env
-         | uu____13540 ->
+         | uu____13659 ->
              let env1 = FStar_TypeChecker_Env.push_sigelt env se  in
              (match se.FStar_Syntax_Syntax.sigel with
               | FStar_Syntax_Syntax.Sig_pragma
-                  (FStar_Syntax_Syntax.PushOptions uu____13542) ->
+                  (FStar_Syntax_Syntax.PushOptions uu____13661) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___1771_13549 = env1  in
-                     let uu____13550 = FStar_Options.using_facts_from ()  in
+                    (let uu___1791_13668 = env1  in
+                     let uu____13669 = FStar_Options.using_facts_from ()  in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___1771_13549.FStar_TypeChecker_Env.solver);
+                         (uu___1791_13668.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___1771_13549.FStar_TypeChecker_Env.range);
+                         (uu___1791_13668.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___1771_13549.FStar_TypeChecker_Env.curmodule);
+                         (uu___1791_13668.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___1771_13549.FStar_TypeChecker_Env.gamma);
+                         (uu___1791_13668.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___1771_13549.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___1791_13668.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___1771_13549.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___1791_13668.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___1771_13549.FStar_TypeChecker_Env.modules);
+                         (uu___1791_13668.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___1771_13549.FStar_TypeChecker_Env.expected_typ);
+                         (uu___1791_13668.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___1771_13549.FStar_TypeChecker_Env.sigtab);
+                         (uu___1791_13668.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___1771_13549.FStar_TypeChecker_Env.attrtab);
+                         (uu___1791_13668.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.is_pattern =
-                         (uu___1771_13549.FStar_TypeChecker_Env.is_pattern);
+                         (uu___1791_13668.FStar_TypeChecker_Env.is_pattern);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___1771_13549.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___1791_13668.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___1771_13549.FStar_TypeChecker_Env.effects);
+                         (uu___1791_13668.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___1771_13549.FStar_TypeChecker_Env.generalize);
+                         (uu___1791_13668.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___1771_13549.FStar_TypeChecker_Env.letrecs);
+                         (uu___1791_13668.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___1771_13549.FStar_TypeChecker_Env.top_level);
+                         (uu___1791_13668.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___1771_13549.FStar_TypeChecker_Env.check_uvars);
+                         (uu___1791_13668.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___1771_13549.FStar_TypeChecker_Env.use_eq);
+                         (uu___1791_13668.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___1771_13549.FStar_TypeChecker_Env.is_iface);
+                         (uu___1791_13668.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___1771_13549.FStar_TypeChecker_Env.admit);
+                         (uu___1791_13668.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___1771_13549.FStar_TypeChecker_Env.lax);
+                         (uu___1791_13668.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___1771_13549.FStar_TypeChecker_Env.lax_universes);
+                         (uu___1791_13668.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___1771_13549.FStar_TypeChecker_Env.phase1);
+                         (uu___1791_13668.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___1771_13549.FStar_TypeChecker_Env.failhard);
+                         (uu___1791_13668.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___1771_13549.FStar_TypeChecker_Env.nosynth);
+                         (uu___1791_13668.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___1771_13549.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___1791_13668.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___1771_13549.FStar_TypeChecker_Env.tc_term);
+                         (uu___1791_13668.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___1771_13549.FStar_TypeChecker_Env.type_of);
+                         (uu___1791_13668.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___1771_13549.FStar_TypeChecker_Env.universe_of);
+                         (uu___1791_13668.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___1771_13549.FStar_TypeChecker_Env.check_type_of);
+                         (uu___1791_13668.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___1771_13549.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___1791_13668.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___1771_13549.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___1791_13668.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___1771_13549.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___1791_13668.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___1771_13549.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____13550;
+                         (uu___1791_13668.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu____13669;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___1771_13549.FStar_TypeChecker_Env.synth_hook);
+                         (uu___1791_13668.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___1771_13549.FStar_TypeChecker_Env.splice);
+                         (uu___1791_13668.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___1771_13549.FStar_TypeChecker_Env.postprocess);
+                         (uu___1791_13668.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.is_native_tactic =
-                         (uu___1771_13549.FStar_TypeChecker_Env.is_native_tactic);
+                         (uu___1791_13668.FStar_TypeChecker_Env.is_native_tactic);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___1771_13549.FStar_TypeChecker_Env.identifier_info);
+                         (uu___1791_13668.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___1771_13549.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___1791_13668.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___1771_13549.FStar_TypeChecker_Env.dsenv);
+                         (uu___1791_13668.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___1771_13549.FStar_TypeChecker_Env.nbe);
+                         (uu___1791_13668.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___1771_13549.FStar_TypeChecker_Env.strict_args_tab);
+                         (uu___1791_13668.FStar_TypeChecker_Env.strict_args_tab);
                        FStar_TypeChecker_Env.erasable_types_tab =
-                         (uu___1771_13549.FStar_TypeChecker_Env.erasable_types_tab)
+                         (uu___1791_13668.FStar_TypeChecker_Env.erasable_types_tab)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
                   (FStar_Syntax_Syntax.PopOptions ) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___1771_13554 = env1  in
-                     let uu____13555 = FStar_Options.using_facts_from ()  in
+                    (let uu___1791_13673 = env1  in
+                     let uu____13674 = FStar_Options.using_facts_from ()  in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___1771_13554.FStar_TypeChecker_Env.solver);
+                         (uu___1791_13673.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___1771_13554.FStar_TypeChecker_Env.range);
+                         (uu___1791_13673.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___1771_13554.FStar_TypeChecker_Env.curmodule);
+                         (uu___1791_13673.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___1771_13554.FStar_TypeChecker_Env.gamma);
+                         (uu___1791_13673.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___1771_13554.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___1791_13673.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___1771_13554.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___1791_13673.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___1771_13554.FStar_TypeChecker_Env.modules);
+                         (uu___1791_13673.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___1771_13554.FStar_TypeChecker_Env.expected_typ);
+                         (uu___1791_13673.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___1771_13554.FStar_TypeChecker_Env.sigtab);
+                         (uu___1791_13673.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___1771_13554.FStar_TypeChecker_Env.attrtab);
+                         (uu___1791_13673.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.is_pattern =
-                         (uu___1771_13554.FStar_TypeChecker_Env.is_pattern);
+                         (uu___1791_13673.FStar_TypeChecker_Env.is_pattern);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___1771_13554.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___1791_13673.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___1771_13554.FStar_TypeChecker_Env.effects);
+                         (uu___1791_13673.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___1771_13554.FStar_TypeChecker_Env.generalize);
+                         (uu___1791_13673.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___1771_13554.FStar_TypeChecker_Env.letrecs);
+                         (uu___1791_13673.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___1771_13554.FStar_TypeChecker_Env.top_level);
+                         (uu___1791_13673.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___1771_13554.FStar_TypeChecker_Env.check_uvars);
+                         (uu___1791_13673.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___1771_13554.FStar_TypeChecker_Env.use_eq);
+                         (uu___1791_13673.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___1771_13554.FStar_TypeChecker_Env.is_iface);
+                         (uu___1791_13673.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___1771_13554.FStar_TypeChecker_Env.admit);
+                         (uu___1791_13673.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___1771_13554.FStar_TypeChecker_Env.lax);
+                         (uu___1791_13673.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___1771_13554.FStar_TypeChecker_Env.lax_universes);
+                         (uu___1791_13673.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___1771_13554.FStar_TypeChecker_Env.phase1);
+                         (uu___1791_13673.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___1771_13554.FStar_TypeChecker_Env.failhard);
+                         (uu___1791_13673.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___1771_13554.FStar_TypeChecker_Env.nosynth);
+                         (uu___1791_13673.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___1771_13554.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___1791_13673.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___1771_13554.FStar_TypeChecker_Env.tc_term);
+                         (uu___1791_13673.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___1771_13554.FStar_TypeChecker_Env.type_of);
+                         (uu___1791_13673.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___1771_13554.FStar_TypeChecker_Env.universe_of);
+                         (uu___1791_13673.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___1771_13554.FStar_TypeChecker_Env.check_type_of);
+                         (uu___1791_13673.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___1771_13554.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___1791_13673.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___1771_13554.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___1791_13673.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___1771_13554.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___1791_13673.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___1771_13554.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____13555;
+                         (uu___1791_13673.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu____13674;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___1771_13554.FStar_TypeChecker_Env.synth_hook);
+                         (uu___1791_13673.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___1771_13554.FStar_TypeChecker_Env.splice);
+                         (uu___1791_13673.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___1771_13554.FStar_TypeChecker_Env.postprocess);
+                         (uu___1791_13673.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.is_native_tactic =
-                         (uu___1771_13554.FStar_TypeChecker_Env.is_native_tactic);
+                         (uu___1791_13673.FStar_TypeChecker_Env.is_native_tactic);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___1771_13554.FStar_TypeChecker_Env.identifier_info);
+                         (uu___1791_13673.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___1771_13554.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___1791_13673.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___1771_13554.FStar_TypeChecker_Env.dsenv);
+                         (uu___1791_13673.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___1771_13554.FStar_TypeChecker_Env.nbe);
+                         (uu___1791_13673.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___1771_13554.FStar_TypeChecker_Env.strict_args_tab);
+                         (uu___1791_13673.FStar_TypeChecker_Env.strict_args_tab);
                        FStar_TypeChecker_Env.erasable_types_tab =
-                         (uu___1771_13554.FStar_TypeChecker_Env.erasable_types_tab)
+                         (uu___1791_13673.FStar_TypeChecker_Env.erasable_types_tab)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
-                  (FStar_Syntax_Syntax.SetOptions uu____13556) ->
+                  (FStar_Syntax_Syntax.SetOptions uu____13675) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___1771_13561 = env1  in
-                     let uu____13562 = FStar_Options.using_facts_from ()  in
+                    (let uu___1791_13680 = env1  in
+                     let uu____13681 = FStar_Options.using_facts_from ()  in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___1771_13561.FStar_TypeChecker_Env.solver);
+                         (uu___1791_13680.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___1771_13561.FStar_TypeChecker_Env.range);
+                         (uu___1791_13680.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___1771_13561.FStar_TypeChecker_Env.curmodule);
+                         (uu___1791_13680.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___1771_13561.FStar_TypeChecker_Env.gamma);
+                         (uu___1791_13680.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___1771_13561.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___1791_13680.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___1771_13561.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___1791_13680.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___1771_13561.FStar_TypeChecker_Env.modules);
+                         (uu___1791_13680.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___1771_13561.FStar_TypeChecker_Env.expected_typ);
+                         (uu___1791_13680.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___1771_13561.FStar_TypeChecker_Env.sigtab);
+                         (uu___1791_13680.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___1771_13561.FStar_TypeChecker_Env.attrtab);
+                         (uu___1791_13680.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.is_pattern =
-                         (uu___1771_13561.FStar_TypeChecker_Env.is_pattern);
+                         (uu___1791_13680.FStar_TypeChecker_Env.is_pattern);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___1771_13561.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___1791_13680.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___1771_13561.FStar_TypeChecker_Env.effects);
+                         (uu___1791_13680.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___1771_13561.FStar_TypeChecker_Env.generalize);
+                         (uu___1791_13680.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___1771_13561.FStar_TypeChecker_Env.letrecs);
+                         (uu___1791_13680.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___1771_13561.FStar_TypeChecker_Env.top_level);
+                         (uu___1791_13680.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___1771_13561.FStar_TypeChecker_Env.check_uvars);
+                         (uu___1791_13680.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___1771_13561.FStar_TypeChecker_Env.use_eq);
+                         (uu___1791_13680.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___1771_13561.FStar_TypeChecker_Env.is_iface);
+                         (uu___1791_13680.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___1771_13561.FStar_TypeChecker_Env.admit);
+                         (uu___1791_13680.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___1771_13561.FStar_TypeChecker_Env.lax);
+                         (uu___1791_13680.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___1771_13561.FStar_TypeChecker_Env.lax_universes);
+                         (uu___1791_13680.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___1771_13561.FStar_TypeChecker_Env.phase1);
+                         (uu___1791_13680.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___1771_13561.FStar_TypeChecker_Env.failhard);
+                         (uu___1791_13680.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___1771_13561.FStar_TypeChecker_Env.nosynth);
+                         (uu___1791_13680.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___1771_13561.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___1791_13680.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___1771_13561.FStar_TypeChecker_Env.tc_term);
+                         (uu___1791_13680.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___1771_13561.FStar_TypeChecker_Env.type_of);
+                         (uu___1791_13680.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___1771_13561.FStar_TypeChecker_Env.universe_of);
+                         (uu___1791_13680.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___1771_13561.FStar_TypeChecker_Env.check_type_of);
+                         (uu___1791_13680.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___1771_13561.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___1791_13680.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___1771_13561.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___1791_13680.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___1771_13561.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___1791_13680.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___1771_13561.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____13562;
+                         (uu___1791_13680.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu____13681;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___1771_13561.FStar_TypeChecker_Env.synth_hook);
+                         (uu___1791_13680.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___1771_13561.FStar_TypeChecker_Env.splice);
+                         (uu___1791_13680.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___1771_13561.FStar_TypeChecker_Env.postprocess);
+                         (uu___1791_13680.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.is_native_tactic =
-                         (uu___1771_13561.FStar_TypeChecker_Env.is_native_tactic);
+                         (uu___1791_13680.FStar_TypeChecker_Env.is_native_tactic);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___1771_13561.FStar_TypeChecker_Env.identifier_info);
+                         (uu___1791_13680.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___1771_13561.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___1791_13680.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___1771_13561.FStar_TypeChecker_Env.dsenv);
+                         (uu___1791_13680.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___1771_13561.FStar_TypeChecker_Env.nbe);
+                         (uu___1791_13680.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___1771_13561.FStar_TypeChecker_Env.strict_args_tab);
+                         (uu___1791_13680.FStar_TypeChecker_Env.strict_args_tab);
                        FStar_TypeChecker_Env.erasable_types_tab =
-                         (uu___1771_13561.FStar_TypeChecker_Env.erasable_types_tab)
+                         (uu___1791_13680.FStar_TypeChecker_Env.erasable_types_tab)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
-                  (FStar_Syntax_Syntax.ResetOptions uu____13563) ->
+                  (FStar_Syntax_Syntax.ResetOptions uu____13682) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___1771_13570 = env1  in
-                     let uu____13571 = FStar_Options.using_facts_from ()  in
+                    (let uu___1791_13689 = env1  in
+                     let uu____13690 = FStar_Options.using_facts_from ()  in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___1771_13570.FStar_TypeChecker_Env.solver);
+                         (uu___1791_13689.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___1771_13570.FStar_TypeChecker_Env.range);
+                         (uu___1791_13689.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___1771_13570.FStar_TypeChecker_Env.curmodule);
+                         (uu___1791_13689.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___1771_13570.FStar_TypeChecker_Env.gamma);
+                         (uu___1791_13689.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___1771_13570.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___1791_13689.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___1771_13570.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___1791_13689.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___1771_13570.FStar_TypeChecker_Env.modules);
+                         (uu___1791_13689.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___1771_13570.FStar_TypeChecker_Env.expected_typ);
+                         (uu___1791_13689.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___1771_13570.FStar_TypeChecker_Env.sigtab);
+                         (uu___1791_13689.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___1771_13570.FStar_TypeChecker_Env.attrtab);
+                         (uu___1791_13689.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.is_pattern =
-                         (uu___1771_13570.FStar_TypeChecker_Env.is_pattern);
+                         (uu___1791_13689.FStar_TypeChecker_Env.is_pattern);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___1771_13570.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___1791_13689.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___1771_13570.FStar_TypeChecker_Env.effects);
+                         (uu___1791_13689.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___1771_13570.FStar_TypeChecker_Env.generalize);
+                         (uu___1791_13689.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___1771_13570.FStar_TypeChecker_Env.letrecs);
+                         (uu___1791_13689.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___1771_13570.FStar_TypeChecker_Env.top_level);
+                         (uu___1791_13689.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___1771_13570.FStar_TypeChecker_Env.check_uvars);
+                         (uu___1791_13689.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___1771_13570.FStar_TypeChecker_Env.use_eq);
+                         (uu___1791_13689.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___1771_13570.FStar_TypeChecker_Env.is_iface);
+                         (uu___1791_13689.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___1771_13570.FStar_TypeChecker_Env.admit);
+                         (uu___1791_13689.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___1771_13570.FStar_TypeChecker_Env.lax);
+                         (uu___1791_13689.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___1771_13570.FStar_TypeChecker_Env.lax_universes);
+                         (uu___1791_13689.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___1771_13570.FStar_TypeChecker_Env.phase1);
+                         (uu___1791_13689.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___1771_13570.FStar_TypeChecker_Env.failhard);
+                         (uu___1791_13689.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___1771_13570.FStar_TypeChecker_Env.nosynth);
+                         (uu___1791_13689.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___1771_13570.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___1791_13689.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___1771_13570.FStar_TypeChecker_Env.tc_term);
+                         (uu___1791_13689.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___1771_13570.FStar_TypeChecker_Env.type_of);
+                         (uu___1791_13689.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___1771_13570.FStar_TypeChecker_Env.universe_of);
+                         (uu___1791_13689.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___1771_13570.FStar_TypeChecker_Env.check_type_of);
+                         (uu___1791_13689.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___1771_13570.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___1791_13689.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___1771_13570.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___1791_13689.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___1771_13570.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___1791_13689.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___1771_13570.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____13571;
+                         (uu___1791_13689.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu____13690;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___1771_13570.FStar_TypeChecker_Env.synth_hook);
+                         (uu___1791_13689.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___1771_13570.FStar_TypeChecker_Env.splice);
+                         (uu___1791_13689.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___1771_13570.FStar_TypeChecker_Env.postprocess);
+                         (uu___1791_13689.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.is_native_tactic =
-                         (uu___1771_13570.FStar_TypeChecker_Env.is_native_tactic);
+                         (uu___1791_13689.FStar_TypeChecker_Env.is_native_tactic);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___1771_13570.FStar_TypeChecker_Env.identifier_info);
+                         (uu___1791_13689.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___1771_13570.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___1791_13689.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___1771_13570.FStar_TypeChecker_Env.dsenv);
+                         (uu___1791_13689.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___1771_13570.FStar_TypeChecker_Env.nbe);
+                         (uu___1791_13689.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___1771_13570.FStar_TypeChecker_Env.strict_args_tab);
+                         (uu___1791_13689.FStar_TypeChecker_Env.strict_args_tab);
                        FStar_TypeChecker_Env.erasable_types_tab =
-                         (uu___1771_13570.FStar_TypeChecker_Env.erasable_types_tab)
+                         (uu___1791_13689.FStar_TypeChecker_Env.erasable_types_tab)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
                   (FStar_Syntax_Syntax.RestartSolver ) ->
@@ -7825,16 +8004,16 @@ let (add_sigelt_to_env :
                     (FStar_List.fold_left
                        (fun env3  ->
                           fun a  ->
-                            let uu____13587 =
+                            let uu____13706 =
                               FStar_Syntax_Util.action_as_lb
                                 ne.FStar_Syntax_Syntax.mname a
                                 (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
                                in
                             FStar_TypeChecker_Env.push_sigelt env3
-                              uu____13587) env2)
+                              uu____13706) env2)
               | FStar_Syntax_Syntax.Sig_sub_effect sub1 ->
                   FStar_TypeChecker_Env.update_effect_lattice env1 sub1
-              | uu____13589 -> env1))
+              | uu____13708 -> env1))
   
 let (tc_decls :
   FStar_TypeChecker_Env.env ->
@@ -7844,34 +8023,34 @@ let (tc_decls :
   =
   fun env  ->
     fun ses  ->
-      let rec process_one_decl uu____13658 se =
-        match uu____13658 with
+      let rec process_one_decl uu____13777 se =
+        match uu____13777 with
         | (ses1,exports,env1,hidden) ->
-            ((let uu____13711 =
+            ((let uu____13830 =
                 FStar_TypeChecker_Env.debug env1 FStar_Options.Low  in
-              if uu____13711
+              if uu____13830
               then
-                let uu____13714 = FStar_Syntax_Print.sigelt_to_string se  in
+                let uu____13833 = FStar_Syntax_Print.sigelt_to_string se  in
                 FStar_Util.print1
-                  ">>>>>>>>>>>>>>Checking top-level decl %s\n" uu____13714
+                  ">>>>>>>>>>>>>>Checking top-level decl %s\n" uu____13833
               else ());
-             (let uu____13719 = tc_decl env1 se  in
-              match uu____13719 with
+             (let uu____13838 = tc_decl env1 se  in
+              match uu____13838 with
               | (ses',ses_elaborated,env2) ->
                   let ses'1 =
                     FStar_All.pipe_right ses'
                       (FStar_List.map
                          (fun se1  ->
-                            (let uu____13772 =
+                            (let uu____13891 =
                                FStar_TypeChecker_Env.debug env2
                                  (FStar_Options.Other "UF")
                                 in
-                             if uu____13772
+                             if uu____13891
                              then
-                               let uu____13776 =
+                               let uu____13895 =
                                  FStar_Syntax_Print.sigelt_to_string se1  in
                                FStar_Util.print1
-                                 "About to elim vars from %s\n" uu____13776
+                                 "About to elim vars from %s\n" uu____13895
                              else ());
                             FStar_TypeChecker_Normalize.elim_uvars env2 se1))
                      in
@@ -7879,17 +8058,17 @@ let (tc_decls :
                     FStar_All.pipe_right ses_elaborated
                       (FStar_List.map
                          (fun se1  ->
-                            (let uu____13792 =
+                            (let uu____13911 =
                                FStar_TypeChecker_Env.debug env2
                                  (FStar_Options.Other "UF")
                                 in
-                             if uu____13792
+                             if uu____13911
                              then
-                               let uu____13796 =
+                               let uu____13915 =
                                  FStar_Syntax_Print.sigelt_to_string se1  in
                                FStar_Util.print1
                                  "About to elim vars from (elaborated) %s\\m"
-                                 uu____13796
+                                 uu____13915
                              else ());
                             FStar_TypeChecker_Normalize.elim_uvars env2 se1))
                      in
@@ -7914,43 +8093,43 @@ let (tc_decls :
                            env2)
                        in
                     FStar_Syntax_Unionfind.reset ();
-                    (let uu____13814 =
+                    (let uu____13933 =
                        (FStar_Options.log_types ()) ||
                          (FStar_All.pipe_left
                             (FStar_TypeChecker_Env.debug env3)
                             (FStar_Options.Other "LogTypes"))
                         in
-                     if uu____13814
+                     if uu____13933
                      then
-                       let uu____13819 =
+                       let uu____13938 =
                          FStar_List.fold_left
                            (fun s  ->
                               fun se1  ->
-                                let uu____13828 =
-                                  let uu____13830 =
+                                let uu____13947 =
+                                  let uu____13949 =
                                     FStar_Syntax_Print.sigelt_to_string se1
                                      in
-                                  Prims.op_Hat uu____13830 "\n"  in
-                                Prims.op_Hat s uu____13828) "" ses'1
+                                  Prims.op_Hat uu____13949 "\n"  in
+                                Prims.op_Hat s uu____13947) "" ses'1
                           in
-                       FStar_Util.print1 "Checked: %s\n" uu____13819
+                       FStar_Util.print1 "Checked: %s\n" uu____13938
                      else ());
                     FStar_List.iter
                       (fun se1  ->
                          (env3.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.encode_sig
                            env3 se1) ses'1;
-                    (let uu____13840 =
-                       let uu____13849 =
+                    (let uu____13959 =
+                       let uu____13968 =
                          FStar_Options.use_extracted_interfaces ()  in
-                       if uu____13849
+                       if uu____13968
                        then ((FStar_List.rev_append ses'1 exports), [])
                        else
-                         (let accum_exports_hidden uu____13891 se1 =
-                            match uu____13891 with
+                         (let accum_exports_hidden uu____14010 se1 =
+                            match uu____14010 with
                             | (exports1,hidden1) ->
-                                let uu____13919 = for_export env3 hidden1 se1
+                                let uu____14038 = for_export env3 hidden1 se1
                                    in
-                                (match uu____13919 with
+                                (match uu____14038 with
                                  | (se_exported,hidden2) ->
                                      ((FStar_List.rev_append se_exported
                                          exports1), hidden2))
@@ -7958,33 +8137,33 @@ let (tc_decls :
                           FStar_List.fold_left accum_exports_hidden
                             (exports, hidden) ses'1)
                         in
-                     match uu____13840 with
+                     match uu____13959 with
                      | (exports1,hidden1) ->
                          (((FStar_List.rev_append ses'1 ses1), exports1,
                             env3, hidden1), ses_elaborated1))))))
          in
       let process_one_decl_timed acc se =
-        let uu____14073 = acc  in
-        match uu____14073 with
-        | (uu____14108,uu____14109,env1,uu____14111) ->
+        let uu____14192 = acc  in
+        match uu____14192 with
+        | (uu____14227,uu____14228,env1,uu____14230) ->
             let r =
-              let uu____14145 =
-                let uu____14149 =
-                  let uu____14151 = FStar_TypeChecker_Env.current_module env1
+              let uu____14264 =
+                let uu____14268 =
+                  let uu____14270 = FStar_TypeChecker_Env.current_module env1
                      in
-                  FStar_Ident.string_of_lid uu____14151  in
-                FStar_Pervasives_Native.Some uu____14149  in
+                  FStar_Ident.string_of_lid uu____14270  in
+                FStar_Pervasives_Native.Some uu____14268  in
               FStar_Profiling.profile
-                (fun uu____14174  -> process_one_decl acc se) uu____14145
+                (fun uu____14293  -> process_one_decl acc se) uu____14264
                 "FStar.TypeChecker.Tc.process_one_decl"
                in
-            ((let uu____14177 = FStar_Options.profile_group_by_decls ()  in
-              if uu____14177
+            ((let uu____14296 = FStar_Options.profile_group_by_decls ()  in
+              if uu____14296
               then
                 let tag =
                   match FStar_Syntax_Util.lids_of_sigelt se with
-                  | hd1::uu____14184 -> FStar_Ident.string_of_lid hd1
-                  | uu____14187 ->
+                  | hd1::uu____14303 -> FStar_Ident.string_of_lid hd1
+                  | uu____14306 ->
                       FStar_Range.string_of_range
                         (FStar_Syntax_Util.range_of_sigelt se)
                    in
@@ -7992,11 +8171,11 @@ let (tc_decls :
               else ());
              r)
          in
-      let uu____14192 =
+      let uu____14311 =
         FStar_Util.fold_flatten process_one_decl_timed ([], [], env, []) ses
          in
-      match uu____14192 with
-      | (ses1,exports,env1,uu____14240) ->
+      match uu____14311 with
+      | (ses1,exports,env1,uu____14359) ->
           ((FStar_List.rev_append ses1 []),
             (FStar_List.rev_append exports []), env1)
   
@@ -8009,193 +8188,193 @@ let (check_exports :
     fun modul  ->
       fun exports  ->
         let env1 =
-          let uu___1857_14278 = env  in
+          let uu___1877_14397 = env  in
           {
             FStar_TypeChecker_Env.solver =
-              (uu___1857_14278.FStar_TypeChecker_Env.solver);
+              (uu___1877_14397.FStar_TypeChecker_Env.solver);
             FStar_TypeChecker_Env.range =
-              (uu___1857_14278.FStar_TypeChecker_Env.range);
+              (uu___1877_14397.FStar_TypeChecker_Env.range);
             FStar_TypeChecker_Env.curmodule =
-              (uu___1857_14278.FStar_TypeChecker_Env.curmodule);
+              (uu___1877_14397.FStar_TypeChecker_Env.curmodule);
             FStar_TypeChecker_Env.gamma =
-              (uu___1857_14278.FStar_TypeChecker_Env.gamma);
+              (uu___1877_14397.FStar_TypeChecker_Env.gamma);
             FStar_TypeChecker_Env.gamma_sig =
-              (uu___1857_14278.FStar_TypeChecker_Env.gamma_sig);
+              (uu___1877_14397.FStar_TypeChecker_Env.gamma_sig);
             FStar_TypeChecker_Env.gamma_cache =
-              (uu___1857_14278.FStar_TypeChecker_Env.gamma_cache);
+              (uu___1877_14397.FStar_TypeChecker_Env.gamma_cache);
             FStar_TypeChecker_Env.modules =
-              (uu___1857_14278.FStar_TypeChecker_Env.modules);
+              (uu___1877_14397.FStar_TypeChecker_Env.modules);
             FStar_TypeChecker_Env.expected_typ =
-              (uu___1857_14278.FStar_TypeChecker_Env.expected_typ);
+              (uu___1877_14397.FStar_TypeChecker_Env.expected_typ);
             FStar_TypeChecker_Env.sigtab =
-              (uu___1857_14278.FStar_TypeChecker_Env.sigtab);
+              (uu___1877_14397.FStar_TypeChecker_Env.sigtab);
             FStar_TypeChecker_Env.attrtab =
-              (uu___1857_14278.FStar_TypeChecker_Env.attrtab);
+              (uu___1877_14397.FStar_TypeChecker_Env.attrtab);
             FStar_TypeChecker_Env.is_pattern =
-              (uu___1857_14278.FStar_TypeChecker_Env.is_pattern);
+              (uu___1877_14397.FStar_TypeChecker_Env.is_pattern);
             FStar_TypeChecker_Env.instantiate_imp =
-              (uu___1857_14278.FStar_TypeChecker_Env.instantiate_imp);
+              (uu___1877_14397.FStar_TypeChecker_Env.instantiate_imp);
             FStar_TypeChecker_Env.effects =
-              (uu___1857_14278.FStar_TypeChecker_Env.effects);
+              (uu___1877_14397.FStar_TypeChecker_Env.effects);
             FStar_TypeChecker_Env.generalize =
-              (uu___1857_14278.FStar_TypeChecker_Env.generalize);
+              (uu___1877_14397.FStar_TypeChecker_Env.generalize);
             FStar_TypeChecker_Env.letrecs =
-              (uu___1857_14278.FStar_TypeChecker_Env.letrecs);
+              (uu___1877_14397.FStar_TypeChecker_Env.letrecs);
             FStar_TypeChecker_Env.top_level = true;
             FStar_TypeChecker_Env.check_uvars =
-              (uu___1857_14278.FStar_TypeChecker_Env.check_uvars);
+              (uu___1877_14397.FStar_TypeChecker_Env.check_uvars);
             FStar_TypeChecker_Env.use_eq =
-              (uu___1857_14278.FStar_TypeChecker_Env.use_eq);
+              (uu___1877_14397.FStar_TypeChecker_Env.use_eq);
             FStar_TypeChecker_Env.is_iface =
-              (uu___1857_14278.FStar_TypeChecker_Env.is_iface);
+              (uu___1877_14397.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit =
-              (uu___1857_14278.FStar_TypeChecker_Env.admit);
+              (uu___1877_14397.FStar_TypeChecker_Env.admit);
             FStar_TypeChecker_Env.lax = true;
             FStar_TypeChecker_Env.lax_universes = true;
             FStar_TypeChecker_Env.phase1 =
-              (uu___1857_14278.FStar_TypeChecker_Env.phase1);
+              (uu___1877_14397.FStar_TypeChecker_Env.phase1);
             FStar_TypeChecker_Env.failhard =
-              (uu___1857_14278.FStar_TypeChecker_Env.failhard);
+              (uu___1877_14397.FStar_TypeChecker_Env.failhard);
             FStar_TypeChecker_Env.nosynth =
-              (uu___1857_14278.FStar_TypeChecker_Env.nosynth);
+              (uu___1877_14397.FStar_TypeChecker_Env.nosynth);
             FStar_TypeChecker_Env.uvar_subtyping =
-              (uu___1857_14278.FStar_TypeChecker_Env.uvar_subtyping);
+              (uu___1877_14397.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.tc_term =
-              (uu___1857_14278.FStar_TypeChecker_Env.tc_term);
+              (uu___1877_14397.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.type_of =
-              (uu___1857_14278.FStar_TypeChecker_Env.type_of);
+              (uu___1877_14397.FStar_TypeChecker_Env.type_of);
             FStar_TypeChecker_Env.universe_of =
-              (uu___1857_14278.FStar_TypeChecker_Env.universe_of);
+              (uu___1877_14397.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.check_type_of =
-              (uu___1857_14278.FStar_TypeChecker_Env.check_type_of);
+              (uu___1877_14397.FStar_TypeChecker_Env.check_type_of);
             FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___1857_14278.FStar_TypeChecker_Env.use_bv_sorts);
+              (uu___1877_14397.FStar_TypeChecker_Env.use_bv_sorts);
             FStar_TypeChecker_Env.qtbl_name_and_index =
-              (uu___1857_14278.FStar_TypeChecker_Env.qtbl_name_and_index);
+              (uu___1877_14397.FStar_TypeChecker_Env.qtbl_name_and_index);
             FStar_TypeChecker_Env.normalized_eff_names =
-              (uu___1857_14278.FStar_TypeChecker_Env.normalized_eff_names);
+              (uu___1877_14397.FStar_TypeChecker_Env.normalized_eff_names);
             FStar_TypeChecker_Env.fv_delta_depths =
-              (uu___1857_14278.FStar_TypeChecker_Env.fv_delta_depths);
+              (uu___1877_14397.FStar_TypeChecker_Env.fv_delta_depths);
             FStar_TypeChecker_Env.proof_ns =
-              (uu___1857_14278.FStar_TypeChecker_Env.proof_ns);
+              (uu___1877_14397.FStar_TypeChecker_Env.proof_ns);
             FStar_TypeChecker_Env.synth_hook =
-              (uu___1857_14278.FStar_TypeChecker_Env.synth_hook);
+              (uu___1877_14397.FStar_TypeChecker_Env.synth_hook);
             FStar_TypeChecker_Env.splice =
-              (uu___1857_14278.FStar_TypeChecker_Env.splice);
+              (uu___1877_14397.FStar_TypeChecker_Env.splice);
             FStar_TypeChecker_Env.postprocess =
-              (uu___1857_14278.FStar_TypeChecker_Env.postprocess);
+              (uu___1877_14397.FStar_TypeChecker_Env.postprocess);
             FStar_TypeChecker_Env.is_native_tactic =
-              (uu___1857_14278.FStar_TypeChecker_Env.is_native_tactic);
+              (uu___1877_14397.FStar_TypeChecker_Env.is_native_tactic);
             FStar_TypeChecker_Env.identifier_info =
-              (uu___1857_14278.FStar_TypeChecker_Env.identifier_info);
+              (uu___1877_14397.FStar_TypeChecker_Env.identifier_info);
             FStar_TypeChecker_Env.tc_hooks =
-              (uu___1857_14278.FStar_TypeChecker_Env.tc_hooks);
+              (uu___1877_14397.FStar_TypeChecker_Env.tc_hooks);
             FStar_TypeChecker_Env.dsenv =
-              (uu___1857_14278.FStar_TypeChecker_Env.dsenv);
+              (uu___1877_14397.FStar_TypeChecker_Env.dsenv);
             FStar_TypeChecker_Env.nbe =
-              (uu___1857_14278.FStar_TypeChecker_Env.nbe);
+              (uu___1877_14397.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___1857_14278.FStar_TypeChecker_Env.strict_args_tab);
+              (uu___1877_14397.FStar_TypeChecker_Env.strict_args_tab);
             FStar_TypeChecker_Env.erasable_types_tab =
-              (uu___1857_14278.FStar_TypeChecker_Env.erasable_types_tab)
+              (uu___1877_14397.FStar_TypeChecker_Env.erasable_types_tab)
           }  in
         let check_term lid univs1 t =
-          let uu____14298 = FStar_Syntax_Subst.open_univ_vars univs1 t  in
-          match uu____14298 with
+          let uu____14417 = FStar_Syntax_Subst.open_univ_vars univs1 t  in
+          match uu____14417 with
           | (univs2,t1) ->
-              ((let uu____14306 =
-                  let uu____14308 =
-                    let uu____14314 =
+              ((let uu____14425 =
+                  let uu____14427 =
+                    let uu____14433 =
                       FStar_TypeChecker_Env.set_current_module env1
                         modul.FStar_Syntax_Syntax.name
                        in
-                    FStar_TypeChecker_Env.debug uu____14314  in
-                  FStar_All.pipe_left uu____14308
+                    FStar_TypeChecker_Env.debug uu____14433  in
+                  FStar_All.pipe_left uu____14427
                     (FStar_Options.Other "Exports")
                    in
-                if uu____14306
+                if uu____14425
                 then
-                  let uu____14318 = FStar_Syntax_Print.lid_to_string lid  in
-                  let uu____14320 =
-                    let uu____14322 =
+                  let uu____14437 = FStar_Syntax_Print.lid_to_string lid  in
+                  let uu____14439 =
+                    let uu____14441 =
                       FStar_All.pipe_right univs2
                         (FStar_List.map
                            (fun x  ->
                               FStar_Syntax_Print.univ_to_string
                                 (FStar_Syntax_Syntax.U_name x)))
                        in
-                    FStar_All.pipe_right uu____14322
+                    FStar_All.pipe_right uu____14441
                       (FStar_String.concat ", ")
                      in
-                  let uu____14339 = FStar_Syntax_Print.term_to_string t1  in
+                  let uu____14458 = FStar_Syntax_Print.term_to_string t1  in
                   FStar_Util.print3 "Checking for export %s <%s> : %s\n"
-                    uu____14318 uu____14320 uu____14339
+                    uu____14437 uu____14439 uu____14458
                 else ());
                (let env2 = FStar_TypeChecker_Env.push_univ_vars env1 univs2
                    in
-                let uu____14345 =
+                let uu____14464 =
                   FStar_TypeChecker_TcTerm.tc_trivial_guard env2 t1  in
-                FStar_All.pipe_right uu____14345 (fun a2  -> ())))
+                FStar_All.pipe_right uu____14464 (fun a2  -> ())))
            in
         let check_term1 lid univs1 t =
-          (let uu____14371 =
-             let uu____14373 =
+          (let uu____14490 =
+             let uu____14492 =
                FStar_Syntax_Print.lid_to_string
                  modul.FStar_Syntax_Syntax.name
                 in
-             let uu____14375 = FStar_Syntax_Print.lid_to_string lid  in
+             let uu____14494 = FStar_Syntax_Print.lid_to_string lid  in
              FStar_Util.format2
                "Interface of %s violates its abstraction (add a 'private' qualifier to '%s'?)"
-               uu____14373 uu____14375
+               uu____14492 uu____14494
               in
-           FStar_Errors.message_prefix.FStar_Errors.set_prefix uu____14371);
+           FStar_Errors.message_prefix.FStar_Errors.set_prefix uu____14490);
           check_term lid univs1 t;
           FStar_Errors.message_prefix.FStar_Errors.clear_prefix ()  in
         let rec check_sigelt se =
           match se.FStar_Syntax_Syntax.sigel with
-          | FStar_Syntax_Syntax.Sig_bundle (ses,uu____14386) ->
-              let uu____14395 =
-                let uu____14397 =
+          | FStar_Syntax_Syntax.Sig_bundle (ses,uu____14505) ->
+              let uu____14514 =
+                let uu____14516 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                     (FStar_List.contains FStar_Syntax_Syntax.Private)
                    in
-                Prims.op_Negation uu____14397  in
-              if uu____14395
+                Prims.op_Negation uu____14516  in
+              if uu____14514
               then FStar_All.pipe_right ses (FStar_List.iter check_sigelt)
               else ()
           | FStar_Syntax_Syntax.Sig_inductive_typ
-              (l,univs1,binders,typ,uu____14411,uu____14412) ->
+              (l,univs1,binders,typ,uu____14530,uu____14531) ->
               let t =
-                let uu____14424 =
-                  let uu____14431 =
-                    let uu____14432 =
-                      let uu____14447 = FStar_Syntax_Syntax.mk_Total typ  in
-                      (binders, uu____14447)  in
-                    FStar_Syntax_Syntax.Tm_arrow uu____14432  in
-                  FStar_Syntax_Syntax.mk uu____14431  in
-                uu____14424 FStar_Pervasives_Native.None
+                let uu____14543 =
+                  let uu____14550 =
+                    let uu____14551 =
+                      let uu____14566 = FStar_Syntax_Syntax.mk_Total typ  in
+                      (binders, uu____14566)  in
+                    FStar_Syntax_Syntax.Tm_arrow uu____14551  in
+                  FStar_Syntax_Syntax.mk uu____14550  in
+                uu____14543 FStar_Pervasives_Native.None
                   se.FStar_Syntax_Syntax.sigrng
                  in
               check_term1 l univs1 t
           | FStar_Syntax_Syntax.Sig_datacon
-              (l,univs1,t,uu____14463,uu____14464,uu____14465) ->
+              (l,univs1,t,uu____14582,uu____14583,uu____14584) ->
               check_term1 l univs1 t
           | FStar_Syntax_Syntax.Sig_declare_typ (l,univs1,t) ->
-              let uu____14475 =
-                let uu____14477 =
+              let uu____14594 =
+                let uu____14596 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                     (FStar_List.contains FStar_Syntax_Syntax.Private)
                    in
-                Prims.op_Negation uu____14477  in
-              if uu____14475 then check_term1 l univs1 t else ()
-          | FStar_Syntax_Syntax.Sig_let ((uu____14485,lbs),uu____14487) ->
-              let uu____14498 =
-                let uu____14500 =
+                Prims.op_Negation uu____14596  in
+              if uu____14594 then check_term1 l univs1 t else ()
+          | FStar_Syntax_Syntax.Sig_let ((uu____14604,lbs),uu____14606) ->
+              let uu____14617 =
+                let uu____14619 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                     (FStar_List.contains FStar_Syntax_Syntax.Private)
                    in
-                Prims.op_Negation uu____14500  in
-              if uu____14498
+                Prims.op_Negation uu____14619  in
+              if uu____14617
               then
                 FStar_All.pipe_right lbs
                   (FStar_List.iter
@@ -8209,13 +8388,13 @@ let (check_exports :
               else ()
           | FStar_Syntax_Syntax.Sig_effect_abbrev
               (l,univs1,binders,comp,flags) ->
-              let uu____14523 =
-                let uu____14525 =
+              let uu____14642 =
+                let uu____14644 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                     (FStar_List.contains FStar_Syntax_Syntax.Private)
                    in
-                Prims.op_Negation uu____14525  in
-              if uu____14523
+                Prims.op_Negation uu____14644  in
+              if uu____14642
               then
                 let arrow1 =
                   FStar_Syntax_Syntax.mk
@@ -8225,18 +8404,18 @@ let (check_exports :
                    in
                 check_term1 l univs1 arrow1
               else ()
-          | FStar_Syntax_Syntax.Sig_main uu____14546 -> ()
-          | FStar_Syntax_Syntax.Sig_assume uu____14547 -> ()
-          | FStar_Syntax_Syntax.Sig_new_effect uu____14554 -> ()
-          | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____14555 -> ()
-          | FStar_Syntax_Syntax.Sig_sub_effect uu____14556 -> ()
-          | FStar_Syntax_Syntax.Sig_splice uu____14557 -> ()
-          | FStar_Syntax_Syntax.Sig_pragma uu____14564 -> ()  in
-        let uu____14565 =
+          | FStar_Syntax_Syntax.Sig_main uu____14665 -> ()
+          | FStar_Syntax_Syntax.Sig_assume uu____14666 -> ()
+          | FStar_Syntax_Syntax.Sig_new_effect uu____14673 -> ()
+          | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____14674 -> ()
+          | FStar_Syntax_Syntax.Sig_sub_effect uu____14675 -> ()
+          | FStar_Syntax_Syntax.Sig_splice uu____14676 -> ()
+          | FStar_Syntax_Syntax.Sig_pragma uu____14683 -> ()  in
+        let uu____14684 =
           FStar_Ident.lid_equals modul.FStar_Syntax_Syntax.name
             FStar_Parser_Const.prims_lid
            in
-        if uu____14565 then () else FStar_List.iter check_sigelt exports
+        if uu____14684 then () else FStar_List.iter check_sigelt exports
   
 let (extract_interface :
   FStar_TypeChecker_Env.env ->
@@ -8284,149 +8463,153 @@ let (extract_interface :
           (fun q  ->
              match q with
              | FStar_Syntax_Syntax.Discriminator l -> true
-             | FStar_Syntax_Syntax.Projector (l,uu____14671) -> true
-             | uu____14673 -> false) quals
+             | FStar_Syntax_Syntax.Projector (l,uu____14790) -> true
+             | uu____14792 -> false) quals
          in
       let vals_of_abstract_inductive s =
         let mk_typ_for_abstract_inductive bs t r =
           match bs with
           | [] -> t
-          | uu____14703 ->
+          | uu____14822 ->
               (match t.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_arrow (bs',c) ->
                    FStar_Syntax_Syntax.mk
                      (FStar_Syntax_Syntax.Tm_arrow
                         ((FStar_List.append bs bs'), c))
                      FStar_Pervasives_Native.None r
-               | uu____14742 ->
-                   let uu____14743 =
-                     let uu____14750 =
-                       let uu____14751 =
-                         let uu____14766 = FStar_Syntax_Syntax.mk_Total t  in
-                         (bs, uu____14766)  in
-                       FStar_Syntax_Syntax.Tm_arrow uu____14751  in
-                     FStar_Syntax_Syntax.mk uu____14750  in
-                   uu____14743 FStar_Pervasives_Native.None r)
+               | uu____14861 ->
+                   let uu____14862 =
+                     let uu____14869 =
+                       let uu____14870 =
+                         let uu____14885 = FStar_Syntax_Syntax.mk_Total t  in
+                         (bs, uu____14885)  in
+                       FStar_Syntax_Syntax.Tm_arrow uu____14870  in
+                     FStar_Syntax_Syntax.mk uu____14869  in
+                   uu____14862 FStar_Pervasives_Native.None r)
            in
         match s.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_inductive_typ
-            (lid,uvs,bs,t,uu____14783,uu____14784) ->
+            (lid,uvs,bs,t,uu____14902,uu____14903) ->
             let s1 =
-              let uu___1983_14794 = s  in
-              let uu____14795 =
-                let uu____14796 =
-                  let uu____14803 =
+              let uu___2003_14913 = s  in
+              let uu____14914 =
+                let uu____14915 =
+                  let uu____14922 =
                     mk_typ_for_abstract_inductive bs t
                       s.FStar_Syntax_Syntax.sigrng
                      in
-                  (lid, uvs, uu____14803)  in
-                FStar_Syntax_Syntax.Sig_declare_typ uu____14796  in
-              let uu____14804 =
-                let uu____14807 =
-                  let uu____14810 =
+                  (lid, uvs, uu____14922)  in
+                FStar_Syntax_Syntax.Sig_declare_typ uu____14915  in
+              let uu____14923 =
+                let uu____14926 =
+                  let uu____14929 =
                     filter_out_abstract_and_noeq
                       s.FStar_Syntax_Syntax.sigquals
                      in
-                  FStar_Syntax_Syntax.New :: uu____14810  in
-                FStar_Syntax_Syntax.Assumption :: uu____14807  in
+                  FStar_Syntax_Syntax.New :: uu____14929  in
+                FStar_Syntax_Syntax.Assumption :: uu____14926  in
               {
-                FStar_Syntax_Syntax.sigel = uu____14795;
+                FStar_Syntax_Syntax.sigel = uu____14914;
                 FStar_Syntax_Syntax.sigrng =
-                  (uu___1983_14794.FStar_Syntax_Syntax.sigrng);
-                FStar_Syntax_Syntax.sigquals = uu____14804;
+                  (uu___2003_14913.FStar_Syntax_Syntax.sigrng);
+                FStar_Syntax_Syntax.sigquals = uu____14923;
                 FStar_Syntax_Syntax.sigmeta =
-                  (uu___1983_14794.FStar_Syntax_Syntax.sigmeta);
+                  (uu___2003_14913.FStar_Syntax_Syntax.sigmeta);
                 FStar_Syntax_Syntax.sigattrs =
-                  (uu___1983_14794.FStar_Syntax_Syntax.sigattrs)
+                  (uu___2003_14913.FStar_Syntax_Syntax.sigattrs);
+                FStar_Syntax_Syntax.sigopts =
+                  (uu___2003_14913.FStar_Syntax_Syntax.sigopts)
               }  in
             [s1]
-        | uu____14813 -> failwith "Impossible!"  in
-      let val_of_lb s lid uu____14838 lbdef =
-        match uu____14838 with
+        | uu____14932 -> failwith "Impossible!"  in
+      let val_of_lb s lid uu____14957 lbdef =
+        match uu____14957 with
         | (uvs,t) ->
             let attrs =
-              let uu____14849 =
+              let uu____14968 =
                 FStar_TypeChecker_Util.must_erase_for_extraction en lbdef  in
-              if uu____14849
+              if uu____14968
               then
-                let uu____14854 =
-                  let uu____14855 =
+                let uu____14973 =
+                  let uu____14974 =
                     FStar_Syntax_Syntax.lid_as_fv
                       FStar_Parser_Const.must_erase_for_extraction_attr
                       FStar_Syntax_Syntax.delta_constant
                       FStar_Pervasives_Native.None
                      in
-                  FStar_All.pipe_right uu____14855
+                  FStar_All.pipe_right uu____14974
                     FStar_Syntax_Syntax.fv_to_tm
                    in
-                uu____14854 :: (s.FStar_Syntax_Syntax.sigattrs)
+                uu____14973 :: (s.FStar_Syntax_Syntax.sigattrs)
               else s.FStar_Syntax_Syntax.sigattrs  in
-            let uu___1996_14858 = s  in
-            let uu____14859 =
-              let uu____14862 =
+            let uu___2016_14977 = s  in
+            let uu____14978 =
+              let uu____14981 =
                 filter_out_abstract_and_inline s.FStar_Syntax_Syntax.sigquals
                  in
-              FStar_Syntax_Syntax.Assumption :: uu____14862  in
+              FStar_Syntax_Syntax.Assumption :: uu____14981  in
             {
               FStar_Syntax_Syntax.sigel =
                 (FStar_Syntax_Syntax.Sig_declare_typ (lid, uvs, t));
               FStar_Syntax_Syntax.sigrng =
-                (uu___1996_14858.FStar_Syntax_Syntax.sigrng);
-              FStar_Syntax_Syntax.sigquals = uu____14859;
+                (uu___2016_14977.FStar_Syntax_Syntax.sigrng);
+              FStar_Syntax_Syntax.sigquals = uu____14978;
               FStar_Syntax_Syntax.sigmeta =
-                (uu___1996_14858.FStar_Syntax_Syntax.sigmeta);
-              FStar_Syntax_Syntax.sigattrs = attrs
+                (uu___2016_14977.FStar_Syntax_Syntax.sigmeta);
+              FStar_Syntax_Syntax.sigattrs = attrs;
+              FStar_Syntax_Syntax.sigopts =
+                (uu___2016_14977.FStar_Syntax_Syntax.sigopts)
             }
          in
       let should_keep_lbdef t =
         let comp_effect_name1 c =
           match c.FStar_Syntax_Syntax.n with
           | FStar_Syntax_Syntax.Comp c1 -> c1.FStar_Syntax_Syntax.effect_name
-          | uu____14880 -> failwith "Impossible!"  in
+          | uu____14999 -> failwith "Impossible!"  in
         let c_opt =
-          let uu____14887 = FStar_Syntax_Util.is_unit t  in
-          if uu____14887
+          let uu____15006 = FStar_Syntax_Util.is_unit t  in
+          if uu____15006
           then
-            let uu____14894 = FStar_Syntax_Syntax.mk_Total t  in
-            FStar_Pervasives_Native.Some uu____14894
+            let uu____15013 = FStar_Syntax_Syntax.mk_Total t  in
+            FStar_Pervasives_Native.Some uu____15013
           else
-            (let uu____14901 =
-               let uu____14902 = FStar_Syntax_Subst.compress t  in
-               uu____14902.FStar_Syntax_Syntax.n  in
-             match uu____14901 with
-             | FStar_Syntax_Syntax.Tm_arrow (uu____14909,c) ->
+            (let uu____15020 =
+               let uu____15021 = FStar_Syntax_Subst.compress t  in
+               uu____15021.FStar_Syntax_Syntax.n  in
+             match uu____15020 with
+             | FStar_Syntax_Syntax.Tm_arrow (uu____15028,c) ->
                  FStar_Pervasives_Native.Some c
-             | uu____14933 -> FStar_Pervasives_Native.None)
+             | uu____15052 -> FStar_Pervasives_Native.None)
            in
         match c_opt with
         | FStar_Pervasives_Native.None  -> true
         | FStar_Pervasives_Native.Some c ->
-            let uu____14945 = FStar_Syntax_Util.is_lemma_comp c  in
-            if uu____14945
+            let uu____15064 = FStar_Syntax_Util.is_lemma_comp c  in
+            if uu____15064
             then false
             else
-              (let uu____14952 = FStar_Syntax_Util.is_pure_or_ghost_comp c
+              (let uu____15071 = FStar_Syntax_Util.is_pure_or_ghost_comp c
                   in
-               if uu____14952
+               if uu____15071
                then true
                else
-                 (let uu____14959 = comp_effect_name1 c  in
-                  FStar_TypeChecker_Env.is_reifiable_effect en uu____14959))
+                 (let uu____15078 = comp_effect_name1 c  in
+                  FStar_TypeChecker_Env.is_reifiable_effect en uu____15078))
          in
       let extract_sigelt s =
-        (let uu____14971 =
+        (let uu____15090 =
            FStar_TypeChecker_Env.debug en FStar_Options.Extreme  in
-         if uu____14971
+         if uu____15090
          then
-           let uu____14974 = FStar_Syntax_Print.sigelt_to_string s  in
-           FStar_Util.print1 "Extracting interface for %s\n" uu____14974
+           let uu____15093 = FStar_Syntax_Print.sigelt_to_string s  in
+           FStar_Util.print1 "Extracting interface for %s\n" uu____15093
          else ());
         (match s.FStar_Syntax_Syntax.sigel with
-         | FStar_Syntax_Syntax.Sig_inductive_typ uu____14981 ->
+         | FStar_Syntax_Syntax.Sig_inductive_typ uu____15100 ->
              failwith "Impossible! extract_interface: bare data constructor"
-         | FStar_Syntax_Syntax.Sig_datacon uu____15001 ->
+         | FStar_Syntax_Syntax.Sig_datacon uu____15120 ->
              failwith "Impossible! extract_interface: bare data constructor"
-         | FStar_Syntax_Syntax.Sig_splice uu____15020 ->
+         | FStar_Syntax_Syntax.Sig_splice uu____15139 ->
              failwith
                "Impossible! extract_interface: trying to extract splice"
          | FStar_Syntax_Syntax.Sig_bundle (sigelts,lidents1) ->
@@ -8438,72 +8621,74 @@ let (extract_interface :
                        fun s1  ->
                          match s1.FStar_Syntax_Syntax.sigel with
                          | FStar_Syntax_Syntax.Sig_inductive_typ
-                             (lid,uu____15066,uu____15067,uu____15068,uu____15069,uu____15070)
+                             (lid,uu____15185,uu____15186,uu____15187,uu____15188,uu____15189)
                              ->
-                             ((let uu____15080 =
-                                 let uu____15083 =
+                             ((let uu____15199 =
+                                 let uu____15202 =
                                    FStar_ST.op_Bang abstract_inductive_tycons
                                     in
-                                 lid :: uu____15083  in
+                                 lid :: uu____15202  in
                                FStar_ST.op_Colon_Equals
-                                 abstract_inductive_tycons uu____15080);
-                              (let uu____15132 =
+                                 abstract_inductive_tycons uu____15199);
+                              (let uu____15251 =
                                  vals_of_abstract_inductive s1  in
-                               FStar_List.append uu____15132 sigelts1))
+                               FStar_List.append uu____15251 sigelts1))
                          | FStar_Syntax_Syntax.Sig_datacon
-                             (lid,uu____15136,uu____15137,uu____15138,uu____15139,uu____15140)
+                             (lid,uu____15255,uu____15256,uu____15257,uu____15258,uu____15259)
                              ->
-                             ((let uu____15148 =
-                                 let uu____15151 =
+                             ((let uu____15267 =
+                                 let uu____15270 =
                                    FStar_ST.op_Bang
                                      abstract_inductive_datacons
                                     in
-                                 lid :: uu____15151  in
+                                 lid :: uu____15270  in
                                FStar_ST.op_Colon_Equals
-                                 abstract_inductive_datacons uu____15148);
+                                 abstract_inductive_datacons uu____15267);
                               sigelts1)
-                         | uu____15200 ->
+                         | uu____15319 ->
                              failwith
                                "Impossible! extract_interface: Sig_bundle can't have anything other than Sig_inductive_typ and Sig_datacon")
                     [])
              else [s]
          | FStar_Syntax_Syntax.Sig_declare_typ (lid,uvs,t) ->
-             let uu____15209 =
+             let uu____15328 =
                is_projector_or_discriminator_of_an_abstract_inductive
                  s.FStar_Syntax_Syntax.sigquals
                 in
-             if uu____15209
+             if uu____15328
              then []
              else
                if is_assume s.FStar_Syntax_Syntax.sigquals
                then
-                 (let uu____15219 =
-                    let uu___2060_15220 = s  in
-                    let uu____15221 =
+                 (let uu____15338 =
+                    let uu___2080_15339 = s  in
+                    let uu____15340 =
                       filter_out_abstract s.FStar_Syntax_Syntax.sigquals  in
                     {
                       FStar_Syntax_Syntax.sigel =
-                        (uu___2060_15220.FStar_Syntax_Syntax.sigel);
+                        (uu___2080_15339.FStar_Syntax_Syntax.sigel);
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___2060_15220.FStar_Syntax_Syntax.sigrng);
-                      FStar_Syntax_Syntax.sigquals = uu____15221;
+                        (uu___2080_15339.FStar_Syntax_Syntax.sigrng);
+                      FStar_Syntax_Syntax.sigquals = uu____15340;
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___2060_15220.FStar_Syntax_Syntax.sigmeta);
+                        (uu___2080_15339.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___2060_15220.FStar_Syntax_Syntax.sigattrs)
+                        (uu___2080_15339.FStar_Syntax_Syntax.sigattrs);
+                      FStar_Syntax_Syntax.sigopts =
+                        (uu___2080_15339.FStar_Syntax_Syntax.sigopts)
                     }  in
-                  [uu____15219])
+                  [uu____15338])
                else []
          | FStar_Syntax_Syntax.Sig_let (lbs,lids) ->
-             let uu____15232 =
+             let uu____15351 =
                is_projector_or_discriminator_of_an_abstract_inductive
                  s.FStar_Syntax_Syntax.sigquals
                 in
-             if uu____15232
+             if uu____15351
              then []
              else
-               (let uu____15239 = lbs  in
-                match uu____15239 with
+               (let uu____15358 = lbs  in
+                match uu____15358 with
                 | (flbs,slbs) ->
                     let typs_and_defs =
                       FStar_All.pipe_right slbs
@@ -8515,17 +8700,17 @@ let (extract_interface :
                        in
                     let is_lemma1 =
                       FStar_List.existsML
-                        (fun uu____15301  ->
-                           match uu____15301 with
-                           | (uu____15309,t,uu____15311) ->
+                        (fun uu____15420  ->
+                           match uu____15420 with
+                           | (uu____15428,t,uu____15430) ->
                                FStar_All.pipe_right t
                                  FStar_Syntax_Util.is_lemma) typs_and_defs
                        in
                     let vals =
                       FStar_List.map2
                         (fun lid  ->
-                           fun uu____15328  ->
-                             match uu____15328 with
+                           fun uu____15447  ->
+                             match uu____15447 with
                              | (u,t,d) -> val_of_lb s lid (u, t) d) lids
                         typs_and_defs
                        in
@@ -8537,9 +8722,9 @@ let (extract_interface :
                     else
                       (let should_keep_defs =
                          FStar_List.existsML
-                           (fun uu____15355  ->
-                              match uu____15355 with
-                              | (uu____15363,t,uu____15365) ->
+                           (fun uu____15474  ->
+                              match uu____15474 with
+                              | (uu____15482,t,uu____15484) ->
                                   FStar_All.pipe_right t should_keep_lbdef)
                            typs_and_defs
                           in
@@ -8547,75 +8732,79 @@ let (extract_interface :
          | FStar_Syntax_Syntax.Sig_main t ->
              failwith
                "Did not anticipate main would arise when extracting interfaces!"
-         | FStar_Syntax_Syntax.Sig_assume (lid,uu____15377,uu____15378) ->
+         | FStar_Syntax_Syntax.Sig_assume (lid,uu____15496,uu____15497) ->
              let is_haseq = FStar_TypeChecker_TcInductive.is_haseq_lid lid
                 in
              if is_haseq
              then
                let is_haseq_of_abstract_inductive =
-                 let uu____15386 = FStar_ST.op_Bang abstract_inductive_tycons
+                 let uu____15505 = FStar_ST.op_Bang abstract_inductive_tycons
                     in
                  FStar_List.existsML
                    (fun l  ->
-                      let uu____15415 =
+                      let uu____15534 =
                         FStar_TypeChecker_TcInductive.get_haseq_axiom_lid l
                          in
-                      FStar_Ident.lid_equals lid uu____15415) uu____15386
+                      FStar_Ident.lid_equals lid uu____15534) uu____15505
                   in
                (if is_haseq_of_abstract_inductive
                 then
-                  let uu____15419 =
-                    let uu___2102_15420 = s  in
-                    let uu____15421 =
+                  let uu____15538 =
+                    let uu___2122_15539 = s  in
+                    let uu____15540 =
                       filter_out_abstract s.FStar_Syntax_Syntax.sigquals  in
                     {
                       FStar_Syntax_Syntax.sigel =
-                        (uu___2102_15420.FStar_Syntax_Syntax.sigel);
+                        (uu___2122_15539.FStar_Syntax_Syntax.sigel);
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___2102_15420.FStar_Syntax_Syntax.sigrng);
-                      FStar_Syntax_Syntax.sigquals = uu____15421;
+                        (uu___2122_15539.FStar_Syntax_Syntax.sigrng);
+                      FStar_Syntax_Syntax.sigquals = uu____15540;
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___2102_15420.FStar_Syntax_Syntax.sigmeta);
+                        (uu___2122_15539.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___2102_15420.FStar_Syntax_Syntax.sigattrs)
+                        (uu___2122_15539.FStar_Syntax_Syntax.sigattrs);
+                      FStar_Syntax_Syntax.sigopts =
+                        (uu___2122_15539.FStar_Syntax_Syntax.sigopts)
                     }  in
-                  [uu____15419]
+                  [uu____15538]
                 else [])
              else
-               (let uu____15428 =
-                  let uu___2104_15429 = s  in
-                  let uu____15430 =
+               (let uu____15547 =
+                  let uu___2124_15548 = s  in
+                  let uu____15549 =
                     filter_out_abstract s.FStar_Syntax_Syntax.sigquals  in
                   {
                     FStar_Syntax_Syntax.sigel =
-                      (uu___2104_15429.FStar_Syntax_Syntax.sigel);
+                      (uu___2124_15548.FStar_Syntax_Syntax.sigel);
                     FStar_Syntax_Syntax.sigrng =
-                      (uu___2104_15429.FStar_Syntax_Syntax.sigrng);
-                    FStar_Syntax_Syntax.sigquals = uu____15430;
+                      (uu___2124_15548.FStar_Syntax_Syntax.sigrng);
+                    FStar_Syntax_Syntax.sigquals = uu____15549;
                     FStar_Syntax_Syntax.sigmeta =
-                      (uu___2104_15429.FStar_Syntax_Syntax.sigmeta);
+                      (uu___2124_15548.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
-                      (uu___2104_15429.FStar_Syntax_Syntax.sigattrs)
+                      (uu___2124_15548.FStar_Syntax_Syntax.sigattrs);
+                    FStar_Syntax_Syntax.sigopts =
+                      (uu___2124_15548.FStar_Syntax_Syntax.sigopts)
                   }  in
-                [uu____15428])
-         | FStar_Syntax_Syntax.Sig_new_effect uu____15433 -> [s]
-         | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____15434 -> [s]
-         | FStar_Syntax_Syntax.Sig_sub_effect uu____15435 -> [s]
-         | FStar_Syntax_Syntax.Sig_effect_abbrev uu____15436 -> [s]
-         | FStar_Syntax_Syntax.Sig_pragma uu____15449 -> [s])
+                [uu____15547])
+         | FStar_Syntax_Syntax.Sig_new_effect uu____15552 -> [s]
+         | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____15553 -> [s]
+         | FStar_Syntax_Syntax.Sig_sub_effect uu____15554 -> [s]
+         | FStar_Syntax_Syntax.Sig_effect_abbrev uu____15555 -> [s]
+         | FStar_Syntax_Syntax.Sig_pragma uu____15568 -> [s])
          in
-      let uu___2116_15450 = m  in
-      let uu____15451 =
-        let uu____15452 =
+      let uu___2136_15569 = m  in
+      let uu____15570 =
+        let uu____15571 =
           FStar_All.pipe_right m.FStar_Syntax_Syntax.declarations
             (FStar_List.map extract_sigelt)
            in
-        FStar_All.pipe_right uu____15452 FStar_List.flatten  in
+        FStar_All.pipe_right uu____15571 FStar_List.flatten  in
       {
-        FStar_Syntax_Syntax.name = (uu___2116_15450.FStar_Syntax_Syntax.name);
-        FStar_Syntax_Syntax.declarations = uu____15451;
+        FStar_Syntax_Syntax.name = (uu___2136_15569.FStar_Syntax_Syntax.name);
+        FStar_Syntax_Syntax.declarations = uu____15570;
         FStar_Syntax_Syntax.exports =
-          (uu___2116_15450.FStar_Syntax_Syntax.exports);
+          (uu___2136_15569.FStar_Syntax_Syntax.exports);
         FStar_Syntax_Syntax.is_interface = true
       }
   
@@ -8628,7 +8817,7 @@ let (snapshot_context :
   fun env  ->
     fun msg  ->
       FStar_Util.atomically
-        (fun uu____15503  -> FStar_TypeChecker_Env.snapshot env msg)
+        (fun uu____15622  -> FStar_TypeChecker_Env.snapshot env msg)
   
 let (rollback_context :
   FStar_TypeChecker_Env.solver_t ->
@@ -8641,7 +8830,7 @@ let (rollback_context :
     fun msg  ->
       fun depth  ->
         FStar_Util.atomically
-          (fun uu____15550  ->
+          (fun uu____15669  ->
              let env = FStar_TypeChecker_Env.rollback solver msg depth  in
              env)
   
@@ -8649,8 +8838,8 @@ let (push_context :
   FStar_TypeChecker_Env.env -> Prims.string -> FStar_TypeChecker_Env.env) =
   fun env  ->
     fun msg  ->
-      let uu____15565 = snapshot_context env msg  in
-      FStar_Pervasives_Native.snd uu____15565
+      let uu____15684 = snapshot_context env msg  in
+      FStar_Pervasives_Native.snd uu____15684
   
 let (pop_context :
   FStar_TypeChecker_Env.env -> Prims.string -> FStar_TypeChecker_Env.env) =
@@ -8676,8 +8865,8 @@ let (tc_partial_modul :
         if modul.FStar_Syntax_Syntax.is_interface
         then "interface"
         else "implementation"  in
-      (let uu____15654 = FStar_Options.debug_any ()  in
-       if uu____15654
+      (let uu____15773 = FStar_Options.debug_any ()  in
+       if uu____15773
        then
          FStar_Util.print3 "%s %s of %s\n" action label1
            (modul.FStar_Syntax_Syntax.name).FStar_Ident.str
@@ -8689,115 +8878,115 @@ let (tc_partial_modul :
             else "module") (modul.FStar_Syntax_Syntax.name).FStar_Ident.str
           in
        let env1 =
-         let uu___2141_15670 = env  in
+         let uu___2161_15789 = env  in
          {
            FStar_TypeChecker_Env.solver =
-             (uu___2141_15670.FStar_TypeChecker_Env.solver);
+             (uu___2161_15789.FStar_TypeChecker_Env.solver);
            FStar_TypeChecker_Env.range =
-             (uu___2141_15670.FStar_TypeChecker_Env.range);
+             (uu___2161_15789.FStar_TypeChecker_Env.range);
            FStar_TypeChecker_Env.curmodule =
-             (uu___2141_15670.FStar_TypeChecker_Env.curmodule);
+             (uu___2161_15789.FStar_TypeChecker_Env.curmodule);
            FStar_TypeChecker_Env.gamma =
-             (uu___2141_15670.FStar_TypeChecker_Env.gamma);
+             (uu___2161_15789.FStar_TypeChecker_Env.gamma);
            FStar_TypeChecker_Env.gamma_sig =
-             (uu___2141_15670.FStar_TypeChecker_Env.gamma_sig);
+             (uu___2161_15789.FStar_TypeChecker_Env.gamma_sig);
            FStar_TypeChecker_Env.gamma_cache =
-             (uu___2141_15670.FStar_TypeChecker_Env.gamma_cache);
+             (uu___2161_15789.FStar_TypeChecker_Env.gamma_cache);
            FStar_TypeChecker_Env.modules =
-             (uu___2141_15670.FStar_TypeChecker_Env.modules);
+             (uu___2161_15789.FStar_TypeChecker_Env.modules);
            FStar_TypeChecker_Env.expected_typ =
-             (uu___2141_15670.FStar_TypeChecker_Env.expected_typ);
+             (uu___2161_15789.FStar_TypeChecker_Env.expected_typ);
            FStar_TypeChecker_Env.sigtab =
-             (uu___2141_15670.FStar_TypeChecker_Env.sigtab);
+             (uu___2161_15789.FStar_TypeChecker_Env.sigtab);
            FStar_TypeChecker_Env.attrtab =
-             (uu___2141_15670.FStar_TypeChecker_Env.attrtab);
+             (uu___2161_15789.FStar_TypeChecker_Env.attrtab);
            FStar_TypeChecker_Env.is_pattern =
-             (uu___2141_15670.FStar_TypeChecker_Env.is_pattern);
+             (uu___2161_15789.FStar_TypeChecker_Env.is_pattern);
            FStar_TypeChecker_Env.instantiate_imp =
-             (uu___2141_15670.FStar_TypeChecker_Env.instantiate_imp);
+             (uu___2161_15789.FStar_TypeChecker_Env.instantiate_imp);
            FStar_TypeChecker_Env.effects =
-             (uu___2141_15670.FStar_TypeChecker_Env.effects);
+             (uu___2161_15789.FStar_TypeChecker_Env.effects);
            FStar_TypeChecker_Env.generalize =
-             (uu___2141_15670.FStar_TypeChecker_Env.generalize);
+             (uu___2161_15789.FStar_TypeChecker_Env.generalize);
            FStar_TypeChecker_Env.letrecs =
-             (uu___2141_15670.FStar_TypeChecker_Env.letrecs);
+             (uu___2161_15789.FStar_TypeChecker_Env.letrecs);
            FStar_TypeChecker_Env.top_level =
-             (uu___2141_15670.FStar_TypeChecker_Env.top_level);
+             (uu___2161_15789.FStar_TypeChecker_Env.top_level);
            FStar_TypeChecker_Env.check_uvars =
-             (uu___2141_15670.FStar_TypeChecker_Env.check_uvars);
+             (uu___2161_15789.FStar_TypeChecker_Env.check_uvars);
            FStar_TypeChecker_Env.use_eq =
-             (uu___2141_15670.FStar_TypeChecker_Env.use_eq);
+             (uu___2161_15789.FStar_TypeChecker_Env.use_eq);
            FStar_TypeChecker_Env.is_iface =
              (modul.FStar_Syntax_Syntax.is_interface);
            FStar_TypeChecker_Env.admit = (Prims.op_Negation verify);
            FStar_TypeChecker_Env.lax =
-             (uu___2141_15670.FStar_TypeChecker_Env.lax);
+             (uu___2161_15789.FStar_TypeChecker_Env.lax);
            FStar_TypeChecker_Env.lax_universes =
-             (uu___2141_15670.FStar_TypeChecker_Env.lax_universes);
+             (uu___2161_15789.FStar_TypeChecker_Env.lax_universes);
            FStar_TypeChecker_Env.phase1 =
-             (uu___2141_15670.FStar_TypeChecker_Env.phase1);
+             (uu___2161_15789.FStar_TypeChecker_Env.phase1);
            FStar_TypeChecker_Env.failhard =
-             (uu___2141_15670.FStar_TypeChecker_Env.failhard);
+             (uu___2161_15789.FStar_TypeChecker_Env.failhard);
            FStar_TypeChecker_Env.nosynth =
-             (uu___2141_15670.FStar_TypeChecker_Env.nosynth);
+             (uu___2161_15789.FStar_TypeChecker_Env.nosynth);
            FStar_TypeChecker_Env.uvar_subtyping =
-             (uu___2141_15670.FStar_TypeChecker_Env.uvar_subtyping);
+             (uu___2161_15789.FStar_TypeChecker_Env.uvar_subtyping);
            FStar_TypeChecker_Env.tc_term =
-             (uu___2141_15670.FStar_TypeChecker_Env.tc_term);
+             (uu___2161_15789.FStar_TypeChecker_Env.tc_term);
            FStar_TypeChecker_Env.type_of =
-             (uu___2141_15670.FStar_TypeChecker_Env.type_of);
+             (uu___2161_15789.FStar_TypeChecker_Env.type_of);
            FStar_TypeChecker_Env.universe_of =
-             (uu___2141_15670.FStar_TypeChecker_Env.universe_of);
+             (uu___2161_15789.FStar_TypeChecker_Env.universe_of);
            FStar_TypeChecker_Env.check_type_of =
-             (uu___2141_15670.FStar_TypeChecker_Env.check_type_of);
+             (uu___2161_15789.FStar_TypeChecker_Env.check_type_of);
            FStar_TypeChecker_Env.use_bv_sorts =
-             (uu___2141_15670.FStar_TypeChecker_Env.use_bv_sorts);
+             (uu___2161_15789.FStar_TypeChecker_Env.use_bv_sorts);
            FStar_TypeChecker_Env.qtbl_name_and_index =
-             (uu___2141_15670.FStar_TypeChecker_Env.qtbl_name_and_index);
+             (uu___2161_15789.FStar_TypeChecker_Env.qtbl_name_and_index);
            FStar_TypeChecker_Env.normalized_eff_names =
-             (uu___2141_15670.FStar_TypeChecker_Env.normalized_eff_names);
+             (uu___2161_15789.FStar_TypeChecker_Env.normalized_eff_names);
            FStar_TypeChecker_Env.fv_delta_depths =
-             (uu___2141_15670.FStar_TypeChecker_Env.fv_delta_depths);
+             (uu___2161_15789.FStar_TypeChecker_Env.fv_delta_depths);
            FStar_TypeChecker_Env.proof_ns =
-             (uu___2141_15670.FStar_TypeChecker_Env.proof_ns);
+             (uu___2161_15789.FStar_TypeChecker_Env.proof_ns);
            FStar_TypeChecker_Env.synth_hook =
-             (uu___2141_15670.FStar_TypeChecker_Env.synth_hook);
+             (uu___2161_15789.FStar_TypeChecker_Env.synth_hook);
            FStar_TypeChecker_Env.splice =
-             (uu___2141_15670.FStar_TypeChecker_Env.splice);
+             (uu___2161_15789.FStar_TypeChecker_Env.splice);
            FStar_TypeChecker_Env.postprocess =
-             (uu___2141_15670.FStar_TypeChecker_Env.postprocess);
+             (uu___2161_15789.FStar_TypeChecker_Env.postprocess);
            FStar_TypeChecker_Env.is_native_tactic =
-             (uu___2141_15670.FStar_TypeChecker_Env.is_native_tactic);
+             (uu___2161_15789.FStar_TypeChecker_Env.is_native_tactic);
            FStar_TypeChecker_Env.identifier_info =
-             (uu___2141_15670.FStar_TypeChecker_Env.identifier_info);
+             (uu___2161_15789.FStar_TypeChecker_Env.identifier_info);
            FStar_TypeChecker_Env.tc_hooks =
-             (uu___2141_15670.FStar_TypeChecker_Env.tc_hooks);
+             (uu___2161_15789.FStar_TypeChecker_Env.tc_hooks);
            FStar_TypeChecker_Env.dsenv =
-             (uu___2141_15670.FStar_TypeChecker_Env.dsenv);
+             (uu___2161_15789.FStar_TypeChecker_Env.dsenv);
            FStar_TypeChecker_Env.nbe =
-             (uu___2141_15670.FStar_TypeChecker_Env.nbe);
+             (uu___2161_15789.FStar_TypeChecker_Env.nbe);
            FStar_TypeChecker_Env.strict_args_tab =
-             (uu___2141_15670.FStar_TypeChecker_Env.strict_args_tab);
+             (uu___2161_15789.FStar_TypeChecker_Env.strict_args_tab);
            FStar_TypeChecker_Env.erasable_types_tab =
-             (uu___2141_15670.FStar_TypeChecker_Env.erasable_types_tab)
+             (uu___2161_15789.FStar_TypeChecker_Env.erasable_types_tab)
          }  in
        let env2 =
          FStar_TypeChecker_Env.set_current_module env1
            modul.FStar_Syntax_Syntax.name
           in
-       let uu____15672 = tc_decls env2 modul.FStar_Syntax_Syntax.declarations
+       let uu____15791 = tc_decls env2 modul.FStar_Syntax_Syntax.declarations
           in
-       match uu____15672 with
+       match uu____15791 with
        | (ses,exports,env3) ->
-           ((let uu___2149_15705 = modul  in
+           ((let uu___2169_15824 = modul  in
              {
                FStar_Syntax_Syntax.name =
-                 (uu___2149_15705.FStar_Syntax_Syntax.name);
+                 (uu___2169_15824.FStar_Syntax_Syntax.name);
                FStar_Syntax_Syntax.declarations = ses;
                FStar_Syntax_Syntax.exports =
-                 (uu___2149_15705.FStar_Syntax_Syntax.exports);
+                 (uu___2169_15824.FStar_Syntax_Syntax.exports);
                FStar_Syntax_Syntax.is_interface =
-                 (uu___2149_15705.FStar_Syntax_Syntax.is_interface)
+                 (uu___2169_15824.FStar_Syntax_Syntax.is_interface)
              }), exports, env3))
   
 let (tc_more_partial_modul :
@@ -8810,21 +8999,21 @@ let (tc_more_partial_modul :
   fun env  ->
     fun modul  ->
       fun decls  ->
-        let uu____15734 = tc_decls env decls  in
-        match uu____15734 with
+        let uu____15853 = tc_decls env decls  in
+        match uu____15853 with
         | (ses,exports,env1) ->
             let modul1 =
-              let uu___2158_15765 = modul  in
+              let uu___2178_15884 = modul  in
               {
                 FStar_Syntax_Syntax.name =
-                  (uu___2158_15765.FStar_Syntax_Syntax.name);
+                  (uu___2178_15884.FStar_Syntax_Syntax.name);
                 FStar_Syntax_Syntax.declarations =
                   (FStar_List.append modul.FStar_Syntax_Syntax.declarations
                      ses);
                 FStar_Syntax_Syntax.exports =
-                  (uu___2158_15765.FStar_Syntax_Syntax.exports);
+                  (uu___2178_15884.FStar_Syntax_Syntax.exports);
                 FStar_Syntax_Syntax.is_interface =
-                  (uu___2158_15765.FStar_Syntax_Syntax.is_interface)
+                  (uu___2178_15884.FStar_Syntax_Syntax.is_interface)
               }  in
             (modul1, exports, env1)
   
@@ -8841,8 +9030,8 @@ let rec (tc_modul :
             (m.FStar_Syntax_Syntax.name).FStar_Ident.str
            in
         let env01 = push_context env0 msg  in
-        let uu____15826 = tc_partial_modul env01 m  in
-        match uu____15826 with
+        let uu____15945 = tc_partial_modul env01 m  in
+        match uu____15945 with
         | (modul,non_private_decls,env) ->
             finish_partial_modul false iface_exists env modul
               non_private_decls
@@ -8866,54 +9055,54 @@ and (finish_partial_modul :
                   && (FStar_Options.use_extracted_interfaces ()))
                  && (Prims.op_Negation m.FStar_Syntax_Syntax.is_interface))
                 &&
-                (let uu____15863 = FStar_Errors.get_err_count ()  in
-                 uu____15863 = Prims.int_zero)
+                (let uu____15982 = FStar_Errors.get_err_count ()  in
+                 uu____15982 = Prims.int_zero)
                in
             if should_extract_interface
             then
               let modul_iface = extract_interface en m  in
-              ((let uu____15874 =
+              ((let uu____15993 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug en)
                     FStar_Options.Low
                    in
-                if uu____15874
+                if uu____15993
                 then
-                  let uu____15878 =
-                    let uu____15880 =
+                  let uu____15997 =
+                    let uu____15999 =
                       FStar_Options.should_verify
                         (m.FStar_Syntax_Syntax.name).FStar_Ident.str
                        in
-                    if uu____15880 then "" else " (in lax mode) "  in
-                  let uu____15888 =
-                    let uu____15890 =
+                    if uu____15999 then "" else " (in lax mode) "  in
+                  let uu____16007 =
+                    let uu____16009 =
                       FStar_Options.dump_module
                         (m.FStar_Syntax_Syntax.name).FStar_Ident.str
                        in
-                    if uu____15890
+                    if uu____16009
                     then
-                      let uu____15894 =
-                        let uu____15896 =
+                      let uu____16013 =
+                        let uu____16015 =
                           FStar_Syntax_Print.modul_to_string m  in
-                        Prims.op_Hat uu____15896 "\n"  in
-                      Prims.op_Hat "\nfrom: " uu____15894
+                        Prims.op_Hat uu____16015 "\n"  in
+                      Prims.op_Hat "\nfrom: " uu____16013
                     else ""  in
-                  let uu____15903 =
-                    let uu____15905 =
+                  let uu____16022 =
+                    let uu____16024 =
                       FStar_Options.dump_module
                         (m.FStar_Syntax_Syntax.name).FStar_Ident.str
                        in
-                    if uu____15905
+                    if uu____16024
                     then
-                      let uu____15909 =
-                        let uu____15911 =
+                      let uu____16028 =
+                        let uu____16030 =
                           FStar_Syntax_Print.modul_to_string modul_iface  in
-                        Prims.op_Hat uu____15911 "\n"  in
-                      Prims.op_Hat "\nto: " uu____15909
+                        Prims.op_Hat uu____16030 "\n"  in
+                      Prims.op_Hat "\nto: " uu____16028
                     else ""  in
                   FStar_Util.print4
                     "Extracting and type checking module %s interface%s%s%s\n"
-                    (m.FStar_Syntax_Syntax.name).FStar_Ident.str uu____15878
-                    uu____15888 uu____15903
+                    (m.FStar_Syntax_Syntax.name).FStar_Ident.str uu____15997
+                    uu____16007 uu____16022
                 else ());
                (let en0 =
                   let en0 =
@@ -8922,258 +9111,258 @@ and (finish_partial_modul :
                          (m.FStar_Syntax_Syntax.name).FStar_Ident.str)
                      in
                   let en01 =
-                    let uu___2184_15925 = en0  in
+                    let uu___2204_16044 = en0  in
                     {
                       FStar_TypeChecker_Env.solver =
-                        (uu___2184_15925.FStar_TypeChecker_Env.solver);
+                        (uu___2204_16044.FStar_TypeChecker_Env.solver);
                       FStar_TypeChecker_Env.range =
-                        (uu___2184_15925.FStar_TypeChecker_Env.range);
+                        (uu___2204_16044.FStar_TypeChecker_Env.range);
                       FStar_TypeChecker_Env.curmodule =
-                        (uu___2184_15925.FStar_TypeChecker_Env.curmodule);
+                        (uu___2204_16044.FStar_TypeChecker_Env.curmodule);
                       FStar_TypeChecker_Env.gamma =
-                        (uu___2184_15925.FStar_TypeChecker_Env.gamma);
+                        (uu___2204_16044.FStar_TypeChecker_Env.gamma);
                       FStar_TypeChecker_Env.gamma_sig =
-                        (uu___2184_15925.FStar_TypeChecker_Env.gamma_sig);
+                        (uu___2204_16044.FStar_TypeChecker_Env.gamma_sig);
                       FStar_TypeChecker_Env.gamma_cache =
-                        (uu___2184_15925.FStar_TypeChecker_Env.gamma_cache);
+                        (uu___2204_16044.FStar_TypeChecker_Env.gamma_cache);
                       FStar_TypeChecker_Env.modules =
-                        (uu___2184_15925.FStar_TypeChecker_Env.modules);
+                        (uu___2204_16044.FStar_TypeChecker_Env.modules);
                       FStar_TypeChecker_Env.expected_typ =
-                        (uu___2184_15925.FStar_TypeChecker_Env.expected_typ);
+                        (uu___2204_16044.FStar_TypeChecker_Env.expected_typ);
                       FStar_TypeChecker_Env.sigtab =
-                        (uu___2184_15925.FStar_TypeChecker_Env.sigtab);
+                        (uu___2204_16044.FStar_TypeChecker_Env.sigtab);
                       FStar_TypeChecker_Env.attrtab =
-                        (uu___2184_15925.FStar_TypeChecker_Env.attrtab);
+                        (uu___2204_16044.FStar_TypeChecker_Env.attrtab);
                       FStar_TypeChecker_Env.is_pattern =
-                        (uu___2184_15925.FStar_TypeChecker_Env.is_pattern);
+                        (uu___2204_16044.FStar_TypeChecker_Env.is_pattern);
                       FStar_TypeChecker_Env.instantiate_imp =
-                        (uu___2184_15925.FStar_TypeChecker_Env.instantiate_imp);
+                        (uu___2204_16044.FStar_TypeChecker_Env.instantiate_imp);
                       FStar_TypeChecker_Env.effects =
-                        (uu___2184_15925.FStar_TypeChecker_Env.effects);
+                        (uu___2204_16044.FStar_TypeChecker_Env.effects);
                       FStar_TypeChecker_Env.generalize =
-                        (uu___2184_15925.FStar_TypeChecker_Env.generalize);
+                        (uu___2204_16044.FStar_TypeChecker_Env.generalize);
                       FStar_TypeChecker_Env.letrecs =
-                        (uu___2184_15925.FStar_TypeChecker_Env.letrecs);
+                        (uu___2204_16044.FStar_TypeChecker_Env.letrecs);
                       FStar_TypeChecker_Env.top_level =
-                        (uu___2184_15925.FStar_TypeChecker_Env.top_level);
+                        (uu___2204_16044.FStar_TypeChecker_Env.top_level);
                       FStar_TypeChecker_Env.check_uvars =
-                        (uu___2184_15925.FStar_TypeChecker_Env.check_uvars);
+                        (uu___2204_16044.FStar_TypeChecker_Env.check_uvars);
                       FStar_TypeChecker_Env.use_eq =
-                        (uu___2184_15925.FStar_TypeChecker_Env.use_eq);
+                        (uu___2204_16044.FStar_TypeChecker_Env.use_eq);
                       FStar_TypeChecker_Env.is_iface =
-                        (uu___2184_15925.FStar_TypeChecker_Env.is_iface);
+                        (uu___2204_16044.FStar_TypeChecker_Env.is_iface);
                       FStar_TypeChecker_Env.admit =
-                        (uu___2184_15925.FStar_TypeChecker_Env.admit);
+                        (uu___2204_16044.FStar_TypeChecker_Env.admit);
                       FStar_TypeChecker_Env.lax =
-                        (uu___2184_15925.FStar_TypeChecker_Env.lax);
+                        (uu___2204_16044.FStar_TypeChecker_Env.lax);
                       FStar_TypeChecker_Env.lax_universes =
-                        (uu___2184_15925.FStar_TypeChecker_Env.lax_universes);
+                        (uu___2204_16044.FStar_TypeChecker_Env.lax_universes);
                       FStar_TypeChecker_Env.phase1 =
-                        (uu___2184_15925.FStar_TypeChecker_Env.phase1);
+                        (uu___2204_16044.FStar_TypeChecker_Env.phase1);
                       FStar_TypeChecker_Env.failhard =
-                        (uu___2184_15925.FStar_TypeChecker_Env.failhard);
+                        (uu___2204_16044.FStar_TypeChecker_Env.failhard);
                       FStar_TypeChecker_Env.nosynth =
-                        (uu___2184_15925.FStar_TypeChecker_Env.nosynth);
+                        (uu___2204_16044.FStar_TypeChecker_Env.nosynth);
                       FStar_TypeChecker_Env.uvar_subtyping =
-                        (uu___2184_15925.FStar_TypeChecker_Env.uvar_subtyping);
+                        (uu___2204_16044.FStar_TypeChecker_Env.uvar_subtyping);
                       FStar_TypeChecker_Env.tc_term =
-                        (uu___2184_15925.FStar_TypeChecker_Env.tc_term);
+                        (uu___2204_16044.FStar_TypeChecker_Env.tc_term);
                       FStar_TypeChecker_Env.type_of =
-                        (uu___2184_15925.FStar_TypeChecker_Env.type_of);
+                        (uu___2204_16044.FStar_TypeChecker_Env.type_of);
                       FStar_TypeChecker_Env.universe_of =
-                        (uu___2184_15925.FStar_TypeChecker_Env.universe_of);
+                        (uu___2204_16044.FStar_TypeChecker_Env.universe_of);
                       FStar_TypeChecker_Env.check_type_of =
-                        (uu___2184_15925.FStar_TypeChecker_Env.check_type_of);
+                        (uu___2204_16044.FStar_TypeChecker_Env.check_type_of);
                       FStar_TypeChecker_Env.use_bv_sorts =
-                        (uu___2184_15925.FStar_TypeChecker_Env.use_bv_sorts);
+                        (uu___2204_16044.FStar_TypeChecker_Env.use_bv_sorts);
                       FStar_TypeChecker_Env.qtbl_name_and_index =
-                        (uu___2184_15925.FStar_TypeChecker_Env.qtbl_name_and_index);
+                        (uu___2204_16044.FStar_TypeChecker_Env.qtbl_name_and_index);
                       FStar_TypeChecker_Env.normalized_eff_names =
-                        (uu___2184_15925.FStar_TypeChecker_Env.normalized_eff_names);
+                        (uu___2204_16044.FStar_TypeChecker_Env.normalized_eff_names);
                       FStar_TypeChecker_Env.fv_delta_depths =
-                        (uu___2184_15925.FStar_TypeChecker_Env.fv_delta_depths);
+                        (uu___2204_16044.FStar_TypeChecker_Env.fv_delta_depths);
                       FStar_TypeChecker_Env.proof_ns =
-                        (uu___2184_15925.FStar_TypeChecker_Env.proof_ns);
+                        (uu___2204_16044.FStar_TypeChecker_Env.proof_ns);
                       FStar_TypeChecker_Env.synth_hook =
-                        (uu___2184_15925.FStar_TypeChecker_Env.synth_hook);
+                        (uu___2204_16044.FStar_TypeChecker_Env.synth_hook);
                       FStar_TypeChecker_Env.splice =
-                        (uu___2184_15925.FStar_TypeChecker_Env.splice);
+                        (uu___2204_16044.FStar_TypeChecker_Env.splice);
                       FStar_TypeChecker_Env.postprocess =
-                        (uu___2184_15925.FStar_TypeChecker_Env.postprocess);
+                        (uu___2204_16044.FStar_TypeChecker_Env.postprocess);
                       FStar_TypeChecker_Env.is_native_tactic =
-                        (uu___2184_15925.FStar_TypeChecker_Env.is_native_tactic);
+                        (uu___2204_16044.FStar_TypeChecker_Env.is_native_tactic);
                       FStar_TypeChecker_Env.identifier_info =
-                        (uu___2184_15925.FStar_TypeChecker_Env.identifier_info);
+                        (uu___2204_16044.FStar_TypeChecker_Env.identifier_info);
                       FStar_TypeChecker_Env.tc_hooks =
-                        (uu___2184_15925.FStar_TypeChecker_Env.tc_hooks);
+                        (uu___2204_16044.FStar_TypeChecker_Env.tc_hooks);
                       FStar_TypeChecker_Env.dsenv =
                         (en.FStar_TypeChecker_Env.dsenv);
                       FStar_TypeChecker_Env.nbe =
-                        (uu___2184_15925.FStar_TypeChecker_Env.nbe);
+                        (uu___2204_16044.FStar_TypeChecker_Env.nbe);
                       FStar_TypeChecker_Env.strict_args_tab =
-                        (uu___2184_15925.FStar_TypeChecker_Env.strict_args_tab);
+                        (uu___2204_16044.FStar_TypeChecker_Env.strict_args_tab);
                       FStar_TypeChecker_Env.erasable_types_tab =
-                        (uu___2184_15925.FStar_TypeChecker_Env.erasable_types_tab)
+                        (uu___2204_16044.FStar_TypeChecker_Env.erasable_types_tab)
                     }  in
                   let en02 =
-                    let uu___2187_15927 = en01  in
-                    let uu____15928 =
-                      let uu____15943 =
+                    let uu___2207_16046 = en01  in
+                    let uu____16047 =
+                      let uu____16062 =
                         FStar_All.pipe_right
                           en.FStar_TypeChecker_Env.qtbl_name_and_index
                           FStar_Pervasives_Native.fst
                          in
-                      (uu____15943, FStar_Pervasives_Native.None)  in
+                      (uu____16062, FStar_Pervasives_Native.None)  in
                     {
                       FStar_TypeChecker_Env.solver =
-                        (uu___2187_15927.FStar_TypeChecker_Env.solver);
+                        (uu___2207_16046.FStar_TypeChecker_Env.solver);
                       FStar_TypeChecker_Env.range =
-                        (uu___2187_15927.FStar_TypeChecker_Env.range);
+                        (uu___2207_16046.FStar_TypeChecker_Env.range);
                       FStar_TypeChecker_Env.curmodule =
-                        (uu___2187_15927.FStar_TypeChecker_Env.curmodule);
+                        (uu___2207_16046.FStar_TypeChecker_Env.curmodule);
                       FStar_TypeChecker_Env.gamma =
-                        (uu___2187_15927.FStar_TypeChecker_Env.gamma);
+                        (uu___2207_16046.FStar_TypeChecker_Env.gamma);
                       FStar_TypeChecker_Env.gamma_sig =
-                        (uu___2187_15927.FStar_TypeChecker_Env.gamma_sig);
+                        (uu___2207_16046.FStar_TypeChecker_Env.gamma_sig);
                       FStar_TypeChecker_Env.gamma_cache =
-                        (uu___2187_15927.FStar_TypeChecker_Env.gamma_cache);
+                        (uu___2207_16046.FStar_TypeChecker_Env.gamma_cache);
                       FStar_TypeChecker_Env.modules =
-                        (uu___2187_15927.FStar_TypeChecker_Env.modules);
+                        (uu___2207_16046.FStar_TypeChecker_Env.modules);
                       FStar_TypeChecker_Env.expected_typ =
-                        (uu___2187_15927.FStar_TypeChecker_Env.expected_typ);
+                        (uu___2207_16046.FStar_TypeChecker_Env.expected_typ);
                       FStar_TypeChecker_Env.sigtab =
-                        (uu___2187_15927.FStar_TypeChecker_Env.sigtab);
+                        (uu___2207_16046.FStar_TypeChecker_Env.sigtab);
                       FStar_TypeChecker_Env.attrtab =
-                        (uu___2187_15927.FStar_TypeChecker_Env.attrtab);
+                        (uu___2207_16046.FStar_TypeChecker_Env.attrtab);
                       FStar_TypeChecker_Env.is_pattern =
-                        (uu___2187_15927.FStar_TypeChecker_Env.is_pattern);
+                        (uu___2207_16046.FStar_TypeChecker_Env.is_pattern);
                       FStar_TypeChecker_Env.instantiate_imp =
-                        (uu___2187_15927.FStar_TypeChecker_Env.instantiate_imp);
+                        (uu___2207_16046.FStar_TypeChecker_Env.instantiate_imp);
                       FStar_TypeChecker_Env.effects =
-                        (uu___2187_15927.FStar_TypeChecker_Env.effects);
+                        (uu___2207_16046.FStar_TypeChecker_Env.effects);
                       FStar_TypeChecker_Env.generalize =
-                        (uu___2187_15927.FStar_TypeChecker_Env.generalize);
+                        (uu___2207_16046.FStar_TypeChecker_Env.generalize);
                       FStar_TypeChecker_Env.letrecs =
-                        (uu___2187_15927.FStar_TypeChecker_Env.letrecs);
+                        (uu___2207_16046.FStar_TypeChecker_Env.letrecs);
                       FStar_TypeChecker_Env.top_level =
-                        (uu___2187_15927.FStar_TypeChecker_Env.top_level);
+                        (uu___2207_16046.FStar_TypeChecker_Env.top_level);
                       FStar_TypeChecker_Env.check_uvars =
-                        (uu___2187_15927.FStar_TypeChecker_Env.check_uvars);
+                        (uu___2207_16046.FStar_TypeChecker_Env.check_uvars);
                       FStar_TypeChecker_Env.use_eq =
-                        (uu___2187_15927.FStar_TypeChecker_Env.use_eq);
+                        (uu___2207_16046.FStar_TypeChecker_Env.use_eq);
                       FStar_TypeChecker_Env.is_iface =
-                        (uu___2187_15927.FStar_TypeChecker_Env.is_iface);
+                        (uu___2207_16046.FStar_TypeChecker_Env.is_iface);
                       FStar_TypeChecker_Env.admit =
-                        (uu___2187_15927.FStar_TypeChecker_Env.admit);
+                        (uu___2207_16046.FStar_TypeChecker_Env.admit);
                       FStar_TypeChecker_Env.lax =
-                        (uu___2187_15927.FStar_TypeChecker_Env.lax);
+                        (uu___2207_16046.FStar_TypeChecker_Env.lax);
                       FStar_TypeChecker_Env.lax_universes =
-                        (uu___2187_15927.FStar_TypeChecker_Env.lax_universes);
+                        (uu___2207_16046.FStar_TypeChecker_Env.lax_universes);
                       FStar_TypeChecker_Env.phase1 =
-                        (uu___2187_15927.FStar_TypeChecker_Env.phase1);
+                        (uu___2207_16046.FStar_TypeChecker_Env.phase1);
                       FStar_TypeChecker_Env.failhard =
-                        (uu___2187_15927.FStar_TypeChecker_Env.failhard);
+                        (uu___2207_16046.FStar_TypeChecker_Env.failhard);
                       FStar_TypeChecker_Env.nosynth =
-                        (uu___2187_15927.FStar_TypeChecker_Env.nosynth);
+                        (uu___2207_16046.FStar_TypeChecker_Env.nosynth);
                       FStar_TypeChecker_Env.uvar_subtyping =
-                        (uu___2187_15927.FStar_TypeChecker_Env.uvar_subtyping);
+                        (uu___2207_16046.FStar_TypeChecker_Env.uvar_subtyping);
                       FStar_TypeChecker_Env.tc_term =
-                        (uu___2187_15927.FStar_TypeChecker_Env.tc_term);
+                        (uu___2207_16046.FStar_TypeChecker_Env.tc_term);
                       FStar_TypeChecker_Env.type_of =
-                        (uu___2187_15927.FStar_TypeChecker_Env.type_of);
+                        (uu___2207_16046.FStar_TypeChecker_Env.type_of);
                       FStar_TypeChecker_Env.universe_of =
-                        (uu___2187_15927.FStar_TypeChecker_Env.universe_of);
+                        (uu___2207_16046.FStar_TypeChecker_Env.universe_of);
                       FStar_TypeChecker_Env.check_type_of =
-                        (uu___2187_15927.FStar_TypeChecker_Env.check_type_of);
+                        (uu___2207_16046.FStar_TypeChecker_Env.check_type_of);
                       FStar_TypeChecker_Env.use_bv_sorts =
-                        (uu___2187_15927.FStar_TypeChecker_Env.use_bv_sorts);
-                      FStar_TypeChecker_Env.qtbl_name_and_index = uu____15928;
+                        (uu___2207_16046.FStar_TypeChecker_Env.use_bv_sorts);
+                      FStar_TypeChecker_Env.qtbl_name_and_index = uu____16047;
                       FStar_TypeChecker_Env.normalized_eff_names =
-                        (uu___2187_15927.FStar_TypeChecker_Env.normalized_eff_names);
+                        (uu___2207_16046.FStar_TypeChecker_Env.normalized_eff_names);
                       FStar_TypeChecker_Env.fv_delta_depths =
-                        (uu___2187_15927.FStar_TypeChecker_Env.fv_delta_depths);
+                        (uu___2207_16046.FStar_TypeChecker_Env.fv_delta_depths);
                       FStar_TypeChecker_Env.proof_ns =
-                        (uu___2187_15927.FStar_TypeChecker_Env.proof_ns);
+                        (uu___2207_16046.FStar_TypeChecker_Env.proof_ns);
                       FStar_TypeChecker_Env.synth_hook =
-                        (uu___2187_15927.FStar_TypeChecker_Env.synth_hook);
+                        (uu___2207_16046.FStar_TypeChecker_Env.synth_hook);
                       FStar_TypeChecker_Env.splice =
-                        (uu___2187_15927.FStar_TypeChecker_Env.splice);
+                        (uu___2207_16046.FStar_TypeChecker_Env.splice);
                       FStar_TypeChecker_Env.postprocess =
-                        (uu___2187_15927.FStar_TypeChecker_Env.postprocess);
+                        (uu___2207_16046.FStar_TypeChecker_Env.postprocess);
                       FStar_TypeChecker_Env.is_native_tactic =
-                        (uu___2187_15927.FStar_TypeChecker_Env.is_native_tactic);
+                        (uu___2207_16046.FStar_TypeChecker_Env.is_native_tactic);
                       FStar_TypeChecker_Env.identifier_info =
-                        (uu___2187_15927.FStar_TypeChecker_Env.identifier_info);
+                        (uu___2207_16046.FStar_TypeChecker_Env.identifier_info);
                       FStar_TypeChecker_Env.tc_hooks =
-                        (uu___2187_15927.FStar_TypeChecker_Env.tc_hooks);
+                        (uu___2207_16046.FStar_TypeChecker_Env.tc_hooks);
                       FStar_TypeChecker_Env.dsenv =
-                        (uu___2187_15927.FStar_TypeChecker_Env.dsenv);
+                        (uu___2207_16046.FStar_TypeChecker_Env.dsenv);
                       FStar_TypeChecker_Env.nbe =
-                        (uu___2187_15927.FStar_TypeChecker_Env.nbe);
+                        (uu___2207_16046.FStar_TypeChecker_Env.nbe);
                       FStar_TypeChecker_Env.strict_args_tab =
-                        (uu___2187_15927.FStar_TypeChecker_Env.strict_args_tab);
+                        (uu___2207_16046.FStar_TypeChecker_Env.strict_args_tab);
                       FStar_TypeChecker_Env.erasable_types_tab =
-                        (uu___2187_15927.FStar_TypeChecker_Env.erasable_types_tab)
+                        (uu___2207_16046.FStar_TypeChecker_Env.erasable_types_tab)
                     }  in
-                  let uu____15989 =
-                    let uu____15991 = FStar_Options.interactive ()  in
-                    Prims.op_Negation uu____15991  in
-                  if uu____15989
+                  let uu____16108 =
+                    let uu____16110 = FStar_Options.interactive ()  in
+                    Prims.op_Negation uu____16110  in
+                  if uu____16108
                   then
-                    ((let uu____15995 =
+                    ((let uu____16114 =
                         FStar_Options.restore_cmd_line_options true  in
-                      FStar_All.pipe_right uu____15995 (fun a3  -> ()));
+                      FStar_All.pipe_right uu____16114 (fun a3  -> ()));
                      en02)
                   else en02  in
-                let uu____15999 = tc_modul en0 modul_iface true  in
-                match uu____15999 with
+                let uu____16118 = tc_modul en0 modul_iface true  in
+                match uu____16118 with
                 | (modul_iface1,env) ->
-                    ((let uu___2196_16012 = m  in
+                    ((let uu___2216_16131 = m  in
                       {
                         FStar_Syntax_Syntax.name =
-                          (uu___2196_16012.FStar_Syntax_Syntax.name);
+                          (uu___2216_16131.FStar_Syntax_Syntax.name);
                         FStar_Syntax_Syntax.declarations =
-                          (uu___2196_16012.FStar_Syntax_Syntax.declarations);
+                          (uu___2216_16131.FStar_Syntax_Syntax.declarations);
                         FStar_Syntax_Syntax.exports =
                           (modul_iface1.FStar_Syntax_Syntax.exports);
                         FStar_Syntax_Syntax.is_interface =
-                          (uu___2196_16012.FStar_Syntax_Syntax.is_interface)
+                          (uu___2216_16131.FStar_Syntax_Syntax.is_interface)
                       }), env)))
             else
               (let modul =
-                 let uu___2198_16016 = m  in
+                 let uu___2218_16135 = m  in
                  {
                    FStar_Syntax_Syntax.name =
-                     (uu___2198_16016.FStar_Syntax_Syntax.name);
+                     (uu___2218_16135.FStar_Syntax_Syntax.name);
                    FStar_Syntax_Syntax.declarations =
-                     (uu___2198_16016.FStar_Syntax_Syntax.declarations);
+                     (uu___2218_16135.FStar_Syntax_Syntax.declarations);
                    FStar_Syntax_Syntax.exports = exports;
                    FStar_Syntax_Syntax.is_interface =
-                     (uu___2198_16016.FStar_Syntax_Syntax.is_interface)
+                     (uu___2218_16135.FStar_Syntax_Syntax.is_interface)
                  }  in
                let env = FStar_TypeChecker_Env.finish_module en modul  in
-               (let uu____16019 =
+               (let uu____16138 =
                   FStar_All.pipe_right
                     env.FStar_TypeChecker_Env.qtbl_name_and_index
                     FStar_Pervasives_Native.fst
                    in
-                FStar_All.pipe_right uu____16019 FStar_Util.smap_clear);
-               (let uu____16055 =
-                  ((let uu____16059 = FStar_Options.lax ()  in
-                    Prims.op_Negation uu____16059) &&
+                FStar_All.pipe_right uu____16138 FStar_Util.smap_clear);
+               (let uu____16174 =
+                  ((let uu____16178 = FStar_Options.lax ()  in
+                    Prims.op_Negation uu____16178) &&
                      (Prims.op_Negation loading_from_cache))
                     &&
-                    (let uu____16062 =
+                    (let uu____16181 =
                        FStar_Options.use_extracted_interfaces ()  in
-                     Prims.op_Negation uu____16062)
+                     Prims.op_Negation uu____16181)
                    in
-                if uu____16055 then check_exports env modul exports else ());
-               (let uu____16068 =
+                if uu____16174 then check_exports env modul exports else ());
+               (let uu____16187 =
                   pop_context env
                     (Prims.op_Hat "Ending modul "
                        (modul.FStar_Syntax_Syntax.name).FStar_Ident.str)
                    in
-                FStar_All.pipe_right uu____16068 (fun a4  -> ()));
+                FStar_All.pipe_right uu____16187 (fun a4  -> ()));
                (modul, env))
 
 let (load_checked_module :
@@ -9187,11 +9376,11 @@ let (load_checked_module :
           m.FStar_Syntax_Syntax.name
          in
       let env1 =
-        let uu____16083 =
-          let uu____16085 =
+        let uu____16202 =
+          let uu____16204 =
             FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
-          Prims.op_Hat "Internals for " uu____16085  in
-        push_context env uu____16083  in
+          Prims.op_Hat "Internals for " uu____16204  in
+        push_context env uu____16202  in
       let env2 =
         FStar_List.fold_left
           (fun env2  ->
@@ -9201,15 +9390,15 @@ let (load_checked_module :
                FStar_All.pipe_right lids
                  (FStar_List.iter
                     (fun lid  ->
-                       let uu____16107 =
+                       let uu____16226 =
                          FStar_TypeChecker_Env.lookup_sigelt env3 lid  in
                        ()));
                env3) env1 m.FStar_Syntax_Syntax.declarations
          in
-      let uu____16110 =
+      let uu____16229 =
         finish_partial_modul true true env2 m m.FStar_Syntax_Syntax.exports
          in
-      match uu____16110 with | (uu____16117,env3) -> env3
+      match uu____16229 with | (uu____16236,env3) -> env3
   
 let (check_module :
   FStar_TypeChecker_Env.env ->
@@ -9219,138 +9408,138 @@ let (check_module :
   fun env  ->
     fun m  ->
       fun b  ->
-        (let uu____16142 = FStar_Options.debug_any ()  in
-         if uu____16142
+        (let uu____16261 = FStar_Options.debug_any ()  in
+         if uu____16261
          then
-           let uu____16145 =
+           let uu____16264 =
              FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name  in
            FStar_Util.print2 "Checking %s: %s\n"
              (if m.FStar_Syntax_Syntax.is_interface
               then "i'face"
-              else "module") uu____16145
+              else "module") uu____16264
          else ());
-        (let uu____16157 =
+        (let uu____16276 =
            FStar_Options.dump_module
              (m.FStar_Syntax_Syntax.name).FStar_Ident.str
             in
-         if uu____16157
+         if uu____16276
          then
-           let uu____16160 = FStar_Syntax_Print.modul_to_string m  in
-           FStar_Util.print1 "Module before type checking:\n%s\n" uu____16160
+           let uu____16279 = FStar_Syntax_Print.modul_to_string m  in
+           FStar_Util.print1 "Module before type checking:\n%s\n" uu____16279
          else ());
         (let env1 =
-           let uu___2228_16166 = env  in
-           let uu____16167 =
-             let uu____16169 =
+           let uu___2248_16285 = env  in
+           let uu____16286 =
+             let uu____16288 =
                FStar_Options.should_verify
                  (m.FStar_Syntax_Syntax.name).FStar_Ident.str
                 in
-             Prims.op_Negation uu____16169  in
+             Prims.op_Negation uu____16288  in
            {
              FStar_TypeChecker_Env.solver =
-               (uu___2228_16166.FStar_TypeChecker_Env.solver);
+               (uu___2248_16285.FStar_TypeChecker_Env.solver);
              FStar_TypeChecker_Env.range =
-               (uu___2228_16166.FStar_TypeChecker_Env.range);
+               (uu___2248_16285.FStar_TypeChecker_Env.range);
              FStar_TypeChecker_Env.curmodule =
-               (uu___2228_16166.FStar_TypeChecker_Env.curmodule);
+               (uu___2248_16285.FStar_TypeChecker_Env.curmodule);
              FStar_TypeChecker_Env.gamma =
-               (uu___2228_16166.FStar_TypeChecker_Env.gamma);
+               (uu___2248_16285.FStar_TypeChecker_Env.gamma);
              FStar_TypeChecker_Env.gamma_sig =
-               (uu___2228_16166.FStar_TypeChecker_Env.gamma_sig);
+               (uu___2248_16285.FStar_TypeChecker_Env.gamma_sig);
              FStar_TypeChecker_Env.gamma_cache =
-               (uu___2228_16166.FStar_TypeChecker_Env.gamma_cache);
+               (uu___2248_16285.FStar_TypeChecker_Env.gamma_cache);
              FStar_TypeChecker_Env.modules =
-               (uu___2228_16166.FStar_TypeChecker_Env.modules);
+               (uu___2248_16285.FStar_TypeChecker_Env.modules);
              FStar_TypeChecker_Env.expected_typ =
-               (uu___2228_16166.FStar_TypeChecker_Env.expected_typ);
+               (uu___2248_16285.FStar_TypeChecker_Env.expected_typ);
              FStar_TypeChecker_Env.sigtab =
-               (uu___2228_16166.FStar_TypeChecker_Env.sigtab);
+               (uu___2248_16285.FStar_TypeChecker_Env.sigtab);
              FStar_TypeChecker_Env.attrtab =
-               (uu___2228_16166.FStar_TypeChecker_Env.attrtab);
+               (uu___2248_16285.FStar_TypeChecker_Env.attrtab);
              FStar_TypeChecker_Env.is_pattern =
-               (uu___2228_16166.FStar_TypeChecker_Env.is_pattern);
+               (uu___2248_16285.FStar_TypeChecker_Env.is_pattern);
              FStar_TypeChecker_Env.instantiate_imp =
-               (uu___2228_16166.FStar_TypeChecker_Env.instantiate_imp);
+               (uu___2248_16285.FStar_TypeChecker_Env.instantiate_imp);
              FStar_TypeChecker_Env.effects =
-               (uu___2228_16166.FStar_TypeChecker_Env.effects);
+               (uu___2248_16285.FStar_TypeChecker_Env.effects);
              FStar_TypeChecker_Env.generalize =
-               (uu___2228_16166.FStar_TypeChecker_Env.generalize);
+               (uu___2248_16285.FStar_TypeChecker_Env.generalize);
              FStar_TypeChecker_Env.letrecs =
-               (uu___2228_16166.FStar_TypeChecker_Env.letrecs);
+               (uu___2248_16285.FStar_TypeChecker_Env.letrecs);
              FStar_TypeChecker_Env.top_level =
-               (uu___2228_16166.FStar_TypeChecker_Env.top_level);
+               (uu___2248_16285.FStar_TypeChecker_Env.top_level);
              FStar_TypeChecker_Env.check_uvars =
-               (uu___2228_16166.FStar_TypeChecker_Env.check_uvars);
+               (uu___2248_16285.FStar_TypeChecker_Env.check_uvars);
              FStar_TypeChecker_Env.use_eq =
-               (uu___2228_16166.FStar_TypeChecker_Env.use_eq);
+               (uu___2248_16285.FStar_TypeChecker_Env.use_eq);
              FStar_TypeChecker_Env.is_iface =
-               (uu___2228_16166.FStar_TypeChecker_Env.is_iface);
+               (uu___2248_16285.FStar_TypeChecker_Env.is_iface);
              FStar_TypeChecker_Env.admit =
-               (uu___2228_16166.FStar_TypeChecker_Env.admit);
-             FStar_TypeChecker_Env.lax = uu____16167;
+               (uu___2248_16285.FStar_TypeChecker_Env.admit);
+             FStar_TypeChecker_Env.lax = uu____16286;
              FStar_TypeChecker_Env.lax_universes =
-               (uu___2228_16166.FStar_TypeChecker_Env.lax_universes);
+               (uu___2248_16285.FStar_TypeChecker_Env.lax_universes);
              FStar_TypeChecker_Env.phase1 =
-               (uu___2228_16166.FStar_TypeChecker_Env.phase1);
+               (uu___2248_16285.FStar_TypeChecker_Env.phase1);
              FStar_TypeChecker_Env.failhard =
-               (uu___2228_16166.FStar_TypeChecker_Env.failhard);
+               (uu___2248_16285.FStar_TypeChecker_Env.failhard);
              FStar_TypeChecker_Env.nosynth =
-               (uu___2228_16166.FStar_TypeChecker_Env.nosynth);
+               (uu___2248_16285.FStar_TypeChecker_Env.nosynth);
              FStar_TypeChecker_Env.uvar_subtyping =
-               (uu___2228_16166.FStar_TypeChecker_Env.uvar_subtyping);
+               (uu___2248_16285.FStar_TypeChecker_Env.uvar_subtyping);
              FStar_TypeChecker_Env.tc_term =
-               (uu___2228_16166.FStar_TypeChecker_Env.tc_term);
+               (uu___2248_16285.FStar_TypeChecker_Env.tc_term);
              FStar_TypeChecker_Env.type_of =
-               (uu___2228_16166.FStar_TypeChecker_Env.type_of);
+               (uu___2248_16285.FStar_TypeChecker_Env.type_of);
              FStar_TypeChecker_Env.universe_of =
-               (uu___2228_16166.FStar_TypeChecker_Env.universe_of);
+               (uu___2248_16285.FStar_TypeChecker_Env.universe_of);
              FStar_TypeChecker_Env.check_type_of =
-               (uu___2228_16166.FStar_TypeChecker_Env.check_type_of);
+               (uu___2248_16285.FStar_TypeChecker_Env.check_type_of);
              FStar_TypeChecker_Env.use_bv_sorts =
-               (uu___2228_16166.FStar_TypeChecker_Env.use_bv_sorts);
+               (uu___2248_16285.FStar_TypeChecker_Env.use_bv_sorts);
              FStar_TypeChecker_Env.qtbl_name_and_index =
-               (uu___2228_16166.FStar_TypeChecker_Env.qtbl_name_and_index);
+               (uu___2248_16285.FStar_TypeChecker_Env.qtbl_name_and_index);
              FStar_TypeChecker_Env.normalized_eff_names =
-               (uu___2228_16166.FStar_TypeChecker_Env.normalized_eff_names);
+               (uu___2248_16285.FStar_TypeChecker_Env.normalized_eff_names);
              FStar_TypeChecker_Env.fv_delta_depths =
-               (uu___2228_16166.FStar_TypeChecker_Env.fv_delta_depths);
+               (uu___2248_16285.FStar_TypeChecker_Env.fv_delta_depths);
              FStar_TypeChecker_Env.proof_ns =
-               (uu___2228_16166.FStar_TypeChecker_Env.proof_ns);
+               (uu___2248_16285.FStar_TypeChecker_Env.proof_ns);
              FStar_TypeChecker_Env.synth_hook =
-               (uu___2228_16166.FStar_TypeChecker_Env.synth_hook);
+               (uu___2248_16285.FStar_TypeChecker_Env.synth_hook);
              FStar_TypeChecker_Env.splice =
-               (uu___2228_16166.FStar_TypeChecker_Env.splice);
+               (uu___2248_16285.FStar_TypeChecker_Env.splice);
              FStar_TypeChecker_Env.postprocess =
-               (uu___2228_16166.FStar_TypeChecker_Env.postprocess);
+               (uu___2248_16285.FStar_TypeChecker_Env.postprocess);
              FStar_TypeChecker_Env.is_native_tactic =
-               (uu___2228_16166.FStar_TypeChecker_Env.is_native_tactic);
+               (uu___2248_16285.FStar_TypeChecker_Env.is_native_tactic);
              FStar_TypeChecker_Env.identifier_info =
-               (uu___2228_16166.FStar_TypeChecker_Env.identifier_info);
+               (uu___2248_16285.FStar_TypeChecker_Env.identifier_info);
              FStar_TypeChecker_Env.tc_hooks =
-               (uu___2228_16166.FStar_TypeChecker_Env.tc_hooks);
+               (uu___2248_16285.FStar_TypeChecker_Env.tc_hooks);
              FStar_TypeChecker_Env.dsenv =
-               (uu___2228_16166.FStar_TypeChecker_Env.dsenv);
+               (uu___2248_16285.FStar_TypeChecker_Env.dsenv);
              FStar_TypeChecker_Env.nbe =
-               (uu___2228_16166.FStar_TypeChecker_Env.nbe);
+               (uu___2248_16285.FStar_TypeChecker_Env.nbe);
              FStar_TypeChecker_Env.strict_args_tab =
-               (uu___2228_16166.FStar_TypeChecker_Env.strict_args_tab);
+               (uu___2248_16285.FStar_TypeChecker_Env.strict_args_tab);
              FStar_TypeChecker_Env.erasable_types_tab =
-               (uu___2228_16166.FStar_TypeChecker_Env.erasable_types_tab)
+               (uu___2248_16285.FStar_TypeChecker_Env.erasable_types_tab)
            }  in
-         let uu____16171 = tc_modul env1 m b  in
-         match uu____16171 with
+         let uu____16290 = tc_modul env1 m b  in
+         match uu____16290 with
          | (m1,env2) ->
-             ((let uu____16183 =
+             ((let uu____16302 =
                  FStar_Options.dump_module
                    (m1.FStar_Syntax_Syntax.name).FStar_Ident.str
                   in
-               if uu____16183
+               if uu____16302
                then
-                 let uu____16186 = FStar_Syntax_Print.modul_to_string m1  in
+                 let uu____16305 = FStar_Syntax_Print.modul_to_string m1  in
                  FStar_Util.print1 "Module after type checking:\n%s\n"
-                   uu____16186
+                   uu____16305
                else ());
-              (let uu____16192 =
+              (let uu____16311 =
                  (FStar_Options.dump_module
                     (m1.FStar_Syntax_Syntax.name).FStar_Ident.str)
                    &&
@@ -9358,7 +9547,7 @@ let (check_module :
                       (m1.FStar_Syntax_Syntax.name).FStar_Ident.str
                       (FStar_Options.Other "Normalize"))
                   in
-               if uu____16192
+               if uu____16311
                then
                  let normalize_toplevel_lets se =
                    match se.FStar_Syntax_Syntax.sigel with
@@ -9375,74 +9564,76 @@ let (check_module :
                            FStar_TypeChecker_Env.AllowUnboundUniverses]
                           in
                        let update lb =
-                         let uu____16230 =
+                         let uu____16349 =
                            FStar_Syntax_Subst.open_univ_vars
                              lb.FStar_Syntax_Syntax.lbunivs
                              lb.FStar_Syntax_Syntax.lbdef
                             in
-                         match uu____16230 with
+                         match uu____16349 with
                          | (univnames1,e) ->
-                             let uu___2250_16237 = lb  in
-                             let uu____16238 =
-                               let uu____16241 =
+                             let uu___2270_16356 = lb  in
+                             let uu____16357 =
+                               let uu____16360 =
                                  FStar_TypeChecker_Env.push_univ_vars env2
                                    univnames1
                                   in
-                               n1 uu____16241 e  in
+                               n1 uu____16360 e  in
                              {
                                FStar_Syntax_Syntax.lbname =
-                                 (uu___2250_16237.FStar_Syntax_Syntax.lbname);
+                                 (uu___2270_16356.FStar_Syntax_Syntax.lbname);
                                FStar_Syntax_Syntax.lbunivs =
-                                 (uu___2250_16237.FStar_Syntax_Syntax.lbunivs);
+                                 (uu___2270_16356.FStar_Syntax_Syntax.lbunivs);
                                FStar_Syntax_Syntax.lbtyp =
-                                 (uu___2250_16237.FStar_Syntax_Syntax.lbtyp);
+                                 (uu___2270_16356.FStar_Syntax_Syntax.lbtyp);
                                FStar_Syntax_Syntax.lbeff =
-                                 (uu___2250_16237.FStar_Syntax_Syntax.lbeff);
-                               FStar_Syntax_Syntax.lbdef = uu____16238;
+                                 (uu___2270_16356.FStar_Syntax_Syntax.lbeff);
+                               FStar_Syntax_Syntax.lbdef = uu____16357;
                                FStar_Syntax_Syntax.lbattrs =
-                                 (uu___2250_16237.FStar_Syntax_Syntax.lbattrs);
+                                 (uu___2270_16356.FStar_Syntax_Syntax.lbattrs);
                                FStar_Syntax_Syntax.lbpos =
-                                 (uu___2250_16237.FStar_Syntax_Syntax.lbpos)
+                                 (uu___2270_16356.FStar_Syntax_Syntax.lbpos)
                              }
                           in
-                       let uu___2252_16242 = se  in
-                       let uu____16243 =
-                         let uu____16244 =
-                           let uu____16251 =
-                             let uu____16252 = FStar_List.map update lbs  in
-                             (b1, uu____16252)  in
-                           (uu____16251, ids)  in
-                         FStar_Syntax_Syntax.Sig_let uu____16244  in
+                       let uu___2272_16361 = se  in
+                       let uu____16362 =
+                         let uu____16363 =
+                           let uu____16370 =
+                             let uu____16371 = FStar_List.map update lbs  in
+                             (b1, uu____16371)  in
+                           (uu____16370, ids)  in
+                         FStar_Syntax_Syntax.Sig_let uu____16363  in
                        {
-                         FStar_Syntax_Syntax.sigel = uu____16243;
+                         FStar_Syntax_Syntax.sigel = uu____16362;
                          FStar_Syntax_Syntax.sigrng =
-                           (uu___2252_16242.FStar_Syntax_Syntax.sigrng);
+                           (uu___2272_16361.FStar_Syntax_Syntax.sigrng);
                          FStar_Syntax_Syntax.sigquals =
-                           (uu___2252_16242.FStar_Syntax_Syntax.sigquals);
+                           (uu___2272_16361.FStar_Syntax_Syntax.sigquals);
                          FStar_Syntax_Syntax.sigmeta =
-                           (uu___2252_16242.FStar_Syntax_Syntax.sigmeta);
+                           (uu___2272_16361.FStar_Syntax_Syntax.sigmeta);
                          FStar_Syntax_Syntax.sigattrs =
-                           (uu___2252_16242.FStar_Syntax_Syntax.sigattrs)
+                           (uu___2272_16361.FStar_Syntax_Syntax.sigattrs);
+                         FStar_Syntax_Syntax.sigopts =
+                           (uu___2272_16361.FStar_Syntax_Syntax.sigopts)
                        }
-                   | uu____16260 -> se  in
+                   | uu____16379 -> se  in
                  let normalized_module =
-                   let uu___2256_16262 = m1  in
-                   let uu____16263 =
+                   let uu___2276_16381 = m1  in
+                   let uu____16382 =
                      FStar_List.map normalize_toplevel_lets
                        m1.FStar_Syntax_Syntax.declarations
                       in
                    {
                      FStar_Syntax_Syntax.name =
-                       (uu___2256_16262.FStar_Syntax_Syntax.name);
-                     FStar_Syntax_Syntax.declarations = uu____16263;
+                       (uu___2276_16381.FStar_Syntax_Syntax.name);
+                     FStar_Syntax_Syntax.declarations = uu____16382;
                      FStar_Syntax_Syntax.exports =
-                       (uu___2256_16262.FStar_Syntax_Syntax.exports);
+                       (uu___2276_16381.FStar_Syntax_Syntax.exports);
                      FStar_Syntax_Syntax.is_interface =
-                       (uu___2256_16262.FStar_Syntax_Syntax.is_interface)
+                       (uu___2276_16381.FStar_Syntax_Syntax.is_interface)
                    }  in
-                 let uu____16264 =
+                 let uu____16383 =
                    FStar_Syntax_Print.modul_to_string normalized_module  in
-                 FStar_Util.print1 "%s\n" uu____16264
+                 FStar_Util.print1 "%s\n" uu____16383
                else ());
               (m1, env2)))
   

--- a/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
@@ -230,7 +230,10 @@ let (tc_tycon :
                                                      (uu___61_451.FStar_Syntax_Syntax.sigmeta);
                                                    FStar_Syntax_Syntax.sigattrs
                                                      =
-                                                     (uu___61_451.FStar_Syntax_Syntax.sigattrs)
+                                                     (uu___61_451.FStar_Syntax_Syntax.sigattrs);
+                                                   FStar_Syntax_Syntax.sigopts
+                                                     =
+                                                     (uu___61_451.FStar_Syntax_Syntax.sigopts)
                                                  }), u, guard1)))))))))
       | uu____456 -> failwith "impossible"
   
@@ -684,7 +687,10 @@ let (tc_data :
                                                          (uu___183_1471.FStar_Syntax_Syntax.sigmeta);
                                                        FStar_Syntax_Syntax.sigattrs
                                                          =
-                                                         (uu___183_1471.FStar_Syntax_Syntax.sigattrs)
+                                                         (uu___183_1471.FStar_Syntax_Syntax.sigattrs);
+                                                       FStar_Syntax_Syntax.sigopts
+                                                         =
+                                                         (uu___183_1471.FStar_Syntax_Syntax.sigopts)
                                                      }), g))))))))))))
         | uu____1475 -> failwith "impossible"
   
@@ -846,7 +852,10 @@ let (generalize_and_inst_within :
                                                         (uu___260_2069.FStar_Syntax_Syntax.sigmeta);
                                                       FStar_Syntax_Syntax.sigattrs
                                                         =
-                                                        (uu___260_2069.FStar_Syntax_Syntax.sigattrs)
+                                                        (uu___260_2069.FStar_Syntax_Syntax.sigattrs);
+                                                      FStar_Syntax_Syntax.sigopts
+                                                        =
+                                                        (uu___260_2069.FStar_Syntax_Syntax.sigopts)
                                                     })
                                            | uu____2074 ->
                                                failwith "Impossible"))
@@ -865,46 +874,48 @@ let (generalize_and_inst_within :
                                    let tc_insts =
                                      FStar_All.pipe_right tcs1
                                        (FStar_List.map
-                                          (fun uu___0_2104  ->
-                                             match uu___0_2104 with
+                                          (fun uu___0_2105  ->
+                                             match uu___0_2105 with
                                              | {
                                                  FStar_Syntax_Syntax.sigel =
                                                    FStar_Syntax_Syntax.Sig_inductive_typ
-                                                   (tc,uu____2110,uu____2111,uu____2112,uu____2113,uu____2114);
+                                                   (tc,uu____2111,uu____2112,uu____2113,uu____2114,uu____2115);
                                                  FStar_Syntax_Syntax.sigrng =
-                                                   uu____2115;
+                                                   uu____2116;
                                                  FStar_Syntax_Syntax.sigquals
-                                                   = uu____2116;
-                                                 FStar_Syntax_Syntax.sigmeta
                                                    = uu____2117;
+                                                 FStar_Syntax_Syntax.sigmeta
+                                                   = uu____2118;
                                                  FStar_Syntax_Syntax.sigattrs
-                                                   = uu____2118;_}
+                                                   = uu____2119;
+                                                 FStar_Syntax_Syntax.sigopts
+                                                   = uu____2120;_}
                                                  -> (tc, uvs_universes)
-                                             | uu____2131 ->
+                                             | uu____2135 ->
                                                  failwith "Impossible"))
                                       in
                                    FStar_List.map2
-                                     (fun uu____2155  ->
+                                     (fun uu____2159  ->
                                         fun d  ->
-                                          match uu____2155 with
-                                          | (t3,uu____2164) ->
+                                          match uu____2159 with
+                                          | (t3,uu____2168) ->
                                               (match d.FStar_Syntax_Syntax.sigel
                                                with
                                                | FStar_Syntax_Syntax.Sig_datacon
-                                                   (l,uu____2170,uu____2171,tc,ntps,mutuals)
+                                                   (l,uu____2174,uu____2175,tc,ntps,mutuals)
                                                    ->
                                                    let ty =
-                                                     let uu____2182 =
+                                                     let uu____2186 =
                                                        FStar_Syntax_InstFV.instantiate
                                                          tc_insts
                                                          t3.FStar_Syntax_Syntax.sort
                                                         in
                                                      FStar_All.pipe_right
-                                                       uu____2182
+                                                       uu____2186
                                                        (FStar_Syntax_Subst.close_univ_vars
                                                           uvs1)
                                                       in
-                                                   let uu___296_2183 = d  in
+                                                   let uu___297_2187 = d  in
                                                    {
                                                      FStar_Syntax_Syntax.sigel
                                                        =
@@ -913,18 +924,21 @@ let (generalize_and_inst_within :
                                                             ntps, mutuals));
                                                      FStar_Syntax_Syntax.sigrng
                                                        =
-                                                       (uu___296_2183.FStar_Syntax_Syntax.sigrng);
+                                                       (uu___297_2187.FStar_Syntax_Syntax.sigrng);
                                                      FStar_Syntax_Syntax.sigquals
                                                        =
-                                                       (uu___296_2183.FStar_Syntax_Syntax.sigquals);
+                                                       (uu___297_2187.FStar_Syntax_Syntax.sigquals);
                                                      FStar_Syntax_Syntax.sigmeta
                                                        =
-                                                       (uu___296_2183.FStar_Syntax_Syntax.sigmeta);
+                                                       (uu___297_2187.FStar_Syntax_Syntax.sigmeta);
                                                      FStar_Syntax_Syntax.sigattrs
                                                        =
-                                                       (uu___296_2183.FStar_Syntax_Syntax.sigattrs)
+                                                       (uu___297_2187.FStar_Syntax_Syntax.sigattrs);
+                                                     FStar_Syntax_Syntax.sigopts
+                                                       =
+                                                       (uu___297_2187.FStar_Syntax_Syntax.sigopts)
                                                    }
-                                               | uu____2187 ->
+                                               | uu____2191 ->
                                                    failwith "Impossible"))
                                      data_types datas
                                 in
@@ -933,11 +947,11 @@ let (generalize_and_inst_within :
 let (debug_log : FStar_TypeChecker_Env.env_t -> Prims.string -> unit) =
   fun env  ->
     fun s  ->
-      let uu____2206 =
+      let uu____2210 =
         FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
           (FStar_Options.Other "Positivity")
          in
-      if uu____2206
+      if uu____2210
       then
         FStar_Util.print_string
           (Prims.op_Hat "Positivity::" (Prims.op_Hat s "\n"))
@@ -947,25 +961,25 @@ let (ty_occurs_in :
   FStar_Ident.lident -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun ty_lid  ->
     fun t  ->
-      let uu____2228 = FStar_Syntax_Free.fvars t  in
-      FStar_Util.set_mem ty_lid uu____2228
+      let uu____2232 = FStar_Syntax_Free.fvars t  in
+      FStar_Util.set_mem ty_lid uu____2232
   
 let (try_get_fv :
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.fv * FStar_Syntax_Syntax.universes))
   =
   fun t  ->
-    let uu____2245 =
-      let uu____2246 = FStar_Syntax_Subst.compress t  in
-      uu____2246.FStar_Syntax_Syntax.n  in
-    match uu____2245 with
+    let uu____2249 =
+      let uu____2250 = FStar_Syntax_Subst.compress t  in
+      uu____2250.FStar_Syntax_Syntax.n  in
+    match uu____2249 with
     | FStar_Syntax_Syntax.Tm_fvar fv -> (fv, [])
     | FStar_Syntax_Syntax.Tm_uinst (t1,us) ->
         (match t1.FStar_Syntax_Syntax.n with
          | FStar_Syntax_Syntax.Tm_fvar fv -> (fv, us)
-         | uu____2265 ->
+         | uu____2269 ->
              failwith "Node is a Tm_uinst, but Tm_uinst is not an fvar")
-    | uu____2271 -> failwith "Node is not an fvar or a Tm_uinst"
+    | uu____2275 -> failwith "Node is not an fvar or a Tm_uinst"
   
 type unfolded_memo_elt =
   (FStar_Ident.lident * FStar_Syntax_Syntax.args) Prims.list
@@ -979,16 +993,16 @@ let (already_unfolded :
     fun arrghs  ->
       fun unfolded  ->
         fun env  ->
-          let uu____2308 = FStar_ST.op_Bang unfolded  in
+          let uu____2312 = FStar_ST.op_Bang unfolded  in
           FStar_List.existsML
-            (fun uu____2357  ->
-               match uu____2357 with
+            (fun uu____2361  ->
+               match uu____2361 with
                | (lid,l) ->
                    (FStar_Ident.lid_equals lid ilid) &&
                      (let args =
-                        let uu____2401 =
+                        let uu____2405 =
                           FStar_List.splitAt (FStar_List.length l) arrghs  in
-                        FStar_Pervasives_Native.fst uu____2401  in
+                        FStar_Pervasives_Native.fst uu____2405  in
                       FStar_List.fold_left2
                         (fun b  ->
                            fun a  ->
@@ -997,7 +1011,7 @@ let (already_unfolded :
                                  (FStar_TypeChecker_Rel.teq_nosmt_force env
                                     (FStar_Pervasives_Native.fst a)
                                     (FStar_Pervasives_Native.fst a'))) true
-                        args l)) uu____2308
+                        args l)) uu____2312
   
 let rec (ty_strictly_positive_in_type :
   FStar_Ident.lident ->
@@ -1008,11 +1022,11 @@ let rec (ty_strictly_positive_in_type :
     fun btype  ->
       fun unfolded  ->
         fun env  ->
-          (let uu____2606 =
-             let uu____2608 = FStar_Syntax_Print.term_to_string btype  in
-             Prims.op_Hat "Checking strict positivity in type: " uu____2608
+          (let uu____2610 =
+             let uu____2612 = FStar_Syntax_Print.term_to_string btype  in
+             Prims.op_Hat "Checking strict positivity in type: " uu____2612
               in
-           debug_log env uu____2606);
+           debug_log env uu____2610);
           (let btype1 =
              FStar_TypeChecker_Normalize.normalize
                [FStar_TypeChecker_Env.Beta;
@@ -1023,40 +1037,40 @@ let rec (ty_strictly_positive_in_type :
                FStar_TypeChecker_Env.Zeta;
                FStar_TypeChecker_Env.AllowUnboundUniverses] env btype
               in
-           (let uu____2613 =
-              let uu____2615 = FStar_Syntax_Print.term_to_string btype1  in
+           (let uu____2617 =
+              let uu____2619 = FStar_Syntax_Print.term_to_string btype1  in
               Prims.op_Hat
                 "Checking strict positivity in type, after normalization: "
-                uu____2615
+                uu____2619
                in
-            debug_log env uu____2613);
-           (let uu____2620 = ty_occurs_in ty_lid btype1  in
-            Prims.op_Negation uu____2620) ||
+            debug_log env uu____2617);
+           (let uu____2624 = ty_occurs_in ty_lid btype1  in
+            Prims.op_Negation uu____2624) ||
              ((debug_log env "ty does occur in this type, pressing ahead";
-               (let uu____2633 =
-                  let uu____2634 = FStar_Syntax_Subst.compress btype1  in
-                  uu____2634.FStar_Syntax_Syntax.n  in
-                match uu____2633 with
+               (let uu____2637 =
+                  let uu____2638 = FStar_Syntax_Subst.compress btype1  in
+                  uu____2638.FStar_Syntax_Syntax.n  in
+                match uu____2637 with
                 | FStar_Syntax_Syntax.Tm_app (t,args) ->
-                    let uu____2664 = try_get_fv t  in
-                    (match uu____2664 with
+                    let uu____2668 = try_get_fv t  in
+                    (match uu____2668 with
                      | (fv,us) ->
-                         let uu____2672 =
+                         let uu____2676 =
                            FStar_Ident.lid_equals
                              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                              ty_lid
                             in
-                         if uu____2672
+                         if uu____2676
                          then
                            (debug_log env
                               "Checking strict positivity in the Tm_app node where head lid is ty itself, checking that ty does not occur in the arguments";
                             FStar_List.for_all
-                              (fun uu____2688  ->
-                                 match uu____2688 with
-                                 | (t1,uu____2697) ->
-                                     let uu____2702 = ty_occurs_in ty_lid t1
+                              (fun uu____2692  ->
+                                 match uu____2692 with
+                                 | (t1,uu____2701) ->
+                                     let uu____2706 = ty_occurs_in ty_lid t1
                                         in
-                                     Prims.op_Negation uu____2702) args)
+                                     Prims.op_Negation uu____2706) args)
                          else
                            (debug_log env
                               "Checking strict positivity in the Tm_app node, head lid is not ty, so checking nested positivity";
@@ -1067,18 +1081,18 @@ let rec (ty_strictly_positive_in_type :
                     (debug_log env "Checking strict positivity in Tm_arrow";
                      (let check_comp1 =
                         let c1 =
-                          let uu____2737 =
+                          let uu____2741 =
                             FStar_TypeChecker_Env.unfold_effect_abbrev env c
                              in
-                          FStar_All.pipe_right uu____2737
+                          FStar_All.pipe_right uu____2741
                             FStar_Syntax_Syntax.mk_Comp
                            in
                         (FStar_Syntax_Util.is_pure_or_ghost_comp c1) ||
-                          (let uu____2741 =
+                          (let uu____2745 =
                              FStar_TypeChecker_Env.lookup_effect_quals env
                                (FStar_Syntax_Util.comp_effect_name c1)
                               in
-                           FStar_All.pipe_right uu____2741
+                           FStar_All.pipe_right uu____2745
                              (FStar_List.existsb
                                 (fun q  ->
                                    q = FStar_Syntax_Syntax.TotalEffect)))
@@ -1092,86 +1106,86 @@ let rec (ty_strictly_positive_in_type :
                         (debug_log env
                            "Checking struict positivity, Pure arrow, checking that ty does not occur in the binders, and that it is strictly positive in the return type";
                          (FStar_List.for_all
-                            (fun uu____2768  ->
-                               match uu____2768 with
-                               | (b,uu____2777) ->
-                                   let uu____2782 =
+                            (fun uu____2772  ->
+                               match uu____2772 with
+                               | (b,uu____2781) ->
+                                   let uu____2786 =
                                      ty_occurs_in ty_lid
                                        b.FStar_Syntax_Syntax.sort
                                       in
-                                   Prims.op_Negation uu____2782) sbs)
+                                   Prims.op_Negation uu____2786) sbs)
                            &&
-                           ((let uu____2788 =
+                           ((let uu____2792 =
                                FStar_Syntax_Subst.open_term sbs
                                  (FStar_Syntax_Util.comp_result c)
                                 in
-                             match uu____2788 with
-                             | (uu____2794,return_type) ->
-                                 let uu____2796 =
+                             match uu____2792 with
+                             | (uu____2798,return_type) ->
+                                 let uu____2800 =
                                    FStar_TypeChecker_Env.push_binders env sbs
                                     in
                                  ty_strictly_positive_in_type ty_lid
-                                   return_type unfolded uu____2796)))))
-                | FStar_Syntax_Syntax.Tm_fvar uu____2797 ->
+                                   return_type unfolded uu____2800)))))
+                | FStar_Syntax_Syntax.Tm_fvar uu____2801 ->
                     (debug_log env
                        "Checking strict positivity in an fvar, return true";
                      true)
-                | FStar_Syntax_Syntax.Tm_type uu____2801 ->
+                | FStar_Syntax_Syntax.Tm_type uu____2805 ->
                     (debug_log env
                        "Checking strict positivity in an Tm_type, return true";
                      true)
-                | FStar_Syntax_Syntax.Tm_uinst (t,uu____2806) ->
+                | FStar_Syntax_Syntax.Tm_uinst (t,uu____2810) ->
                     (debug_log env
                        "Checking strict positivity in an Tm_uinst, recur on the term inside (mostly it should be the same inductive)";
                      ty_strictly_positive_in_type ty_lid t unfolded env)
-                | FStar_Syntax_Syntax.Tm_refine (bv,uu____2814) ->
+                | FStar_Syntax_Syntax.Tm_refine (bv,uu____2818) ->
                     (debug_log env
                        "Checking strict positivity in an Tm_refine, recur in the bv sort)";
                      ty_strictly_positive_in_type ty_lid
                        bv.FStar_Syntax_Syntax.sort unfolded env)
-                | FStar_Syntax_Syntax.Tm_match (uu____2821,branches) ->
+                | FStar_Syntax_Syntax.Tm_match (uu____2825,branches) ->
                     (debug_log env
                        "Checking strict positivity in an Tm_match, recur in the branches)";
                      FStar_List.for_all
-                       (fun uu____2880  ->
-                          match uu____2880 with
-                          | (p,uu____2893,t) ->
+                       (fun uu____2884  ->
+                          match uu____2884 with
+                          | (p,uu____2897,t) ->
                               let bs =
-                                let uu____2912 =
+                                let uu____2916 =
                                   FStar_Syntax_Syntax.pat_bvs p  in
                                 FStar_List.map FStar_Syntax_Syntax.mk_binder
-                                  uu____2912
+                                  uu____2916
                                  in
-                              let uu____2921 =
+                              let uu____2925 =
                                 FStar_Syntax_Subst.open_term bs t  in
-                              (match uu____2921 with
+                              (match uu____2925 with
                                | (bs1,t1) ->
-                                   let uu____2929 =
+                                   let uu____2933 =
                                      FStar_TypeChecker_Env.push_binders env
                                        bs1
                                       in
                                    ty_strictly_positive_in_type ty_lid t1
-                                     unfolded uu____2929)) branches)
-                | FStar_Syntax_Syntax.Tm_ascribed (t,uu____2931,uu____2932)
+                                     unfolded uu____2933)) branches)
+                | FStar_Syntax_Syntax.Tm_ascribed (t,uu____2935,uu____2936)
                     ->
                     (debug_log env
                        "Checking strict positivity in an Tm_ascribed, recur)";
                      ty_strictly_positive_in_type ty_lid t unfolded env)
-                | uu____2975 ->
-                    ((let uu____2977 =
-                        let uu____2979 =
-                          let uu____2981 =
+                | uu____2979 ->
+                    ((let uu____2981 =
+                        let uu____2983 =
+                          let uu____2985 =
                             FStar_Syntax_Print.tag_of_term btype1  in
-                          let uu____2983 =
-                            let uu____2985 =
+                          let uu____2987 =
+                            let uu____2989 =
                               FStar_Syntax_Print.term_to_string btype1  in
-                            Prims.op_Hat " and term: " uu____2985  in
-                          Prims.op_Hat uu____2981 uu____2983  in
+                            Prims.op_Hat " and term: " uu____2989  in
+                          Prims.op_Hat uu____2985 uu____2987  in
                         Prims.op_Hat
                           "Checking strict positivity, unexpected tag: "
-                          uu____2979
+                          uu____2983
                          in
-                      debug_log env uu____2977);
+                      debug_log env uu____2981);
                      false)))))
 
 and (ty_nested_positive_in_inductive :
@@ -1187,86 +1201,86 @@ and (ty_nested_positive_in_inductive :
         fun args  ->
           fun unfolded  ->
             fun env  ->
-              (let uu____2998 =
-                 let uu____3000 =
-                   let uu____3002 =
-                     let uu____3004 = FStar_Syntax_Print.args_to_string args
+              (let uu____3002 =
+                 let uu____3004 =
+                   let uu____3006 =
+                     let uu____3008 = FStar_Syntax_Print.args_to_string args
                         in
-                     Prims.op_Hat " applied to arguments: " uu____3004  in
-                   Prims.op_Hat ilid.FStar_Ident.str uu____3002  in
+                     Prims.op_Hat " applied to arguments: " uu____3008  in
+                   Prims.op_Hat ilid.FStar_Ident.str uu____3006  in
                  Prims.op_Hat "Checking nested positivity in the inductive "
-                   uu____3000
+                   uu____3004
                   in
-               debug_log env uu____2998);
-              (let uu____3008 =
+               debug_log env uu____3002);
+              (let uu____3012 =
                  FStar_TypeChecker_Env.datacons_of_typ env ilid  in
-               match uu____3008 with
+               match uu____3012 with
                | (b,idatas) ->
                    if Prims.op_Negation b
                    then
-                     let uu____3027 =
-                       let uu____3029 =
+                     let uu____3031 =
+                       let uu____3033 =
                          FStar_Syntax_Syntax.lid_as_fv ilid
                            FStar_Syntax_Syntax.delta_constant
                            FStar_Pervasives_Native.None
                           in
-                       FStar_TypeChecker_Env.fv_has_attr env uu____3029
+                       FStar_TypeChecker_Env.fv_has_attr env uu____3033
                          FStar_Parser_Const.assume_strictly_positive_attr_lid
                         in
-                     (if uu____3027
+                     (if uu____3031
                       then
-                        ((let uu____3033 =
-                            let uu____3035 = FStar_Ident.string_of_lid ilid
+                        ((let uu____3037 =
+                            let uu____3039 = FStar_Ident.string_of_lid ilid
                                in
                             FStar_Util.format1
                               "Checking nested positivity, special case decorated with `assume_strictly_positive` %s; return true"
-                              uu____3035
+                              uu____3039
                              in
-                          debug_log env uu____3033);
+                          debug_log env uu____3037);
                          true)
                       else
                         (debug_log env
                            "Checking nested positivity, not an inductive, return false";
                          false))
                    else
-                     (let uu____3046 =
+                     (let uu____3050 =
                         already_unfolded ilid args unfolded env  in
-                      if uu____3046
+                      if uu____3050
                       then
                         (debug_log env
                            "Checking nested positivity, we have already unfolded this inductive with these args";
                          true)
                       else
                         (let num_ibs =
-                           let uu____3057 =
+                           let uu____3061 =
                              FStar_TypeChecker_Env.num_inductive_ty_params
                                env ilid
                               in
-                           FStar_Option.get uu____3057  in
-                         (let uu____3063 =
-                            let uu____3065 =
-                              let uu____3067 =
+                           FStar_Option.get uu____3061  in
+                         (let uu____3067 =
+                            let uu____3069 =
+                              let uu____3071 =
                                 FStar_Util.string_of_int num_ibs  in
-                              Prims.op_Hat uu____3067
+                              Prims.op_Hat uu____3071
                                 ", also adding to the memo table"
                                in
                             Prims.op_Hat
                               "Checking nested positivity, number of type parameters is "
-                              uu____3065
+                              uu____3069
                              in
-                          debug_log env uu____3063);
-                         (let uu____3072 =
-                            let uu____3073 = FStar_ST.op_Bang unfolded  in
-                            let uu____3099 =
-                              let uu____3106 =
-                                let uu____3111 =
-                                  let uu____3112 =
+                          debug_log env uu____3067);
+                         (let uu____3076 =
+                            let uu____3077 = FStar_ST.op_Bang unfolded  in
+                            let uu____3103 =
+                              let uu____3110 =
+                                let uu____3115 =
+                                  let uu____3116 =
                                     FStar_List.splitAt num_ibs args  in
-                                  FStar_Pervasives_Native.fst uu____3112  in
-                                (ilid, uu____3111)  in
-                              [uu____3106]  in
-                            FStar_List.append uu____3073 uu____3099  in
-                          FStar_ST.op_Colon_Equals unfolded uu____3072);
+                                  FStar_Pervasives_Native.fst uu____3116  in
+                                (ilid, uu____3115)  in
+                              [uu____3110]  in
+                            FStar_List.append uu____3077 uu____3103  in
+                          FStar_ST.op_Colon_Equals unfolded uu____3076);
                          FStar_List.for_all
                            (fun d  ->
                               ty_nested_positive_in_dlid ty_lid d ilid us
@@ -1295,9 +1309,9 @@ and (ty_nested_positive_in_dlid :
                        (Prims.op_Hat dlid.FStar_Ident.str
                           (Prims.op_Hat " of the inductive "
                              ilid.FStar_Ident.str)));
-                  (let uu____3211 =
+                  (let uu____3215 =
                      FStar_TypeChecker_Env.lookup_datacon env dlid  in
-                   match uu____3211 with
+                   match uu____3215 with
                    | (univ_unif_vars,dt) ->
                        (FStar_List.iter2
                           (fun u'  ->
@@ -1305,7 +1319,7 @@ and (ty_nested_positive_in_dlid :
                                match u' with
                                | FStar_Syntax_Syntax.U_unif u'' ->
                                    FStar_Syntax_Unionfind.univ_change u'' u
-                               | uu____3234 ->
+                               | uu____3238 ->
                                    failwith
                                      "Impossible! Expected universe unification variables")
                           univ_unif_vars us;
@@ -1320,48 +1334,48 @@ and (ty_nested_positive_in_dlid :
                              FStar_TypeChecker_Env.AllowUnboundUniverses] env
                              dt
                             in
-                         (let uu____3238 =
-                            let uu____3240 =
+                         (let uu____3242 =
+                            let uu____3244 =
                               FStar_Syntax_Print.term_to_string dt1  in
                             Prims.op_Hat
                               "Checking nested positivity in the data constructor type: "
-                              uu____3240
+                              uu____3244
                              in
-                          debug_log env uu____3238);
-                         (let uu____3243 =
-                            let uu____3244 = FStar_Syntax_Subst.compress dt1
+                          debug_log env uu____3242);
+                         (let uu____3247 =
+                            let uu____3248 = FStar_Syntax_Subst.compress dt1
                                in
-                            uu____3244.FStar_Syntax_Syntax.n  in
-                          match uu____3243 with
+                            uu____3248.FStar_Syntax_Syntax.n  in
+                          match uu____3247 with
                           | FStar_Syntax_Syntax.Tm_arrow (dbs,c) ->
                               (debug_log env
                                  "Checked nested positivity in Tm_arrow data constructor type";
-                               (let uu____3272 =
+                               (let uu____3276 =
                                   FStar_List.splitAt num_ibs dbs  in
-                                match uu____3272 with
+                                match uu____3276 with
                                 | (ibs,dbs1) ->
                                     let ibs1 =
                                       FStar_Syntax_Subst.open_binders ibs  in
                                     let dbs2 =
-                                      let uu____3336 =
-                                        FStar_Syntax_Subst.opening_of_binders
-                                          ibs1
-                                         in
-                                      FStar_Syntax_Subst.subst_binders
-                                        uu____3336 dbs1
-                                       in
-                                    let c1 =
                                       let uu____3340 =
                                         FStar_Syntax_Subst.opening_of_binders
                                           ibs1
                                          in
-                                      FStar_Syntax_Subst.subst_comp
-                                        uu____3340 c
+                                      FStar_Syntax_Subst.subst_binders
+                                        uu____3340 dbs1
                                        in
-                                    let uu____3343 =
+                                    let c1 =
+                                      let uu____3344 =
+                                        FStar_Syntax_Subst.opening_of_binders
+                                          ibs1
+                                         in
+                                      FStar_Syntax_Subst.subst_comp
+                                        uu____3344 c
+                                       in
+                                    let uu____3347 =
                                       FStar_List.splitAt num_ibs args  in
-                                    (match uu____3343 with
-                                     | (args1,uu____3378) ->
+                                    (match uu____3347 with
+                                     | (args1,uu____3382) ->
                                          let subst1 =
                                            FStar_List.fold_left2
                                              (fun subst1  ->
@@ -1380,48 +1394,48 @@ and (ty_nested_positive_in_dlid :
                                              subst1 dbs2
                                             in
                                          let c2 =
-                                           let uu____3470 =
+                                           let uu____3474 =
                                              FStar_Syntax_Subst.shift_subst
                                                (FStar_List.length dbs3)
                                                subst1
                                               in
                                            FStar_Syntax_Subst.subst_comp
-                                             uu____3470 c1
+                                             uu____3474 c1
                                             in
-                                         ((let uu____3480 =
-                                             let uu____3482 =
-                                               let uu____3484 =
+                                         ((let uu____3484 =
+                                             let uu____3486 =
+                                               let uu____3488 =
                                                  FStar_Syntax_Print.binders_to_string
                                                    "; " dbs3
                                                   in
-                                               let uu____3487 =
-                                                 let uu____3489 =
+                                               let uu____3491 =
+                                                 let uu____3493 =
                                                    FStar_Syntax_Print.comp_to_string
                                                      c2
                                                     in
                                                  Prims.op_Hat ", and c: "
-                                                   uu____3489
+                                                   uu____3493
                                                   in
-                                               Prims.op_Hat uu____3484
-                                                 uu____3487
+                                               Prims.op_Hat uu____3488
+                                                 uu____3491
                                                 in
                                              Prims.op_Hat
                                                "Checking nested positivity in the unfolded data constructor binders as: "
-                                               uu____3482
+                                               uu____3486
                                               in
-                                           debug_log env uu____3480);
+                                           debug_log env uu____3484);
                                           ty_nested_positive_in_type ty_lid
                                             (FStar_Syntax_Syntax.Tm_arrow
                                                (dbs3, c2)) ilid num_ibs
                                             unfolded env))))
-                          | uu____3503 ->
+                          | uu____3507 ->
                               (debug_log env
                                  "Checking nested positivity in the data constructor type that is not an arrow";
-                               (let uu____3506 =
-                                  let uu____3507 =
+                               (let uu____3510 =
+                                  let uu____3511 =
                                     FStar_Syntax_Subst.compress dt1  in
-                                  uu____3507.FStar_Syntax_Syntax.n  in
-                                ty_nested_positive_in_type ty_lid uu____3506
+                                  uu____3511.FStar_Syntax_Syntax.n  in
+                                ty_nested_positive_in_type ty_lid uu____3510
                                   ilid num_ibs unfolded env))))))
 
 and (ty_nested_positive_in_type :
@@ -1441,51 +1455,51 @@ and (ty_nested_positive_in_type :
               | FStar_Syntax_Syntax.Tm_app (t1,args) ->
                   (debug_log env
                      "Checking nested positivity in an Tm_app node, which is expected to be the ilid itself";
-                   (let uu____3546 = try_get_fv t1  in
-                    match uu____3546 with
-                    | (fv,uu____3553) ->
-                        let uu____3554 =
+                   (let uu____3550 = try_get_fv t1  in
+                    match uu____3550 with
+                    | (fv,uu____3557) ->
+                        let uu____3558 =
                           FStar_Ident.lid_equals
                             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                             ilid
                            in
-                        if uu____3554
+                        if uu____3558
                         then true
                         else
                           failwith "Impossible, expected the type to be ilid"))
               | FStar_Syntax_Syntax.Tm_arrow (sbs,c) ->
-                  ((let uu____3586 =
-                      let uu____3588 =
+                  ((let uu____3590 =
+                      let uu____3592 =
                         FStar_Syntax_Print.binders_to_string "; " sbs  in
                       Prims.op_Hat
                         "Checking nested positivity in an Tm_arrow node, with binders as: "
-                        uu____3588
+                        uu____3592
                        in
-                    debug_log env uu____3586);
+                    debug_log env uu____3590);
                    (let sbs1 = FStar_Syntax_Subst.open_binders sbs  in
-                    let uu____3593 =
+                    let uu____3597 =
                       FStar_List.fold_left
-                        (fun uu____3614  ->
+                        (fun uu____3618  ->
                            fun b  ->
-                             match uu____3614 with
+                             match uu____3618 with
                              | (r,env1) ->
                                  if Prims.op_Negation r
                                  then (r, env1)
                                  else
-                                   (let uu____3645 =
+                                   (let uu____3649 =
                                       ty_strictly_positive_in_type ty_lid
                                         (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
                                         unfolded env1
                                        in
-                                    let uu____3649 =
+                                    let uu____3653 =
                                       FStar_TypeChecker_Env.push_binders env1
                                         [b]
                                        in
-                                    (uu____3645, uu____3649))) (true, env)
+                                    (uu____3649, uu____3653))) (true, env)
                         sbs1
                        in
-                    match uu____3593 with | (b,uu____3667) -> b))
-              | uu____3670 ->
+                    match uu____3597 with | (b,uu____3671) -> b))
+              | uu____3674 ->
                   failwith "Nested positive check, unhandled case"
 
 let (ty_positive_in_datacon :
@@ -1501,9 +1515,9 @@ let (ty_positive_in_datacon :
         fun us  ->
           fun unfolded  ->
             fun env  ->
-              let uu____3706 = FStar_TypeChecker_Env.lookup_datacon env dlid
+              let uu____3710 = FStar_TypeChecker_Env.lookup_datacon env dlid
                  in
-              match uu____3706 with
+              match uu____3710 with
               | (univ_unif_vars,dt) ->
                   (FStar_List.iter2
                      (fun u'  ->
@@ -1511,73 +1525,73 @@ let (ty_positive_in_datacon :
                           match u' with
                           | FStar_Syntax_Syntax.U_unif u'' ->
                               FStar_Syntax_Unionfind.univ_change u'' u
-                          | uu____3729 ->
+                          | uu____3733 ->
                               failwith
                                 "Impossible! Expected universe unification variables")
                      univ_unif_vars us;
-                   (let uu____3732 =
-                      let uu____3734 = FStar_Syntax_Print.term_to_string dt
+                   (let uu____3736 =
+                      let uu____3738 = FStar_Syntax_Print.term_to_string dt
                          in
                       Prims.op_Hat "Checking data constructor type: "
-                        uu____3734
+                        uu____3738
                        in
-                    debug_log env uu____3732);
-                   (let uu____3737 =
-                      let uu____3738 = FStar_Syntax_Subst.compress dt  in
-                      uu____3738.FStar_Syntax_Syntax.n  in
-                    match uu____3737 with
-                    | FStar_Syntax_Syntax.Tm_fvar uu____3742 ->
+                    debug_log env uu____3736);
+                   (let uu____3741 =
+                      let uu____3742 = FStar_Syntax_Subst.compress dt  in
+                      uu____3742.FStar_Syntax_Syntax.n  in
+                    match uu____3741 with
+                    | FStar_Syntax_Syntax.Tm_fvar uu____3746 ->
                         (debug_log env
                            "Data constructor type is simply an fvar, returning true";
                          true)
-                    | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____3747) ->
+                    | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____3751) ->
                         let dbs1 =
-                          let uu____3777 =
+                          let uu____3781 =
                             FStar_List.splitAt (FStar_List.length ty_bs) dbs
                              in
-                          FStar_Pervasives_Native.snd uu____3777  in
+                          FStar_Pervasives_Native.snd uu____3781  in
                         let dbs2 =
-                          let uu____3827 =
+                          let uu____3831 =
                             FStar_Syntax_Subst.opening_of_binders ty_bs  in
-                          FStar_Syntax_Subst.subst_binders uu____3827 dbs1
+                          FStar_Syntax_Subst.subst_binders uu____3831 dbs1
                            in
                         let dbs3 = FStar_Syntax_Subst.open_binders dbs2  in
-                        ((let uu____3832 =
-                            let uu____3834 =
-                              let uu____3836 =
+                        ((let uu____3836 =
+                            let uu____3838 =
+                              let uu____3840 =
                                 FStar_Util.string_of_int
                                   (FStar_List.length dbs3)
                                  in
-                              Prims.op_Hat uu____3836 " binders"  in
+                              Prims.op_Hat uu____3840 " binders"  in
                             Prims.op_Hat
                               "Data constructor type is an arrow type, so checking strict positivity in "
-                              uu____3834
+                              uu____3838
                              in
-                          debug_log env uu____3832);
-                         (let uu____3846 =
+                          debug_log env uu____3836);
+                         (let uu____3850 =
                             FStar_List.fold_left
-                              (fun uu____3867  ->
+                              (fun uu____3871  ->
                                  fun b  ->
-                                   match uu____3867 with
+                                   match uu____3871 with
                                    | (r,env1) ->
                                        if Prims.op_Negation r
                                        then (r, env1)
                                        else
-                                         (let uu____3898 =
+                                         (let uu____3902 =
                                             ty_strictly_positive_in_type
                                               ty_lid
                                               (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
                                               unfolded env1
                                              in
-                                          let uu____3902 =
+                                          let uu____3906 =
                                             FStar_TypeChecker_Env.push_binders
                                               env1 [b]
                                              in
-                                          (uu____3898, uu____3902)))
+                                          (uu____3902, uu____3906)))
                               (true, env) dbs3
                              in
-                          match uu____3846 with | (b,uu____3920) -> b))
-                    | FStar_Syntax_Syntax.Tm_app (uu____3923,uu____3924) ->
+                          match uu____3850 with | (b,uu____3924) -> b))
+                    | FStar_Syntax_Syntax.Tm_app (uu____3927,uu____3928) ->
                         (debug_log env
                            "Data constructor type is a Tm_app, so returning true";
                          true)
@@ -1585,7 +1599,7 @@ let (ty_positive_in_datacon :
                         (debug_log env
                            "Data constructor type is a Tm_uinst, so recursing in the base type";
                          ty_strictly_positive_in_type ty_lid t unfolded env)
-                    | uu____3960 ->
+                    | uu____3964 ->
                         failwith
                           "Unexpected data constructor type when checking positivity"))
   
@@ -1594,33 +1608,33 @@ let (check_positivity :
   fun ty  ->
     fun env  ->
       let unfolded_inductives = FStar_Util.mk_ref []  in
-      let uu____3983 =
+      let uu____3987 =
         match ty.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_inductive_typ
-            (lid,us,bs,uu____3999,uu____4000,uu____4001) -> (lid, us, bs)
-        | uu____4010 -> failwith "Impossible!"  in
-      match uu____3983 with
+            (lid,us,bs,uu____4003,uu____4004,uu____4005) -> (lid, us, bs)
+        | uu____4014 -> failwith "Impossible!"  in
+      match uu____3987 with
       | (ty_lid,ty_us,ty_bs) ->
-          let uu____4022 = FStar_Syntax_Subst.univ_var_opening ty_us  in
-          (match uu____4022 with
+          let uu____4026 = FStar_Syntax_Subst.univ_var_opening ty_us  in
+          (match uu____4026 with
            | (ty_usubst,ty_us1) ->
                let env1 = FStar_TypeChecker_Env.push_univ_vars env ty_us1  in
                let env2 = FStar_TypeChecker_Env.push_binders env1 ty_bs  in
                let ty_bs1 = FStar_Syntax_Subst.subst_binders ty_usubst ty_bs
                   in
                let ty_bs2 = FStar_Syntax_Subst.open_binders ty_bs1  in
-               let uu____4046 =
-                 let uu____4049 =
+               let uu____4050 =
+                 let uu____4053 =
                    FStar_TypeChecker_Env.datacons_of_typ env2 ty_lid  in
-                 FStar_Pervasives_Native.snd uu____4049  in
+                 FStar_Pervasives_Native.snd uu____4053  in
                FStar_List.for_all
                  (fun d  ->
-                    let uu____4063 =
+                    let uu____4067 =
                       FStar_List.map (fun s  -> FStar_Syntax_Syntax.U_name s)
                         ty_us1
                        in
-                    ty_positive_in_datacon ty_lid d ty_bs2 uu____4063
-                      unfolded_inductives env2) uu____4046)
+                    ty_positive_in_datacon ty_lid d ty_bs2 uu____4067
+                      unfolded_inductives env2) uu____4050)
   
 let (check_exn_positivity :
   FStar_Ident.lid -> FStar_TypeChecker_Env.env -> Prims.bool) =
@@ -1634,8 +1648,8 @@ let (datacon_typ : FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.term) =
   fun data  ->
     match data.FStar_Syntax_Syntax.sigel with
     | FStar_Syntax_Syntax.Sig_datacon
-        (uu____4098,uu____4099,t,uu____4101,uu____4102,uu____4103) -> t
-    | uu____4110 -> failwith "Impossible!"
+        (uu____4102,uu____4103,t,uu____4105,uu____4106,uu____4107) -> t
+    | uu____4114 -> failwith "Impossible!"
   
 let (haseq_suffix : Prims.string) = "__uu___haseq" 
 let (is_haseq_lid : FStar_Ident.lid -> Prims.bool) =
@@ -1644,26 +1658,26 @@ let (is_haseq_lid : FStar_Ident.lid -> Prims.bool) =
     let len = FStar_String.length str  in
     let haseq_suffix_len = FStar_String.length haseq_suffix  in
     (len > haseq_suffix_len) &&
-      (let uu____4127 =
-         let uu____4129 =
+      (let uu____4131 =
+         let uu____4133 =
            FStar_String.substring str (len - haseq_suffix_len)
              haseq_suffix_len
             in
-         FStar_String.compare uu____4129 haseq_suffix  in
-       uu____4127 = Prims.int_zero)
+         FStar_String.compare uu____4133 haseq_suffix  in
+       uu____4131 = Prims.int_zero)
   
 let (get_haseq_axiom_lid : FStar_Ident.lid -> FStar_Ident.lid) =
   fun lid  ->
-    let uu____4139 =
-      let uu____4142 =
-        let uu____4145 =
+    let uu____4143 =
+      let uu____4146 =
+        let uu____4149 =
           FStar_Ident.id_of_text
             (Prims.op_Hat (lid.FStar_Ident.ident).FStar_Ident.idText
                haseq_suffix)
            in
-        [uu____4145]  in
-      FStar_List.append lid.FStar_Ident.ns uu____4142  in
-    FStar_Ident.lid_of_ids uu____4139
+        [uu____4149]  in
+      FStar_List.append lid.FStar_Ident.ns uu____4146  in
+    FStar_Ident.lid_of_ids uu____4143
   
 let (get_optimized_haseq_axiom :
   FStar_TypeChecker_Env.env ->
@@ -1678,187 +1692,187 @@ let (get_optimized_haseq_axiom :
     fun ty  ->
       fun usubst  ->
         fun us  ->
-          let uu____4191 =
+          let uu____4195 =
             match ty.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_inductive_typ
-                (lid,uu____4205,bs,t,uu____4208,uu____4209) -> (lid, bs, t)
-            | uu____4218 -> failwith "Impossible!"  in
-          match uu____4191 with
+                (lid,uu____4209,bs,t,uu____4212,uu____4213) -> (lid, bs, t)
+            | uu____4222 -> failwith "Impossible!"  in
+          match uu____4195 with
           | (lid,bs,t) ->
               let bs1 = FStar_Syntax_Subst.subst_binders usubst bs  in
               let t1 =
-                let uu____4241 =
+                let uu____4245 =
                   FStar_Syntax_Subst.shift_subst (FStar_List.length bs1)
                     usubst
                    in
-                FStar_Syntax_Subst.subst uu____4241 t  in
-              let uu____4250 = FStar_Syntax_Subst.open_term bs1 t1  in
-              (match uu____4250 with
+                FStar_Syntax_Subst.subst uu____4245 t  in
+              let uu____4254 = FStar_Syntax_Subst.open_term bs1 t1  in
+              (match uu____4254 with
                | (bs2,t2) ->
                    let ibs =
-                     let uu____4268 =
-                       let uu____4269 = FStar_Syntax_Subst.compress t2  in
-                       uu____4269.FStar_Syntax_Syntax.n  in
-                     match uu____4268 with
-                     | FStar_Syntax_Syntax.Tm_arrow (ibs,uu____4273) -> ibs
-                     | uu____4294 -> []  in
+                     let uu____4272 =
+                       let uu____4273 = FStar_Syntax_Subst.compress t2  in
+                       uu____4273.FStar_Syntax_Syntax.n  in
+                     match uu____4272 with
+                     | FStar_Syntax_Syntax.Tm_arrow (ibs,uu____4277) -> ibs
+                     | uu____4298 -> []  in
                    let ibs1 = FStar_Syntax_Subst.open_binders ibs  in
                    let ind =
-                     let uu____4303 =
+                     let uu____4307 =
                        FStar_Syntax_Syntax.fvar lid
                          FStar_Syntax_Syntax.delta_constant
                          FStar_Pervasives_Native.None
                         in
-                     let uu____4304 =
+                     let uu____4308 =
                        FStar_List.map
                          (fun u  -> FStar_Syntax_Syntax.U_name u) us
                         in
-                     FStar_Syntax_Syntax.mk_Tm_uinst uu____4303 uu____4304
+                     FStar_Syntax_Syntax.mk_Tm_uinst uu____4307 uu____4308
                       in
                    let ind1 =
-                     let uu____4310 =
-                       let uu____4315 =
+                     let uu____4314 =
+                       let uu____4319 =
                          FStar_List.map
-                           (fun uu____4332  ->
-                              match uu____4332 with
+                           (fun uu____4336  ->
+                              match uu____4336 with
                               | (bv,aq) ->
-                                  let uu____4351 =
+                                  let uu____4355 =
                                     FStar_Syntax_Syntax.bv_to_name bv  in
-                                  (uu____4351, aq)) bs2
+                                  (uu____4355, aq)) bs2
                           in
-                       FStar_Syntax_Syntax.mk_Tm_app ind uu____4315  in
-                     uu____4310 FStar_Pervasives_Native.None
+                       FStar_Syntax_Syntax.mk_Tm_app ind uu____4319  in
+                     uu____4314 FStar_Pervasives_Native.None
                        FStar_Range.dummyRange
                       in
                    let ind2 =
-                     let uu____4357 =
-                       let uu____4362 =
+                     let uu____4361 =
+                       let uu____4366 =
                          FStar_List.map
-                           (fun uu____4379  ->
-                              match uu____4379 with
+                           (fun uu____4383  ->
+                              match uu____4383 with
                               | (bv,aq) ->
-                                  let uu____4398 =
+                                  let uu____4402 =
                                     FStar_Syntax_Syntax.bv_to_name bv  in
-                                  (uu____4398, aq)) ibs1
+                                  (uu____4402, aq)) ibs1
                           in
-                       FStar_Syntax_Syntax.mk_Tm_app ind1 uu____4362  in
-                     uu____4357 FStar_Pervasives_Native.None
+                       FStar_Syntax_Syntax.mk_Tm_app ind1 uu____4366  in
+                     uu____4361 FStar_Pervasives_Native.None
                        FStar_Range.dummyRange
                       in
                    let haseq_ind =
-                     let uu____4404 =
-                       let uu____4409 =
-                         let uu____4410 = FStar_Syntax_Syntax.as_arg ind2  in
-                         [uu____4410]  in
+                     let uu____4408 =
+                       let uu____4413 =
+                         let uu____4414 = FStar_Syntax_Syntax.as_arg ind2  in
+                         [uu____4414]  in
                        FStar_Syntax_Syntax.mk_Tm_app
-                         FStar_Syntax_Util.t_haseq uu____4409
+                         FStar_Syntax_Util.t_haseq uu____4413
                         in
-                     uu____4404 FStar_Pervasives_Native.None
+                     uu____4408 FStar_Pervasives_Native.None
                        FStar_Range.dummyRange
                       in
                    let bs' =
                      FStar_List.filter
                        (fun b  ->
-                          let uu____4459 =
-                            let uu____4460 = FStar_Syntax_Util.type_u ()  in
-                            FStar_Pervasives_Native.fst uu____4460  in
+                          let uu____4463 =
+                            let uu____4464 = FStar_Syntax_Util.type_u ()  in
+                            FStar_Pervasives_Native.fst uu____4464  in
                           FStar_TypeChecker_Rel.subtype_nosmt_force en
                             (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
-                            uu____4459) bs2
+                            uu____4463) bs2
                       in
                    let haseq_bs =
                      FStar_List.fold_left
                        (fun t3  ->
                           fun b  ->
-                            let uu____4473 =
-                              let uu____4476 =
-                                let uu____4481 =
-                                  let uu____4482 =
-                                    let uu____4491 =
+                            let uu____4477 =
+                              let uu____4480 =
+                                let uu____4485 =
+                                  let uu____4486 =
+                                    let uu____4495 =
                                       FStar_Syntax_Syntax.bv_to_name
                                         (FStar_Pervasives_Native.fst b)
                                        in
-                                    FStar_Syntax_Syntax.as_arg uu____4491  in
-                                  [uu____4482]  in
+                                    FStar_Syntax_Syntax.as_arg uu____4495  in
+                                  [uu____4486]  in
                                 FStar_Syntax_Syntax.mk_Tm_app
-                                  FStar_Syntax_Util.t_haseq uu____4481
+                                  FStar_Syntax_Util.t_haseq uu____4485
                                  in
-                              uu____4476 FStar_Pervasives_Native.None
+                              uu____4480 FStar_Pervasives_Native.None
                                 FStar_Range.dummyRange
                                in
-                            FStar_Syntax_Util.mk_conj t3 uu____4473)
+                            FStar_Syntax_Util.mk_conj t3 uu____4477)
                        FStar_Syntax_Util.t_true bs'
                       in
                    let fml = FStar_Syntax_Util.mk_imp haseq_bs haseq_ind  in
                    let fml1 =
-                     let uu___630_4514 = fml  in
-                     let uu____4515 =
-                       let uu____4516 =
-                         let uu____4523 =
-                           let uu____4524 =
-                             let uu____4545 =
+                     let uu___631_4518 = fml  in
+                     let uu____4519 =
+                       let uu____4520 =
+                         let uu____4527 =
+                           let uu____4528 =
+                             let uu____4549 =
                                FStar_Syntax_Syntax.binders_to_names ibs1  in
-                             let uu____4550 =
-                               let uu____4563 =
-                                 let uu____4574 =
+                             let uu____4554 =
+                               let uu____4567 =
+                                 let uu____4578 =
                                    FStar_Syntax_Syntax.as_arg haseq_ind  in
-                                 [uu____4574]  in
-                               [uu____4563]  in
-                             (uu____4545, uu____4550)  in
-                           FStar_Syntax_Syntax.Meta_pattern uu____4524  in
-                         (fml, uu____4523)  in
-                       FStar_Syntax_Syntax.Tm_meta uu____4516  in
+                                 [uu____4578]  in
+                               [uu____4567]  in
+                             (uu____4549, uu____4554)  in
+                           FStar_Syntax_Syntax.Meta_pattern uu____4528  in
+                         (fml, uu____4527)  in
+                       FStar_Syntax_Syntax.Tm_meta uu____4520  in
                      {
-                       FStar_Syntax_Syntax.n = uu____4515;
+                       FStar_Syntax_Syntax.n = uu____4519;
                        FStar_Syntax_Syntax.pos =
-                         (uu___630_4514.FStar_Syntax_Syntax.pos);
+                         (uu___631_4518.FStar_Syntax_Syntax.pos);
                        FStar_Syntax_Syntax.vars =
-                         (uu___630_4514.FStar_Syntax_Syntax.vars)
+                         (uu___631_4518.FStar_Syntax_Syntax.vars)
                      }  in
                    let fml2 =
                      FStar_List.fold_right
                        (fun b  ->
                           fun t3  ->
-                            let uu____4643 =
-                              let uu____4648 =
-                                let uu____4649 =
-                                  let uu____4658 =
-                                    let uu____4659 =
+                            let uu____4647 =
+                              let uu____4652 =
+                                let uu____4653 =
+                                  let uu____4662 =
+                                    let uu____4663 =
                                       FStar_Syntax_Subst.close [b] t3  in
                                     FStar_Syntax_Util.abs
                                       [((FStar_Pervasives_Native.fst b),
                                          FStar_Pervasives_Native.None)]
-                                      uu____4659 FStar_Pervasives_Native.None
+                                      uu____4663 FStar_Pervasives_Native.None
                                      in
-                                  FStar_Syntax_Syntax.as_arg uu____4658  in
-                                [uu____4649]  in
+                                  FStar_Syntax_Syntax.as_arg uu____4662  in
+                                [uu____4653]  in
                               FStar_Syntax_Syntax.mk_Tm_app
-                                FStar_Syntax_Util.tforall uu____4648
+                                FStar_Syntax_Util.tforall uu____4652
                                in
-                            uu____4643 FStar_Pervasives_Native.None
+                            uu____4647 FStar_Pervasives_Native.None
                               FStar_Range.dummyRange) ibs1 fml1
                       in
                    let fml3 =
                      FStar_List.fold_right
                        (fun b  ->
                           fun t3  ->
-                            let uu____4712 =
-                              let uu____4717 =
-                                let uu____4718 =
-                                  let uu____4727 =
-                                    let uu____4728 =
+                            let uu____4716 =
+                              let uu____4721 =
+                                let uu____4722 =
+                                  let uu____4731 =
+                                    let uu____4732 =
                                       FStar_Syntax_Subst.close [b] t3  in
                                     FStar_Syntax_Util.abs
                                       [((FStar_Pervasives_Native.fst b),
                                          FStar_Pervasives_Native.None)]
-                                      uu____4728 FStar_Pervasives_Native.None
+                                      uu____4732 FStar_Pervasives_Native.None
                                      in
-                                  FStar_Syntax_Syntax.as_arg uu____4727  in
-                                [uu____4718]  in
+                                  FStar_Syntax_Syntax.as_arg uu____4731  in
+                                [uu____4722]  in
                               FStar_Syntax_Syntax.mk_Tm_app
-                                FStar_Syntax_Util.tforall uu____4717
+                                FStar_Syntax_Util.tforall uu____4721
                                in
-                            uu____4712 FStar_Pervasives_Native.None
+                            uu____4716 FStar_Pervasives_Native.None
                               FStar_Range.dummyRange) bs2 fml2
                       in
                    let axiom_lid = get_haseq_axiom_lid lid  in
@@ -1876,47 +1890,47 @@ let (optimized_haseq_soundness_for_data :
         fun bs  ->
           let dt = datacon_typ data  in
           let dt1 = FStar_Syntax_Subst.subst usubst dt  in
-          let uu____4803 =
-            let uu____4804 = FStar_Syntax_Subst.compress dt1  in
-            uu____4804.FStar_Syntax_Syntax.n  in
-          match uu____4803 with
-          | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____4808) ->
+          let uu____4807 =
+            let uu____4808 = FStar_Syntax_Subst.compress dt1  in
+            uu____4808.FStar_Syntax_Syntax.n  in
+          match uu____4807 with
+          | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____4812) ->
               let dbs1 =
-                let uu____4838 =
+                let uu____4842 =
                   FStar_List.splitAt (FStar_List.length bs) dbs  in
-                FStar_Pervasives_Native.snd uu____4838  in
+                FStar_Pervasives_Native.snd uu____4842  in
               let dbs2 =
-                let uu____4888 = FStar_Syntax_Subst.opening_of_binders bs  in
-                FStar_Syntax_Subst.subst_binders uu____4888 dbs1  in
+                let uu____4892 = FStar_Syntax_Subst.opening_of_binders bs  in
+                FStar_Syntax_Subst.subst_binders uu____4892 dbs1  in
               let dbs3 = FStar_Syntax_Subst.open_binders dbs2  in
               let cond =
                 FStar_List.fold_left
                   (fun t  ->
                      fun b  ->
                        let haseq_b =
-                         let uu____4903 =
-                           let uu____4908 =
-                             let uu____4909 =
+                         let uu____4907 =
+                           let uu____4912 =
+                             let uu____4913 =
                                FStar_Syntax_Syntax.as_arg
                                  (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
                                 in
-                             [uu____4909]  in
+                             [uu____4913]  in
                            FStar_Syntax_Syntax.mk_Tm_app
-                             FStar_Syntax_Util.t_haseq uu____4908
+                             FStar_Syntax_Util.t_haseq uu____4912
                             in
-                         uu____4903 FStar_Pervasives_Native.None
+                         uu____4907 FStar_Pervasives_Native.None
                            FStar_Range.dummyRange
                           in
                        let sort_range =
                          ((FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.pos
                           in
                        let haseq_b1 =
-                         let uu____4940 =
+                         let uu____4944 =
                            FStar_Util.format1
                              "Failed to prove that the type '%s' supports decidable equality because of this argument; add either the 'noeq' or 'unopteq' qualifier"
                              ty_lid.FStar_Ident.str
                             in
-                         FStar_TypeChecker_Util.label uu____4940 sort_range
+                         FStar_TypeChecker_Util.label uu____4944 sort_range
                            haseq_b
                           in
                        FStar_Syntax_Util.mk_conj t haseq_b1)
@@ -1925,25 +1939,25 @@ let (optimized_haseq_soundness_for_data :
               FStar_List.fold_right
                 (fun b  ->
                    fun t  ->
-                     let uu____4948 =
-                       let uu____4953 =
-                         let uu____4954 =
-                           let uu____4963 =
-                             let uu____4964 = FStar_Syntax_Subst.close [b] t
+                     let uu____4952 =
+                       let uu____4957 =
+                         let uu____4958 =
+                           let uu____4967 =
+                             let uu____4968 = FStar_Syntax_Subst.close [b] t
                                 in
                              FStar_Syntax_Util.abs
                                [((FStar_Pervasives_Native.fst b),
-                                  FStar_Pervasives_Native.None)] uu____4964
+                                  FStar_Pervasives_Native.None)] uu____4968
                                FStar_Pervasives_Native.None
                               in
-                           FStar_Syntax_Syntax.as_arg uu____4963  in
-                         [uu____4954]  in
+                           FStar_Syntax_Syntax.as_arg uu____4967  in
+                         [uu____4958]  in
                        FStar_Syntax_Syntax.mk_Tm_app
-                         FStar_Syntax_Util.tforall uu____4953
+                         FStar_Syntax_Util.tforall uu____4957
                         in
-                     uu____4948 FStar_Pervasives_Native.None
+                     uu____4952 FStar_Pervasives_Native.None
                        FStar_Range.dummyRange) dbs3 cond
-          | uu____5011 -> FStar_Syntax_Util.t_true
+          | uu____5015 -> FStar_Syntax_Util.t_true
   
 let (optimized_haseq_ty :
   FStar_Syntax_Syntax.sigelts ->
@@ -1967,19 +1981,19 @@ let (optimized_haseq_ty :
             let lid =
               match ty.FStar_Syntax_Syntax.sigel with
               | FStar_Syntax_Syntax.Sig_inductive_typ
-                  (lid,uu____5102,uu____5103,uu____5104,uu____5105,uu____5106)
+                  (lid,uu____5106,uu____5107,uu____5108,uu____5109,uu____5110)
                   -> lid
-              | uu____5115 -> failwith "Impossible!"  in
-            let uu____5117 = acc  in
-            match uu____5117 with
-            | (uu____5154,en,uu____5156,uu____5157) ->
-                let uu____5178 = get_optimized_haseq_axiom en ty usubst us
+              | uu____5119 -> failwith "Impossible!"  in
+            let uu____5121 = acc  in
+            match uu____5121 with
+            | (uu____5158,en,uu____5160,uu____5161) ->
+                let uu____5182 = get_optimized_haseq_axiom en ty usubst us
                    in
-                (match uu____5178 with
+                (match uu____5182 with
                  | (axiom_lid,fml,bs,ibs,haseq_bs) ->
                      let guard = FStar_Syntax_Util.mk_conj haseq_bs fml  in
-                     let uu____5215 = acc  in
-                     (match uu____5215 with
+                     let uu____5219 = acc  in
+                     (match uu____5219 with
                       | (l_axioms,env,guard',cond') ->
                           let env1 =
                             FStar_TypeChecker_Env.push_binders env bs  in
@@ -1990,28 +2004,28 @@ let (optimized_haseq_ty :
                               (fun s  ->
                                  match s.FStar_Syntax_Syntax.sigel with
                                  | FStar_Syntax_Syntax.Sig_datacon
-                                     (uu____5290,uu____5291,uu____5292,t_lid,uu____5294,uu____5295)
+                                     (uu____5294,uu____5295,uu____5296,t_lid,uu____5298,uu____5299)
                                      -> t_lid = lid
-                                 | uu____5302 -> failwith "Impossible")
+                                 | uu____5306 -> failwith "Impossible")
                               all_datas_in_the_bundle
                              in
                           let cond =
                             FStar_List.fold_left
                               (fun acc1  ->
                                  fun d  ->
-                                   let uu____5317 =
+                                   let uu____5321 =
                                      optimized_haseq_soundness_for_data lid d
                                        usubst bs
                                       in
-                                   FStar_Syntax_Util.mk_conj acc1 uu____5317)
+                                   FStar_Syntax_Util.mk_conj acc1 uu____5321)
                               FStar_Syntax_Util.t_true t_datas
                              in
-                          let uu____5320 =
+                          let uu____5324 =
                             FStar_Syntax_Util.mk_conj guard' guard  in
-                          let uu____5323 =
+                          let uu____5327 =
                             FStar_Syntax_Util.mk_conj cond' cond  in
                           ((FStar_List.append l_axioms [(axiom_lid, fml)]),
-                            env2, uu____5320, uu____5323)))
+                            env2, uu____5324, uu____5327)))
   
 let (optimized_haseq_scheme :
   FStar_Syntax_Syntax.sigelt ->
@@ -2023,17 +2037,17 @@ let (optimized_haseq_scheme :
     fun tcs  ->
       fun datas  ->
         fun env0  ->
-          let uu____5381 =
+          let uu____5385 =
             let ty = FStar_List.hd tcs  in
             match ty.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_inductive_typ
-                (uu____5391,us,uu____5393,t,uu____5395,uu____5396) -> 
+                (uu____5395,us,uu____5397,t,uu____5399,uu____5400) -> 
                 (us, t)
-            | uu____5405 -> failwith "Impossible!"  in
-          match uu____5381 with
+            | uu____5409 -> failwith "Impossible!"  in
+          match uu____5385 with
           | (us,t) ->
-              let uu____5415 = FStar_Syntax_Subst.univ_var_opening us  in
-              (match uu____5415 with
+              let uu____5419 = FStar_Syntax_Subst.univ_var_opening us  in
+              (match uu____5419 with
                | (usubst,us1) ->
                    let env = FStar_TypeChecker_Env.push_sigelt env0 sig_bndle
                       in
@@ -2043,49 +2057,49 @@ let (optimized_haseq_scheme :
                       env sig_bndle;
                     (let env1 = FStar_TypeChecker_Env.push_univ_vars env us1
                         in
-                     let uu____5441 =
+                     let uu____5445 =
                        FStar_List.fold_left
                          (optimized_haseq_ty datas usubst us1)
                          ([], env1, FStar_Syntax_Util.t_true,
                            FStar_Syntax_Util.t_true) tcs
                         in
-                     match uu____5441 with
+                     match uu____5445 with
                      | (axioms,env2,guard,cond) ->
                          let phi =
-                           let uu____5519 = FStar_Syntax_Util.arrow_formals t
+                           let uu____5523 = FStar_Syntax_Util.arrow_formals t
                               in
-                           match uu____5519 with
-                           | (uu____5534,t1) ->
-                               let uu____5556 =
+                           match uu____5523 with
+                           | (uu____5538,t1) ->
+                               let uu____5560 =
                                  FStar_Syntax_Util.is_eqtype_no_unrefine t1
                                   in
-                               if uu____5556
+                               if uu____5560
                                then cond
                                else FStar_Syntax_Util.mk_imp guard cond
                             in
-                         let uu____5561 =
+                         let uu____5565 =
                            FStar_TypeChecker_TcTerm.tc_trivial_guard env2 phi
                             in
-                         (match uu____5561 with
-                          | (phi1,uu____5569) ->
-                              ((let uu____5571 =
+                         (match uu____5565 with
+                          | (phi1,uu____5573) ->
+                              ((let uu____5575 =
                                   FStar_TypeChecker_Env.should_verify env2
                                    in
-                                if uu____5571
+                                if uu____5575
                                 then
-                                  let uu____5574 =
+                                  let uu____5578 =
                                     FStar_TypeChecker_Env.guard_of_guard_formula
                                       (FStar_TypeChecker_Common.NonTrivial
                                          phi1)
                                      in
                                   FStar_TypeChecker_Rel.force_trivial_guard
-                                    env2 uu____5574
+                                    env2 uu____5578
                                 else ());
                                (let ses =
                                   FStar_List.fold_left
                                     (fun l  ->
-                                       fun uu____5592  ->
-                                         match uu____5592 with
+                                       fun uu____5596  ->
+                                         match uu____5596 with
                                          | (lid,fml) ->
                                              let fml1 =
                                                FStar_Syntax_Subst.close_univ_vars
@@ -2104,7 +2118,10 @@ let (optimized_haseq_scheme :
                                                     =
                                                     FStar_Syntax_Syntax.default_sigmeta;
                                                   FStar_Syntax_Syntax.sigattrs
-                                                    = []
+                                                    = [];
+                                                  FStar_Syntax_Syntax.sigopts
+                                                    =
+                                                    FStar_Pervasives_Native.None
                                                 }]) [] axioms
                                    in
                                 (env2.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.pop
@@ -2127,51 +2144,51 @@ let (unoptimized_haseq_data :
           fun acc  ->
             fun data  ->
               let rec is_mutual t =
-                let uu____5664 =
-                  let uu____5665 = FStar_Syntax_Subst.compress t  in
-                  uu____5665.FStar_Syntax_Syntax.n  in
-                match uu____5664 with
+                let uu____5668 =
+                  let uu____5669 = FStar_Syntax_Subst.compress t  in
+                  uu____5669.FStar_Syntax_Syntax.n  in
+                match uu____5668 with
                 | FStar_Syntax_Syntax.Tm_fvar fv ->
                     FStar_List.existsb
                       (fun lid  ->
                          FStar_Ident.lid_equals lid
                            (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
                       mutuals
-                | FStar_Syntax_Syntax.Tm_uinst (t',uu____5673) ->
+                | FStar_Syntax_Syntax.Tm_uinst (t',uu____5677) ->
                     is_mutual t'
                 | FStar_Syntax_Syntax.Tm_refine (bv,t') ->
                     is_mutual bv.FStar_Syntax_Syntax.sort
                 | FStar_Syntax_Syntax.Tm_app (t',args) ->
-                    let uu____5710 = is_mutual t'  in
-                    if uu____5710
+                    let uu____5714 = is_mutual t'  in
+                    if uu____5714
                     then true
                     else
-                      (let uu____5717 =
+                      (let uu____5721 =
                          FStar_List.map FStar_Pervasives_Native.fst args  in
-                       exists_mutual uu____5717)
-                | FStar_Syntax_Syntax.Tm_meta (t',uu____5737) -> is_mutual t'
-                | uu____5742 -> false
+                       exists_mutual uu____5721)
+                | FStar_Syntax_Syntax.Tm_meta (t',uu____5741) -> is_mutual t'
+                | uu____5746 -> false
               
-              and exists_mutual uu___1_5744 =
-                match uu___1_5744 with
+              and exists_mutual uu___1_5748 =
+                match uu___1_5748 with
                 | [] -> false
                 | hd1::tl1 -> (is_mutual hd1) || (exists_mutual tl1)
                in
               let dt = datacon_typ data  in
               let dt1 = FStar_Syntax_Subst.subst usubst dt  in
-              let uu____5765 =
-                let uu____5766 = FStar_Syntax_Subst.compress dt1  in
-                uu____5766.FStar_Syntax_Syntax.n  in
-              match uu____5765 with
-              | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____5772) ->
+              let uu____5769 =
+                let uu____5770 = FStar_Syntax_Subst.compress dt1  in
+                uu____5770.FStar_Syntax_Syntax.n  in
+              match uu____5769 with
+              | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____5776) ->
                   let dbs1 =
-                    let uu____5802 =
+                    let uu____5806 =
                       FStar_List.splitAt (FStar_List.length bs) dbs  in
-                    FStar_Pervasives_Native.snd uu____5802  in
+                    FStar_Pervasives_Native.snd uu____5806  in
                   let dbs2 =
-                    let uu____5852 = FStar_Syntax_Subst.opening_of_binders bs
+                    let uu____5856 = FStar_Syntax_Subst.opening_of_binders bs
                        in
-                    FStar_Syntax_Subst.subst_binders uu____5852 dbs1  in
+                    FStar_Syntax_Subst.subst_binders uu____5856 dbs1  in
                   let dbs3 = FStar_Syntax_Subst.open_binders dbs2  in
                   let cond =
                     FStar_List.fold_left
@@ -2181,22 +2198,22 @@ let (unoptimized_haseq_data :
                              (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
                               in
                            let haseq_sort =
-                             let uu____5872 =
-                               let uu____5877 =
-                                 let uu____5878 =
+                             let uu____5876 =
+                               let uu____5881 =
+                                 let uu____5882 =
                                    FStar_Syntax_Syntax.as_arg
                                      (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
                                     in
-                                 [uu____5878]  in
+                                 [uu____5882]  in
                                FStar_Syntax_Syntax.mk_Tm_app
-                                 FStar_Syntax_Util.t_haseq uu____5877
+                                 FStar_Syntax_Util.t_haseq uu____5881
                                 in
-                             uu____5872 FStar_Pervasives_Native.None
+                             uu____5876 FStar_Pervasives_Native.None
                                FStar_Range.dummyRange
                               in
                            let haseq_sort1 =
-                             let uu____5908 = is_mutual sort  in
-                             if uu____5908
+                             let uu____5912 = is_mutual sort  in
+                             if uu____5912
                              then
                                FStar_Syntax_Util.mk_imp haseq_ind haseq_sort
                              else haseq_sort  in
@@ -2207,27 +2224,27 @@ let (unoptimized_haseq_data :
                     FStar_List.fold_right
                       (fun b  ->
                          fun t  ->
-                           let uu____5921 =
-                             let uu____5926 =
-                               let uu____5927 =
-                                 let uu____5936 =
-                                   let uu____5937 =
+                           let uu____5925 =
+                             let uu____5930 =
+                               let uu____5931 =
+                                 let uu____5940 =
+                                   let uu____5941 =
                                      FStar_Syntax_Subst.close [b] t  in
                                    FStar_Syntax_Util.abs
                                      [((FStar_Pervasives_Native.fst b),
                                         FStar_Pervasives_Native.None)]
-                                     uu____5937 FStar_Pervasives_Native.None
+                                     uu____5941 FStar_Pervasives_Native.None
                                     in
-                                 FStar_Syntax_Syntax.as_arg uu____5936  in
-                               [uu____5927]  in
+                                 FStar_Syntax_Syntax.as_arg uu____5940  in
+                               [uu____5931]  in
                              FStar_Syntax_Syntax.mk_Tm_app
-                               FStar_Syntax_Util.tforall uu____5926
+                               FStar_Syntax_Util.tforall uu____5930
                               in
-                           uu____5921 FStar_Pervasives_Native.None
+                           uu____5925 FStar_Pervasives_Native.None
                              FStar_Range.dummyRange) dbs3 cond
                      in
                   FStar_Syntax_Util.mk_conj acc cond1
-              | uu____5984 -> acc
+              | uu____5988 -> acc
   
 let (unoptimized_haseq_ty :
   FStar_Syntax_Syntax.sigelt Prims.list ->
@@ -2244,87 +2261,87 @@ let (unoptimized_haseq_ty :
         fun us  ->
           fun acc  ->
             fun ty  ->
-              let uu____6034 =
+              let uu____6038 =
                 match ty.FStar_Syntax_Syntax.sigel with
                 | FStar_Syntax_Syntax.Sig_inductive_typ
-                    (lid,uu____6056,bs,t,uu____6059,d_lids) ->
+                    (lid,uu____6060,bs,t,uu____6063,d_lids) ->
                     (lid, bs, t, d_lids)
-                | uu____6071 -> failwith "Impossible!"  in
-              match uu____6034 with
+                | uu____6075 -> failwith "Impossible!"  in
+              match uu____6038 with
               | (lid,bs,t,d_lids) ->
                   let bs1 = FStar_Syntax_Subst.subst_binders usubst bs  in
                   let t1 =
-                    let uu____6095 =
+                    let uu____6099 =
                       FStar_Syntax_Subst.shift_subst (FStar_List.length bs1)
                         usubst
                        in
-                    FStar_Syntax_Subst.subst uu____6095 t  in
-                  let uu____6104 = FStar_Syntax_Subst.open_term bs1 t1  in
-                  (match uu____6104 with
+                    FStar_Syntax_Subst.subst uu____6099 t  in
+                  let uu____6108 = FStar_Syntax_Subst.open_term bs1 t1  in
+                  (match uu____6108 with
                    | (bs2,t2) ->
                        let ibs =
-                         let uu____6114 =
-                           let uu____6115 = FStar_Syntax_Subst.compress t2
+                         let uu____6118 =
+                           let uu____6119 = FStar_Syntax_Subst.compress t2
                               in
-                           uu____6115.FStar_Syntax_Syntax.n  in
-                         match uu____6114 with
-                         | FStar_Syntax_Syntax.Tm_arrow (ibs,uu____6119) ->
+                           uu____6119.FStar_Syntax_Syntax.n  in
+                         match uu____6118 with
+                         | FStar_Syntax_Syntax.Tm_arrow (ibs,uu____6123) ->
                              ibs
-                         | uu____6140 -> []  in
+                         | uu____6144 -> []  in
                        let ibs1 = FStar_Syntax_Subst.open_binders ibs  in
                        let ind =
-                         let uu____6149 =
+                         let uu____6153 =
                            FStar_Syntax_Syntax.fvar lid
                              FStar_Syntax_Syntax.delta_constant
                              FStar_Pervasives_Native.None
                             in
-                         let uu____6150 =
+                         let uu____6154 =
                            FStar_List.map
                              (fun u  -> FStar_Syntax_Syntax.U_name u) us
                             in
-                         FStar_Syntax_Syntax.mk_Tm_uinst uu____6149
-                           uu____6150
+                         FStar_Syntax_Syntax.mk_Tm_uinst uu____6153
+                           uu____6154
                           in
                        let ind1 =
-                         let uu____6156 =
-                           let uu____6161 =
+                         let uu____6160 =
+                           let uu____6165 =
                              FStar_List.map
-                               (fun uu____6178  ->
-                                  match uu____6178 with
+                               (fun uu____6182  ->
+                                  match uu____6182 with
                                   | (bv,aq) ->
-                                      let uu____6197 =
+                                      let uu____6201 =
                                         FStar_Syntax_Syntax.bv_to_name bv  in
-                                      (uu____6197, aq)) bs2
+                                      (uu____6201, aq)) bs2
                               in
-                           FStar_Syntax_Syntax.mk_Tm_app ind uu____6161  in
-                         uu____6156 FStar_Pervasives_Native.None
+                           FStar_Syntax_Syntax.mk_Tm_app ind uu____6165  in
+                         uu____6160 FStar_Pervasives_Native.None
                            FStar_Range.dummyRange
                           in
                        let ind2 =
-                         let uu____6203 =
-                           let uu____6208 =
+                         let uu____6207 =
+                           let uu____6212 =
                              FStar_List.map
-                               (fun uu____6225  ->
-                                  match uu____6225 with
+                               (fun uu____6229  ->
+                                  match uu____6229 with
                                   | (bv,aq) ->
-                                      let uu____6244 =
+                                      let uu____6248 =
                                         FStar_Syntax_Syntax.bv_to_name bv  in
-                                      (uu____6244, aq)) ibs1
+                                      (uu____6248, aq)) ibs1
                               in
-                           FStar_Syntax_Syntax.mk_Tm_app ind1 uu____6208  in
-                         uu____6203 FStar_Pervasives_Native.None
+                           FStar_Syntax_Syntax.mk_Tm_app ind1 uu____6212  in
+                         uu____6207 FStar_Pervasives_Native.None
                            FStar_Range.dummyRange
                           in
                        let haseq_ind =
-                         let uu____6250 =
-                           let uu____6255 =
-                             let uu____6256 = FStar_Syntax_Syntax.as_arg ind2
+                         let uu____6254 =
+                           let uu____6259 =
+                             let uu____6260 = FStar_Syntax_Syntax.as_arg ind2
                                 in
-                             [uu____6256]  in
+                             [uu____6260]  in
                            FStar_Syntax_Syntax.mk_Tm_app
-                             FStar_Syntax_Util.t_haseq uu____6255
+                             FStar_Syntax_Util.t_haseq uu____6259
                             in
-                         uu____6250 FStar_Pervasives_Native.None
+                         uu____6254 FStar_Pervasives_Native.None
                            FStar_Range.dummyRange
                           in
                        let t_datas =
@@ -2332,9 +2349,9 @@ let (unoptimized_haseq_ty :
                            (fun s  ->
                               match s.FStar_Syntax_Syntax.sigel with
                               | FStar_Syntax_Syntax.Sig_datacon
-                                  (uu____6293,uu____6294,uu____6295,t_lid,uu____6297,uu____6298)
+                                  (uu____6297,uu____6298,uu____6299,t_lid,uu____6301,uu____6302)
                                   -> t_lid = lid
-                              | uu____6305 -> failwith "Impossible")
+                              | uu____6309 -> failwith "Impossible")
                            all_datas_in_the_bundle
                           in
                        let data_cond =
@@ -2345,81 +2362,81 @@ let (unoptimized_haseq_ty :
                        let fml = FStar_Syntax_Util.mk_imp data_cond haseq_ind
                           in
                        let fml1 =
-                         let uu___867_6317 = fml  in
-                         let uu____6318 =
-                           let uu____6319 =
-                             let uu____6326 =
-                               let uu____6327 =
-                                 let uu____6348 =
+                         let uu___868_6321 = fml  in
+                         let uu____6322 =
+                           let uu____6323 =
+                             let uu____6330 =
+                               let uu____6331 =
+                                 let uu____6352 =
                                    FStar_Syntax_Syntax.binders_to_names ibs1
                                     in
-                                 let uu____6353 =
-                                   let uu____6366 =
-                                     let uu____6377 =
+                                 let uu____6357 =
+                                   let uu____6370 =
+                                     let uu____6381 =
                                        FStar_Syntax_Syntax.as_arg haseq_ind
                                         in
-                                     [uu____6377]  in
-                                   [uu____6366]  in
-                                 (uu____6348, uu____6353)  in
-                               FStar_Syntax_Syntax.Meta_pattern uu____6327
+                                     [uu____6381]  in
+                                   [uu____6370]  in
+                                 (uu____6352, uu____6357)  in
+                               FStar_Syntax_Syntax.Meta_pattern uu____6331
                                 in
-                             (fml, uu____6326)  in
-                           FStar_Syntax_Syntax.Tm_meta uu____6319  in
+                             (fml, uu____6330)  in
+                           FStar_Syntax_Syntax.Tm_meta uu____6323  in
                          {
-                           FStar_Syntax_Syntax.n = uu____6318;
+                           FStar_Syntax_Syntax.n = uu____6322;
                            FStar_Syntax_Syntax.pos =
-                             (uu___867_6317.FStar_Syntax_Syntax.pos);
+                             (uu___868_6321.FStar_Syntax_Syntax.pos);
                            FStar_Syntax_Syntax.vars =
-                             (uu___867_6317.FStar_Syntax_Syntax.vars)
+                             (uu___868_6321.FStar_Syntax_Syntax.vars)
                          }  in
                        let fml2 =
                          FStar_List.fold_right
                            (fun b  ->
                               fun t3  ->
-                                let uu____6446 =
-                                  let uu____6451 =
-                                    let uu____6452 =
-                                      let uu____6461 =
-                                        let uu____6462 =
+                                let uu____6450 =
+                                  let uu____6455 =
+                                    let uu____6456 =
+                                      let uu____6465 =
+                                        let uu____6466 =
                                           FStar_Syntax_Subst.close [b] t3  in
                                         FStar_Syntax_Util.abs
                                           [((FStar_Pervasives_Native.fst b),
                                              FStar_Pervasives_Native.None)]
-                                          uu____6462
+                                          uu____6466
                                           FStar_Pervasives_Native.None
                                          in
-                                      FStar_Syntax_Syntax.as_arg uu____6461
+                                      FStar_Syntax_Syntax.as_arg uu____6465
                                        in
-                                    [uu____6452]  in
+                                    [uu____6456]  in
                                   FStar_Syntax_Syntax.mk_Tm_app
-                                    FStar_Syntax_Util.tforall uu____6451
+                                    FStar_Syntax_Util.tforall uu____6455
                                    in
-                                uu____6446 FStar_Pervasives_Native.None
+                                uu____6450 FStar_Pervasives_Native.None
                                   FStar_Range.dummyRange) ibs1 fml1
                           in
                        let fml3 =
                          FStar_List.fold_right
                            (fun b  ->
                               fun t3  ->
-                                let uu____6515 =
-                                  let uu____6520 =
-                                    let uu____6521 =
-                                      let uu____6530 =
-                                        let uu____6531 =
+                                let uu____6519 =
+                                  let uu____6524 =
+                                    let uu____6525 =
+                                      let uu____6534 =
+                                        let uu____6535 =
                                           FStar_Syntax_Subst.close [b] t3  in
                                         FStar_Syntax_Util.abs
                                           [((FStar_Pervasives_Native.fst b),
                                              FStar_Pervasives_Native.None)]
-                                          uu____6531
+                                          uu____6535
                                           FStar_Pervasives_Native.None
                                          in
-                                      FStar_Syntax_Syntax.as_arg uu____6530
+                                      FStar_Syntax_Syntax.as_arg uu____6534
                                        in
-                                    [uu____6521]  in
+                                    [uu____6525]  in
                                   FStar_Syntax_Syntax.mk_Tm_app
-                                    FStar_Syntax_Util.tforall uu____6520
+                                    FStar_Syntax_Util.tforall uu____6524
                                    in
-                                uu____6515 FStar_Pervasives_Native.None
+                                uu____6519 FStar_Pervasives_Native.None
                                   FStar_Range.dummyRange) bs2 fml2
                           in
                        FStar_Syntax_Util.mk_conj acc fml3)
@@ -2439,21 +2456,21 @@ let (unoptimized_haseq_scheme :
               (fun ty  ->
                  match ty.FStar_Syntax_Syntax.sigel with
                  | FStar_Syntax_Syntax.Sig_inductive_typ
-                     (lid,uu____6623,uu____6624,uu____6625,uu____6626,uu____6627)
+                     (lid,uu____6627,uu____6628,uu____6629,uu____6630,uu____6631)
                      -> lid
-                 | uu____6636 -> failwith "Impossible!") tcs
+                 | uu____6640 -> failwith "Impossible!") tcs
              in
-          let uu____6638 =
+          let uu____6642 =
             let ty = FStar_List.hd tcs  in
             match ty.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_inductive_typ
-                (lid,us,uu____6650,uu____6651,uu____6652,uu____6653) ->
+                (lid,us,uu____6654,uu____6655,uu____6656,uu____6657) ->
                 (lid, us)
-            | uu____6662 -> failwith "Impossible!"  in
-          match uu____6638 with
+            | uu____6666 -> failwith "Impossible!"  in
+          match uu____6642 with
           | (lid,us) ->
-              let uu____6672 = FStar_Syntax_Subst.univ_var_opening us  in
-              (match uu____6672 with
+              let uu____6676 = FStar_Syntax_Subst.univ_var_opening us  in
+              (match uu____6676 with
                | (usubst,us1) ->
                    let fml =
                      FStar_List.fold_left
@@ -2461,18 +2478,20 @@ let (unoptimized_haseq_scheme :
                        FStar_Syntax_Util.t_true tcs
                       in
                    let se =
-                     let uu____6699 =
-                       let uu____6700 =
-                         let uu____6707 = get_haseq_axiom_lid lid  in
-                         (uu____6707, us1, fml)  in
-                       FStar_Syntax_Syntax.Sig_assume uu____6700  in
+                     let uu____6703 =
+                       let uu____6704 =
+                         let uu____6711 = get_haseq_axiom_lid lid  in
+                         (uu____6711, us1, fml)  in
+                       FStar_Syntax_Syntax.Sig_assume uu____6704  in
                      {
-                       FStar_Syntax_Syntax.sigel = uu____6699;
+                       FStar_Syntax_Syntax.sigel = uu____6703;
                        FStar_Syntax_Syntax.sigrng = FStar_Range.dummyRange;
                        FStar_Syntax_Syntax.sigquals = [];
                        FStar_Syntax_Syntax.sigmeta =
                          FStar_Syntax_Syntax.default_sigmeta;
-                       FStar_Syntax_Syntax.sigattrs = []
+                       FStar_Syntax_Syntax.sigattrs = [];
+                       FStar_Syntax_Syntax.sigopts =
+                         FStar_Pervasives_Native.None
                      }  in
                    [se])
   
@@ -2488,167 +2507,169 @@ let (check_inductive_well_typedness :
     fun ses  ->
       fun quals  ->
         fun lids  ->
-          let uu____6761 =
+          let uu____6765 =
             FStar_All.pipe_right ses
               (FStar_List.partition
-                 (fun uu___2_6786  ->
-                    match uu___2_6786 with
+                 (fun uu___2_6791  ->
+                    match uu___2_6791 with
                     | {
                         FStar_Syntax_Syntax.sigel =
-                          FStar_Syntax_Syntax.Sig_inductive_typ uu____6788;
-                        FStar_Syntax_Syntax.sigrng = uu____6789;
-                        FStar_Syntax_Syntax.sigquals = uu____6790;
-                        FStar_Syntax_Syntax.sigmeta = uu____6791;
-                        FStar_Syntax_Syntax.sigattrs = uu____6792;_} -> true
-                    | uu____6814 -> false))
+                          FStar_Syntax_Syntax.Sig_inductive_typ uu____6793;
+                        FStar_Syntax_Syntax.sigrng = uu____6794;
+                        FStar_Syntax_Syntax.sigquals = uu____6795;
+                        FStar_Syntax_Syntax.sigmeta = uu____6796;
+                        FStar_Syntax_Syntax.sigattrs = uu____6797;
+                        FStar_Syntax_Syntax.sigopts = uu____6798;_} -> true
+                    | uu____6822 -> false))
              in
-          match uu____6761 with
+          match uu____6765 with
           | (tys,datas) ->
-              ((let uu____6837 =
+              ((let uu____6845 =
                   FStar_All.pipe_right datas
                     (FStar_Util.for_some
-                       (fun uu___3_6848  ->
-                          match uu___3_6848 with
+                       (fun uu___3_6857  ->
+                          match uu___3_6857 with
                           | {
                               FStar_Syntax_Syntax.sigel =
-                                FStar_Syntax_Syntax.Sig_datacon uu____6850;
-                              FStar_Syntax_Syntax.sigrng = uu____6851;
-                              FStar_Syntax_Syntax.sigquals = uu____6852;
-                              FStar_Syntax_Syntax.sigmeta = uu____6853;
-                              FStar_Syntax_Syntax.sigattrs = uu____6854;_} ->
+                                FStar_Syntax_Syntax.Sig_datacon uu____6859;
+                              FStar_Syntax_Syntax.sigrng = uu____6860;
+                              FStar_Syntax_Syntax.sigquals = uu____6861;
+                              FStar_Syntax_Syntax.sigmeta = uu____6862;
+                              FStar_Syntax_Syntax.sigattrs = uu____6863;
+                              FStar_Syntax_Syntax.sigopts = uu____6864;_} ->
                               false
-                          | uu____6875 -> true))
+                          | uu____6887 -> true))
                    in
-                if uu____6837
+                if uu____6845
                 then
-                  let uu____6878 = FStar_TypeChecker_Env.get_range env  in
+                  let uu____6890 = FStar_TypeChecker_Env.get_range env  in
                   FStar_Errors.raise_error
                     (FStar_Errors.Fatal_NonInductiveInMutuallyDefinedType,
                       "Mutually defined type contains a non-inductive element")
-                    uu____6878
+                    uu____6890
                 else ());
                (let univs1 =
                   if (FStar_List.length tys) = Prims.int_zero
                   then []
                   else
-                    (let uu____6893 =
-                       let uu____6894 = FStar_List.hd tys  in
-                       uu____6894.FStar_Syntax_Syntax.sigel  in
-                     match uu____6893 with
+                    (let uu____6905 =
+                       let uu____6906 = FStar_List.hd tys  in
+                       uu____6906.FStar_Syntax_Syntax.sigel  in
+                     match uu____6905 with
                      | FStar_Syntax_Syntax.Sig_inductive_typ
-                         (uu____6897,uvs,uu____6899,uu____6900,uu____6901,uu____6902)
+                         (uu____6909,uvs,uu____6911,uu____6912,uu____6913,uu____6914)
                          -> uvs
-                     | uu____6911 -> failwith "Impossible, can't happen!")
+                     | uu____6923 -> failwith "Impossible, can't happen!")
                    in
                 let env0 = env  in
-                let uu____6916 =
+                let uu____6928 =
                   FStar_List.fold_right
                     (fun tc  ->
-                       fun uu____6955  ->
-                         match uu____6955 with
+                       fun uu____6967  ->
+                         match uu____6967 with
                          | (env1,all_tcs,g) ->
-                             let uu____6995 = tc_tycon env1 tc  in
-                             (match uu____6995 with
+                             let uu____7007 = tc_tycon env1 tc  in
+                             (match uu____7007 with
                               | (env2,tc1,tc_u,guard) ->
                                   let g' =
                                     FStar_TypeChecker_Rel.universe_inequality
                                       FStar_Syntax_Syntax.U_zero tc_u
                                      in
-                                  ((let uu____7022 =
+                                  ((let uu____7034 =
                                       FStar_TypeChecker_Env.debug env2
                                         FStar_Options.Low
                                        in
-                                    if uu____7022
+                                    if uu____7034
                                     then
-                                      let uu____7025 =
+                                      let uu____7037 =
                                         FStar_Syntax_Print.sigelt_to_string
                                           tc1
                                          in
                                       FStar_Util.print1
-                                        "Checked inductive: %s\n" uu____7025
+                                        "Checked inductive: %s\n" uu____7037
                                     else ());
-                                   (let uu____7030 =
-                                      let uu____7031 =
+                                   (let uu____7042 =
+                                      let uu____7043 =
                                         FStar_TypeChecker_Env.conj_guard
                                           guard g'
                                          in
                                       FStar_TypeChecker_Env.conj_guard g
-                                        uu____7031
+                                        uu____7043
                                        in
                                     (env2, ((tc1, tc_u) :: all_tcs),
-                                      uu____7030))))) tys
+                                      uu____7042))))) tys
                     (env, [], FStar_TypeChecker_Env.trivial_guard)
                    in
-                match uu____6916 with
+                match uu____6928 with
                 | (env1,tcs,g) ->
-                    let uu____7077 =
+                    let uu____7089 =
                       FStar_List.fold_right
                         (fun se  ->
-                           fun uu____7099  ->
-                             match uu____7099 with
+                           fun uu____7111  ->
+                             match uu____7111 with
                              | (datas1,g1) ->
-                                 let uu____7118 =
-                                   let uu____7123 = tc_data env1 tcs  in
-                                   uu____7123 se  in
-                                 (match uu____7118 with
+                                 let uu____7130 =
+                                   let uu____7135 = tc_data env1 tcs  in
+                                   uu____7135 se  in
+                                 (match uu____7130 with
                                   | (data,g') ->
-                                      let uu____7140 =
+                                      let uu____7152 =
                                         FStar_TypeChecker_Env.conj_guard g1
                                           g'
                                          in
-                                      ((data :: datas1), uu____7140))) datas
+                                      ((data :: datas1), uu____7152))) datas
                         ([], g)
                        in
-                    (match uu____7077 with
+                    (match uu____7089 with
                      | (datas1,g1) ->
-                         let uu____7161 =
+                         let uu____7173 =
                            let tc_universe_vars =
                              FStar_List.map FStar_Pervasives_Native.snd tcs
                               in
                            let g2 =
-                             let uu___976_7178 = g1  in
+                             let uu___979_7190 = g1  in
                              {
                                FStar_TypeChecker_Env.guard_f =
-                                 (uu___976_7178.FStar_TypeChecker_Env.guard_f);
+                                 (uu___979_7190.FStar_TypeChecker_Env.guard_f);
                                FStar_TypeChecker_Env.deferred =
-                                 (uu___976_7178.FStar_TypeChecker_Env.deferred);
+                                 (uu___979_7190.FStar_TypeChecker_Env.deferred);
                                FStar_TypeChecker_Env.univ_ineqs =
                                  (tc_universe_vars,
                                    (FStar_Pervasives_Native.snd
                                       g1.FStar_TypeChecker_Env.univ_ineqs));
                                FStar_TypeChecker_Env.implicits =
-                                 (uu___976_7178.FStar_TypeChecker_Env.implicits)
+                                 (uu___979_7190.FStar_TypeChecker_Env.implicits)
                              }  in
-                           (let uu____7188 =
+                           (let uu____7200 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env0)
                                 (FStar_Options.Other "GenUniverses")
                                in
-                            if uu____7188
+                            if uu____7200
                             then
-                              let uu____7193 =
+                              let uu____7205 =
                                 FStar_TypeChecker_Rel.guard_to_string env1 g2
                                  in
                               FStar_Util.print1
                                 "@@@@@@Guard before (possible) generalization: %s\n"
-                                uu____7193
+                                uu____7205
                             else ());
                            FStar_TypeChecker_Rel.force_trivial_guard env0 g2;
                            if (FStar_List.length univs1) = Prims.int_zero
                            then generalize_and_inst_within env0 tcs datas1
                            else
-                             (let uu____7212 =
+                             (let uu____7224 =
                                 FStar_List.map FStar_Pervasives_Native.fst
                                   tcs
                                  in
-                              (uu____7212, datas1))
+                              (uu____7224, datas1))
                             in
-                         (match uu____7161 with
+                         (match uu____7173 with
                           | (tcs1,datas2) ->
                               let sig_bndle =
-                                let uu____7244 =
+                                let uu____7256 =
                                   FStar_TypeChecker_Env.get_range env0  in
-                                let uu____7245 =
+                                let uu____7257 =
                                   FStar_List.collect
                                     (fun s  -> s.FStar_Syntax_Syntax.sigattrs)
                                     ses
@@ -2658,11 +2679,13 @@ let (check_inductive_well_typedness :
                                     (FStar_Syntax_Syntax.Sig_bundle
                                        ((FStar_List.append tcs1 datas2),
                                          lids));
-                                  FStar_Syntax_Syntax.sigrng = uu____7244;
+                                  FStar_Syntax_Syntax.sigrng = uu____7256;
                                   FStar_Syntax_Syntax.sigquals = quals;
                                   FStar_Syntax_Syntax.sigmeta =
                                     FStar_Syntax_Syntax.default_sigmeta;
-                                  FStar_Syntax_Syntax.sigattrs = uu____7245
+                                  FStar_Syntax_Syntax.sigattrs = uu____7257;
+                                  FStar_Syntax_Syntax.sigopts =
+                                    FStar_Pervasives_Native.None
                                 }  in
                               (FStar_All.pipe_right tcs1
                                  (FStar_List.iter
@@ -2670,62 +2693,62 @@ let (check_inductive_well_typedness :
                                        match se.FStar_Syntax_Syntax.sigel
                                        with
                                        | FStar_Syntax_Syntax.Sig_inductive_typ
-                                           (l,univs2,binders,typ,uu____7271,uu____7272)
+                                           (l,univs2,binders,typ,uu____7283,uu____7284)
                                            ->
                                            let fail1 expected inferred =
-                                             let uu____7292 =
-                                               let uu____7298 =
-                                                 let uu____7300 =
+                                             let uu____7304 =
+                                               let uu____7310 =
+                                                 let uu____7312 =
                                                    FStar_Syntax_Print.tscheme_to_string
                                                      expected
                                                     in
-                                                 let uu____7302 =
+                                                 let uu____7314 =
                                                    FStar_Syntax_Print.tscheme_to_string
                                                      inferred
                                                     in
                                                  FStar_Util.format2
                                                    "Expected an inductive with type %s; got %s"
-                                                   uu____7300 uu____7302
+                                                   uu____7312 uu____7314
                                                   in
                                                (FStar_Errors.Fatal_UnexpectedInductivetype,
-                                                 uu____7298)
+                                                 uu____7310)
                                                 in
                                              FStar_Errors.raise_error
-                                               uu____7292
+                                               uu____7304
                                                se.FStar_Syntax_Syntax.sigrng
                                               in
-                                           let uu____7306 =
+                                           let uu____7318 =
                                              FStar_TypeChecker_Env.try_lookup_val_decl
                                                env0 l
                                               in
-                                           (match uu____7306 with
+                                           (match uu____7318 with
                                             | FStar_Pervasives_Native.None 
                                                 -> ()
                                             | FStar_Pervasives_Native.Some
-                                                (expected_typ1,uu____7322) ->
+                                                (expected_typ1,uu____7334) ->
                                                 let inferred_typ =
                                                   let body =
                                                     match binders with
                                                     | [] -> typ
-                                                    | uu____7353 ->
-                                                        let uu____7354 =
-                                                          let uu____7361 =
-                                                            let uu____7362 =
-                                                              let uu____7377
+                                                    | uu____7365 ->
+                                                        let uu____7366 =
+                                                          let uu____7373 =
+                                                            let uu____7374 =
+                                                              let uu____7389
                                                                 =
                                                                 FStar_Syntax_Syntax.mk_Total
                                                                   typ
                                                                  in
                                                               (binders,
-                                                                uu____7377)
+                                                                uu____7389)
                                                                in
                                                             FStar_Syntax_Syntax.Tm_arrow
-                                                              uu____7362
+                                                              uu____7374
                                                              in
                                                           FStar_Syntax_Syntax.mk
-                                                            uu____7361
+                                                            uu____7373
                                                            in
-                                                        uu____7354
+                                                        uu____7366
                                                           FStar_Pervasives_Native.None
                                                           se.FStar_Syntax_Syntax.sigrng
                                                      in
@@ -2737,25 +2760,25 @@ let (check_inductive_well_typedness :
                                                        (FStar_Pervasives_Native.fst
                                                           expected_typ1))
                                                 then
-                                                  let uu____7399 =
+                                                  let uu____7411 =
                                                     FStar_TypeChecker_Env.inst_tscheme
                                                       inferred_typ
                                                      in
-                                                  (match uu____7399 with
-                                                   | (uu____7404,inferred) ->
-                                                       let uu____7406 =
+                                                  (match uu____7411 with
+                                                   | (uu____7416,inferred) ->
+                                                       let uu____7418 =
                                                          FStar_TypeChecker_Env.inst_tscheme
                                                            expected_typ1
                                                           in
-                                                       (match uu____7406 with
-                                                        | (uu____7411,expected)
+                                                       (match uu____7418 with
+                                                        | (uu____7423,expected)
                                                             ->
-                                                            let uu____7413 =
+                                                            let uu____7425 =
                                                               FStar_TypeChecker_Rel.teq_nosmt_force
                                                                 env0 inferred
                                                                 expected
                                                                in
-                                                            if uu____7413
+                                                            if uu____7425
                                                             then ()
                                                             else
                                                               fail1
@@ -2764,7 +2787,7 @@ let (check_inductive_well_typedness :
                                                 else
                                                   fail1 expected_typ1
                                                     inferred_typ)
-                                       | uu____7420 -> ()));
+                                       | uu____7432 -> ()));
                                (sig_bndle, tcs1, datas2))))))
   
 let (early_prims_inductives : Prims.string Prims.list) =
@@ -2806,39 +2829,39 @@ let (mk_discriminator_and_indexed_projectors :
                         let tps = inductive_tps  in
                         let arg_typ =
                           let inst_tc =
-                            let uu____7538 =
-                              let uu____7545 =
-                                let uu____7546 =
-                                  let uu____7553 =
-                                    let uu____7556 =
+                            let uu____7550 =
+                              let uu____7557 =
+                                let uu____7558 =
+                                  let uu____7565 =
+                                    let uu____7568 =
                                       FStar_Syntax_Syntax.lid_as_fv tc
                                         FStar_Syntax_Syntax.delta_constant
                                         FStar_Pervasives_Native.None
                                        in
-                                    FStar_Syntax_Syntax.fv_to_tm uu____7556
+                                    FStar_Syntax_Syntax.fv_to_tm uu____7568
                                      in
-                                  (uu____7553, inst_univs)  in
-                                FStar_Syntax_Syntax.Tm_uinst uu____7546  in
-                              FStar_Syntax_Syntax.mk uu____7545  in
-                            uu____7538 FStar_Pervasives_Native.None p  in
+                                  (uu____7565, inst_univs)  in
+                                FStar_Syntax_Syntax.Tm_uinst uu____7558  in
+                              FStar_Syntax_Syntax.mk uu____7557  in
+                            uu____7550 FStar_Pervasives_Native.None p  in
                           let args =
                             FStar_All.pipe_right
                               (FStar_List.append tps indices)
                               (FStar_List.map
-                                 (fun uu____7590  ->
-                                    match uu____7590 with
+                                 (fun uu____7602  ->
+                                    match uu____7602 with
                                     | (x,imp) ->
-                                        let uu____7609 =
+                                        let uu____7621 =
                                           FStar_Syntax_Syntax.bv_to_name x
                                            in
-                                        (uu____7609, imp)))
+                                        (uu____7621, imp)))
                              in
                           FStar_Syntax_Syntax.mk_Tm_app inst_tc args
                             FStar_Pervasives_Native.None p
                            in
                         let unrefined_arg_binder =
-                          let uu____7613 = projectee arg_typ  in
-                          FStar_Syntax_Syntax.mk_binder uu____7613  in
+                          let uu____7625 = projectee arg_typ  in
+                          FStar_Syntax_Syntax.mk_binder uu____7625  in
                         let arg_binder =
                           if Prims.op_Negation refine_domain
                           then unrefined_arg_binder
@@ -2851,76 +2874,76 @@ let (mk_discriminator_and_indexed_projectors :
                                 in
                              let sort =
                                let disc_fvar =
-                                 let uu____7636 =
+                                 let uu____7648 =
                                    FStar_Ident.set_lid_range disc_name p  in
-                                 FStar_Syntax_Syntax.fvar uu____7636
+                                 FStar_Syntax_Syntax.fvar uu____7648
                                    (FStar_Syntax_Syntax.Delta_equational_at_level
                                       Prims.int_one)
                                    FStar_Pervasives_Native.None
                                   in
-                               let uu____7638 =
-                                 let uu____7641 =
-                                   let uu____7644 =
-                                     let uu____7649 =
+                               let uu____7650 =
+                                 let uu____7653 =
+                                   let uu____7656 =
+                                     let uu____7661 =
                                        FStar_Syntax_Syntax.mk_Tm_uinst
                                          disc_fvar inst_univs
                                         in
-                                     let uu____7650 =
-                                       let uu____7651 =
-                                         let uu____7660 =
+                                     let uu____7662 =
+                                       let uu____7663 =
+                                         let uu____7672 =
                                            FStar_Syntax_Syntax.bv_to_name x
                                             in
                                          FStar_All.pipe_left
                                            FStar_Syntax_Syntax.as_arg
-                                           uu____7660
+                                           uu____7672
                                           in
-                                       [uu____7651]  in
-                                     FStar_Syntax_Syntax.mk_Tm_app uu____7649
-                                       uu____7650
+                                       [uu____7663]  in
+                                     FStar_Syntax_Syntax.mk_Tm_app uu____7661
+                                       uu____7662
                                       in
-                                   uu____7644 FStar_Pervasives_Native.None p
+                                   uu____7656 FStar_Pervasives_Native.None p
                                     in
-                                 FStar_Syntax_Util.b2t uu____7641  in
-                               FStar_Syntax_Util.refine x uu____7638  in
-                             let uu____7685 =
-                               let uu___1050_7686 = projectee arg_typ  in
+                                 FStar_Syntax_Util.b2t uu____7653  in
+                               FStar_Syntax_Util.refine x uu____7650  in
+                             let uu____7697 =
+                               let uu___1053_7698 = projectee arg_typ  in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___1050_7686.FStar_Syntax_Syntax.ppname);
+                                   (uu___1053_7698.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___1050_7686.FStar_Syntax_Syntax.index);
+                                   (uu___1053_7698.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = sort
                                }  in
-                             FStar_Syntax_Syntax.mk_binder uu____7685)
+                             FStar_Syntax_Syntax.mk_binder uu____7697)
                            in
                         let ntps = FStar_List.length tps  in
                         let all_params =
-                          let uu____7703 =
+                          let uu____7715 =
                             FStar_List.map
-                              (fun uu____7727  ->
-                                 match uu____7727 with
-                                 | (x,uu____7741) ->
+                              (fun uu____7739  ->
+                                 match uu____7739 with
+                                 | (x,uu____7753) ->
                                      (x,
                                        (FStar_Pervasives_Native.Some
                                           FStar_Syntax_Syntax.imp_tag))) tps
                              in
-                          FStar_List.append uu____7703 fields  in
+                          FStar_List.append uu____7715 fields  in
                         let imp_binders =
                           FStar_All.pipe_right
                             (FStar_List.append tps indices)
                             (FStar_List.map
-                               (fun uu____7800  ->
-                                  match uu____7800 with
-                                  | (x,uu____7814) ->
+                               (fun uu____7812  ->
+                                  match uu____7812 with
+                                  | (x,uu____7826) ->
                                       (x,
                                         (FStar_Pervasives_Native.Some
                                            FStar_Syntax_Syntax.imp_tag))))
                            in
                         let early_prims_inductive =
-                          (let uu____7825 =
+                          (let uu____7837 =
                              FStar_TypeChecker_Env.current_module env  in
                            FStar_Ident.lid_equals
-                             FStar_Parser_Const.prims_lid uu____7825)
+                             FStar_Parser_Const.prims_lid uu____7837)
                             &&
                             (FStar_List.existsb
                                (fun s  ->
@@ -2937,20 +2960,20 @@ let (mk_discriminator_and_indexed_projectors :
                              let no_decl = false  in
                              let only_decl =
                                early_prims_inductive ||
-                                 (let uu____7846 =
-                                    let uu____7848 =
+                                 (let uu____7858 =
+                                    let uu____7860 =
                                       FStar_TypeChecker_Env.current_module
                                         env
                                        in
-                                    uu____7848.FStar_Ident.str  in
+                                    uu____7860.FStar_Ident.str  in
                                   FStar_Options.dont_gen_projectors
-                                    uu____7846)
+                                    uu____7858)
                                 in
                              let quals =
-                               let uu____7852 =
+                               let uu____7864 =
                                  FStar_List.filter
-                                   (fun uu___4_7856  ->
-                                      match uu___4_7856 with
+                                   (fun uu___4_7868  ->
+                                      match uu___4_7868 with
                                       | FStar_Syntax_Syntax.Abstract  ->
                                           Prims.op_Negation only_decl
                                       | FStar_Syntax_Syntax.Inline_for_extraction
@@ -2958,7 +2981,7 @@ let (mk_discriminator_and_indexed_projectors :
                                       | FStar_Syntax_Syntax.NoExtract  ->
                                           true
                                       | FStar_Syntax_Syntax.Private  -> true
-                                      | uu____7861 -> false) iquals
+                                      | uu____7873 -> false) iquals
                                   in
                                FStar_List.append
                                  ((FStar_Syntax_Syntax.Discriminator lid) ::
@@ -2966,7 +2989,7 @@ let (mk_discriminator_and_indexed_projectors :
                                   then
                                     [FStar_Syntax_Syntax.Logic;
                                     FStar_Syntax_Syntax.Assumption]
-                                  else [])) uu____7852
+                                  else [])) uu____7864
                                 in
                              let binders =
                                FStar_List.append imp_binders
@@ -2982,38 +3005,40 @@ let (mk_discriminator_and_indexed_projectors :
                                    FStar_Syntax_Syntax.mk_Total
                                      FStar_Syntax_Util.t_bool
                                   in
-                               let uu____7906 =
+                               let uu____7918 =
                                  FStar_Syntax_Util.arrow binders bool_typ  in
                                FStar_All.pipe_left
                                  (FStar_Syntax_Subst.close_univ_vars uvs)
-                                 uu____7906
+                                 uu____7918
                                 in
                              let decl =
-                               let uu____7910 =
+                               let uu____7922 =
                                  FStar_Ident.range_of_lid discriminator_name
                                   in
                                {
                                  FStar_Syntax_Syntax.sigel =
                                    (FStar_Syntax_Syntax.Sig_declare_typ
                                       (discriminator_name, uvs, t));
-                                 FStar_Syntax_Syntax.sigrng = uu____7910;
+                                 FStar_Syntax_Syntax.sigrng = uu____7922;
                                  FStar_Syntax_Syntax.sigquals = quals;
                                  FStar_Syntax_Syntax.sigmeta =
                                    FStar_Syntax_Syntax.default_sigmeta;
-                                 FStar_Syntax_Syntax.sigattrs = []
+                                 FStar_Syntax_Syntax.sigattrs = [];
+                                 FStar_Syntax_Syntax.sigopts =
+                                   FStar_Pervasives_Native.None
                                }  in
-                             (let uu____7912 =
+                             (let uu____7924 =
                                 FStar_TypeChecker_Env.debug env
                                   (FStar_Options.Other "LogTypes")
                                  in
-                              if uu____7912
+                              if uu____7924
                               then
-                                let uu____7916 =
+                                let uu____7928 =
                                   FStar_Syntax_Print.sigelt_to_string decl
                                    in
                                 FStar_Util.print1
                                   "Declaration of a discriminator %s\n"
-                                  uu____7916
+                                  uu____7928
                               else ());
                              if only_decl
                              then [decl]
@@ -3026,8 +3051,8 @@ let (mk_discriminator_and_indexed_projectors :
                                        FStar_All.pipe_right all_params
                                          (FStar_List.mapi
                                             (fun j  ->
-                                               fun uu____7977  ->
-                                                 match uu____7977 with
+                                               fun uu____7989  ->
+                                                 match uu____7989 with
                                                  | (x,imp) ->
                                                      let b =
                                                        FStar_Syntax_Syntax.is_implicit
@@ -3035,71 +3060,71 @@ let (mk_discriminator_and_indexed_projectors :
                                                         in
                                                      if b && (j < ntps)
                                                      then
-                                                       let uu____8002 =
-                                                         let uu____8005 =
-                                                           let uu____8006 =
-                                                             let uu____8013 =
+                                                       let uu____8014 =
+                                                         let uu____8017 =
+                                                           let uu____8018 =
+                                                             let uu____8025 =
                                                                FStar_Syntax_Syntax.gen_bv
                                                                  (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
                                                                  FStar_Pervasives_Native.None
                                                                  FStar_Syntax_Syntax.tun
                                                                 in
-                                                             (uu____8013,
+                                                             (uu____8025,
                                                                FStar_Syntax_Syntax.tun)
                                                               in
                                                            FStar_Syntax_Syntax.Pat_dot_term
-                                                             uu____8006
+                                                             uu____8018
                                                             in
-                                                         pos uu____8005  in
-                                                       (uu____8002, b)
+                                                         pos uu____8017  in
+                                                       (uu____8014, b)
                                                      else
-                                                       (let uu____8021 =
-                                                          let uu____8024 =
-                                                            let uu____8025 =
+                                                       (let uu____8033 =
+                                                          let uu____8036 =
+                                                            let uu____8037 =
                                                               FStar_Syntax_Syntax.gen_bv
                                                                 (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
                                                                 FStar_Pervasives_Native.None
                                                                 FStar_Syntax_Syntax.tun
                                                                in
                                                             FStar_Syntax_Syntax.Pat_wild
-                                                              uu____8025
+                                                              uu____8037
                                                              in
-                                                          pos uu____8024  in
-                                                        (uu____8021, b))))
+                                                          pos uu____8036  in
+                                                        (uu____8033, b))))
                                         in
                                      let pat_true =
-                                       let uu____8044 =
-                                         let uu____8047 =
-                                           let uu____8048 =
-                                             let uu____8062 =
+                                       let uu____8056 =
+                                         let uu____8059 =
+                                           let uu____8060 =
+                                             let uu____8074 =
                                                FStar_Syntax_Syntax.lid_as_fv
                                                  lid
                                                  FStar_Syntax_Syntax.delta_constant
                                                  (FStar_Pervasives_Native.Some
                                                     fvq)
                                                 in
-                                             (uu____8062, arg_pats)  in
+                                             (uu____8074, arg_pats)  in
                                            FStar_Syntax_Syntax.Pat_cons
-                                             uu____8048
+                                             uu____8060
                                             in
-                                         pos uu____8047  in
-                                       (uu____8044,
+                                         pos uu____8059  in
+                                       (uu____8056,
                                          FStar_Pervasives_Native.None,
                                          FStar_Syntax_Util.exp_true_bool)
                                         in
                                      let pat_false =
-                                       let uu____8097 =
-                                         let uu____8100 =
-                                           let uu____8101 =
+                                       let uu____8109 =
+                                         let uu____8112 =
+                                           let uu____8113 =
                                              FStar_Syntax_Syntax.new_bv
                                                FStar_Pervasives_Native.None
                                                FStar_Syntax_Syntax.tun
                                               in
                                            FStar_Syntax_Syntax.Pat_wild
-                                             uu____8101
+                                             uu____8113
                                             in
-                                         pos uu____8100  in
-                                       (uu____8097,
+                                         pos uu____8112  in
+                                       (uu____8109,
                                          FStar_Pervasives_Native.None,
                                          FStar_Syntax_Util.exp_false_bool)
                                         in
@@ -3108,36 +3133,36 @@ let (mk_discriminator_and_indexed_projectors :
                                          (FStar_Pervasives_Native.fst
                                             unrefined_arg_binder)
                                         in
-                                     let uu____8115 =
-                                       let uu____8122 =
-                                         let uu____8123 =
-                                           let uu____8146 =
-                                             let uu____8163 =
+                                     let uu____8127 =
+                                       let uu____8134 =
+                                         let uu____8135 =
+                                           let uu____8158 =
+                                             let uu____8175 =
                                                FStar_Syntax_Util.branch
                                                  pat_true
                                                 in
-                                             let uu____8178 =
-                                               let uu____8195 =
+                                             let uu____8190 =
+                                               let uu____8207 =
                                                  FStar_Syntax_Util.branch
                                                    pat_false
                                                   in
-                                               [uu____8195]  in
-                                             uu____8163 :: uu____8178  in
-                                           (arg_exp, uu____8146)  in
+                                               [uu____8207]  in
+                                             uu____8175 :: uu____8190  in
+                                           (arg_exp, uu____8158)  in
                                          FStar_Syntax_Syntax.Tm_match
-                                           uu____8123
+                                           uu____8135
                                           in
-                                       FStar_Syntax_Syntax.mk uu____8122  in
-                                     uu____8115 FStar_Pervasives_Native.None
+                                       FStar_Syntax_Syntax.mk uu____8134  in
+                                     uu____8127 FStar_Pervasives_Native.None
                                        p)
                                    in
                                 let dd =
-                                  let uu____8271 =
+                                  let uu____8283 =
                                     FStar_All.pipe_right quals
                                       (FStar_List.contains
                                          FStar_Syntax_Syntax.Abstract)
                                      in
-                                  if uu____8271
+                                  if uu____8283
                                   then
                                     FStar_Syntax_Syntax.Delta_abstract
                                       (FStar_Syntax_Syntax.Delta_equational_at_level
@@ -3155,60 +3180,62 @@ let (mk_discriminator_and_indexed_projectors :
                                   then t
                                   else FStar_Syntax_Syntax.tun  in
                                 let lb =
-                                  let uu____8293 =
-                                    let uu____8298 =
+                                  let uu____8305 =
+                                    let uu____8310 =
                                       FStar_Syntax_Syntax.lid_as_fv
                                         discriminator_name dd
                                         FStar_Pervasives_Native.None
                                        in
-                                    FStar_Util.Inr uu____8298  in
-                                  let uu____8299 =
+                                    FStar_Util.Inr uu____8310  in
+                                  let uu____8311 =
                                     FStar_Syntax_Subst.close_univ_vars uvs
                                       imp
                                      in
-                                  FStar_Syntax_Util.mk_letbinding uu____8293
+                                  FStar_Syntax_Util.mk_letbinding uu____8305
                                     uvs lbtyp
                                     FStar_Parser_Const.effect_Tot_lid
-                                    uu____8299 [] FStar_Range.dummyRange
+                                    uu____8311 [] FStar_Range.dummyRange
                                    in
                                 let impl =
-                                  let uu____8305 =
-                                    let uu____8306 =
-                                      let uu____8313 =
-                                        let uu____8316 =
-                                          let uu____8317 =
+                                  let uu____8317 =
+                                    let uu____8318 =
+                                      let uu____8325 =
+                                        let uu____8328 =
+                                          let uu____8329 =
                                             FStar_All.pipe_right
                                               lb.FStar_Syntax_Syntax.lbname
                                               FStar_Util.right
                                              in
-                                          FStar_All.pipe_right uu____8317
+                                          FStar_All.pipe_right uu____8329
                                             (fun fv  ->
                                                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
                                            in
-                                        [uu____8316]  in
-                                      ((false, [lb]), uu____8313)  in
-                                    FStar_Syntax_Syntax.Sig_let uu____8306
+                                        [uu____8328]  in
+                                      ((false, [lb]), uu____8325)  in
+                                    FStar_Syntax_Syntax.Sig_let uu____8318
                                      in
                                   {
-                                    FStar_Syntax_Syntax.sigel = uu____8305;
+                                    FStar_Syntax_Syntax.sigel = uu____8317;
                                     FStar_Syntax_Syntax.sigrng = p;
                                     FStar_Syntax_Syntax.sigquals = quals;
                                     FStar_Syntax_Syntax.sigmeta =
                                       FStar_Syntax_Syntax.default_sigmeta;
-                                    FStar_Syntax_Syntax.sigattrs = []
+                                    FStar_Syntax_Syntax.sigattrs = [];
+                                    FStar_Syntax_Syntax.sigopts =
+                                      FStar_Pervasives_Native.None
                                   }  in
-                                (let uu____8331 =
+                                (let uu____8343 =
                                    FStar_TypeChecker_Env.debug env
                                      (FStar_Options.Other "LogTypes")
                                     in
-                                 if uu____8331
+                                 if uu____8343
                                  then
-                                   let uu____8335 =
+                                   let uu____8347 =
                                      FStar_Syntax_Print.sigelt_to_string impl
                                       in
                                    FStar_Util.print1
                                      "Implementation of a discriminator %s\n"
-                                     uu____8335
+                                     uu____8347
                                  else ());
                                 [decl; impl]))
                            in
@@ -3225,18 +3252,18 @@ let (mk_discriminator_and_indexed_projectors :
                           FStar_All.pipe_right fields
                             (FStar_List.mapi
                                (fun i  ->
-                                  fun uu____8408  ->
-                                    match uu____8408 with
-                                    | (a,uu____8417) ->
-                                        let uu____8422 =
+                                  fun uu____8420  ->
+                                    match uu____8420 with
+                                    | (a,uu____8429) ->
+                                        let uu____8434 =
                                           FStar_Syntax_Util.mk_field_projector_name
                                             lid a i
                                            in
-                                        (match uu____8422 with
-                                         | (field_name,uu____8428) ->
+                                        (match uu____8434 with
+                                         | (field_name,uu____8440) ->
                                              let field_proj_tm =
-                                               let uu____8430 =
-                                                 let uu____8431 =
+                                               let uu____8442 =
+                                                 let uu____8443 =
                                                    FStar_Syntax_Syntax.lid_as_fv
                                                      field_name
                                                      (FStar_Syntax_Syntax.Delta_equational_at_level
@@ -3244,10 +3271,10 @@ let (mk_discriminator_and_indexed_projectors :
                                                      FStar_Pervasives_Native.None
                                                     in
                                                  FStar_Syntax_Syntax.fv_to_tm
-                                                   uu____8431
+                                                   uu____8443
                                                   in
                                                FStar_Syntax_Syntax.mk_Tm_uinst
-                                                 uu____8430 inst_univs
+                                                 uu____8442 inst_univs
                                                 in
                                              let proj =
                                                FStar_Syntax_Syntax.mk_Tm_app
@@ -3258,22 +3285,22 @@ let (mk_discriminator_and_indexed_projectors :
                                              FStar_Syntax_Syntax.NT (a, proj))))
                            in
                         let projectors_ses =
-                          let uu____8457 =
+                          let uu____8469 =
                             FStar_All.pipe_right fields
                               (FStar_List.mapi
                                  (fun i  ->
-                                    fun uu____8499  ->
-                                      match uu____8499 with
-                                      | (x,uu____8510) ->
+                                    fun uu____8511  ->
+                                      match uu____8511 with
+                                      | (x,uu____8522) ->
                                           let p1 =
                                             FStar_Syntax_Syntax.range_of_bv x
                                              in
-                                          let uu____8516 =
+                                          let uu____8528 =
                                             FStar_Syntax_Util.mk_field_projector_name
                                               lid x i
                                              in
-                                          (match uu____8516 with
-                                           | (field_name,uu____8524) ->
+                                          (match uu____8528 with
+                                           | (field_name,uu____8536) ->
                                                let t =
                                                  let result_comp =
                                                    let t =
@@ -3289,50 +3316,50 @@ let (mk_discriminator_and_indexed_projectors :
                                                      FStar_Syntax_Syntax.mk_Total
                                                        t
                                                     in
-                                                 let uu____8537 =
+                                                 let uu____8549 =
                                                    FStar_Syntax_Util.arrow
                                                      binders result_comp
                                                     in
                                                  FStar_All.pipe_left
                                                    (FStar_Syntax_Subst.close_univ_vars
-                                                      uvs) uu____8537
+                                                      uvs) uu____8549
                                                   in
                                                let only_decl =
                                                  early_prims_inductive ||
-                                                   (let uu____8543 =
-                                                      let uu____8545 =
+                                                   (let uu____8555 =
+                                                      let uu____8557 =
                                                         FStar_TypeChecker_Env.current_module
                                                           env
                                                          in
-                                                      uu____8545.FStar_Ident.str
+                                                      uu____8557.FStar_Ident.str
                                                        in
                                                     FStar_Options.dont_gen_projectors
-                                                      uu____8543)
+                                                      uu____8555)
                                                   in
                                                let no_decl = false  in
                                                let quals q =
                                                  if only_decl
                                                  then
-                                                   let uu____8564 =
+                                                   let uu____8576 =
                                                      FStar_List.filter
-                                                       (fun uu___5_8568  ->
-                                                          match uu___5_8568
+                                                       (fun uu___5_8580  ->
+                                                          match uu___5_8580
                                                           with
                                                           | FStar_Syntax_Syntax.Abstract
                                                                -> false
-                                                          | uu____8571 ->
+                                                          | uu____8583 ->
                                                               true) q
                                                       in
                                                    FStar_Syntax_Syntax.Assumption
-                                                     :: uu____8564
+                                                     :: uu____8576
                                                  else q  in
                                                let quals1 =
                                                  let iquals1 =
                                                    FStar_All.pipe_right
                                                      iquals
                                                      (FStar_List.filter
-                                                        (fun uu___6_8586  ->
-                                                           match uu___6_8586
+                                                        (fun uu___6_8598  ->
+                                                           match uu___6_8598
                                                            with
                                                            | FStar_Syntax_Syntax.Inline_for_extraction
                                                                 -> true
@@ -3342,7 +3369,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                                 -> true
                                                            | FStar_Syntax_Syntax.Private
                                                                 -> true
-                                                           | uu____8592 ->
+                                                           | uu____8604 ->
                                                                false))
                                                     in
                                                  quals
@@ -3358,7 +3385,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                    [FStar_Syntax_Util.attr_substitute]
                                                   in
                                                let decl =
-                                                 let uu____8603 =
+                                                 let uu____8615 =
                                                    FStar_Ident.range_of_lid
                                                      field_name
                                                     in
@@ -3368,30 +3395,33 @@ let (mk_discriminator_and_indexed_projectors :
                                                      (FStar_Syntax_Syntax.Sig_declare_typ
                                                         (field_name, uvs, t));
                                                    FStar_Syntax_Syntax.sigrng
-                                                     = uu____8603;
+                                                     = uu____8615;
                                                    FStar_Syntax_Syntax.sigquals
                                                      = quals1;
                                                    FStar_Syntax_Syntax.sigmeta
                                                      =
                                                      FStar_Syntax_Syntax.default_sigmeta;
                                                    FStar_Syntax_Syntax.sigattrs
-                                                     = attrs
+                                                     = attrs;
+                                                   FStar_Syntax_Syntax.sigopts
+                                                     =
+                                                     FStar_Pervasives_Native.None
                                                  }  in
-                                               ((let uu____8605 =
+                                               ((let uu____8617 =
                                                    FStar_TypeChecker_Env.debug
                                                      env
                                                      (FStar_Options.Other
                                                         "LogTypes")
                                                     in
-                                                 if uu____8605
+                                                 if uu____8617
                                                  then
-                                                   let uu____8609 =
+                                                   let uu____8621 =
                                                      FStar_Syntax_Print.sigelt_to_string
                                                        decl
                                                       in
                                                    FStar_Util.print1
                                                      "Declaration of a projector %s\n"
-                                                     uu____8609
+                                                     uu____8621
                                                  else ());
                                                 if only_decl
                                                 then [decl]
@@ -3407,9 +3437,9 @@ let (mk_discriminator_and_indexed_projectors :
                                                        all_params
                                                        (FStar_List.mapi
                                                           (fun j  ->
-                                                             fun uu____8663 
+                                                             fun uu____8675 
                                                                ->
-                                                               match uu____8663
+                                                               match uu____8675
                                                                with
                                                                | (x1,imp) ->
                                                                    let b =
@@ -3419,47 +3449,24 @@ let (mk_discriminator_and_indexed_projectors :
                                                                     (i + ntps)
                                                                     = j
                                                                    then
-                                                                    let uu____8689
+                                                                    let uu____8701
                                                                     =
                                                                     pos
                                                                     (FStar_Syntax_Syntax.Pat_var
                                                                     projection)
                                                                      in
-                                                                    (uu____8689,
+                                                                    (uu____8701,
                                                                     b)
                                                                    else
                                                                     if
                                                                     b &&
                                                                     (j < ntps)
                                                                     then
-                                                                    (let uu____8705
+                                                                    (let uu____8717
                                                                     =
-                                                                    let uu____8708
+                                                                    let uu____8720
                                                                     =
-                                                                    let uu____8709
-                                                                    =
-                                                                    let uu____8716
-                                                                    =
-                                                                    FStar_Syntax_Syntax.gen_bv
-                                                                    (x1.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                                                                    FStar_Pervasives_Native.None
-                                                                    FStar_Syntax_Syntax.tun
-                                                                     in
-                                                                    (uu____8716,
-                                                                    FStar_Syntax_Syntax.tun)
-                                                                     in
-                                                                    FStar_Syntax_Syntax.Pat_dot_term
-                                                                    uu____8709
-                                                                     in
-                                                                    pos
-                                                                    uu____8708
-                                                                     in
-                                                                    (uu____8705,
-                                                                    b))
-                                                                    else
-                                                                    (let uu____8724
-                                                                    =
-                                                                    let uu____8727
+                                                                    let uu____8721
                                                                     =
                                                                     let uu____8728
                                                                     =
@@ -3468,61 +3475,84 @@ let (mk_discriminator_and_indexed_projectors :
                                                                     FStar_Pervasives_Native.None
                                                                     FStar_Syntax_Syntax.tun
                                                                      in
-                                                                    FStar_Syntax_Syntax.Pat_wild
-                                                                    uu____8728
+                                                                    (uu____8728,
+                                                                    FStar_Syntax_Syntax.tun)
+                                                                     in
+                                                                    FStar_Syntax_Syntax.Pat_dot_term
+                                                                    uu____8721
                                                                      in
                                                                     pos
-                                                                    uu____8727
+                                                                    uu____8720
                                                                      in
-                                                                    (uu____8724,
+                                                                    (uu____8717,
+                                                                    b))
+                                                                    else
+                                                                    (let uu____8736
+                                                                    =
+                                                                    let uu____8739
+                                                                    =
+                                                                    let uu____8740
+                                                                    =
+                                                                    FStar_Syntax_Syntax.gen_bv
+                                                                    (x1.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
+                                                                    FStar_Pervasives_Native.None
+                                                                    FStar_Syntax_Syntax.tun
+                                                                     in
+                                                                    FStar_Syntax_Syntax.Pat_wild
+                                                                    uu____8740
+                                                                     in
+                                                                    pos
+                                                                    uu____8739
+                                                                     in
+                                                                    (uu____8736,
                                                                     b))))
                                                       in
                                                    let pat =
-                                                     let uu____8747 =
-                                                       let uu____8750 =
-                                                         let uu____8751 =
-                                                           let uu____8765 =
+                                                     let uu____8759 =
+                                                       let uu____8762 =
+                                                         let uu____8763 =
+                                                           let uu____8777 =
                                                              FStar_Syntax_Syntax.lid_as_fv
                                                                lid
                                                                FStar_Syntax_Syntax.delta_constant
                                                                (FStar_Pervasives_Native.Some
                                                                   fvq)
                                                               in
-                                                           (uu____8765,
+                                                           (uu____8777,
                                                              arg_pats)
                                                             in
                                                          FStar_Syntax_Syntax.Pat_cons
-                                                           uu____8751
+                                                           uu____8763
                                                           in
-                                                       pos uu____8750  in
-                                                     let uu____8775 =
+                                                       pos uu____8762  in
+                                                     let uu____8787 =
                                                        FStar_Syntax_Syntax.bv_to_name
                                                          projection
                                                         in
-                                                     (uu____8747,
+                                                     (uu____8759,
                                                        FStar_Pervasives_Native.None,
-                                                       uu____8775)
+                                                       uu____8787)
                                                       in
                                                    let body =
-                                                     let uu____8791 =
-                                                       let uu____8798 =
-                                                         let uu____8799 =
-                                                           let uu____8822 =
-                                                             let uu____8839 =
+                                                     let uu____8803 =
+                                                       let uu____8810 =
+                                                         let uu____8811 =
+                                                           let uu____8834 =
+                                                             let uu____8851 =
                                                                FStar_Syntax_Util.branch
                                                                  pat
                                                                 in
-                                                             [uu____8839]  in
+                                                             [uu____8851]  in
                                                            (arg_exp,
-                                                             uu____8822)
+                                                             uu____8834)
                                                             in
                                                          FStar_Syntax_Syntax.Tm_match
-                                                           uu____8799
+                                                           uu____8811
                                                           in
                                                        FStar_Syntax_Syntax.mk
-                                                         uu____8798
+                                                         uu____8810
                                                         in
-                                                     uu____8791
+                                                     uu____8803
                                                        FStar_Pervasives_Native.None
                                                        p1
                                                       in
@@ -3532,13 +3562,13 @@ let (mk_discriminator_and_indexed_projectors :
                                                        FStar_Pervasives_Native.None
                                                       in
                                                    let dd =
-                                                     let uu____8904 =
+                                                     let uu____8916 =
                                                        FStar_All.pipe_right
                                                          quals1
                                                          (FStar_List.contains
                                                             FStar_Syntax_Syntax.Abstract)
                                                         in
-                                                     if uu____8904
+                                                     if uu____8916
                                                      then
                                                        FStar_Syntax_Syntax.Delta_abstract
                                                          (FStar_Syntax_Syntax.Delta_equational_at_level
@@ -3554,22 +3584,22 @@ let (mk_discriminator_and_indexed_projectors :
                                                        FStar_Syntax_Syntax.tun
                                                       in
                                                    let lb =
-                                                     let uu____8923 =
-                                                       let uu____8928 =
+                                                     let uu____8935 =
+                                                       let uu____8940 =
                                                          FStar_Syntax_Syntax.lid_as_fv
                                                            field_name dd
                                                            FStar_Pervasives_Native.None
                                                           in
                                                        FStar_Util.Inr
-                                                         uu____8928
+                                                         uu____8940
                                                         in
-                                                     let uu____8929 =
+                                                     let uu____8941 =
                                                        FStar_Syntax_Subst.close_univ_vars
                                                          uvs imp
                                                         in
                                                      {
                                                        FStar_Syntax_Syntax.lbname
-                                                         = uu____8923;
+                                                         = uu____8935;
                                                        FStar_Syntax_Syntax.lbunivs
                                                          = uvs;
                                                        FStar_Syntax_Syntax.lbtyp
@@ -3578,7 +3608,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                          =
                                                          FStar_Parser_Const.effect_Tot_lid;
                                                        FStar_Syntax_Syntax.lbdef
-                                                         = uu____8929;
+                                                         = uu____8941;
                                                        FStar_Syntax_Syntax.lbattrs
                                                          = [];
                                                        FStar_Syntax_Syntax.lbpos
@@ -3586,30 +3616,30 @@ let (mk_discriminator_and_indexed_projectors :
                                                          FStar_Range.dummyRange
                                                      }  in
                                                    let impl =
-                                                     let uu____8935 =
-                                                       let uu____8936 =
-                                                         let uu____8943 =
-                                                           let uu____8946 =
-                                                             let uu____8947 =
+                                                     let uu____8947 =
+                                                       let uu____8948 =
+                                                         let uu____8955 =
+                                                           let uu____8958 =
+                                                             let uu____8959 =
                                                                FStar_All.pipe_right
                                                                  lb.FStar_Syntax_Syntax.lbname
                                                                  FStar_Util.right
                                                                 in
                                                              FStar_All.pipe_right
-                                                               uu____8947
+                                                               uu____8959
                                                                (fun fv  ->
                                                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
                                                               in
-                                                           [uu____8946]  in
+                                                           [uu____8958]  in
                                                          ((false, [lb]),
-                                                           uu____8943)
+                                                           uu____8955)
                                                           in
                                                        FStar_Syntax_Syntax.Sig_let
-                                                         uu____8936
+                                                         uu____8948
                                                         in
                                                      {
                                                        FStar_Syntax_Syntax.sigel
-                                                         = uu____8935;
+                                                         = uu____8947;
                                                        FStar_Syntax_Syntax.sigrng
                                                          = p1;
                                                        FStar_Syntax_Syntax.sigquals
@@ -3618,29 +3648,32 @@ let (mk_discriminator_and_indexed_projectors :
                                                          =
                                                          FStar_Syntax_Syntax.default_sigmeta;
                                                        FStar_Syntax_Syntax.sigattrs
-                                                         = attrs
+                                                         = attrs;
+                                                       FStar_Syntax_Syntax.sigopts
+                                                         =
+                                                         FStar_Pervasives_Native.None
                                                      }  in
-                                                   (let uu____8961 =
+                                                   (let uu____8973 =
                                                       FStar_TypeChecker_Env.debug
                                                         env
                                                         (FStar_Options.Other
                                                            "LogTypes")
                                                        in
-                                                    if uu____8961
+                                                    if uu____8973
                                                     then
-                                                      let uu____8965 =
+                                                      let uu____8977 =
                                                         FStar_Syntax_Print.sigelt_to_string
                                                           impl
                                                          in
                                                       FStar_Util.print1
                                                         "Implementation of a projector %s\n"
-                                                        uu____8965
+                                                        uu____8977
                                                     else ());
                                                    if no_decl
                                                    then [impl]
                                                    else [decl; impl])))))
                              in
-                          FStar_All.pipe_right uu____8457 FStar_List.flatten
+                          FStar_All.pipe_right uu____8469 FStar_List.flatten
                            in
                         FStar_List.append discriminator_ses projectors_ses
   
@@ -3656,52 +3689,52 @@ let (mk_data_operations :
         fun se  ->
           match se.FStar_Syntax_Syntax.sigel with
           | FStar_Syntax_Syntax.Sig_datacon
-              (constr_lid,uvs,t,typ_lid,n_typars,uu____9019) when
-              let uu____9026 =
+              (constr_lid,uvs,t,typ_lid,n_typars,uu____9031) when
+              let uu____9038 =
                 FStar_Ident.lid_equals constr_lid
                   FStar_Parser_Const.lexcons_lid
                  in
-              Prims.op_Negation uu____9026 ->
-              let uu____9028 = FStar_Syntax_Subst.univ_var_opening uvs  in
-              (match uu____9028 with
+              Prims.op_Negation uu____9038 ->
+              let uu____9040 = FStar_Syntax_Subst.univ_var_opening uvs  in
+              (match uu____9040 with
                | (univ_opening,uvs1) ->
                    let t1 = FStar_Syntax_Subst.subst univ_opening t  in
-                   let uu____9050 = FStar_Syntax_Util.arrow_formals t1  in
-                   (match uu____9050 with
-                    | (formals,uu____9068) ->
-                        let uu____9089 =
+                   let uu____9062 = FStar_Syntax_Util.arrow_formals t1  in
+                   (match uu____9062 with
+                    | (formals,uu____9080) ->
+                        let uu____9101 =
                           let tps_opt =
                             FStar_Util.find_map tcs
                               (fun se1  ->
-                                 let uu____9124 =
-                                   let uu____9126 =
-                                     let uu____9127 =
+                                 let uu____9136 =
+                                   let uu____9138 =
+                                     let uu____9139 =
                                        FStar_Syntax_Util.lid_of_sigelt se1
                                         in
-                                     FStar_Util.must uu____9127  in
-                                   FStar_Ident.lid_equals typ_lid uu____9126
+                                     FStar_Util.must uu____9139  in
+                                   FStar_Ident.lid_equals typ_lid uu____9138
                                     in
-                                 if uu____9124
+                                 if uu____9136
                                  then
                                    match se1.FStar_Syntax_Syntax.sigel with
                                    | FStar_Syntax_Syntax.Sig_inductive_typ
-                                       (uu____9149,uvs',tps,typ0,uu____9153,constrs)
+                                       (uu____9161,uvs',tps,typ0,uu____9165,constrs)
                                        ->
                                        FStar_Pervasives_Native.Some
                                          (tps, typ0,
                                            ((FStar_List.length constrs) >
                                               Prims.int_one))
-                                   | uu____9173 -> failwith "Impossible"
+                                   | uu____9185 -> failwith "Impossible"
                                  else FStar_Pervasives_Native.None)
                              in
                           match tps_opt with
                           | FStar_Pervasives_Native.Some x -> x
                           | FStar_Pervasives_Native.None  ->
-                              let uu____9222 =
+                              let uu____9234 =
                                 FStar_Ident.lid_equals typ_lid
                                   FStar_Parser_Const.exn_lid
                                  in
-                              if uu____9222
+                              if uu____9234
                               then ([], FStar_Syntax_Util.ktype0, true)
                               else
                                 FStar_Errors.raise_error
@@ -3709,7 +3742,7 @@ let (mk_data_operations :
                                     "Unexpected data constructor")
                                   se.FStar_Syntax_Syntax.sigrng
                            in
-                        (match uu____9089 with
+                        (match uu____9101 with
                          | (inductive_tps,typ0,should_refine) ->
                              let inductive_tps1 =
                                FStar_Syntax_Subst.subst_binders univ_opening
@@ -3717,41 +3750,41 @@ let (mk_data_operations :
                                 in
                              let typ01 =
                                FStar_Syntax_Subst.subst univ_opening typ0  in
-                             let uu____9260 =
+                             let uu____9272 =
                                FStar_Syntax_Util.arrow_formals typ01  in
-                             (match uu____9260 with
-                              | (indices,uu____9278) ->
+                             (match uu____9272 with
+                              | (indices,uu____9290) ->
                                   let refine_domain =
-                                    let uu____9301 =
+                                    let uu____9313 =
                                       FStar_All.pipe_right
                                         se.FStar_Syntax_Syntax.sigquals
                                         (FStar_Util.for_some
-                                           (fun uu___7_9308  ->
-                                              match uu___7_9308 with
+                                           (fun uu___7_9320  ->
+                                              match uu___7_9320 with
                                               | FStar_Syntax_Syntax.RecordConstructor
-                                                  uu____9310 -> true
-                                              | uu____9320 -> false))
+                                                  uu____9322 -> true
+                                              | uu____9332 -> false))
                                        in
-                                    if uu____9301
+                                    if uu____9313
                                     then false
                                     else should_refine  in
                                   let fv_qual =
-                                    let filter_records uu___8_9335 =
-                                      match uu___8_9335 with
+                                    let filter_records uu___8_9347 =
+                                      match uu___8_9347 with
                                       | FStar_Syntax_Syntax.RecordConstructor
-                                          (uu____9338,fns) ->
+                                          (uu____9350,fns) ->
                                           FStar_Pervasives_Native.Some
                                             (FStar_Syntax_Syntax.Record_ctor
                                                (constr_lid, fns))
-                                      | uu____9350 ->
+                                      | uu____9362 ->
                                           FStar_Pervasives_Native.None
                                        in
-                                    let uu____9351 =
+                                    let uu____9363 =
                                       FStar_Util.find_map
                                         se.FStar_Syntax_Syntax.sigquals
                                         filter_records
                                        in
-                                    match uu____9351 with
+                                    match uu____9363 with
                                     | FStar_Pervasives_Native.None  ->
                                         FStar_Syntax_Syntax.Data_ctor
                                     | FStar_Pervasives_Native.Some q -> q  in
@@ -3768,27 +3801,27 @@ let (mk_data_operations :
                                       iquals
                                     else iquals  in
                                   let fields =
-                                    let uu____9364 =
+                                    let uu____9376 =
                                       FStar_Util.first_N n_typars formals  in
-                                    match uu____9364 with
+                                    match uu____9376 with
                                     | (imp_tps,fields) ->
                                         let rename =
                                           FStar_List.map2
-                                            (fun uu____9447  ->
-                                               fun uu____9448  ->
-                                                 match (uu____9447,
-                                                         uu____9448)
+                                            (fun uu____9459  ->
+                                               fun uu____9460  ->
+                                                 match (uu____9459,
+                                                         uu____9460)
                                                  with
-                                                 | ((x,uu____9474),(x',uu____9476))
+                                                 | ((x,uu____9486),(x',uu____9488))
                                                      ->
-                                                     let uu____9497 =
-                                                       let uu____9504 =
+                                                     let uu____9509 =
+                                                       let uu____9516 =
                                                          FStar_Syntax_Syntax.bv_to_name
                                                            x'
                                                           in
-                                                       (x, uu____9504)  in
+                                                       (x, uu____9516)  in
                                                      FStar_Syntax_Syntax.NT
-                                                       uu____9497) imp_tps
+                                                       uu____9509) imp_tps
                                             inductive_tps1
                                            in
                                         FStar_Syntax_Subst.subst_binders
@@ -3803,5 +3836,5 @@ let (mk_data_operations :
                                     iquals1 fv_qual refine_domain env typ_lid
                                     constr_lid uvs1 inductive_tps1 indices
                                     fields erasable1))))
-          | uu____9511 -> []
+          | uu____9523 -> []
   

--- a/src/ocaml-output/FStar_TypeChecker_Util.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Util.ml
@@ -4330,7 +4330,9 @@ let (mk_toplevel_definition :
              FStar_Syntax_Syntax.sigmeta =
                (uu___1457_11219.FStar_Syntax_Syntax.sigmeta);
              FStar_Syntax_Syntax.sigattrs =
-               (uu___1457_11219.FStar_Syntax_Syntax.sigattrs)
+               (uu___1457_11219.FStar_Syntax_Syntax.sigattrs);
+             FStar_Syntax_Syntax.sigopts =
+               (uu___1457_11219.FStar_Syntax_Syntax.sigopts)
            }), uu____11217))
   
 let (check_sigelt_quals :

--- a/src/parser/FStar.Parser.Const.fs
+++ b/src/parser/FStar.Parser.Const.fs
@@ -303,6 +303,7 @@ let assume_strictly_positive_attr_lid = psconst "assume_strictly_positive"
 let unifier_hint_injective_lid = psconst "unifier_hint_injective"
 let postprocess_with = p2l ["FStar"; "Tactics"; "Effect"; "postprocess_with"]
 let postprocess_extr_with = p2l ["FStar"; "Tactics"; "Effect"; "postprocess_for_extraction_with"]
+let check_with_lid = lid_of_path (["FStar"; "Reflection"; "Basic"; "check_with"]) FStar.Range.dummyRange
 
 let gen_reset =
     let x = U.mk_ref 0 in

--- a/src/reflection/FStar.Reflection.Basic.fs
+++ b/src/reflection/FStar.Reflection.Basic.fs
@@ -23,6 +23,7 @@ module Env = FStar.TypeChecker.Env
 module Err = FStar.Errors
 module Z = FStar.BigInt
 module DsEnv = FStar.Syntax.DsEnv
+module O = FStar.Options
 
 open FStar.Dyn
 
@@ -362,6 +363,9 @@ let sigelt_quals (se : sigelt) : list<qualifier> =
 
 let set_sigelt_quals (quals : list<qualifier>) (se : sigelt) : sigelt =
     { se with sigquals = quals }
+
+let sigelt_opts (se : sigelt) : option<O.optionstate> =
+    se.sigopts
 
 let inspect_sigelt (se : sigelt) : sigelt_view =
     match se.sigel with

--- a/src/reflection/FStar.Reflection.Basic.fs
+++ b/src/reflection/FStar.Reflection.Basic.fs
@@ -189,7 +189,7 @@ let rec inspect_ln (t:term) : term_view =
         let rec inspect_pat p =
             match p.v with
             | Pat_constant c -> Pat_Constant (inspect_const c)
-            | Pat_cons (fv, ps) -> Pat_Cons (fv, List.map (fun (p, _) -> inspect_pat p) ps)
+            | Pat_cons (fv, ps) -> Pat_Cons (fv, List.map (fun (p, b) -> inspect_pat p, b) ps)
             | Pat_var bv -> Pat_Var bv
             | Pat_wild bv -> Pat_Wild bv
             | Pat_dot_term (bv, t) -> Pat_Dot_Term (bv, t)
@@ -298,7 +298,7 @@ let pack_ln (tv:term_view) : term =
         let rec pack_pat p : S.pat =
             match p with
             | Pat_Constant c -> wrap <| Pat_constant (pack_const c)
-            | Pat_Cons (fv, ps) -> wrap <| Pat_cons (fv, List.map (fun p -> pack_pat p, false) ps)
+            | Pat_Cons (fv, ps) -> wrap <| Pat_cons (fv, List.map (fun (p, b) -> pack_pat p, b) ps)
             | Pat_Var  bv -> wrap <| Pat_var bv
             | Pat_Wild bv -> wrap <| Pat_wild bv
             | Pat_Dot_Term (bv, t) -> wrap <| Pat_dot_term (bv, t)

--- a/src/reflection/FStar.Reflection.Basic.fsi
+++ b/src/reflection/FStar.Reflection.Basic.fsi
@@ -8,6 +8,7 @@ open FStar.Order
 module Env = FStar.TypeChecker.Env
 open FStar.Reflection.Data
 open FStar.ST
+module O = FStar.Options
 
 (* Tying a knot into the environment which started execution.
  * Needed to inspect sigelts and the like without needing
@@ -28,6 +29,7 @@ val term_eq               : term -> term -> bool
 val term_to_string        : term -> string
 val comp_to_string        : comp -> string
 val env_open_modules      : Env.env -> list<name>
+val sigelt_opts           : sigelt -> option<O.optionstate>
 
 val sigelt_attrs     : sigelt -> list<attribute>
 val set_sigelt_attrs : list<attribute> -> sigelt -> sigelt

--- a/src/reflection/FStar.Reflection.Data.fs
+++ b/src/reflection/FStar.Reflection.Data.fs
@@ -145,6 +145,8 @@ let fstar_refl_ident            = mk_refl_types_lid_as_term "ident"
 let fstar_refl_ident_fv         = mk_refl_types_lid_as_fv   "ident"
 let fstar_refl_univ_name        = mk_refl_types_lid_as_term "univ_name"
 let fstar_refl_univ_name_fv     = mk_refl_types_lid_as_fv   "univ_name"
+let fstar_refl_optionstate      = mk_refl_types_lid_as_term "optionstate"
+let fstar_refl_optionstate_fv   = mk_refl_types_lid_as_fv   "optionstate"
 
 (* auxiliary types *)
 let fstar_refl_aqualv           = mk_refl_data_lid_as_term "aqualv"

--- a/src/reflection/FStar.Reflection.Data.fs
+++ b/src/reflection/FStar.Reflection.Data.fs
@@ -22,7 +22,7 @@ type vconst =
 
 type pattern =
     | Pat_Constant of vconst
-    | Pat_Cons     of fv * list<pattern>
+    | Pat_Cons     of fv * list<(pattern * bool)>
     | Pat_Var      of bv
     | Pat_Wild     of bv
     | Pat_Dot_Term of bv * term

--- a/src/reflection/FStar.Reflection.Embeddings.fs
+++ b/src/reflection/FStar.Reflection.Embeddings.fs
@@ -250,7 +250,7 @@ let rec e_pattern' () =
         | Pat_Constant c ->
             S.mk_Tm_app ref_Pat_Constant.t [S.as_arg (embed e_const rng c)] None rng
         | Pat_Cons (fv, ps) ->
-            S.mk_Tm_app ref_Pat_Cons.t [S.as_arg (embed e_fv rng fv); S.as_arg (embed (e_list (e_pattern' ())) rng ps)] None rng
+            S.mk_Tm_app ref_Pat_Cons.t [S.as_arg (embed e_fv rng fv); S.as_arg (embed (e_list (e_tuple2 (e_pattern' ()) e_bool)) rng ps)] None rng
         | Pat_Var bv ->
             S.mk_Tm_app ref_Pat_Var.t [S.as_arg (embed e_bv rng bv)] None rng
         | Pat_Wild bv ->
@@ -270,7 +270,7 @@ let rec e_pattern' () =
 
         | Tm_fvar fv, [(f, _); (ps, _)] when S.fv_eq_lid fv ref_Pat_Cons.lid ->
             BU.bind_opt (unembed' w e_fv f) (fun f ->
-            BU.bind_opt (unembed' w (e_list (e_pattern' ())) ps) (fun ps ->
+            BU.bind_opt (unembed' w (e_list (e_tuple2 (e_pattern' ()) e_bool)) ps) (fun ps ->
             Some <| Pat_Cons (f, ps)))
 
         | Tm_fvar fv, [(bv, _)] when S.fv_eq_lid fv ref_Pat_Var.lid ->

--- a/src/reflection/FStar.Reflection.Embeddings.fs
+++ b/src/reflection/FStar.Reflection.Embeddings.fs
@@ -23,6 +23,7 @@ module EMB = FStar.Syntax.Embeddings
 open FStar.Reflection.Basic //needed for inspect_fv, but that feels wrong
 module NBETerm = FStar.TypeChecker.NBETerm
 module PC = FStar.Parser.Const
+module O = FStar.Options
 
 open FStar.Dyn
 
@@ -70,6 +71,21 @@ let e_binder =
             None
     in
     mk_emb embed_binder unembed_binder fstar_refl_binder
+
+let e_optionstate =
+    let embed_optionstate (rng:Range.range) (b:O.optionstate) : term =
+        U.mk_lazy b fstar_refl_optionstate Lazy_optionstate (Some rng)
+    in
+    let unembed_optionstate w (t:term) : option<O.optionstate> =
+        match (SS.compress t).n with
+        | Tm_lazy {blob=b; lkind=Lazy_optionstate} ->
+            Some (undyn b)
+        | _ ->
+            if w then
+                Err.log_issue t.pos (Err.Warning_NotEmbedded, (BU.format1 "Not an embedded optionstate: %s" (Print.term_to_string t)));
+            None
+    in
+    mk_emb embed_optionstate unembed_optionstate fstar_refl_optionstate
 
 let rec mapM_opt (f : ('a -> option<'b>)) (l : list<'a>) : option<list<'b>> =
     match l with
@@ -884,6 +900,10 @@ let unfold_lazy_comp (i : lazyinfo) : term =
 
 let unfold_lazy_env (i : lazyinfo) : term =
     (* Not needed, metaprograms never see concrete environments. *)
+    U.exp_unit
+
+let unfold_lazy_optionstate (i : lazyinfo) : term =
+    (* Not needed, metaprograms never see concrete optionstates . *)
     U.exp_unit
 
 let unfold_lazy_sigelt (i : lazyinfo) : term =

--- a/src/reflection/FStar.Reflection.Embeddings.fsi
+++ b/src/reflection/FStar.Reflection.Embeddings.fsi
@@ -7,10 +7,12 @@ open FStar.Syntax.Embeddings
 open FStar.Order
 open FStar.TypeChecker.Env
 open FStar.Reflection.Data
+module O = FStar.Options
 
 (* Embeddings *)
 val e_bv          : embedding<bv>
 val e_binder      : embedding<binder>
+val e_optionstate : embedding<O.optionstate>
 val e_binder_view : embedding<binder_view>
 val e_binders     : embedding<binders>
 val e_term        : embedding<term>
@@ -46,6 +48,7 @@ val e_term_view_aq  : antiquotations -> embedding<term_view>
 val unfold_lazy_bv     : lazyinfo -> term
 val unfold_lazy_fvar   : lazyinfo -> term
 val unfold_lazy_binder : lazyinfo -> term
+val unfold_lazy_optionstate : lazyinfo -> term
 val unfold_lazy_comp   : lazyinfo -> term
 val unfold_lazy_env    : lazyinfo -> term
 val unfold_lazy_sigelt : lazyinfo -> term

--- a/src/reflection/FStar.Reflection.Interpreter.fs
+++ b/src/reflection/FStar.Reflection.Interpreter.fs
@@ -123,6 +123,9 @@ let reflection_primops : list<Cfg.primitive_step> = [
     mk1 "pack_bv"               pack_bv               E.e_bv_view         E.e_bv
                                 pack_bv               NRE.e_bv_view       NRE.e_bv;
 
+    mk1 "sigelt_opts"           sigelt_opts           E.e_sigelt          (e_option E.e_optionstate)
+                                sigelt_opts           NRE.e_sigelt        (NBET.e_option NRE.e_optionstate);
+
     mk1 "sigelt_attrs"          sigelt_attrs          E.e_sigelt          E.e_attributes
                                 sigelt_attrs          NRE.e_sigelt        NRE.e_attributes;
 

--- a/src/reflection/FStar.Reflection.NBEEmbeddings.fs
+++ b/src/reflection/FStar.Reflection.NBEEmbeddings.fs
@@ -245,7 +245,7 @@ let rec e_pattern' () =
         | Pat_Constant c ->
             mkConstruct ref_Pat_Constant.fv [] [as_arg (embed e_const cb c)]
         | Pat_Cons (fv, ps) ->
-            mkConstruct ref_Pat_Cons.fv [] [as_arg (embed e_fv cb fv); as_arg (embed (e_list (e_pattern' ())) cb ps)]
+            mkConstruct ref_Pat_Cons.fv [] [as_arg (embed e_fv cb fv); as_arg (embed (e_list (e_tuple2 (e_pattern' ()) e_bool)) cb ps)]
         | Pat_Var bv ->
             mkConstruct ref_Pat_Var.fv [] [as_arg (embed e_bv cb bv)]
         | Pat_Wild bv ->
@@ -261,7 +261,7 @@ let rec e_pattern' () =
 
         | Construct (fv, [], [(ps, _); (f, _)]) when S.fv_eq_lid fv ref_Pat_Cons.lid ->
             BU.bind_opt (unembed e_fv cb f) (fun f ->
-            BU.bind_opt (unembed (e_list (e_pattern' ())) cb ps) (fun ps ->
+            BU.bind_opt (unembed (e_list (e_tuple2 (e_pattern' ()) e_bool)) cb ps) (fun ps ->
             Some <| Pat_Cons (f, ps)))
 
         | Construct (fv, [], [(bv, _)]) when S.fv_eq_lid fv ref_Pat_Var.lid ->

--- a/src/reflection/FStar.Reflection.NBEEmbeddings.fs
+++ b/src/reflection/FStar.Reflection.NBEEmbeddings.fs
@@ -8,6 +8,7 @@ open FStar.TypeChecker.NBETerm
 open FStar.Order
 open FStar.Errors
 
+module O = FStar.Options
 module S = FStar.Syntax.Syntax // TODO: remove, it's open
 
 module I = FStar.Ident
@@ -87,6 +88,20 @@ let e_binder =
             None
     in
     mk_emb' embed_binder unembed_binder fstar_refl_binder_fv
+
+let e_optionstate =
+    let embed_optionstate cb (b:O.optionstate) : t =
+        mk_lazy cb b fstar_refl_optionstate Lazy_optionstate
+    in
+    let unembed_optionstate cb (t:t) : option<O.optionstate> =
+        match t with
+        | Lazy (BU.Inl {blob=b; lkind=Lazy_optionstate}, _) ->
+            Some (undyn b)
+        | _ ->
+            Err.log_issue Range.dummyRange (Err.Warning_NotEmbedded, (BU.format1 "Not an embedded optionstate: %s" (t_to_string t)));
+            None
+    in
+    mk_emb' embed_optionstate unembed_optionstate fstar_refl_optionstate_fv
 
 let rec mapM_opt (f : ('a -> option<'b>)) (l : list<'a>) : option<list<'b>> =
     match l with

--- a/src/reflection/FStar.Reflection.NBEEmbeddings.fsi
+++ b/src/reflection/FStar.Reflection.NBEEmbeddings.fsi
@@ -7,10 +7,12 @@ open FStar.TypeChecker.NBETerm
 open FStar.Order
 open FStar.TypeChecker.Env
 open FStar.Reflection.Data
+module O = FStar.Options
 
 (* Embeddings *)
 val e_bv          : embedding<bv>
 val e_binder      : embedding<binder>
+val e_optionstate : embedding<O.optionstate>
 val e_binder_view : embedding<binder_view>
 val e_binders     : embedding<binders>
 val e_term        : embedding<term>

--- a/src/syntax/FStar.Syntax.MutRecTy.fs
+++ b/src/syntax/FStar.Syntax.MutRecTy.fs
@@ -65,7 +65,8 @@ let disentangle_abbrevs_from_bundle
        sigrng = rng;
        sigquals = quals;
        sigmeta = default_sigmeta;
-       sigattrs = sigattrs }, []
+       sigattrs = sigattrs;
+       sigopts = None; }, []
    | _ ->
 
     let type_abbrevs = type_abbrev_sigelts |> List.map begin fun x -> match x.sigel with
@@ -209,7 +210,8 @@ let disentangle_abbrevs_from_bundle
                          sigrng = rng;
                          sigquals = quals;
                          sigmeta = default_sigmeta;
-                         sigattrs = sigattrs }
+                         sigattrs = sigattrs;
+                         sigopts = None; }
       in
 
       (new_bundle, unfolded_type_abbrevs)

--- a/src/syntax/FStar.Syntax.Syntax.fs
+++ b/src/syntax/FStar.Syntax.Syntax.fs
@@ -27,6 +27,7 @@ open FStar.Range
 open FStar.Ident
 open FStar.Const
 open FStar.Dyn
+module O = FStar.Options
 module PC = FStar.Parser.Const
 
 (* Objects with metadata *)
@@ -276,6 +277,7 @@ and lazy_kind =
   | BadLazy
   | Lazy_bv
   | Lazy_binder
+  | Lazy_optionstate
   | Lazy_fvar
   | Lazy_comp
   | Lazy_env
@@ -446,7 +448,8 @@ and sigelt = {
     sigrng:   Range.range;
     sigquals: list<qualifier>;
     sigmeta:  sig_metadata;
-    sigattrs: list<attribute>
+    sigattrs: list<attribute>;
+    sigopts:  option<O.optionstate>; (* Saving the option context where this sigelt was checked in *)
 }
 
 type sigelts = list<sigelt>
@@ -571,7 +574,7 @@ let mk_lb (x, univs, eff, t, e, attrs, pos) = {
   }
 
 let default_sigmeta = { sigmeta_active=true; sigmeta_fact_db_ids=[] }
-let mk_sigelt (e: sigelt') = { sigel = e; sigrng = Range.dummyRange; sigquals=[]; sigmeta=default_sigmeta; sigattrs = [] }
+let mk_sigelt (e: sigelt') = { sigel = e; sigrng = Range.dummyRange; sigquals=[]; sigmeta=default_sigmeta; sigattrs = [] ; sigopts = None }
 let mk_subst (s:subst_t)   = s
 let extend_subst x s : subst_t = x::s
 let argpos (x:arg) = (fst x).pos

--- a/src/syntax/FStar.Syntax.Syntax.fsi
+++ b/src/syntax/FStar.Syntax.Syntax.fsi
@@ -26,6 +26,7 @@ open FStar.Util
 open FStar.Range
 open FStar.Ident
 open FStar.Dyn
+module O = FStar.Options
 
 // JP: all these types are defined twice and every change has to be performed
 // twice (because of the .fs). TODO: move the type definitions into a standalone
@@ -259,6 +260,7 @@ and lazy_kind =
   | BadLazy
   | Lazy_bv
   | Lazy_binder
+  | Lazy_optionstate
   | Lazy_fvar
   | Lazy_comp
   | Lazy_env
@@ -442,7 +444,8 @@ and sigelt = {
     sigrng:   Range.range;
     sigquals: list<qualifier>;
     sigmeta:  sig_metadata;
-    sigattrs: list<attribute>
+    sigattrs: list<attribute>;
+    sigopts:  option<O.optionstate>; (* Saving the option context where this sigelt was checked in *)
 }
 
 type sigelts = list<sigelt>

--- a/src/tactics/FStar.Tactics.Basic.fs
+++ b/src/tactics/FStar.Tactics.Basic.fs
@@ -1994,7 +1994,7 @@ let rec inspect (t:term) : tac<term_view> = wrap_err "inspect" (
         let rec inspect_pat p =
             match p.v with
             | Pat_constant c -> Pat_Constant (inspect_const c)
-            | Pat_cons (fv, ps) -> Pat_Cons (fv, List.map (fun (p, _) -> inspect_pat p) ps)
+            | Pat_cons (fv, ps) -> Pat_Cons (fv, List.map (fun (p, b) -> inspect_pat p, b) ps)
             | Pat_var bv -> Pat_Var bv
             | Pat_wild bv -> Pat_Wild bv
             | Pat_dot_term (bv, t) -> Pat_Dot_Term (bv, t)
@@ -2060,7 +2060,7 @@ let pack (tv:term_view) : tac<term> =
         let rec pack_pat p : S.pat =
             match p with
             | Pat_Constant c -> wrap <| Pat_constant (pack_const c)
-            | Pat_Cons (fv, ps) -> wrap <| Pat_cons (fv, List.map (fun p -> pack_pat p, false) ps)
+            | Pat_Cons (fv, ps) -> wrap <| Pat_cons (fv, List.map (fun (p, b) -> pack_pat p, b) ps)
             | Pat_Var  bv -> wrap <| Pat_var bv
             | Pat_Wild bv -> wrap <| Pat_wild bv
             | Pat_Dot_Term (bv, t) -> wrap <| Pat_dot_term (bv, t)

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
@@ -1942,7 +1942,8 @@ let mk_data_discriminators quals env datas =
           sigrng = range_of_lid disc_name;// FIXME: Isn't that range wrong? // FIXME: Doc?
           sigquals =  quals [(* S.Logic ; *) S.OnlyName ; S.Discriminator d];
           sigmeta = default_sigmeta;
-          sigattrs = []
+          sigattrs = [];
+          sigopts = None;
         })
 
 let mk_indexed_projector_names iquals fvq env lid (fields:list<S.binder>) =
@@ -1974,7 +1975,8 @@ let mk_indexed_projector_names iquals fvq env lid (fields:list<S.binder>) =
                      sigquals = quals;
                      sigrng = range_of_lid field_name;
                      sigmeta = default_sigmeta ;
-                     sigattrs = [] } in // FIXME: Doc?
+                     sigattrs = [];
+                     sigopts = None; } in // FIXME: Doc?
         if only_decl
         then [decl] //only the signature
         else
@@ -1996,7 +1998,8 @@ let mk_indexed_projector_names iquals fvq env lid (fields:list<S.binder>) =
                          sigquals = quals;
                          sigrng = p;
                          sigmeta = default_sigmeta;
-                         sigattrs = [] } in // FIXME: Doc?
+                         sigattrs = [];
+                         sigopts = None; } in // FIXME: Doc?
             if no_decl then [impl] else [decl;impl]) |> List.flatten
 
 // FIXME: Would be nice to add auto-generated docs to these
@@ -2045,7 +2048,8 @@ let mk_typ_abbrev lid uvs typars kopt t lids quals rng =
       sigquals = quals;
       sigrng = rng;
       sigmeta = default_sigmeta ;
-      sigattrs = [] }
+      sigattrs = [];
+      sigopts = None; }
 
 let rec desugar_tycon env (d: AST.decl) quals tcs : (env_t * sigelts) =
   let rng = d.drange in
@@ -2099,8 +2103,9 @@ let rec desugar_tycon env (d: AST.decl) quals tcs : (env_t * sigelts) =
       let se = { sigel = Sig_inductive_typ(qlid, [], typars, k, mutuals, []);
                  sigquals = quals;
                  sigrng = rng;
-                 sigmeta = default_sigmeta  ;
-                 sigattrs = [] } in
+                 sigmeta = default_sigmeta;
+                 sigattrs = [];
+                 sigopts = None } in
       let _env = Env.push_top_level_rec_binding _env id S.delta_constant in
       let _env2 = Env.push_top_level_rec_binding _env' id S.delta_constant in
       _env, _env2, se, tconstr
@@ -2181,7 +2186,8 @@ let rec desugar_tycon env (d: AST.decl) quals tcs : (env_t * sigelts) =
                    sigquals = quals;
                    sigrng = rng;
                    sigmeta = default_sigmeta  ;
-                   sigattrs = [] }
+                   sigattrs = [];
+                   sigopts = None; }
             else let t = desugar_typ env' t in
                  mk_typ_abbrev qlid [] typars kopt t [qlid] quals rng in
 
@@ -2253,13 +2259,15 @@ let rec desugar_tycon env (d: AST.decl) quals tcs : (env_t * sigelts) =
                                             sigquals = quals;
                                             sigrng = rng;
                                             sigmeta = default_sigmeta  ;
-                                            sigattrs = [] }))))
+                                            sigattrs = [];
+                                            sigopts = None; }))))
           in
           ((tname, d.doc), [], { sigel = Sig_inductive_typ(tname, univs, tpars, k, mutuals, constrNames);
                                  sigquals = tname_quals;
                                  sigrng = rng;
                                  sigmeta = default_sigmeta  ;
-                                 sigattrs = [] })::constrs
+                                 sigattrs = [];
+                                 sigopts = None; })::constrs
         | _ -> failwith "impossible")
       in
       let name_docs = docs_tps_sigelts |> List.map (fun (name_doc, _, _) -> name_doc) in
@@ -2310,7 +2318,8 @@ let push_reflect_effect env quals (effect_name:Ident.lid) range =
                            sigrng = range;
                            sigquals = quals;
                            sigmeta = default_sigmeta  ;
-                           sigattrs = [] } in
+                           sigattrs = [];
+                           sigopts = None; } in
          Env.push_sigelt env refl_decl // FIXME: Add docs to refl_decl?
     else env
 
@@ -2469,7 +2478,8 @@ let rec desugar_effect env d (quals: qualifiers) eff_name eff_binders eff_typ ef
            sigquals = qualifiers;
            sigrng = d.drange;
            sigmeta = default_sigmeta  ;
-           sigattrs = [] }
+           sigattrs = [];
+           sigopts = None; }
       else
         let rr = BU.for_some (function S.Reifiable | S.Reflectable _ -> true | _ -> false) qualifiers in
         let un_ts = [], Syntax.tun in
@@ -2496,7 +2506,8 @@ let rec desugar_effect env d (quals: qualifiers) eff_name eff_binders eff_typ ef
            sigquals = qualifiers;
            sigrng = d.drange;
            sigmeta = default_sigmeta  ;
-           sigattrs = [] }
+           sigattrs = [];
+           sigopts = None; }
     in
     let env = push_sigelt env0 se in
     let env = push_doc env mname d.doc in
@@ -2583,7 +2594,8 @@ and desugar_redefine_effect env d trans_qual quals eff_name eff_binders defn =
         sigquals = List.map (trans_qual (Some mname)) quals;
         sigrng = d.drange;
         sigmeta = default_sigmeta  ;
-        sigattrs = [] }
+        sigattrs = [];
+        sigopts = None; }
     in
     let monad_env = env in
     let env = push_sigelt env0 se in
@@ -2601,7 +2613,8 @@ and desugar_redefine_effect env d trans_qual quals eff_name eff_binders defn =
                                sigquals = quals;
                                sigrng = d.drange;
                                sigmeta = default_sigmeta  ;
-                               sigattrs = [] } in
+                               sigattrs = [];
+                               sigopts = None; } in
              push_sigelt env refl_decl // FIXME: Add docs to refl_decl?
         else env in
     let env = push_doc env mname d.doc in
@@ -2673,7 +2686,8 @@ and desugar_decl_noattrs env (d:decl) : (env_t * sigelts) =
                sigquals = [];
                sigrng = d.drange;
                sigmeta = default_sigmeta  ;
-               sigattrs = [] } in
+               sigattrs = [];
+               sigopts = None; } in
     env, [se]
 
   | Fsdoc _ -> env, []
@@ -2750,7 +2764,8 @@ and desugar_decl_noattrs env (d:decl) : (env_t * sigelts) =
               sigquals = [];
               sigrng = d.drange;
               sigmeta = default_sigmeta;
-              sigattrs = [] }]
+              sigattrs = [];
+              sigopts = None; }]
         | _ -> []
     in
     let extra =
@@ -2823,7 +2838,8 @@ and desugar_decl_noattrs env (d:decl) : (env_t * sigelts) =
                     sigquals = quals;
                     sigrng = d.drange;
                     sigmeta = default_sigmeta  ;
-                    sigattrs = attrs } in
+                    sigattrs = attrs;
+                    sigopts = None; } in
           let env = push_sigelt env s in
           // FIXME all bindings in let get the same docs?
           let env = List.fold_left (fun env id -> push_doc env id d.doc) env names in
@@ -2878,7 +2894,8 @@ and desugar_decl_noattrs env (d:decl) : (env_t * sigelts) =
                sigquals = [];
                sigrng = d.drange;
                sigmeta = default_sigmeta  ;
-               sigattrs = [] } in
+               sigattrs = [];
+               sigopts = None; } in
     env, [se]
 
   | Assume(id, t) ->
@@ -2889,7 +2906,8 @@ and desugar_decl_noattrs env (d:decl) : (env_t * sigelts) =
             sigquals = [S.Assumption];
             sigrng = d.drange;
             sigmeta = default_sigmeta  ;
-            sigattrs = [] }]
+            sigattrs = [];
+            sigopts = None; }]
 
   | Val(id, t) ->
     let quals = d.quals in
@@ -2905,7 +2923,8 @@ and desugar_decl_noattrs env (d:decl) : (env_t * sigelts) =
                sigquals = List.map (trans_qual None) quals;
                sigrng = d.drange;
                sigmeta = default_sigmeta  ;
-               sigattrs = attrs } in
+               sigattrs = attrs;
+               sigopts = None; } in
     let env = push_sigelt env se in
     let env = push_doc env lid d.doc in
     env, [se]
@@ -2924,12 +2943,14 @@ and desugar_decl_noattrs env (d:decl) : (env_t * sigelts) =
                sigquals = qual;
                sigrng = d.drange;
                sigmeta = default_sigmeta  ;
-               sigattrs = [] } in
+               sigattrs = [];
+               sigopts = None; } in
     let se' = { sigel = Sig_bundle([se], [l]);
                 sigquals = qual;
                 sigrng = d.drange;
                 sigmeta = default_sigmeta  ;
-                sigattrs = [] } in
+                sigattrs = [];
+                sigopts = None; } in
     let env = push_sigelt env se' in
     let env = push_doc env l d.doc in
     let data_ops = mk_data_projector_names [] env se in
@@ -2961,7 +2982,8 @@ and desugar_decl_noattrs env (d:decl) : (env_t * sigelts) =
                sigquals = [];
                sigrng = d.drange;
                sigmeta = default_sigmeta  ;
-               sigattrs = [] } in
+               sigattrs = [];
+               sigopts = None; } in
     env, [se]
 
   | Splice (ids, t) ->
@@ -2970,7 +2992,8 @@ and desugar_decl_noattrs env (d:decl) : (env_t * sigelts) =
                sigquals = [];
                sigrng = d.drange;
                sigmeta = default_sigmeta;
-               sigattrs = [] } in
+               sigattrs = [];
+               sigopts = None; } in
     let env = push_sigelt env se in
     env, [se]
 

--- a/src/typechecker/FStar.TypeChecker.Tc.fs
+++ b/src/typechecker/FStar.TypeChecker.Tc.fs
@@ -47,6 +47,7 @@ module TcInductive = FStar.TypeChecker.TcInductive
 module PC = FStar.Parser.Const
 module EMB = FStar.Syntax.Embeddings
 module ToSyntax = FStar.ToSyntax.ToSyntax
+module O = FStar.Options
 
 //set the name of the query so that we can correlate hints to source program fragments
 let set_hint_correlator env se =
@@ -890,7 +891,8 @@ let tc_lex_t env ses quals lids =
                    sigquals = [];
                    sigrng = r;
                    sigmeta = default_sigmeta;
-                   sigattrs = [] } in
+                   sigattrs = [];
+                   sigopts = None; } in
 
         let utop = S.new_univ_name (Some r1) in
         let lex_top_t = mk (Tm_uinst(S.fvar (Ident.set_lid_range PC.lex_t_lid r1) delta_constant None, [U_name utop])) None r1 in
@@ -899,7 +901,8 @@ let tc_lex_t env ses quals lids =
                           sigquals = [];
                           sigrng = r1;
                           sigmeta = default_sigmeta;
-                          sigattrs = []  } in
+                          sigattrs = [];
+                          sigopts = None; } in
 
         let ucons1 = S.new_univ_name (Some r2) in
         let ucons2 = S.new_univ_name (Some r2) in
@@ -914,12 +917,14 @@ let tc_lex_t env ses quals lids =
                            sigquals = [];
                            sigrng = r2;
                            sigmeta = default_sigmeta;
-                           sigattrs = []  } in
+                           sigattrs = [];
+                           sigopts = None; } in
         { sigel = Sig_bundle([tc; dc_lextop; dc_lexcons], lids);
           sigquals = [];
           sigrng = Env.get_range env;
           sigmeta = default_sigmeta;
-          sigattrs = []  }
+          sigattrs = [];
+          sigopts = None; }
       | _ ->
         let err_msg =
           BU.format1 "Invalid (re)definition of lex_t: %s\n"
@@ -1151,10 +1156,26 @@ let check_must_erase_attribute env se =
 
     | _ -> ()
 
+(* A(nother) hacky knot, set by FStar.Main *)
+let unembed_optionstate_knot : ref<option<EMB.embedding<O.optionstate>>> = BU.mk_ref None
+let unembed_optionstate (t : term) : option<O.optionstate> =
+    EMB.unembed (BU.must (!unembed_optionstate_knot)) t true EMB.id_norm_cb
+
+let proc_check_with (attrs:list<attribute>) (kont : unit -> 'a) : 'a =
+  match U.get_attribute PC.check_with_lid attrs with
+  | None -> kont ()
+  | Some [(a, None)] ->
+    Options.with_saved_options (fun () ->
+      Options.set (unembed_optionstate a |> BU.must);
+      kont ())
+  | _ -> failwith "huh?"
+
 let tc_decl' env0 se: list<sigelt> * list<sigelt> * Env.env =
   let env = env0 in
   TcUtil.check_sigelt_quals env se;
+  proc_check_with se.sigattrs (fun () ->
   let r = se.sigrng in
+  let se = { se with sigopts = Some (Options.peek ()) } in
   match se.sigel with
   | Sig_inductive_typ _
   | Sig_datacon _ ->
@@ -1632,7 +1653,7 @@ let tc_decl' env0 se: list<sigelt> * list<sigelt> * Env.env =
 
     check_must_erase_attribute env0 se;
 
-    [se], [], env0
+    [se], [], env0)
 
 (* [tc_decl env se] typechecks [se] in environment [env] and returns *)
 (* the list of typechecked sig_elts, and a list of new sig_elts elaborated during typechecking but not yet typechecked *)
@@ -1778,7 +1799,8 @@ let for_export env hidden se : list<sigelt> * list<lident> =
                      sigquals =[Assumption];
                      sigrng = Ident.range_of_lid lid;
                      sigmeta = default_sigmeta;
-                     sigattrs = [] } in
+                     sigattrs = [];
+                     sigopts = None; } in
           [dec], lid::hidden
 
   | Sig_let(lbs, l) ->

--- a/src/typechecker/FStar.TypeChecker.Tc.fsi
+++ b/src/typechecker/FStar.TypeChecker.Tc.fsi
@@ -20,6 +20,7 @@ open FStar.All
 open FStar.Syntax.Syntax
 open FStar.TypeChecker.Env
 open FStar.TypeChecker.Common
+module EMB = FStar.Syntax.Embeddings
 
 
 val check_module: env -> modul -> bool -> modul * env
@@ -34,3 +35,5 @@ val tc_decls: env -> list<sigelt> -> list<sigelt> * list<sigelt> * env
 val tc_partial_modul: env -> modul -> modul * list<sigelt> * env
 val tc_more_partial_modul: env -> modul -> list<sigelt> -> modul * list<sigelt> * env
 val extract_interface: env -> modul -> modul
+
+val unembed_optionstate_knot : ref<option<EMB.embedding<FStar.Options.optionstate>>>

--- a/src/typechecker/FStar.TypeChecker.TcInductive.fs
+++ b/src/typechecker/FStar.TypeChecker.TcInductive.fs
@@ -713,7 +713,8 @@ let optimized_haseq_scheme (sig_bndle:sigelt) (tcs:list<sigelt>) (datas:list<sig
             sigquals = [];
             sigrng = Range.dummyRange;
             sigmeta = default_sigmeta;
-            sigattrs = []  } ]
+            sigattrs = [];
+            sigopts = None; } ]
   ) [] axioms in
 
   env.solver.pop "haseq";
@@ -854,7 +855,8 @@ let unoptimized_haseq_scheme (sig_bndle:sigelt) (tcs:list<sigelt>) (datas:list<s
               sigquals = [];
               sigrng = Range.dummyRange;
               sigmeta = default_sigmeta;
-              sigattrs = []  }
+              sigattrs = [];
+              sigopts = None; }
 
   in
   [se]
@@ -975,7 +977,8 @@ let check_inductive_well_typedness (env:env_t) (ses:list<sigelt>) (quals:list<qu
                     sigquals = quals;
                     sigrng = Env.get_range env0;
                     sigmeta = default_sigmeta;
-                    sigattrs = List.collect (fun s -> s.sigattrs) ses } in
+                    sigattrs = List.collect (fun s -> s.sigattrs) ses;
+                    sigopts = None; } in
 
   (* In any of the tycons had their typed declared using `val`,
      check that the declared and inferred types are compatible *)
@@ -1097,7 +1100,8 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                          sigquals = quals;
                          sigrng = range_of_lid discriminator_name;
                          sigmeta = default_sigmeta;
-                         sigattrs = [] } in
+                         sigattrs = [];
+                         sigopts = None; } in
             if Env.debug env (Options.Other "LogTypes")
             then BU.print1 "Declaration of a discriminator %s\n"  (Print.sigelt_to_string decl);
 
@@ -1140,7 +1144,8 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                              sigquals = quals;
                              sigrng = p;
                              sigmeta = default_sigmeta;
-                             sigattrs = []  } in
+                             sigattrs = [];
+                             sigopts = None; } in
                 if Env.debug env (Options.Other "LogTypes")
                 then BU.print1 "Implementation of a discriminator %s\n"  (Print.sigelt_to_string impl);
                 (* TODO : Are there some cases where we don't want one of these ? *)
@@ -1199,7 +1204,8 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                        sigquals = quals;
                        sigrng = range_of_lid field_name;
                        sigmeta = default_sigmeta;
-                       sigattrs = attrs } in
+                       sigattrs = attrs;
+                       sigopts = None; } in
           if Env.debug env (Options.Other "LogTypes")
           then BU.print1 "Declaration of a projector %s\n"  (Print.sigelt_to_string decl);
           if only_decl
@@ -1236,7 +1242,8 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                            sigquals = quals;
                            sigrng = p;
                            sigmeta = default_sigmeta;
-                           sigattrs = attrs } in
+                           sigattrs = attrs;
+                           sigopts = None; } in
               if Env.debug env (Options.Other "LogTypes")
               then BU.print1 "Implementation of a projector %s\n"  (Print.sigelt_to_string impl);
               if no_decl then [impl] else [decl;impl]) |> List.flatten

--- a/ulib/FStar.Reflection.Basic.fst
+++ b/ulib/FStar.Reflection.Basic.fst
@@ -68,3 +68,10 @@ assume val set_sigelt_attrs : list term -> sigelt -> sigelt
 (* Setting and reading qualifiers from sigelts *)
 assume val sigelt_quals     : sigelt -> list qualifier
 assume val set_sigelt_quals : list qualifier -> sigelt -> sigelt
+
+(* Reading the optionstate under which a particular sigelt was typechecked *)
+assume val sigelt_opts : sigelt -> option optionstate
+
+(* Marker to check a sigelt with a particular optionstate *)
+irreducible
+let check_with (o : optionstate) : unit = ()

--- a/ulib/FStar.Reflection.Data.fst
+++ b/ulib/FStar.Reflection.Data.fst
@@ -33,7 +33,10 @@ type vconst =
 noeq
 type pattern =
     | Pat_Constant : vconst -> pattern              // A built-in constant
-    | Pat_Cons     : fv -> list pattern -> pattern  // A fully applied constructor
+    | Pat_Cons     : fv -> list (pattern * bool) -> pattern
+                                                    // A fully applied constructor, each boolean marks
+                                                    // whether the argument was an explicitly-provided
+                                                    // implicit argument
     | Pat_Var      : bv -> pattern                  // Pattern bound variable
     | Pat_Wild     : bv -> pattern                  // Wildcard (GM: why is this not Pat_var too?)
     | Pat_Dot_Term : bv -> term -> pattern          // Dot pattern: resolved by other elements in the pattern and type

--- a/ulib/FStar.Reflection.Types.fsti
+++ b/ulib/FStar.Reflection.Types.fsti
@@ -23,6 +23,7 @@ assume new type fv
 assume new type comp
 assume new type sigelt // called `def` in the paper, but we keep the internal name here
 assume new type ctx_uvar_and_subst
+assume new type optionstate
 
 type name : eqtype = list string
 type ident = range * string

--- a/ulib/tactics_ml/FStar_Reflection_Types.ml
+++ b/ulib/tactics_ml/FStar_Reflection_Types.ml
@@ -7,6 +7,7 @@ type fv      = FStar_Syntax_Syntax.fv
 type comp    = FStar_Syntax_Syntax.comp
 type bv      = FStar_Syntax_Syntax.bv
 type sigelt  = FStar_Syntax_Syntax.sigelt
+type optionstate = FStar_Options.optionstate
 
 type typ     = term
 type name    = string list


### PR DESCRIPTION
This PR adds a mechanism to obtain the optionstate under which some top-level definition was checked in, and a way to mark new definitions with this optionstate so that they are checked in it. The main changes are:

- `sigelt` now contains a `sigopts : option<optionstate>` field to store the options (starts out empty and is set by `tc_decl`)

- A `sigelt_opts : sigelt -> option optionstate` reflection operator to read it

- A `check_with : optionstate -> unit` attribute to mark definitions so that they are checked in such optionstate.

I'm mostly making this PR because:

- The first change causes an increase in the size of checked files. I've measured an ~10% increase in the size of the `ulib/.cache` directory

- I am not completely sure this is perfectly safe to do, e.g. across modules. I think it is... but perhaps we could restrict the `optionstate` that we set when processing `check_with` to just rlimit/fuel etc. 

cc @msprotz