### PR TITLE
Ghost length for msub

### DIFF
--- a/ulib/LowStar.Monotonic.Buffer.fsti
+++ b/ulib/LowStar.Monotonic.Buffer.fsti
@@ -352,7 +352,7 @@ val gsub_gsub (#a:Type0) (#rrel #rel:srel a)
   (b:mbuffer a rrel rel)
   (i1:U32.t) (len1:U32.t) (sub_rel1:srel a)
   (i2: U32.t) (len2: U32.t) (sub_rel2:srel a)
-  :Lemma (requires (U32.v i1 + U32.v len1 <= length b /\ 
+  :Lemma (requires (U32.v i1 + U32.v len1 <= length b /\
                     U32.v i2 + U32.v len2 <= U32.v len1))
          (ensures  (((compatible_sub b i1 len1 sub_rel1 /\  compatible_sub (mgsub sub_rel1 b i1 len1) i2 len2 sub_rel2) ==> compatible_sub b (U32.add i1 i2) len2 sub_rel2) /\
                     mgsub sub_rel2 (mgsub sub_rel1 b i1 len1) i2 len2 == mgsub sub_rel2 b (U32.add i1 i2) len2))
@@ -1464,7 +1464,7 @@ val modifies_loc_buffer_from_to_intro
     Seq.slice s (U32.v to) (length b) `Seq.equal` Seq.slice s' (U32.v to) (length b)
   ))
   (ensures (modifies (loc_union l (loc_buffer_from_to b from to)) h h'))
-  
+
 
 ///  A memory ``h`` does not contain address ``a`` in region ``r``, denoted
 ///  ``does_not_contain_addr h (r, a)``, only if, either region ``r`` is
@@ -1804,11 +1804,10 @@ val is_null (#a:Type0) (#rrel #rel:srel a) (b:mbuffer a rrel rel)
 /// ``b + i`` (or, equivalently, ``&b[i]``.)
 
 val msub (#a:Type0) (#rrel #rel:srel a) (sub_rel:srel a) (b:mbuffer a rrel rel)
-  (i:U32.t) (len:U32.t)
+  (i:U32.t) (len:Ghost.erased U32.t)
   :HST.Stack (mbuffer a rrel sub_rel)
-             (requires (fun h -> U32.v i + U32.v len <= length b /\ compatible_sub b i len sub_rel /\ live h b))
-             (ensures  (fun h y h' -> h == h' /\ y == mgsub sub_rel b i len))
-
+             (requires (fun h -> U32.v i + U32.v (Ghost.reveal len) <= length b /\ compatible_sub b i (Ghost.reveal len) sub_rel /\ live h b))
+             (ensures  (fun h y h' -> h == h' /\ y == mgsub sub_rel b i (Ghost.reveal len)))
 
 /// ``offset b i`` construct the tail of the buffer ``b`` starting from
 /// offset ``i``, i.e. the sub-buffer of ``b`` starting from offset ``i``


### PR DESCRIPTION
This PR modifies slightly the memory model for arrays to provide a (m)sub primitive that takes a ghost length as argument.
The length field in arrays inside LowStar.Monotonic.Buffer is now ghost.
As this PR modifies the signature of (m)sub, it is breaking for EverCrypt and miTLS. It should not be merged before @mtzguido's changes to the Ghost automatic coercions in order to avoid breakages in clients.