### PR TITLE
Reflect SMT patterns in ``comp_view` for C_Lemma`

### DIFF
--- a/src/reflection/FStar.Reflection.Basic.fs
+++ b/src/reflection/FStar.Reflection.Basic.fs
@@ -213,8 +213,8 @@ let inspect_comp (c : comp) : comp_view =
     | Comp ct -> begin
         if Ident.lid_equals ct.effect_name PC.effect_Lemma_lid then
             match ct.effect_args with
-            | (pre,_)::(post,_)::_ ->
-                C_Lemma (pre, post)
+            | (pre,_)::(post,_)::(pats,_)::_ ->
+                C_Lemma (pre, post, pats)
             | _ ->
                 failwith "inspect_comp: Lemma does not have enough arguments?"
         else if Ident.lid_equals ct.effect_name PC.effect_Tot_lid then
@@ -233,11 +233,11 @@ let inspect_comp (c : comp) : comp_view =
 let pack_comp (cv : comp_view) : comp =
     match cv with
     | C_Total (t, _) -> mk_Total t
-    | C_Lemma (pre, post) ->
+    | C_Lemma (pre, post, pats) ->
         let ct = { comp_univs  = []
                  ; effect_name = PC.effect_Lemma_lid
                  ; result_typ  = S.t_unit
-                 ; effect_args = [S.as_arg pre; S.as_arg post]
+                 ; effect_args = [S.as_arg pre; S.as_arg post; S.as_arg pats]
                  ; flags       = [] } in
         S.mk_Comp ct
 

--- a/src/reflection/FStar.Reflection.Data.fs
+++ b/src/reflection/FStar.Reflection.Data.fs
@@ -91,7 +91,7 @@ type binder_view = bv * aqualv
 
 type comp_view =
     | C_Total of typ * option<term> //optional decreases clause
-    | C_Lemma of term * term
+    | C_Lemma of term * term * term
     | C_Unknown
 
 type sigelt_view =

--- a/src/reflection/FStar.Reflection.Embeddings.fs
+++ b/src/reflection/FStar.Reflection.Embeddings.fs
@@ -513,9 +513,9 @@ let e_comp_view =
                                        S.as_arg (embed (e_option e_term) rng md)]
                         None rng
 
-        | C_Lemma (pre, post) ->
+        | C_Lemma (pre, post, pats) ->
             let post = U.unthunk_lemma_post post in
-            S.mk_Tm_app ref_C_Lemma.t [S.as_arg (embed e_term rng pre); S.as_arg (embed e_term rng post)]
+            S.mk_Tm_app ref_C_Lemma.t [S.as_arg (embed e_term rng pre); S.as_arg (embed e_term rng post); S.as_arg (embed e_term rng pats)]
                         None rng
 
         | C_Unknown ->
@@ -530,10 +530,11 @@ let e_comp_view =
             BU.bind_opt (unembed' w (e_option e_term) md) (fun md ->
             Some <| C_Total (t, md)))
 
-        | Tm_fvar fv, [(pre, _); (post, _)] when S.fv_eq_lid fv ref_C_Lemma.lid ->
+        | Tm_fvar fv, [(pre, _); (post, _); (pats, _)] when S.fv_eq_lid fv ref_C_Lemma.lid ->
             BU.bind_opt (unembed' w e_term pre) (fun pre ->
             BU.bind_opt (unembed' w e_term post) (fun post ->
-            Some <| C_Lemma (pre, post)))
+            BU.bind_opt (unembed' w e_term post) (fun pats ->
+            Some <| C_Lemma (pre, post))))
 
         | Tm_fvar fv, [] when S.fv_eq_lid fv ref_C_Unknown.lid ->
             Some <| C_Unknown

--- a/src/reflection/FStar.Reflection.Embeddings.fs
+++ b/src/reflection/FStar.Reflection.Embeddings.fs
@@ -533,8 +533,8 @@ let e_comp_view =
         | Tm_fvar fv, [(pre, _); (post, _); (pats, _)] when S.fv_eq_lid fv ref_C_Lemma.lid ->
             BU.bind_opt (unembed' w e_term pre) (fun pre ->
             BU.bind_opt (unembed' w e_term post) (fun post ->
-            BU.bind_opt (unembed' w e_term post) (fun pats ->
-            Some <| C_Lemma (pre, post))))
+            BU.bind_opt (unembed' w e_term pats) (fun pats ->
+            Some <| C_Lemma (pre, post, pats))))
 
         | Tm_fvar fv, [] when S.fv_eq_lid fv ref_C_Unknown.lid ->
             Some <| C_Unknown

--- a/src/reflection/FStar.Reflection.NBEEmbeddings.fs
+++ b/src/reflection/FStar.Reflection.NBEEmbeddings.fs
@@ -486,9 +486,9 @@ let e_comp_view =
             mkConstruct ref_C_Total.fv [] [as_arg (embed e_term cb t);
                                     as_arg (embed (e_option e_term) cb md)]
 
-        | C_Lemma (pre, post) ->
+        | C_Lemma (pre, post, pats) ->
             let post = U.unthunk_lemma_post post in
-            mkConstruct ref_C_Lemma.fv [] [as_arg (embed e_term cb pre); as_arg (embed e_term cb post)]
+            mkConstruct ref_C_Lemma.fv [] [as_arg (embed e_term cb pre); as_arg (embed e_term cb post); as_arg (embed e_term cb pats)]
 
         | C_Unknown ->
             mkConstruct ref_C_Unknown.fv [] []
@@ -500,10 +500,11 @@ let e_comp_view =
             BU.bind_opt (unembed (e_option e_term) cb md) (fun md ->
             Some <| C_Total (t, md)))
 
-        | Construct (fv, _, [(post, _); (pre, _)]) when S.fv_eq_lid fv ref_C_Lemma.lid ->
+        | Construct (fv, _, [(post, _); (pre, _); (pats, _)]) when S.fv_eq_lid fv ref_C_Lemma.lid ->
             BU.bind_opt (unembed e_term cb pre) (fun pre ->
             BU.bind_opt (unembed e_term cb post) (fun post ->
-            Some <| C_Lemma (pre, post)))
+            BU.bind_opt (unembed e_term cb post) (fun pats ->
+            Some <| C_Lemma (pre, post, pats))))
 
         | Construct (fv, _, []) when S.fv_eq_lid fv ref_C_Unknown.lid ->
             Some <| C_Unknown

--- a/src/reflection/FStar.Reflection.NBEEmbeddings.fs
+++ b/src/reflection/FStar.Reflection.NBEEmbeddings.fs
@@ -503,7 +503,7 @@ let e_comp_view =
         | Construct (fv, _, [(post, _); (pre, _); (pats, _)]) when S.fv_eq_lid fv ref_C_Lemma.lid ->
             BU.bind_opt (unembed e_term cb pre) (fun pre ->
             BU.bind_opt (unembed e_term cb post) (fun post ->
-            BU.bind_opt (unembed e_term cb post) (fun pats ->
+            BU.bind_opt (unembed e_term cb pats) (fun pats ->
             Some <| C_Lemma (pre, post, pats))))
 
         | Construct (fv, _, []) when S.fv_eq_lid fv ref_C_Unknown.lid ->

--- a/ulib/FStar.Reflection.Data.fst
+++ b/ulib/FStar.Reflection.Data.fst
@@ -80,7 +80,7 @@ type term_view =
 noeq
 type comp_view =
   | C_Total     : ret:typ -> decr:(option term) -> comp_view
-  | C_Lemma     : term -> term -> comp_view // pre & post
+  | C_Lemma     : term -> term -> term -> comp_view // pre & post
   | C_Unknown   : comp_view
 
 noeq
@@ -194,8 +194,8 @@ let smaller_comp cv c =
     match cv with
     | C_Total t md ->
         t << c /\ (match md with | Some d -> d << c | None -> True)
-    | C_Lemma pre post ->
-        pre << c /\ post << c
+    | C_Lemma pre post pats ->
+        pre << c /\ post << c /\ pats << c
     | C_Unknown ->
         True
 

--- a/ulib/FStar.Reflection.Derived.fst
+++ b/ulib/FStar.Reflection.Derived.fst
@@ -245,11 +245,16 @@ and compare_comp (c1 c2 : comp) : order =
                                                    | Some _, None -> Gt
                                                    | Some x, Some y -> compare_term x y)
 
-    | C_Lemma p1 q1, C_Lemma p2 q2 -> lex (compare_term p1 p2) (fun () -> compare_term q1 q2)
+    | C_Lemma p1 q1 s1, C_Lemma p2 q2 s2 ->
+      lex (compare_term p1 p2)
+          (fun () -> 
+            lex (compare_term q1 q2)
+                (fun () -> compare_term s1 s2)
+          )
 
     | C_Unknown, C_Unknown -> Eq
     | C_Total _ _, _  -> Lt | _, C_Total _ _ -> Gt
-    | C_Lemma _ _, _  -> Lt | _, C_Lemma _ _ -> Gt
+    | C_Lemma _ _ _, _  -> Lt | _, C_Lemma _ _ _ -> Gt
     | C_Unknown,   _  -> Lt | _, C_Unknown   -> Gt
 
 let mk_stringlit (s : string) : term =

--- a/ulib/FStar.Tactics.Derived.fst
+++ b/ulib/FStar.Tactics.Derived.fst
@@ -540,7 +540,7 @@ let rec apply_squash_or_lem d t =
     let ty = tc (cur_env ()) t in
     let tys, c = collect_arr ty in
     match inspect_comp c with
-    | C_Lemma pre post ->
+    | C_Lemma pre post _ ->
        begin
        let post = norm_term [] post in
        (* Is the lemma an implication? We can try to intro *)
@@ -756,10 +756,11 @@ and visit_comp (ff : term -> Tac term) (c : comp) : Tac comp =
             | Some d -> Some (visit_tm ff d)
         in
         C_Total ret decr
-    | C_Lemma pre post ->
+    | C_Lemma pre post pats ->
         let pre = visit_tm ff pre in
         let post = visit_tm ff post in
-        C_Lemma pre post
+        let pats = visit_tm ff pats in
+        C_Lemma pre post pats
     | C_Unknown -> C_Unknown
   in
   pack_comp cv'

--- a/ulib/FStar.Tactics.Logic.fst
+++ b/ulib/FStar.Tactics.Logic.fst
@@ -93,7 +93,7 @@ let pose_lemma (t : term) : Tac binder =
   let c = tcc (cur_env ()) t in
   let pre, post =
     match inspect_comp c with
-    | C_Lemma pre post -> pre, post
+    | C_Lemma pre post _ -> pre, post
     | _ -> fail ""
   in
   (* If the precondition is trivial, do not cut by it *)


### PR DESCRIPTION
Hi,

This pull request just adds a third argument to the `comp_view` constructor `C_Lemma`, so that one can inspect the SMTPat of lemmas, and craft lemmas with SMT patterns.