### PR TITLE
Docker containers are nowadays running as build:build instead of FStar:FStar

### DIFF
--- a/.docker/emacs/.emacs
+++ b/.docker/emacs/.emacs
@@ -8,7 +8,7 @@
 
 
 ;;set fstar includes, these should work for most tutorial examples, except those using hyperheap
-(setq fstar-subp-prover-args '("--include" "/home/FStar/FStar/ucontrib/Platform/fst" "--include" "/home/FStar/FStar/ucontrib/CoreCrypto/fst"))
+(setq fstar-subp-prover-args '("--include" "/home/build/FStar/ucontrib/Platform/fst" "--include" "/home/build/FStar/ucontrib/CoreCrypto/fst"))
 
 
 ;;this is what the above corresponds to on the command line:


### PR DESCRIPTION
Nowadays docker containers are running as `build:build` instead of `FStar:FStar`.

This PR makes the corresponding change in the include path used by `fstar-mode` in the emacs-equipped docker containers.