### PR TITLE
Introduce --retry

### DIFF
--- a/src/basic/FStar.Options.fs
+++ b/src/basic/FStar.Options.fs
@@ -605,7 +605,6 @@ let pp_lowercase s =
 let abort_counter : ref<int> =
     mk_ref 0
 
-private
 let interp_quake_arg (s:string)
             : int * int * bool =
            (* min,  max,  keep_going *)

--- a/src/basic/FStar.Options.fs
+++ b/src/basic/FStar.Options.fs
@@ -973,8 +973,11 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
                        | _ -> failwith "impos"),
             SimpleStr "positive integer or pair of positive integers"),
         "Repeats SMT queries to check for robustness\n\t\t\
-         --quake N/M repeats each query M times and checks that it succeeds at least N times.\n\t\t\
-         --quake N is an alias for --quake N/N.");
+         --quake N/M repeats each query checks that it succeeds at least N out of M times, aborting early if possible\n\t\t\
+         --quake N/M/k works as above, except it will unconditionally run M times\n\t\t\
+         --quake N is an alias for --quake N/N\n\t\t\
+         --quake N/k is an alias for --quake N/N/k\n\t\
+         Using --quake disables --retry.");
 
        ( noshort,
         "query_stats",
@@ -1002,8 +1005,7 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
                          Bool true
                        | _ -> failwith "impos"),
             IntStr "positive integer"),
-        "Retry each SMT query N times and succeed on the first try.\n\t\
-         This is equivalent to --quake N/N.");
+        "Retry each SMT query N times and succeed on the first try. Using --retry disables --quake.");
 
        ( noshort,
         "reuse_hint_for",

--- a/src/basic/FStar.Options.fsi
+++ b/src/basic/FStar.Options.fsi
@@ -185,9 +185,11 @@ val print_universes             : unit    -> bool
 val print_z3_statistics         : unit    -> bool
 val quake_lo                    : unit    -> int
 val quake_hi                    : unit    -> int
+val quake_keep                  : unit    -> bool
 val query_stats                 : unit    -> bool
 val record_hints                : unit    -> bool
 val record_options              : unit    -> bool
+val retry                       : unit    -> bool
 val reuse_hint_for              : unit    -> option<string>
 val set_option                  : string  -> option_val -> unit
 val set_options                 : string -> parse_cmdline_res

--- a/src/ocaml-output/FStar_Options.ml
+++ b/src/ocaml-output/FStar_Options.ml
@@ -1262,7 +1262,7 @@ let rec (specs_with_types :
                         String s))
               | uu____6718 -> failwith "impos")),
            (SimpleStr "positive integer or pair of positive integers"))),
-      "Repeats SMT queries to check for robustness\n\t\t--quake N/M repeats each query M times and checks that it succeeds at least N times.\n\t\t--quake N is an alias for --quake N/N.");
+      "Repeats SMT queries to check for robustness\n\t\t--quake N/M repeats each query checks that it succeeds at least N out of M times, aborting early if possible\n\t\t--quake N/M/k works as above, except it will unconditionally run M times\n\t\t--quake N is an alias for --quake N/N\n\t\t--quake N/k is an alias for --quake N/N/k\n\tUsing --quake disables --retry.");
     (FStar_Getopt.noshort, "query_stats", (Const (Bool true)),
       "Print SMT query statistics");
     (FStar_Getopt.noshort, "record_hints", (Const (Bool true)),
@@ -1281,7 +1281,7 @@ let rec (specs_with_types :
                    Bool true)
               | uu____6812 -> failwith "impos")),
            (IntStr "positive integer"))),
-      "Retry each SMT query N times and succeed on the first try.\n\tThis is equivalent to --quake N/N.");
+      "Retry each SMT query N times and succeed on the first try. Using --retry disables --quake.");
     (FStar_Getopt.noshort, "reuse_hint_for", (SimpleStr "toplevel_name"),
       "Optimistically, attempt using the recorded hint for <toplevel_name> (a top-level name in the current module) when trying to verify some other term 'g'");
     (FStar_Getopt.noshort, "silent", (Const (Bool true)),

--- a/src/ocaml-output/FStar_Options.ml
+++ b/src/ocaml-output/FStar_Options.ml
@@ -333,6 +333,7 @@ let (defaults : (Prims.string * option_val) Prims.list) =
   ("quake", (Int Prims.int_zero));
   ("quake_lo", (Int Prims.int_one));
   ("quake_hi", (Int Prims.int_one));
+  ("quake_keep", (Bool false));
   ("query_stats", (Bool false));
   ("record_hints", (Bool false));
   ("record_options", (Bool false));
@@ -386,14 +387,14 @@ let (parse_warn_error_set_get :
   =
   let r = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
   let set1 f =
-    let uu____2302 = FStar_ST.op_Bang r  in
-    match uu____2302 with
+    let uu____2310 = FStar_ST.op_Bang r  in
+    match uu____2310 with
     | FStar_Pervasives_Native.None  ->
         FStar_ST.op_Colon_Equals r (FStar_Pervasives_Native.Some f)
-    | uu____2393 -> failwith "Multiple initialization of FStar.Options"  in
-  let get1 uu____2414 =
-    let uu____2415 = FStar_ST.op_Bang r  in
-    match uu____2415 with
+    | uu____2401 -> failwith "Multiple initialization of FStar.Options"  in
+  let get1 uu____2422 =
+    let uu____2423 = FStar_ST.op_Bang r  in
+    match uu____2423 with
     | FStar_Pervasives_Native.Some f -> f
     | FStar_Pervasives_Native.None  ->
         failwith "FStar.Options is improperly initialized"
@@ -404,18 +405,18 @@ let (initialize_parse_warn_error :
   fun f  -> FStar_Pervasives_Native.fst parse_warn_error_set_get f 
 let (parse_warn_error : Prims.string -> error_flag Prims.list) =
   fun s  ->
-    let uu____2554 = FStar_Pervasives_Native.snd parse_warn_error_set_get ()
+    let uu____2562 = FStar_Pervasives_Native.snd parse_warn_error_set_get ()
        in
-    uu____2554 s
+    uu____2562 s
   
 let (init : unit -> unit) =
-  fun uu____2585  ->
+  fun uu____2593  ->
     let o = internal_peek ()  in
     FStar_Util.smap_clear o;
     FStar_All.pipe_right defaults (FStar_List.iter set_option')
   
 let (clear : unit -> unit) =
-  fun uu____2605  ->
+  fun uu____2613  ->
     let o = FStar_Util.smap_create (Prims.of_int (50))  in
     FStar_ST.op_Colon_Equals fstar_options [[o]];
     FStar_ST.op_Colon_Equals light_off_files [];
@@ -424,266 +425,270 @@ let (clear : unit -> unit) =
 let (_run : unit) = clear () 
 let (get_option : Prims.string -> option_val) =
   fun s  ->
-    let uu____2678 =
-      let uu____2681 = internal_peek ()  in
-      FStar_Util.smap_try_find uu____2681 s  in
-    match uu____2678 with
+    let uu____2686 =
+      let uu____2689 = internal_peek ()  in
+      FStar_Util.smap_try_find uu____2689 s  in
+    match uu____2686 with
     | FStar_Pervasives_Native.None  ->
-        let uu____2684 =
-          let uu____2686 = FStar_String.op_Hat s " not found"  in
-          FStar_String.op_Hat "Impossible: option " uu____2686  in
-        failwith uu____2684
+        let uu____2692 =
+          let uu____2694 = FStar_String.op_Hat s " not found"  in
+          FStar_String.op_Hat "Impossible: option " uu____2694  in
+        failwith uu____2692
     | FStar_Pervasives_Native.Some s1 -> s1
   
 let lookup_opt :
-  'Auu____2698 . Prims.string -> (option_val -> 'Auu____2698) -> 'Auu____2698
-  = fun s  -> fun c  -> let uu____2716 = get_option s  in c uu____2716 
+  'Auu____2706 . Prims.string -> (option_val -> 'Auu____2706) -> 'Auu____2706
+  = fun s  -> fun c  -> let uu____2724 = get_option s  in c uu____2724 
 let (get_abort_on : unit -> Prims.int) =
-  fun uu____2723  -> lookup_opt "abort_on" as_int 
+  fun uu____2731  -> lookup_opt "abort_on" as_int 
 let (get_admit_smt_queries : unit -> Prims.bool) =
-  fun uu____2732  -> lookup_opt "admit_smt_queries" as_bool 
+  fun uu____2740  -> lookup_opt "admit_smt_queries" as_bool 
 let (get_admit_except : unit -> Prims.string FStar_Pervasives_Native.option)
-  = fun uu____2743  -> lookup_opt "admit_except" (as_option as_string) 
+  = fun uu____2751  -> lookup_opt "admit_except" (as_option as_string) 
 let (get_already_cached :
   unit -> Prims.string Prims.list FStar_Pervasives_Native.option) =
-  fun uu____2759  ->
+  fun uu____2767  ->
     lookup_opt "already_cached" (as_option (as_list as_string))
   
 let (get_cache_checked_modules : unit -> Prims.bool) =
-  fun uu____2776  -> lookup_opt "cache_checked_modules" as_bool 
+  fun uu____2784  -> lookup_opt "cache_checked_modules" as_bool 
 let (get_cache_dir : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____2787  -> lookup_opt "cache_dir" (as_option as_string) 
+  fun uu____2795  -> lookup_opt "cache_dir" (as_option as_string) 
 let (get_cache_off : unit -> Prims.bool) =
-  fun uu____2799  -> lookup_opt "cache_off" as_bool 
+  fun uu____2807  -> lookup_opt "cache_off" as_bool 
 let (get_cmi : unit -> Prims.bool) =
-  fun uu____2808  -> lookup_opt "cmi" as_bool 
+  fun uu____2816  -> lookup_opt "cmi" as_bool 
 let (get_codegen : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____2819  -> lookup_opt "codegen" (as_option as_string) 
+  fun uu____2827  -> lookup_opt "codegen" (as_option as_string) 
 let (get_codegen_lib : unit -> Prims.string Prims.list) =
-  fun uu____2833  -> lookup_opt "codegen-lib" (as_list as_string) 
+  fun uu____2841  -> lookup_opt "codegen-lib" (as_list as_string) 
 let (get_debug : unit -> Prims.string Prims.list) =
-  fun uu____2847  -> lookup_opt "debug" (as_list as_string) 
+  fun uu____2855  -> lookup_opt "debug" (as_list as_string) 
 let (get_debug_level : unit -> Prims.string Prims.list) =
-  fun uu____2861  -> lookup_opt "debug_level" as_comma_string_list 
+  fun uu____2869  -> lookup_opt "debug_level" as_comma_string_list 
 let (get_defensive : unit -> Prims.string) =
-  fun uu____2872  -> lookup_opt "defensive" as_string 
+  fun uu____2880  -> lookup_opt "defensive" as_string 
 let (get_dep : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____2883  -> lookup_opt "dep" (as_option as_string) 
+  fun uu____2891  -> lookup_opt "dep" (as_option as_string) 
 let (get_detail_errors : unit -> Prims.bool) =
-  fun uu____2895  -> lookup_opt "detail_errors" as_bool 
+  fun uu____2903  -> lookup_opt "detail_errors" as_bool 
 let (get_detail_hint_replay : unit -> Prims.bool) =
-  fun uu____2904  -> lookup_opt "detail_hint_replay" as_bool 
+  fun uu____2912  -> lookup_opt "detail_hint_replay" as_bool 
 let (get_dump_module : unit -> Prims.string Prims.list) =
-  fun uu____2915  -> lookup_opt "dump_module" (as_list as_string) 
+  fun uu____2923  -> lookup_opt "dump_module" (as_list as_string) 
 let (get_eager_subtyping : unit -> Prims.bool) =
-  fun uu____2927  -> lookup_opt "eager_subtyping" as_bool 
+  fun uu____2935  -> lookup_opt "eager_subtyping" as_bool 
 let (get_expose_interfaces : unit -> Prims.bool) =
-  fun uu____2936  -> lookup_opt "expose_interfaces" as_bool 
+  fun uu____2944  -> lookup_opt "expose_interfaces" as_bool 
 let (get_extract :
   unit -> Prims.string Prims.list FStar_Pervasives_Native.option) =
-  fun uu____2949  -> lookup_opt "extract" (as_option (as_list as_string)) 
+  fun uu____2957  -> lookup_opt "extract" (as_option (as_list as_string)) 
 let (get_extract_module : unit -> Prims.string Prims.list) =
-  fun uu____2968  -> lookup_opt "extract_module" (as_list as_string) 
+  fun uu____2976  -> lookup_opt "extract_module" (as_list as_string) 
 let (get_extract_namespace : unit -> Prims.string Prims.list) =
-  fun uu____2982  -> lookup_opt "extract_namespace" (as_list as_string) 
+  fun uu____2990  -> lookup_opt "extract_namespace" (as_list as_string) 
 let (get_fs_typ_app : unit -> Prims.bool) =
-  fun uu____2994  -> lookup_opt "fs_typ_app" as_bool 
+  fun uu____3002  -> lookup_opt "fs_typ_app" as_bool 
 let (get_hide_uvar_nums : unit -> Prims.bool) =
-  fun uu____3003  -> lookup_opt "hide_uvar_nums" as_bool 
+  fun uu____3011  -> lookup_opt "hide_uvar_nums" as_bool 
 let (get_hint_info : unit -> Prims.bool) =
-  fun uu____3012  -> lookup_opt "hint_info" as_bool 
+  fun uu____3020  -> lookup_opt "hint_info" as_bool 
 let (get_hint_dir : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____3023  -> lookup_opt "hint_dir" (as_option as_string) 
+  fun uu____3031  -> lookup_opt "hint_dir" (as_option as_string) 
 let (get_hint_file : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____3037  -> lookup_opt "hint_file" (as_option as_string) 
+  fun uu____3045  -> lookup_opt "hint_file" (as_option as_string) 
 let (get_in : unit -> Prims.bool) =
-  fun uu____3049  -> lookup_opt "in" as_bool 
+  fun uu____3057  -> lookup_opt "in" as_bool 
 let (get_ide : unit -> Prims.bool) =
-  fun uu____3058  -> lookup_opt "ide" as_bool 
+  fun uu____3066  -> lookup_opt "ide" as_bool 
 let (get_lsp : unit -> Prims.bool) =
-  fun uu____3067  -> lookup_opt "lsp" as_bool 
+  fun uu____3075  -> lookup_opt "lsp" as_bool 
 let (get_include : unit -> Prims.string Prims.list) =
-  fun uu____3078  -> lookup_opt "include" (as_list as_string) 
+  fun uu____3086  -> lookup_opt "include" (as_list as_string) 
 let (get_print : unit -> Prims.bool) =
-  fun uu____3090  -> lookup_opt "print" as_bool 
+  fun uu____3098  -> lookup_opt "print" as_bool 
 let (get_print_in_place : unit -> Prims.bool) =
-  fun uu____3099  -> lookup_opt "print_in_place" as_bool 
+  fun uu____3107  -> lookup_opt "print_in_place" as_bool 
 let (get_initial_fuel : unit -> Prims.int) =
-  fun uu____3108  -> lookup_opt "initial_fuel" as_int 
+  fun uu____3116  -> lookup_opt "initial_fuel" as_int 
 let (get_initial_ifuel : unit -> Prims.int) =
-  fun uu____3117  -> lookup_opt "initial_ifuel" as_int 
+  fun uu____3125  -> lookup_opt "initial_ifuel" as_int 
 let (get_keep_query_captions : unit -> Prims.bool) =
-  fun uu____3126  -> lookup_opt "keep_query_captions" as_bool 
+  fun uu____3134  -> lookup_opt "keep_query_captions" as_bool 
 let (get_lax : unit -> Prims.bool) =
-  fun uu____3135  -> lookup_opt "lax" as_bool 
+  fun uu____3143  -> lookup_opt "lax" as_bool 
 let (get_load : unit -> Prims.string Prims.list) =
-  fun uu____3146  -> lookup_opt "load" (as_list as_string) 
+  fun uu____3154  -> lookup_opt "load" (as_list as_string) 
 let (get_log_queries : unit -> Prims.bool) =
-  fun uu____3158  -> lookup_opt "log_queries" as_bool 
+  fun uu____3166  -> lookup_opt "log_queries" as_bool 
 let (get_log_types : unit -> Prims.bool) =
-  fun uu____3167  -> lookup_opt "log_types" as_bool 
+  fun uu____3175  -> lookup_opt "log_types" as_bool 
 let (get_max_fuel : unit -> Prims.int) =
-  fun uu____3176  -> lookup_opt "max_fuel" as_int 
+  fun uu____3184  -> lookup_opt "max_fuel" as_int 
 let (get_max_ifuel : unit -> Prims.int) =
-  fun uu____3185  -> lookup_opt "max_ifuel" as_int 
+  fun uu____3193  -> lookup_opt "max_ifuel" as_int 
 let (get_min_fuel : unit -> Prims.int) =
-  fun uu____3194  -> lookup_opt "min_fuel" as_int 
+  fun uu____3202  -> lookup_opt "min_fuel" as_int 
 let (get_MLish : unit -> Prims.bool) =
-  fun uu____3203  -> lookup_opt "MLish" as_bool 
+  fun uu____3211  -> lookup_opt "MLish" as_bool 
 let (get_no_default_includes : unit -> Prims.bool) =
-  fun uu____3212  -> lookup_opt "no_default_includes" as_bool 
+  fun uu____3220  -> lookup_opt "no_default_includes" as_bool 
 let (get_no_extract : unit -> Prims.string Prims.list) =
-  fun uu____3223  -> lookup_opt "no_extract" (as_list as_string) 
+  fun uu____3231  -> lookup_opt "no_extract" (as_list as_string) 
 let (get_no_location_info : unit -> Prims.bool) =
-  fun uu____3235  -> lookup_opt "no_location_info" as_bool 
+  fun uu____3243  -> lookup_opt "no_location_info" as_bool 
 let (get_no_plugins : unit -> Prims.bool) =
-  fun uu____3244  -> lookup_opt "no_plugins" as_bool 
+  fun uu____3252  -> lookup_opt "no_plugins" as_bool 
 let (get_no_smt : unit -> Prims.bool) =
-  fun uu____3253  -> lookup_opt "no_smt" as_bool 
+  fun uu____3261  -> lookup_opt "no_smt" as_bool 
 let (get_normalize_pure_terms_for_extraction : unit -> Prims.bool) =
-  fun uu____3262  -> lookup_opt "normalize_pure_terms_for_extraction" as_bool 
+  fun uu____3270  -> lookup_opt "normalize_pure_terms_for_extraction" as_bool 
 let (get_odir : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____3273  -> lookup_opt "odir" (as_option as_string) 
+  fun uu____3281  -> lookup_opt "odir" (as_option as_string) 
 let (get_ugly : unit -> Prims.bool) =
-  fun uu____3285  -> lookup_opt "ugly" as_bool 
+  fun uu____3293  -> lookup_opt "ugly" as_bool 
 let (get_prims : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____3296  -> lookup_opt "prims" (as_option as_string) 
+  fun uu____3304  -> lookup_opt "prims" (as_option as_string) 
 let (get_print_bound_var_types : unit -> Prims.bool) =
-  fun uu____3308  -> lookup_opt "print_bound_var_types" as_bool 
+  fun uu____3316  -> lookup_opt "print_bound_var_types" as_bool 
 let (get_print_effect_args : unit -> Prims.bool) =
-  fun uu____3317  -> lookup_opt "print_effect_args" as_bool 
+  fun uu____3325  -> lookup_opt "print_effect_args" as_bool 
 let (get_print_full_names : unit -> Prims.bool) =
-  fun uu____3326  -> lookup_opt "print_full_names" as_bool 
+  fun uu____3334  -> lookup_opt "print_full_names" as_bool 
 let (get_print_implicits : unit -> Prims.bool) =
-  fun uu____3335  -> lookup_opt "print_implicits" as_bool 
+  fun uu____3343  -> lookup_opt "print_implicits" as_bool 
 let (get_print_universes : unit -> Prims.bool) =
-  fun uu____3344  -> lookup_opt "print_universes" as_bool 
+  fun uu____3352  -> lookup_opt "print_universes" as_bool 
 let (get_print_z3_statistics : unit -> Prims.bool) =
-  fun uu____3353  -> lookup_opt "print_z3_statistics" as_bool 
+  fun uu____3361  -> lookup_opt "print_z3_statistics" as_bool 
 let (get_prn : unit -> Prims.bool) =
-  fun uu____3362  -> lookup_opt "prn" as_bool 
+  fun uu____3370  -> lookup_opt "prn" as_bool 
 let (get_quake_lo : unit -> Prims.int) =
-  fun uu____3371  -> lookup_opt "quake_lo" as_int 
+  fun uu____3379  -> lookup_opt "quake_lo" as_int 
 let (get_quake_hi : unit -> Prims.int) =
-  fun uu____3380  -> lookup_opt "quake_hi" as_int 
+  fun uu____3388  -> lookup_opt "quake_hi" as_int 
+let (get_quake_keep : unit -> Prims.bool) =
+  fun uu____3397  -> lookup_opt "quake_keep" as_bool 
 let (get_query_stats : unit -> Prims.bool) =
-  fun uu____3389  -> lookup_opt "query_stats" as_bool 
+  fun uu____3406  -> lookup_opt "query_stats" as_bool 
 let (get_record_hints : unit -> Prims.bool) =
-  fun uu____3398  -> lookup_opt "record_hints" as_bool 
+  fun uu____3415  -> lookup_opt "record_hints" as_bool 
 let (get_record_options : unit -> Prims.bool) =
-  fun uu____3407  -> lookup_opt "record_options" as_bool 
+  fun uu____3424  -> lookup_opt "record_options" as_bool 
+let (get_retry : unit -> Prims.bool) =
+  fun uu____3433  -> lookup_opt "retry" as_bool 
 let (get_reuse_hint_for :
   unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____3418  -> lookup_opt "reuse_hint_for" (as_option as_string) 
+  fun uu____3444  -> lookup_opt "reuse_hint_for" (as_option as_string) 
 let (get_silent : unit -> Prims.bool) =
-  fun uu____3430  -> lookup_opt "silent" as_bool 
+  fun uu____3456  -> lookup_opt "silent" as_bool 
 let (get_smt : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____3441  -> lookup_opt "smt" (as_option as_string) 
+  fun uu____3467  -> lookup_opt "smt" (as_option as_string) 
 let (get_smtencoding_elim_box : unit -> Prims.bool) =
-  fun uu____3453  -> lookup_opt "smtencoding.elim_box" as_bool 
+  fun uu____3479  -> lookup_opt "smtencoding.elim_box" as_bool 
 let (get_smtencoding_nl_arith_repr : unit -> Prims.string) =
-  fun uu____3462  -> lookup_opt "smtencoding.nl_arith_repr" as_string 
+  fun uu____3488  -> lookup_opt "smtencoding.nl_arith_repr" as_string 
 let (get_smtencoding_l_arith_repr : unit -> Prims.string) =
-  fun uu____3471  -> lookup_opt "smtencoding.l_arith_repr" as_string 
+  fun uu____3497  -> lookup_opt "smtencoding.l_arith_repr" as_string 
 let (get_smtencoding_valid_intro : unit -> Prims.bool) =
-  fun uu____3480  -> lookup_opt "smtencoding.valid_intro" as_bool 
+  fun uu____3506  -> lookup_opt "smtencoding.valid_intro" as_bool 
 let (get_smtencoding_valid_elim : unit -> Prims.bool) =
-  fun uu____3489  -> lookup_opt "smtencoding.valid_elim" as_bool 
+  fun uu____3515  -> lookup_opt "smtencoding.valid_elim" as_bool 
 let (get_tactic_raw_binders : unit -> Prims.bool) =
-  fun uu____3498  -> lookup_opt "tactic_raw_binders" as_bool 
+  fun uu____3524  -> lookup_opt "tactic_raw_binders" as_bool 
 let (get_tactics_failhard : unit -> Prims.bool) =
-  fun uu____3507  -> lookup_opt "tactics_failhard" as_bool 
+  fun uu____3533  -> lookup_opt "tactics_failhard" as_bool 
 let (get_tactics_info : unit -> Prims.bool) =
-  fun uu____3516  -> lookup_opt "tactics_info" as_bool 
+  fun uu____3542  -> lookup_opt "tactics_info" as_bool 
 let (get_tactic_trace : unit -> Prims.bool) =
-  fun uu____3525  -> lookup_opt "tactic_trace" as_bool 
+  fun uu____3551  -> lookup_opt "tactic_trace" as_bool 
 let (get_tactic_trace_d : unit -> Prims.int) =
-  fun uu____3534  -> lookup_opt "tactic_trace_d" as_int 
+  fun uu____3560  -> lookup_opt "tactic_trace_d" as_int 
 let (get_tactics_nbe : unit -> Prims.bool) =
-  fun uu____3543  -> lookup_opt "__tactics_nbe" as_bool 
+  fun uu____3569  -> lookup_opt "__tactics_nbe" as_bool 
 let (get_tcnorm : unit -> Prims.bool) =
-  fun uu____3552  -> lookup_opt "tcnorm" as_bool 
+  fun uu____3578  -> lookup_opt "tcnorm" as_bool 
 let (get_timing : unit -> Prims.bool) =
-  fun uu____3561  -> lookup_opt "timing" as_bool 
+  fun uu____3587  -> lookup_opt "timing" as_bool 
 let (get_trace_error : unit -> Prims.bool) =
-  fun uu____3570  -> lookup_opt "trace_error" as_bool 
+  fun uu____3596  -> lookup_opt "trace_error" as_bool 
 let (get_unthrottle_inductives : unit -> Prims.bool) =
-  fun uu____3579  -> lookup_opt "unthrottle_inductives" as_bool 
+  fun uu____3605  -> lookup_opt "unthrottle_inductives" as_bool 
 let (get_unsafe_tactic_exec : unit -> Prims.bool) =
-  fun uu____3588  -> lookup_opt "unsafe_tactic_exec" as_bool 
+  fun uu____3614  -> lookup_opt "unsafe_tactic_exec" as_bool 
 let (get_use_eq_at_higher_order : unit -> Prims.bool) =
-  fun uu____3597  -> lookup_opt "use_eq_at_higher_order" as_bool 
+  fun uu____3623  -> lookup_opt "use_eq_at_higher_order" as_bool 
 let (get_use_hints : unit -> Prims.bool) =
-  fun uu____3606  -> lookup_opt "use_hints" as_bool 
+  fun uu____3632  -> lookup_opt "use_hints" as_bool 
 let (get_use_hint_hashes : unit -> Prims.bool) =
-  fun uu____3615  -> lookup_opt "use_hint_hashes" as_bool 
+  fun uu____3641  -> lookup_opt "use_hint_hashes" as_bool 
 let (get_use_native_tactics :
   unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____3626  -> lookup_opt "use_native_tactics" (as_option as_string) 
+  fun uu____3652  -> lookup_opt "use_native_tactics" (as_option as_string) 
 let (get_use_tactics : unit -> Prims.bool) =
-  fun uu____3638  ->
-    let uu____3639 = lookup_opt "no_tactics" as_bool  in
-    Prims.op_Negation uu____3639
+  fun uu____3664  ->
+    let uu____3665 = lookup_opt "no_tactics" as_bool  in
+    Prims.op_Negation uu____3665
   
 let (get_using_facts_from :
   unit -> Prims.string Prims.list FStar_Pervasives_Native.option) =
-  fun uu____3653  ->
+  fun uu____3679  ->
     lookup_opt "using_facts_from" (as_option (as_list as_string))
   
 let (get_vcgen_optimize_bind_as_seq :
   unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____3672  ->
+  fun uu____3698  ->
     lookup_opt "vcgen.optimize_bind_as_seq" (as_option as_string)
   
 let (get_verify_module : unit -> Prims.string Prims.list) =
-  fun uu____3686  -> lookup_opt "verify_module" (as_list as_string) 
+  fun uu____3712  -> lookup_opt "verify_module" (as_list as_string) 
 let (get___temp_no_proj : unit -> Prims.string Prims.list) =
-  fun uu____3700  -> lookup_opt "__temp_no_proj" (as_list as_string) 
+  fun uu____3726  -> lookup_opt "__temp_no_proj" (as_list as_string) 
 let (get_version : unit -> Prims.bool) =
-  fun uu____3712  -> lookup_opt "version" as_bool 
+  fun uu____3738  -> lookup_opt "version" as_bool 
 let (get_warn_default_effects : unit -> Prims.bool) =
-  fun uu____3721  -> lookup_opt "warn_default_effects" as_bool 
+  fun uu____3747  -> lookup_opt "warn_default_effects" as_bool 
 let (get_z3cliopt : unit -> Prims.string Prims.list) =
-  fun uu____3732  -> lookup_opt "z3cliopt" (as_list as_string) 
+  fun uu____3758  -> lookup_opt "z3cliopt" (as_list as_string) 
 let (get_z3refresh : unit -> Prims.bool) =
-  fun uu____3744  -> lookup_opt "z3refresh" as_bool 
+  fun uu____3770  -> lookup_opt "z3refresh" as_bool 
 let (get_z3rlimit : unit -> Prims.int) =
-  fun uu____3753  -> lookup_opt "z3rlimit" as_int 
+  fun uu____3779  -> lookup_opt "z3rlimit" as_int 
 let (get_z3rlimit_factor : unit -> Prims.int) =
-  fun uu____3762  -> lookup_opt "z3rlimit_factor" as_int 
+  fun uu____3788  -> lookup_opt "z3rlimit_factor" as_int 
 let (get_z3seed : unit -> Prims.int) =
-  fun uu____3771  -> lookup_opt "z3seed" as_int 
+  fun uu____3797  -> lookup_opt "z3seed" as_int 
 let (get_use_two_phase_tc : unit -> Prims.bool) =
-  fun uu____3780  -> lookup_opt "use_two_phase_tc" as_bool 
+  fun uu____3806  -> lookup_opt "use_two_phase_tc" as_bool 
 let (get_no_positivity : unit -> Prims.bool) =
-  fun uu____3789  -> lookup_opt "__no_positivity" as_bool 
+  fun uu____3815  -> lookup_opt "__no_positivity" as_bool 
 let (get_ml_no_eta_expand_coertions : unit -> Prims.bool) =
-  fun uu____3798  -> lookup_opt "__ml_no_eta_expand_coertions" as_bool 
+  fun uu____3824  -> lookup_opt "__ml_no_eta_expand_coertions" as_bool 
 let (get_warn_error : unit -> Prims.string Prims.list) =
-  fun uu____3809  -> lookup_opt "warn_error" (as_list as_string) 
+  fun uu____3835  -> lookup_opt "warn_error" (as_list as_string) 
 let (get_use_extracted_interfaces : unit -> Prims.bool) =
-  fun uu____3821  -> lookup_opt "use_extracted_interfaces" as_bool 
+  fun uu____3847  -> lookup_opt "use_extracted_interfaces" as_bool 
 let (get_use_nbe : unit -> Prims.bool) =
-  fun uu____3830  -> lookup_opt "use_nbe" as_bool 
+  fun uu____3856  -> lookup_opt "use_nbe" as_bool 
 let (get_use_nbe_for_extraction : unit -> Prims.bool) =
-  fun uu____3839  -> lookup_opt "use_nbe_for_extraction" as_bool 
+  fun uu____3865  -> lookup_opt "use_nbe_for_extraction" as_bool 
 let (get_trivial_pre_for_unannotated_effectful_fns : unit -> Prims.bool) =
-  fun uu____3848  ->
+  fun uu____3874  ->
     lookup_opt "trivial_pre_for_unannotated_effectful_fns" as_bool
   
 let (get_profile :
   unit -> Prims.string Prims.list FStar_Pervasives_Native.option) =
-  fun uu____3861  -> lookup_opt "profile" (as_option (as_list as_string)) 
+  fun uu____3887  -> lookup_opt "profile" (as_option (as_list as_string)) 
 let (get_profile_group_by_decl : unit -> Prims.bool) =
-  fun uu____3878  -> lookup_opt "profile_group_by_decl" as_bool 
+  fun uu____3904  -> lookup_opt "profile_group_by_decl" as_bool 
 let (get_profile_component :
   unit -> Prims.string Prims.list FStar_Pervasives_Native.option) =
-  fun uu____3891  ->
+  fun uu____3917  ->
     lookup_opt "profile_component" (as_option (as_list as_string))
   
 let (dlevel : Prims.string -> debug_level_t) =
-  fun uu___6_3908  ->
-    match uu___6_3908 with
+  fun uu___6_3934  ->
+    match uu___6_3934 with
     | "Low" -> Low
     | "Medium" -> Medium
     | "High" -> High
@@ -694,7 +699,7 @@ let (one_debug_level_geq : debug_level_t -> debug_level_t -> Prims.bool) =
   fun l1  ->
     fun l2  ->
       match l1 with
-      | Other uu____3929 -> l1 = l2
+      | Other uu____3955 -> l1 = l2
       | Low  -> l1 = l2
       | Medium  -> (l2 = Low) || (l2 = Medium)
       | High  -> ((l2 = Low) || (l2 = Medium)) || (l2 = High)
@@ -703,8 +708,8 @@ let (one_debug_level_geq : debug_level_t -> debug_level_t -> Prims.bool) =
   
 let (debug_level_geq : debug_level_t -> Prims.bool) =
   fun l2  ->
-    let uu____3938 = get_debug_level ()  in
-    FStar_All.pipe_right uu____3938
+    let uu____3964 = get_debug_level ()  in
+    FStar_All.pipe_right uu____3964
       (FStar_Util.for_some (fun l1  -> one_debug_level_geq (dlevel l1) l2))
   
 let (universe_include_path_base_dirs : Prims.string Prims.list) =
@@ -712,14 +717,14 @@ let (universe_include_path_base_dirs : Prims.string Prims.list) =
   FStar_All.pipe_right ["/ulib"; "/lib/fstar"]
     (FStar_List.collect
        (fun d  ->
-          let uu____3982 =
+          let uu____4008 =
             FStar_All.pipe_right sub_dirs
               (FStar_List.map
                  (fun s  ->
-                    let uu____3998 = FStar_String.op_Hat "/" s  in
-                    FStar_String.op_Hat d uu____3998))
+                    let uu____4024 = FStar_String.op_Hat "/" s  in
+                    FStar_String.op_Hat d uu____4024))
              in
-          d :: uu____3982))
+          d :: uu____4008))
   
 let (_version : Prims.string FStar_ST.ref) = FStar_Util.mk_ref "" 
 let (_platform : Prims.string FStar_ST.ref) = FStar_Util.mk_ref "" 
@@ -727,77 +732,77 @@ let (_compiler : Prims.string FStar_ST.ref) = FStar_Util.mk_ref ""
 let (_date : Prims.string FStar_ST.ref) = FStar_Util.mk_ref "<not set>" 
 let (_commit : Prims.string FStar_ST.ref) = FStar_Util.mk_ref "" 
 let (display_version : unit -> unit) =
-  fun uu____4037  ->
-    let uu____4038 =
-      let uu____4040 = FStar_ST.op_Bang _version  in
-      let uu____4063 = FStar_ST.op_Bang _platform  in
-      let uu____4086 = FStar_ST.op_Bang _compiler  in
-      let uu____4109 = FStar_ST.op_Bang _date  in
-      let uu____4132 = FStar_ST.op_Bang _commit  in
+  fun uu____4063  ->
+    let uu____4064 =
+      let uu____4066 = FStar_ST.op_Bang _version  in
+      let uu____4089 = FStar_ST.op_Bang _platform  in
+      let uu____4112 = FStar_ST.op_Bang _compiler  in
+      let uu____4135 = FStar_ST.op_Bang _date  in
+      let uu____4158 = FStar_ST.op_Bang _commit  in
       FStar_Util.format5
-        "F* %s\nplatform=%s\ncompiler=%s\ndate=%s\ncommit=%s\n" uu____4040
-        uu____4063 uu____4086 uu____4109 uu____4132
+        "F* %s\nplatform=%s\ncompiler=%s\ndate=%s\ncommit=%s\n" uu____4066
+        uu____4089 uu____4112 uu____4135 uu____4158
        in
-    FStar_Util.print_string uu____4038
+    FStar_Util.print_string uu____4064
   
 let display_usage_aux :
-  'Auu____4163 'Auu____4164 .
-    ('Auu____4163 * Prims.string * 'Auu____4164 FStar_Getopt.opt_variant *
+  'Auu____4189 'Auu____4190 .
+    ('Auu____4189 * Prims.string * 'Auu____4190 FStar_Getopt.opt_variant *
       Prims.string) Prims.list -> unit
   =
   fun specs  ->
     FStar_Util.print_string "fstar.exe [options] file[s]\n";
     FStar_List.iter
-      (fun uu____4219  ->
-         match uu____4219 with
-         | (uu____4232,flag,p,doc) ->
+      (fun uu____4245  ->
+         match uu____4245 with
+         | (uu____4258,flag,p,doc) ->
              (match p with
               | FStar_Getopt.ZeroArgs ig ->
                   if doc = ""
                   then
-                    let uu____4251 =
-                      let uu____4253 = FStar_Util.colorize_bold flag  in
-                      FStar_Util.format1 "  --%s\n" uu____4253  in
-                    FStar_Util.print_string uu____4251
+                    let uu____4277 =
+                      let uu____4279 = FStar_Util.colorize_bold flag  in
+                      FStar_Util.format1 "  --%s\n" uu____4279  in
+                    FStar_Util.print_string uu____4277
                   else
-                    (let uu____4258 =
-                       let uu____4260 = FStar_Util.colorize_bold flag  in
-                       FStar_Util.format2 "  --%s  %s\n" uu____4260 doc  in
-                     FStar_Util.print_string uu____4258)
-              | FStar_Getopt.OneArg (uu____4263,argname) ->
+                    (let uu____4284 =
+                       let uu____4286 = FStar_Util.colorize_bold flag  in
+                       FStar_Util.format2 "  --%s  %s\n" uu____4286 doc  in
+                     FStar_Util.print_string uu____4284)
+              | FStar_Getopt.OneArg (uu____4289,argname) ->
                   if doc = ""
                   then
-                    let uu____4278 =
-                      let uu____4280 = FStar_Util.colorize_bold flag  in
-                      let uu____4282 = FStar_Util.colorize_bold argname  in
-                      FStar_Util.format2 "  --%s %s\n" uu____4280 uu____4282
+                    let uu____4304 =
+                      let uu____4306 = FStar_Util.colorize_bold flag  in
+                      let uu____4308 = FStar_Util.colorize_bold argname  in
+                      FStar_Util.format2 "  --%s %s\n" uu____4306 uu____4308
                        in
-                    FStar_Util.print_string uu____4278
+                    FStar_Util.print_string uu____4304
                   else
-                    (let uu____4287 =
-                       let uu____4289 = FStar_Util.colorize_bold flag  in
-                       let uu____4291 = FStar_Util.colorize_bold argname  in
-                       FStar_Util.format3 "  --%s %s  %s\n" uu____4289
-                         uu____4291 doc
+                    (let uu____4313 =
+                       let uu____4315 = FStar_Util.colorize_bold flag  in
+                       let uu____4317 = FStar_Util.colorize_bold argname  in
+                       FStar_Util.format3 "  --%s %s  %s\n" uu____4315
+                         uu____4317 doc
                         in
-                     FStar_Util.print_string uu____4287))) specs
+                     FStar_Util.print_string uu____4313))) specs
   
 let (mk_spec :
   (FStar_BaseTypes.char * Prims.string * option_val FStar_Getopt.opt_variant
     * Prims.string) -> FStar_Getopt.opt)
   =
   fun o  ->
-    let uu____4326 = o  in
-    match uu____4326 with
+    let uu____4352 = o  in
+    match uu____4352 with
     | (ns,name,arg,desc) ->
         let arg1 =
           match arg with
           | FStar_Getopt.ZeroArgs f ->
-              let g uu____4368 =
-                let uu____4369 = f ()  in set_option name uu____4369  in
+              let g uu____4394 =
+                let uu____4395 = f ()  in set_option name uu____4395  in
               FStar_Getopt.ZeroArgs g
           | FStar_Getopt.OneArg (f,d) ->
-              let g x = let uu____4390 = f x  in set_option name uu____4390
+              let g x = let uu____4416 = f x  in set_option name uu____4416
                  in
               FStar_Getopt.OneArg (g, d)
            in
@@ -807,30 +812,30 @@ let (accumulated_option : Prims.string -> option_val -> option_val) =
   fun name  ->
     fun value  ->
       let prev_values =
-        let uu____4417 = lookup_opt name (as_option as_list')  in
-        FStar_Util.dflt [] uu____4417  in
+        let uu____4443 = lookup_opt name (as_option as_list')  in
+        FStar_Util.dflt [] uu____4443  in
       List (value :: prev_values)
   
 let (reverse_accumulated_option : Prims.string -> option_val -> option_val) =
   fun name  ->
     fun value  ->
       let prev_values =
-        let uu____4446 = lookup_opt name (as_option as_list')  in
-        FStar_Util.dflt [] uu____4446  in
+        let uu____4472 = lookup_opt name (as_option as_list')  in
+        FStar_Util.dflt [] uu____4472  in
       List (FStar_List.append prev_values [value])
   
 let accumulate_string :
-  'Auu____4468 .
-    Prims.string -> ('Auu____4468 -> Prims.string) -> 'Auu____4468 -> unit
+  'Auu____4494 .
+    Prims.string -> ('Auu____4494 -> Prims.string) -> 'Auu____4494 -> unit
   =
   fun name  ->
     fun post_processor  ->
       fun value  ->
-        let uu____4493 =
-          let uu____4494 =
-            let uu____4495 = post_processor value  in String uu____4495  in
-          accumulated_option name uu____4494  in
-        set_option name uu____4493
+        let uu____4519 =
+          let uu____4520 =
+            let uu____4521 = post_processor value  in String uu____4521  in
+          accumulated_option name uu____4520  in
+        set_option name uu____4519
   
 let (add_extract_module : Prims.string -> unit) =
   fun s  -> accumulate_string "extract_module" FStar_String.lowercase s 
@@ -852,55 +857,55 @@ type opt_type =
   | WithSideEffect of ((unit -> unit) * opt_type) 
 let (uu___is_Const : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Const _0 -> true | uu____4617 -> false
+    match projectee with | Const _0 -> true | uu____4643 -> false
   
 let (__proj__Const__item___0 : opt_type -> option_val) =
   fun projectee  -> match projectee with | Const _0 -> _0 
 let (uu___is_IntStr : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | IntStr _0 -> true | uu____4637 -> false
+    match projectee with | IntStr _0 -> true | uu____4663 -> false
   
 let (__proj__IntStr__item___0 : opt_type -> Prims.string) =
   fun projectee  -> match projectee with | IntStr _0 -> _0 
 let (uu___is_BoolStr : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | BoolStr  -> true | uu____4658 -> false
+    match projectee with | BoolStr  -> true | uu____4684 -> false
   
 let (uu___is_PathStr : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | PathStr _0 -> true | uu____4671 -> false
+    match projectee with | PathStr _0 -> true | uu____4697 -> false
   
 let (__proj__PathStr__item___0 : opt_type -> Prims.string) =
   fun projectee  -> match projectee with | PathStr _0 -> _0 
 let (uu___is_SimpleStr : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | SimpleStr _0 -> true | uu____4694 -> false
+    match projectee with | SimpleStr _0 -> true | uu____4720 -> false
   
 let (__proj__SimpleStr__item___0 : opt_type -> Prims.string) =
   fun projectee  -> match projectee with | SimpleStr _0 -> _0 
 let (uu___is_EnumStr : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | EnumStr _0 -> true | uu____4719 -> false
+    match projectee with | EnumStr _0 -> true | uu____4745 -> false
   
 let (__proj__EnumStr__item___0 : opt_type -> Prims.string Prims.list) =
   fun projectee  -> match projectee with | EnumStr _0 -> _0 
 let (uu___is_OpenEnumStr : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | OpenEnumStr _0 -> true | uu____4755 -> false
+    match projectee with | OpenEnumStr _0 -> true | uu____4781 -> false
   
 let (__proj__OpenEnumStr__item___0 :
   opt_type -> (Prims.string Prims.list * Prims.string)) =
   fun projectee  -> match projectee with | OpenEnumStr _0 -> _0 
 let (uu___is_PostProcessed : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | PostProcessed _0 -> true | uu____4805 -> false
+    match projectee with | PostProcessed _0 -> true | uu____4831 -> false
   
 let (__proj__PostProcessed__item___0 :
   opt_type -> ((option_val -> option_val) * opt_type)) =
   fun projectee  -> match projectee with | PostProcessed _0 -> _0 
 let (uu___is_Accumulated : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Accumulated _0 -> true | uu____4845 -> false
+    match projectee with | Accumulated _0 -> true | uu____4871 -> false
   
 let (__proj__Accumulated__item___0 : opt_type -> opt_type) =
   fun projectee  -> match projectee with | Accumulated _0 -> _0 
@@ -908,13 +913,13 @@ let (uu___is_ReverseAccumulated : opt_type -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | ReverseAccumulated _0 -> true
-    | uu____4864 -> false
+    | uu____4890 -> false
   
 let (__proj__ReverseAccumulated__item___0 : opt_type -> opt_type) =
   fun projectee  -> match projectee with | ReverseAccumulated _0 -> _0 
 let (uu___is_WithSideEffect : opt_type -> Prims.bool) =
   fun projectee  ->
-    match projectee with | WithSideEffect _0 -> true | uu____4890 -> false
+    match projectee with | WithSideEffect _0 -> true | uu____4916 -> false
   
 let (__proj__WithSideEffect__item___0 :
   opt_type -> ((unit -> unit) * opt_type)) =
@@ -923,12 +928,12 @@ exception InvalidArgument of Prims.string
 let (uu___is_InvalidArgument : Prims.exn -> Prims.bool) =
   fun projectee  ->
     match projectee with
-    | InvalidArgument uu____4933 -> true
-    | uu____4936 -> false
+    | InvalidArgument uu____4959 -> true
+    | uu____4962 -> false
   
 let (__proj__InvalidArgument__item__uu___ : Prims.exn -> Prims.string) =
   fun projectee  ->
-    match projectee with | InvalidArgument uu____4946 -> uu____4946
+    match projectee with | InvalidArgument uu____4972 -> uu____4972
   
 let rec (parse_opt_val :
   Prims.string -> opt_type -> Prims.string -> option_val) =
@@ -936,20 +941,20 @@ let rec (parse_opt_val :
     fun typ  ->
       fun str_val  ->
         try
-          (fun uu___308_4970  ->
+          (fun uu___311_4996  ->
              match () with
              | () ->
                  (match typ with
                   | Const c -> c
-                  | IntStr uu____4972 ->
-                      let uu____4974 = FStar_Util.safe_int_of_string str_val
+                  | IntStr uu____4998 ->
+                      let uu____5000 = FStar_Util.safe_int_of_string str_val
                          in
-                      (match uu____4974 with
+                      (match uu____5000 with
                        | FStar_Pervasives_Native.Some v1 -> Int v1
                        | FStar_Pervasives_Native.None  ->
                            FStar_Exn.raise (InvalidArgument opt_name))
                   | BoolStr  ->
-                      let uu____4982 =
+                      let uu____5008 =
                         if str_val = "true"
                         then true
                         else
@@ -957,18 +962,18 @@ let rec (parse_opt_val :
                           then false
                           else FStar_Exn.raise (InvalidArgument opt_name)
                          in
-                      Bool uu____4982
-                  | PathStr uu____4999 -> Path str_val
-                  | SimpleStr uu____5001 -> String str_val
+                      Bool uu____5008
+                  | PathStr uu____5025 -> Path str_val
+                  | SimpleStr uu____5027 -> String str_val
                   | EnumStr strs ->
                       if FStar_List.mem str_val strs
                       then String str_val
                       else FStar_Exn.raise (InvalidArgument opt_name)
-                  | OpenEnumStr uu____5011 -> String str_val
+                  | OpenEnumStr uu____5037 -> String str_val
                   | PostProcessed (pp,elem_spec) ->
-                      let uu____5028 =
+                      let uu____5054 =
                         parse_opt_val opt_name elem_spec str_val  in
-                      pp uu____5028
+                      pp uu____5054
                   | Accumulated elem_spec ->
                       let v1 = parse_opt_val opt_name elem_spec str_val  in
                       accumulated_option opt_name v1
@@ -980,19 +985,19 @@ let rec (parse_opt_val :
                        parse_opt_val opt_name elem_spec str_val))) ()
         with
         | InvalidArgument opt_name1 ->
-            let uu____5048 =
+            let uu____5074 =
               FStar_Util.format1 "Invalid argument to --%s" opt_name1  in
-            failwith uu____5048
+            failwith uu____5074
   
 let rec (desc_of_opt_type :
   opt_type -> Prims.string FStar_Pervasives_Native.option) =
   fun typ  ->
     let desc_of_enum cases =
-      let uu____5078 =
-        let uu____5080 =
+      let uu____5104 =
+        let uu____5106 =
           FStar_String.op_Hat (FStar_String.concat "|" cases) "]"  in
-        FStar_String.op_Hat "[" uu____5080  in
-      FStar_Pervasives_Native.Some uu____5078  in
+        FStar_String.op_Hat "[" uu____5106  in
+      FStar_Pervasives_Native.Some uu____5104  in
     match typ with
     | Const c -> FStar_Pervasives_Native.None
     | IntStr desc -> FStar_Pervasives_Native.Some desc
@@ -1001,20 +1006,20 @@ let rec (desc_of_opt_type :
     | SimpleStr desc -> FStar_Pervasives_Native.Some desc
     | EnumStr strs -> desc_of_enum strs
     | OpenEnumStr (strs,desc) -> desc_of_enum (FStar_List.append strs [desc])
-    | PostProcessed (uu____5122,elem_spec) -> desc_of_opt_type elem_spec
+    | PostProcessed (uu____5148,elem_spec) -> desc_of_opt_type elem_spec
     | Accumulated elem_spec -> desc_of_opt_type elem_spec
     | ReverseAccumulated elem_spec -> desc_of_opt_type elem_spec
-    | WithSideEffect (uu____5132,elem_spec) -> desc_of_opt_type elem_spec
+    | WithSideEffect (uu____5158,elem_spec) -> desc_of_opt_type elem_spec
   
 let (arg_spec_of_opt_type :
   Prims.string -> opt_type -> option_val FStar_Getopt.opt_variant) =
   fun opt_name  ->
     fun typ  ->
       let parser = parse_opt_val opt_name typ  in
-      let uu____5163 = desc_of_opt_type typ  in
-      match uu____5163 with
+      let uu____5189 = desc_of_opt_type typ  in
+      match uu____5189 with
       | FStar_Pervasives_Native.None  ->
-          FStar_Getopt.ZeroArgs ((fun uu____5171  -> parser ""))
+          FStar_Getopt.ZeroArgs ((fun uu____5197  -> parser ""))
       | FStar_Pervasives_Native.Some desc ->
           FStar_Getopt.OneArg (parser, desc)
   
@@ -1022,22 +1027,46 @@ let (pp_validate_dir : option_val -> option_val) =
   fun p  -> let pp = as_string p  in FStar_Util.mkdir false pp; p 
 let (pp_lowercase : option_val -> option_val) =
   fun s  ->
-    let uu____5197 =
-      let uu____5199 = as_string s  in FStar_String.lowercase uu____5199  in
-    String uu____5197
+    let uu____5223 =
+      let uu____5225 = as_string s  in FStar_String.lowercase uu____5225  in
+    String uu____5223
   
 let (abort_counter : Prims.int FStar_ST.ref) =
   FStar_Util.mk_ref Prims.int_zero 
+let (interp_quake_arg : Prims.string -> (Prims.int * Prims.int * Prims.bool))
+  =
+  fun s  ->
+    let ios = FStar_Util.int_of_string  in
+    match FStar_Util.split s "/" with
+    | f::[] ->
+        let uu____5283 = ios f  in
+        let uu____5285 = ios f  in (uu____5283, uu____5285, false)
+    | f1::f2::[] ->
+        if f2 = "k"
+        then
+          let uu____5310 = ios f1  in
+          let uu____5312 = ios f1  in (uu____5310, uu____5312, true)
+        else
+          (let uu____5320 = ios f1  in
+           let uu____5322 = ios f2  in (uu____5320, uu____5322, false))
+    | f1::f2::k::[] ->
+        if k = "k"
+        then
+          let uu____5350 = ios f1  in
+          let uu____5352 = ios f2  in (uu____5350, uu____5352, true)
+        else failwith "unexpected value for --quake"
+    | uu____5370 -> failwith "unexpected value for --quake"
+  
 let rec (specs_with_types :
   unit ->
     (FStar_BaseTypes.char * Prims.string * opt_type * Prims.string)
       Prims.list)
   =
-  fun uu____5234  ->
+  fun uu____5408  ->
     [(FStar_Getopt.noshort, "abort_on",
        (PostProcessed
-          (((fun uu___7_5269  ->
-               match uu___7_5269 with
+          (((fun uu___7_5443  ->
+               match uu___7_5443 with
                | Int x -> (FStar_ST.op_Colon_Equals abort_counter x; Int x)
                | x -> failwith "?")), (IntStr "non-negative integer"))),
        "Abort on the n-th error or warning raised. Useful in combination with --trace_error. Count starts at 1, use 0 to disable. (default 0)");
@@ -1120,50 +1149,50 @@ let rec (specs_with_types :
       "Parses and prettyprints in place the files included on the command line");
     (FStar_Getopt.noshort, "fuel",
       (PostProcessed
-         (((fun uu___8_5894  ->
-              match uu___8_5894 with
+         (((fun uu___8_6068  ->
+              match uu___8_6068 with
               | String s ->
                   let p f =
-                    let uu____5905 = FStar_Util.int_of_string f  in
-                    Int uu____5905  in
-                  let uu____5907 =
+                    let uu____6079 = FStar_Util.int_of_string f  in
+                    Int uu____6079  in
+                  let uu____6081 =
                     match FStar_Util.split s "," with
                     | f::[] -> (f, f)
                     | f1::f2::[] -> (f1, f2)
-                    | uu____5936 -> failwith "unexpected value for --fuel"
+                    | uu____6110 -> failwith "unexpected value for --fuel"
                      in
-                  (match uu____5907 with
+                  (match uu____6081 with
                    | (min1,max1) ->
-                       ((let uu____5954 = p min1  in
-                         set_option "initial_fuel" uu____5954);
-                        (let uu____5957 = p max1  in
-                         set_option "max_fuel" uu____5957);
+                       ((let uu____6128 = p min1  in
+                         set_option "initial_fuel" uu____6128);
+                        (let uu____6131 = p max1  in
+                         set_option "max_fuel" uu____6131);
                         String s))
-              | uu____5959 -> failwith "impos")),
+              | uu____6133 -> failwith "impos")),
            (SimpleStr "non-negative integer or pair of non-negative integers"))),
       "Set initial_fuel and max_fuel at once");
     (FStar_Getopt.noshort, "ifuel",
       (PostProcessed
-         (((fun uu___9_5989  ->
-              match uu___9_5989 with
+         (((fun uu___9_6163  ->
+              match uu___9_6163 with
               | String s ->
                   let p f =
-                    let uu____6000 = FStar_Util.int_of_string f  in
-                    Int uu____6000  in
-                  let uu____6002 =
+                    let uu____6174 = FStar_Util.int_of_string f  in
+                    Int uu____6174  in
+                  let uu____6176 =
                     match FStar_Util.split s "," with
                     | f::[] -> (f, f)
                     | f1::f2::[] -> (f1, f2)
-                    | uu____6031 -> failwith "unexpected value for --ifuel"
+                    | uu____6205 -> failwith "unexpected value for --ifuel"
                      in
-                  (match uu____6002 with
+                  (match uu____6176 with
                    | (min1,max1) ->
-                       ((let uu____6049 = p min1  in
-                         set_option "initial_ifuel" uu____6049);
-                        (let uu____6052 = p max1  in
-                         set_option "max_ifuel" uu____6052);
+                       ((let uu____6223 = p min1  in
+                         set_option "initial_ifuel" uu____6223);
+                        (let uu____6226 = p max1  in
+                         set_option "max_ifuel" uu____6226);
                         String s))
-              | uu____6054 -> failwith "impos")),
+              | uu____6228 -> failwith "impos")),
            (SimpleStr "non-negative integer or pair of non-negative integers"))),
       "Set initial_ifuel and max_ifuel at once");
     (FStar_Getopt.noshort, "initial_fuel", (IntStr "non-negative integer"),
@@ -1220,27 +1249,19 @@ let rec (specs_with_types :
       "Print full names (deprecated; use --print_full_names instead)");
     (FStar_Getopt.noshort, "quake",
       (PostProcessed
-         (((fun uu___10_6511  ->
-              match uu___10_6511 with
+         (((fun uu___10_6687  ->
+              match uu___10_6687 with
               | String s ->
-                  let p f =
-                    let uu____6522 = FStar_Util.int_of_string f  in
-                    Int uu____6522  in
-                  let uu____6524 =
-                    match FStar_Util.split s "/" with
-                    | f::[] -> (f, f)
-                    | f1::f2::[] -> (f1, f2)
-                    | uu____6553 -> failwith "unexpected value for --quake"
-                     in
-                  (match uu____6524 with
-                   | (min1,max1) ->
-                       ((let uu____6571 = p min1  in
-                         set_option "quake_lo" uu____6571);
-                        (let uu____6574 = p max1  in
-                         set_option "quake_hi" uu____6574);
+                  let uu____6690 = interp_quake_arg s  in
+                  (match uu____6690 with
+                   | (min1,max1,k) ->
+                       (set_option "quake_lo" (Int min1);
+                        set_option "quake_hi" (Int max1);
+                        set_option "quake_keep" (Bool k);
+                        set_option "retry" (Bool false);
                         String s))
-              | uu____6576 -> failwith "impos")),
-           (SimpleStr "non-negative integer or pair of non-negative integers"))),
+              | uu____6718 -> failwith "impos")),
+           (SimpleStr "positive integer or pair of positive integers"))),
       "Repeats SMT queries to check for robustness\n\t\t--quake N/M repeats each query M times and checks that it succeeds at least N times.\n\t\t--quake N is an alias for --quake N/N.");
     (FStar_Getopt.noshort, "query_stats", (Const (Bool true)),
       "Print SMT query statistics");
@@ -1248,6 +1269,19 @@ let rec (specs_with_types :
       "Record a database of hints for efficient proof replay");
     (FStar_Getopt.noshort, "record_options", (Const (Bool true)),
       "Record the state of options used to check each sigelt, useful for the `check_with` attribute and metaprogramming");
+    (FStar_Getopt.noshort, "retry",
+      (PostProcessed
+         (((fun uu___11_6797  ->
+              match uu___11_6797 with
+              | Int i ->
+                  (set_option "quake_lo" (Int Prims.int_one);
+                   set_option "quake_hi" (Int i);
+                   set_option "quake_keep" (Bool false);
+                   set_option "retry" (Bool true);
+                   Bool true)
+              | uu____6812 -> failwith "impos")),
+           (IntStr "positive integer"))),
+      "Retry each SMT query N times and succeed on the first try.\n\tThis is equivalent to --quake N/N.");
     (FStar_Getopt.noshort, "reuse_hint_for", (SimpleStr "toplevel_name"),
       "Optimistically, attempt using the recorded hint for <toplevel_name> (a top-level name in the current module) when trying to verify some other term 'g'");
     (FStar_Getopt.noshort, "silent", (Const (Bool true)),
@@ -1317,7 +1351,7 @@ let rec (specs_with_types :
       "Don't use this option yet");
     (118, "version",
       (WithSideEffect
-         (((fun uu____7174  ->
+         (((fun uu____7359  ->
               display_version (); FStar_All.exit Prims.int_zero)),
            (Const (Bool true)))), "Display version number");
     (FStar_Getopt.noshort, "warn_default_effects", (Const (Bool true)),
@@ -1351,12 +1385,12 @@ let rec (specs_with_types :
       "Enforce trivial preconditions for unannotated effectful functions (default 'true')");
     (FStar_Getopt.noshort, "__debug_embedding",
       (WithSideEffect
-         (((fun uu____7431  -> FStar_ST.op_Colon_Equals debug_embedding true)),
+         (((fun uu____7616  -> FStar_ST.op_Colon_Equals debug_embedding true)),
            (Const (Bool true)))),
       "Debug messages for embeddings/unembeddings of natively compiled terms");
     (FStar_Getopt.noshort, "eager_embedding",
       (WithSideEffect
-         (((fun uu____7475  -> FStar_ST.op_Colon_Equals eager_embedding true)),
+         (((fun uu____7660  -> FStar_ST.op_Colon_Equals eager_embedding true)),
            (Const (Bool true)))),
       "Eagerly embed and unembed terms to primitive operations and plugins: not recommended except for benchmarking");
     (FStar_Getopt.noshort, "profile_group_by_decl", (Const (Bool true)),
@@ -1373,26 +1407,26 @@ let rec (specs_with_types :
       "\n\tProfiling can be enabled when the compiler is processing a given set of source modules.\n\tPass `--profile FStar.Pervasives` to enable profiling when the compiler is processing any module in FStar.Pervasives.\n\tThis option is a module or namespace selector, like many other options (e.g., `--extract`)");
     (104, "help",
       (WithSideEffect
-         (((fun uu____7572  ->
-              (let uu____7574 = specs ()  in display_usage_aux uu____7574);
+         (((fun uu____7757  ->
+              (let uu____7759 = specs ()  in display_usage_aux uu____7759);
               FStar_All.exit Prims.int_zero)), (Const (Bool true)))),
       "Display this information")]
 
 and (specs : unit -> FStar_Getopt.opt Prims.list) =
-  fun uu____7605  ->
-    let uu____7608 = specs_with_types ()  in
+  fun uu____7790  ->
+    let uu____7793 = specs_with_types ()  in
     FStar_List.map
-      (fun uu____7639  ->
-         match uu____7639 with
+      (fun uu____7824  ->
+         match uu____7824 with
          | (short,long,typ,doc) ->
-             let uu____7661 =
-               let uu____7675 = arg_spec_of_opt_type long typ  in
-               (short, long, uu____7675, doc)  in
-             mk_spec uu____7661) uu____7608
+             let uu____7846 =
+               let uu____7860 = arg_spec_of_opt_type long typ  in
+               (short, long, uu____7860, doc)  in
+             mk_spec uu____7846) uu____7793
 
 let (settable : Prims.string -> Prims.bool) =
-  fun uu___11_7690  ->
-    match uu___11_7690 with
+  fun uu___12_7875  ->
+    match uu___12_7875 with
     | "abort_on" -> true
     | "admit_except" -> true
     | "admit_smt_queries" -> true
@@ -1431,9 +1465,11 @@ let (settable : Prims.string -> Prims.bool) =
     | "prn" -> true
     | "quake_lo" -> true
     | "quake_hi" -> true
+    | "quake_keep" -> true
     | "quake" -> true
     | "query_stats" -> true
     | "record_options" -> true
+    | "retry" -> true
     | "reuse_hint_for" -> true
     | "silent" -> true
     | "smtencoding.elim_box" -> true
@@ -1468,7 +1504,7 @@ let (settable : Prims.string -> Prims.bool) =
     | "profile_group_by_decl" -> true
     | "profile_component" -> true
     | "profile" -> true
-    | uu____7843 -> false
+    | uu____8032 -> false
   
 let (all_specs : FStar_Getopt.opt Prims.list) = specs () 
 let (all_specs_with_types :
@@ -1480,30 +1516,30 @@ let (settable_specs :
   =
   FStar_All.pipe_right all_specs
     (FStar_List.filter
-       (fun uu____7927  ->
-          match uu____7927 with
-          | (uu____7942,x,uu____7944,uu____7945) -> settable x))
+       (fun uu____8116  ->
+          match uu____8116 with
+          | (uu____8131,x,uu____8133,uu____8134) -> settable x))
   
 let (display_usage : unit -> unit) =
-  fun uu____7961  ->
-    let uu____7962 = specs ()  in display_usage_aux uu____7962
+  fun uu____8150  ->
+    let uu____8151 = specs ()  in display_usage_aux uu____8151
   
 let (fstar_bin_directory : Prims.string) = FStar_Util.get_exec_dir () 
 exception File_argument of Prims.string 
 let (uu___is_File_argument : Prims.exn -> Prims.bool) =
   fun projectee  ->
     match projectee with
-    | File_argument uu____7994 -> true
-    | uu____7997 -> false
+    | File_argument uu____8183 -> true
+    | uu____8186 -> false
   
 let (__proj__File_argument__item__uu___ : Prims.exn -> Prims.string) =
   fun projectee  ->
-    match projectee with | File_argument uu____8007 -> uu____8007
+    match projectee with | File_argument uu____8196 -> uu____8196
   
 let (set_options : Prims.string -> FStar_Getopt.parse_cmdline_res) =
   fun s  ->
     try
-      (fun uu___541_8018  ->
+      (fun uu___563_8207  ->
          match () with
          | () ->
              if s = ""
@@ -1513,66 +1549,66 @@ let (set_options : Prims.string -> FStar_Getopt.parse_cmdline_res) =
                  (fun s1  -> FStar_Exn.raise (File_argument s1)) s) ()
     with
     | File_argument s1 ->
-        let uu____8035 =
+        let uu____8224 =
           FStar_Util.format1 "File %s is not a valid option" s1  in
-        FStar_Getopt.Error uu____8035
+        FStar_Getopt.Error uu____8224
   
 let (file_list_ : Prims.string Prims.list FStar_ST.ref) =
   FStar_Util.mk_ref [] 
 let (parse_cmd_line :
   unit -> (FStar_Getopt.parse_cmdline_res * Prims.string Prims.list)) =
-  fun uu____8060  ->
+  fun uu____8249  ->
     let res =
       FStar_Getopt.parse_cmdline all_specs
         (fun i  ->
-           let uu____8066 =
-             let uu____8070 = FStar_ST.op_Bang file_list_  in
-             FStar_List.append uu____8070 [i]  in
-           FStar_ST.op_Colon_Equals file_list_ uu____8066)
+           let uu____8255 =
+             let uu____8259 = FStar_ST.op_Bang file_list_  in
+             FStar_List.append uu____8259 [i]  in
+           FStar_ST.op_Colon_Equals file_list_ uu____8255)
        in
-    let uu____8127 =
-      let uu____8131 = FStar_ST.op_Bang file_list_  in
-      FStar_List.map FStar_Common.try_convert_file_name_to_mixed uu____8131
+    let uu____8316 =
+      let uu____8320 = FStar_ST.op_Bang file_list_  in
+      FStar_List.map FStar_Common.try_convert_file_name_to_mixed uu____8320
        in
-    (res, uu____8127)
+    (res, uu____8316)
   
 let (file_list : unit -> Prims.string Prims.list) =
-  fun uu____8173  -> FStar_ST.op_Bang file_list_ 
+  fun uu____8362  -> FStar_ST.op_Bang file_list_ 
 let (restore_cmd_line_options : Prims.bool -> FStar_Getopt.parse_cmdline_res)
   =
   fun should_clear  ->
     let old_verify_module = get_verify_module ()  in
     if should_clear then clear () else init ();
     (let r =
-       let uu____8216 = specs ()  in
-       FStar_Getopt.parse_cmdline uu____8216 (fun x  -> ())  in
-     (let uu____8223 =
-        let uu____8229 =
-          let uu____8230 =
-            FStar_List.map (fun _8234  -> String _8234) old_verify_module  in
-          List uu____8230  in
-        ("verify_module", uu____8229)  in
-      set_option' uu____8223);
+       let uu____8405 = specs ()  in
+       FStar_Getopt.parse_cmdline uu____8405 (fun x  -> ())  in
+     (let uu____8412 =
+        let uu____8418 =
+          let uu____8419 =
+            FStar_List.map (fun _8423  -> String _8423) old_verify_module  in
+          List uu____8419  in
+        ("verify_module", uu____8418)  in
+      set_option' uu____8412);
      r)
   
 let (module_name_of_file_name : Prims.string -> Prims.string) =
   fun f  ->
     let f1 = FStar_Util.basename f  in
     let f2 =
-      let uu____8250 =
-        let uu____8252 =
-          let uu____8254 =
-            let uu____8256 = FStar_Util.get_file_extension f1  in
-            FStar_String.length uu____8256  in
-          (FStar_String.length f1) - uu____8254  in
-        uu____8252 - Prims.int_one  in
-      FStar_String.substring f1 Prims.int_zero uu____8250  in
+      let uu____8439 =
+        let uu____8441 =
+          let uu____8443 =
+            let uu____8445 = FStar_Util.get_file_extension f1  in
+            FStar_String.length uu____8445  in
+          (FStar_String.length f1) - uu____8443  in
+        uu____8441 - Prims.int_one  in
+      FStar_String.substring f1 Prims.int_zero uu____8439  in
     FStar_String.lowercase f2
   
 let (should_verify : Prims.string -> Prims.bool) =
   fun m  ->
-    let uu____8269 = get_lax ()  in
-    if uu____8269
+    let uu____8458 = get_lax ()  in
+    if uu____8458
     then false
     else
       (let l = get_verify_module ()  in
@@ -1580,7 +1616,7 @@ let (should_verify : Prims.string -> Prims.bool) =
   
 let (should_verify_file : Prims.string -> Prims.bool) =
   fun fn  ->
-    let uu____8290 = module_name_of_file_name fn  in should_verify uu____8290
+    let uu____8479 = module_name_of_file_name fn  in should_verify uu____8479
   
 let (module_name_eq : Prims.string -> Prims.string -> Prims.bool) =
   fun m1  ->
@@ -1588,73 +1624,73 @@ let (module_name_eq : Prims.string -> Prims.string -> Prims.bool) =
   
 let (dont_gen_projectors : Prims.string -> Prims.bool) =
   fun m  ->
-    let uu____8318 = get___temp_no_proj ()  in
-    FStar_All.pipe_right uu____8318 (FStar_List.existsb (module_name_eq m))
+    let uu____8507 = get___temp_no_proj ()  in
+    FStar_All.pipe_right uu____8507 (FStar_List.existsb (module_name_eq m))
   
 let (should_print_message : Prims.string -> Prims.bool) =
   fun m  ->
-    let uu____8336 = should_verify m  in
-    if uu____8336 then m <> "Prims" else false
+    let uu____8525 = should_verify m  in
+    if uu____8525 then m <> "Prims" else false
   
 let (include_path : unit -> Prims.string Prims.list) =
-  fun uu____8353  ->
+  fun uu____8542  ->
     let cache_dir =
-      let uu____8358 = get_cache_dir ()  in
-      match uu____8358 with
+      let uu____8547 = get_cache_dir ()  in
+      match uu____8547 with
       | FStar_Pervasives_Native.None  -> []
       | FStar_Pervasives_Native.Some c -> [c]  in
-    let uu____8372 = get_no_default_includes ()  in
-    if uu____8372
+    let uu____8561 = get_no_default_includes ()  in
+    if uu____8561
     then
-      let uu____8378 = get_include ()  in
-      FStar_List.append cache_dir uu____8378
+      let uu____8567 = get_include ()  in
+      FStar_List.append cache_dir uu____8567
     else
       (let lib_paths =
-         let uu____8389 = FStar_Util.expand_environment_variable "FSTAR_LIB"
+         let uu____8578 = FStar_Util.expand_environment_variable "FSTAR_LIB"
             in
-         match uu____8389 with
+         match uu____8578 with
          | FStar_Pervasives_Native.None  ->
              let fstar_home = FStar_String.op_Hat fstar_bin_directory "/.."
                 in
              let defs = universe_include_path_base_dirs  in
-             let uu____8405 =
+             let uu____8594 =
                FStar_All.pipe_right defs
                  (FStar_List.map (fun x  -> FStar_String.op_Hat fstar_home x))
                 in
-             FStar_All.pipe_right uu____8405
+             FStar_All.pipe_right uu____8594
                (FStar_List.filter FStar_Util.file_exists)
          | FStar_Pervasives_Native.Some s -> [s]  in
-       let uu____8432 =
-         let uu____8436 =
-           let uu____8440 = get_include ()  in
-           FStar_List.append uu____8440 ["."]  in
-         FStar_List.append lib_paths uu____8436  in
-       FStar_List.append cache_dir uu____8432)
+       let uu____8621 =
+         let uu____8625 =
+           let uu____8629 = get_include ()  in
+           FStar_List.append uu____8629 ["."]  in
+         FStar_List.append lib_paths uu____8625  in
+       FStar_List.append cache_dir uu____8621)
   
 let (find_file : Prims.string -> Prims.string FStar_Pervasives_Native.option)
   =
   let file_map = FStar_Util.smap_create (Prims.of_int (100))  in
   fun filename  ->
-    let uu____8471 = FStar_Util.smap_try_find file_map filename  in
-    match uu____8471 with
+    let uu____8660 = FStar_Util.smap_try_find file_map filename  in
+    match uu____8660 with
     | FStar_Pervasives_Native.Some f -> f
     | FStar_Pervasives_Native.None  ->
         let result =
           try
-            (fun uu___592_8502  ->
+            (fun uu___614_8691  ->
                match () with
                | () ->
-                   let uu____8506 = FStar_Util.is_path_absolute filename  in
-                   if uu____8506
+                   let uu____8695 = FStar_Util.is_path_absolute filename  in
+                   if uu____8695
                    then
                      (if FStar_Util.file_exists filename
                       then FStar_Pervasives_Native.Some filename
                       else FStar_Pervasives_Native.None)
                    else
-                     (let uu____8522 =
-                        let uu____8526 = include_path ()  in
-                        FStar_List.rev uu____8526  in
-                      FStar_Util.find_map uu____8522
+                     (let uu____8711 =
+                        let uu____8715 = include_path ()  in
+                        FStar_List.rev uu____8715  in
+                      FStar_Util.find_map uu____8711
                         (fun p  ->
                            let path =
                              if p = "."
@@ -1663,81 +1699,81 @@ let (find_file : Prims.string -> Prims.string FStar_Pervasives_Native.option)
                            if FStar_Util.file_exists path
                            then FStar_Pervasives_Native.Some path
                            else FStar_Pervasives_Native.None))) ()
-          with | uu___591_8554 -> FStar_Pervasives_Native.None  in
+          with | uu___613_8743 -> FStar_Pervasives_Native.None  in
         (if FStar_Option.isSome result
          then FStar_Util.smap_add file_map filename result
          else ();
          result)
   
 let (prims : unit -> Prims.string) =
-  fun uu____8573  ->
-    let uu____8574 = get_prims ()  in
-    match uu____8574 with
+  fun uu____8762  ->
+    let uu____8763 = get_prims ()  in
+    match uu____8763 with
     | FStar_Pervasives_Native.None  ->
         let filename = "prims.fst"  in
-        let uu____8583 = find_file filename  in
-        (match uu____8583 with
+        let uu____8772 = find_file filename  in
+        (match uu____8772 with
          | FStar_Pervasives_Native.Some result -> result
          | FStar_Pervasives_Native.None  ->
-             let uu____8592 =
+             let uu____8781 =
                FStar_Util.format1
                  "unable to find required file \"%s\" in the module search path.\n"
                  filename
                 in
-             failwith uu____8592)
+             failwith uu____8781)
     | FStar_Pervasives_Native.Some x -> x
   
 let (prims_basename : unit -> Prims.string) =
-  fun uu____8605  ->
-    let uu____8606 = prims ()  in FStar_Util.basename uu____8606
+  fun uu____8794  ->
+    let uu____8795 = prims ()  in FStar_Util.basename uu____8795
   
 let (pervasives : unit -> Prims.string) =
-  fun uu____8614  ->
+  fun uu____8803  ->
     let filename = "FStar.Pervasives.fst"  in
-    let uu____8618 = find_file filename  in
-    match uu____8618 with
+    let uu____8807 = find_file filename  in
+    match uu____8807 with
     | FStar_Pervasives_Native.Some result -> result
     | FStar_Pervasives_Native.None  ->
-        let uu____8627 =
+        let uu____8816 =
           FStar_Util.format1
             "unable to find required file \"%s\" in the module search path.\n"
             filename
            in
-        failwith uu____8627
+        failwith uu____8816
   
 let (pervasives_basename : unit -> Prims.string) =
-  fun uu____8637  ->
-    let uu____8638 = pervasives ()  in FStar_Util.basename uu____8638
+  fun uu____8826  ->
+    let uu____8827 = pervasives ()  in FStar_Util.basename uu____8827
   
 let (pervasives_native_basename : unit -> Prims.string) =
-  fun uu____8646  ->
+  fun uu____8835  ->
     let filename = "FStar.Pervasives.Native.fst"  in
-    let uu____8650 = find_file filename  in
-    match uu____8650 with
+    let uu____8839 = find_file filename  in
+    match uu____8839 with
     | FStar_Pervasives_Native.Some result -> FStar_Util.basename result
     | FStar_Pervasives_Native.None  ->
-        let uu____8659 =
+        let uu____8848 =
           FStar_Util.format1
             "unable to find required file \"%s\" in the module search path.\n"
             filename
            in
-        failwith uu____8659
+        failwith uu____8848
   
 let (prepend_output_dir : Prims.string -> Prims.string) =
   fun fname  ->
-    let uu____8672 = get_odir ()  in
-    match uu____8672 with
+    let uu____8861 = get_odir ()  in
+    match uu____8861 with
     | FStar_Pervasives_Native.None  -> fname
     | FStar_Pervasives_Native.Some x -> FStar_Util.join_paths x fname
   
 let (prepend_cache_dir : Prims.string -> Prims.string) =
   fun fpath  ->
-    let uu____8690 = get_cache_dir ()  in
-    match uu____8690 with
+    let uu____8879 = get_cache_dir ()  in
+    match uu____8879 with
     | FStar_Pervasives_Native.None  -> fpath
     | FStar_Pervasives_Native.Some x ->
-        let uu____8699 = FStar_Util.basename fpath  in
-        FStar_Util.join_paths x uu____8699
+        let uu____8888 = FStar_Util.basename fpath  in
+        FStar_Util.join_paths x uu____8888
   
 let (path_of_text : Prims.string -> Prims.string Prims.list) =
   fun text  -> FStar_String.split [46] text 
@@ -1748,8 +1784,8 @@ let (parse_settings :
   fun ns  ->
     let cache = FStar_Util.smap_create (Prims.of_int (31))  in
     let with_cache f s =
-      let uu____8821 = FStar_Util.smap_try_find cache s  in
-      match uu____8821 with
+      let uu____9010 = FStar_Util.smap_try_find cache s  in
+      match uu____9010 with
       | FStar_Pervasives_Native.Some s1 -> s1
       | FStar_Pervasives_Native.None  ->
           let res = f s  in (FStar_Util.smap_add cache s res; res)
@@ -1764,8 +1800,8 @@ let (parse_settings :
           if FStar_Util.starts_with s "-"
           then
             (let path =
-               let uu____8975 = FStar_Util.substring_from s Prims.int_one  in
-               path_of_text uu____8975  in
+               let uu____9164 = FStar_Util.substring_from s Prims.int_one  in
+               path_of_text uu____9164  in
              (path, false))
           else
             (let s1 =
@@ -1774,7 +1810,7 @@ let (parse_settings :
                else s  in
              ((path_of_text s1), true))
        in
-    let uu____8998 =
+    let uu____9187 =
       FStar_All.pipe_right ns
         (FStar_List.collect
            (fun s  ->
@@ -1785,35 +1821,35 @@ let (parse_settings :
                 with_cache
                   (fun s2  ->
                      let s3 = FStar_Util.replace_char s2 32 44  in
-                     let uu____9072 =
-                       let uu____9076 =
+                     let uu____9261 =
+                       let uu____9265 =
                          FStar_All.pipe_right (FStar_Util.splitlines s3)
                            (FStar_List.concatMap
                               (fun s4  -> FStar_Util.split s4 ","))
                           in
-                       FStar_All.pipe_right uu____9076
+                       FStar_All.pipe_right uu____9265
                          (FStar_List.filter (fun s4  -> s4 <> ""))
                         in
-                     FStar_All.pipe_right uu____9072
+                     FStar_All.pipe_right uu____9261
                        (FStar_List.map parse_one_setting)) s1))
        in
-    FStar_All.pipe_right uu____8998 FStar_List.rev
+    FStar_All.pipe_right uu____9187 FStar_List.rev
   
 let (__temp_no_proj : Prims.string -> Prims.bool) =
   fun s  ->
-    let uu____9163 = get___temp_no_proj ()  in
-    FStar_All.pipe_right uu____9163 (FStar_List.contains s)
+    let uu____9352 = get___temp_no_proj ()  in
+    FStar_All.pipe_right uu____9352 (FStar_List.contains s)
   
 let (__temp_fast_implicits : unit -> Prims.bool) =
-  fun uu____9178  -> lookup_opt "__temp_fast_implicits" as_bool 
+  fun uu____9367  -> lookup_opt "__temp_fast_implicits" as_bool 
 let (admit_smt_queries : unit -> Prims.bool) =
-  fun uu____9187  -> get_admit_smt_queries () 
+  fun uu____9376  -> get_admit_smt_queries () 
 let (admit_except : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____9196  -> get_admit_except () 
+  fun uu____9385  -> get_admit_except () 
 let (cache_checked_modules : unit -> Prims.bool) =
-  fun uu____9203  -> get_cache_checked_modules () 
-let (cache_off : unit -> Prims.bool) = fun uu____9210  -> get_cache_off () 
-let (cmi : unit -> Prims.bool) = fun uu____9217  -> get_cmi () 
+  fun uu____9392  -> get_cache_checked_modules () 
+let (cache_off : unit -> Prims.bool) = fun uu____9399  -> get_cache_off () 
+let (cmi : unit -> Prims.bool) = fun uu____9406  -> get_cmi () 
 type codegen_t =
   | OCaml 
   | FSharp 
@@ -1821,308 +1857,310 @@ type codegen_t =
   | Plugin 
 let (uu___is_OCaml : codegen_t -> Prims.bool) =
   fun projectee  ->
-    match projectee with | OCaml  -> true | uu____9227 -> false
+    match projectee with | OCaml  -> true | uu____9416 -> false
   
 let (uu___is_FSharp : codegen_t -> Prims.bool) =
   fun projectee  ->
-    match projectee with | FSharp  -> true | uu____9238 -> false
+    match projectee with | FSharp  -> true | uu____9427 -> false
   
 let (uu___is_Kremlin : codegen_t -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Kremlin  -> true | uu____9249 -> false
+    match projectee with | Kremlin  -> true | uu____9438 -> false
   
 let (uu___is_Plugin : codegen_t -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Plugin  -> true | uu____9260 -> false
+    match projectee with | Plugin  -> true | uu____9449 -> false
   
 let (codegen : unit -> codegen_t FStar_Pervasives_Native.option) =
-  fun uu____9269  ->
-    let uu____9270 = get_codegen ()  in
-    FStar_Util.map_opt uu____9270
-      (fun uu___12_9276  ->
-         match uu___12_9276 with
+  fun uu____9458  ->
+    let uu____9459 = get_codegen ()  in
+    FStar_Util.map_opt uu____9459
+      (fun uu___13_9465  ->
+         match uu___13_9465 with
          | "OCaml" -> OCaml
          | "FSharp" -> FSharp
          | "Kremlin" -> Kremlin
          | "Plugin" -> Plugin
-         | uu____9282 -> failwith "Impossible")
+         | uu____9471 -> failwith "Impossible")
   
 let (codegen_libs : unit -> Prims.string Prims.list Prims.list) =
-  fun uu____9295  ->
-    let uu____9296 = get_codegen_lib ()  in
-    FStar_All.pipe_right uu____9296
+  fun uu____9484  ->
+    let uu____9485 = get_codegen_lib ()  in
+    FStar_All.pipe_right uu____9485
       (FStar_List.map (fun x  -> FStar_Util.split x "."))
   
 let (debug_any : unit -> Prims.bool) =
-  fun uu____9322  -> let uu____9323 = get_debug ()  in uu____9323 <> [] 
+  fun uu____9511  -> let uu____9512 = get_debug ()  in uu____9512 <> [] 
 let (debug_module : Prims.string -> Prims.bool) =
   fun modul  ->
-    let uu____9340 = get_debug ()  in
-    FStar_All.pipe_right uu____9340
+    let uu____9529 = get_debug ()  in
+    FStar_All.pipe_right uu____9529
       (FStar_List.existsb (module_name_eq modul))
   
 let (debug_at_level : Prims.string -> debug_level_t -> Prims.bool) =
   fun modul  ->
     fun level  ->
-      (let uu____9365 = get_debug ()  in
-       FStar_All.pipe_right uu____9365
+      (let uu____9554 = get_debug ()  in
+       FStar_All.pipe_right uu____9554
          (FStar_List.existsb (module_name_eq modul)))
         && (debug_level_geq level)
   
 let (profile_group_by_decls : unit -> Prims.bool) =
-  fun uu____9380  -> get_profile_group_by_decl () 
+  fun uu____9569  -> get_profile_group_by_decl () 
 let (defensive : unit -> Prims.bool) =
-  fun uu____9387  -> let uu____9388 = get_defensive ()  in uu____9388 <> "no" 
+  fun uu____9576  -> let uu____9577 = get_defensive ()  in uu____9577 <> "no" 
 let (defensive_fail : unit -> Prims.bool) =
-  fun uu____9398  ->
-    let uu____9399 = get_defensive ()  in uu____9399 = "fail"
+  fun uu____9587  ->
+    let uu____9588 = get_defensive ()  in uu____9588 = "fail"
   
 let (dep : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____9411  -> get_dep () 
+  fun uu____9600  -> get_dep () 
 let (detail_errors : unit -> Prims.bool) =
-  fun uu____9418  -> get_detail_errors () 
+  fun uu____9607  -> get_detail_errors () 
 let (detail_hint_replay : unit -> Prims.bool) =
-  fun uu____9425  -> get_detail_hint_replay () 
+  fun uu____9614  -> get_detail_hint_replay () 
 let (dump_module : Prims.string -> Prims.bool) =
   fun s  ->
-    let uu____9435 = get_dump_module ()  in
-    FStar_All.pipe_right uu____9435 (FStar_List.existsb (module_name_eq s))
+    let uu____9624 = get_dump_module ()  in
+    FStar_All.pipe_right uu____9624 (FStar_List.existsb (module_name_eq s))
   
 let (eager_subtyping : unit -> Prims.bool) =
-  fun uu____9450  -> get_eager_subtyping () 
+  fun uu____9639  -> get_eager_subtyping () 
 let (expose_interfaces : unit -> Prims.bool) =
-  fun uu____9457  -> get_expose_interfaces () 
+  fun uu____9646  -> get_expose_interfaces () 
 let (fs_typ_app : Prims.string -> Prims.bool) =
   fun filename  ->
-    let uu____9467 = FStar_ST.op_Bang light_off_files  in
-    FStar_List.contains filename uu____9467
+    let uu____9656 = FStar_ST.op_Bang light_off_files  in
+    FStar_List.contains filename uu____9656
   
-let (full_context_dependency : unit -> Prims.bool) = fun uu____9503  -> true 
+let (full_context_dependency : unit -> Prims.bool) = fun uu____9692  -> true 
 let (hide_uvar_nums : unit -> Prims.bool) =
-  fun uu____9511  -> get_hide_uvar_nums () 
+  fun uu____9700  -> get_hide_uvar_nums () 
 let (hint_info : unit -> Prims.bool) =
-  fun uu____9518  -> (get_hint_info ()) || (get_query_stats ()) 
+  fun uu____9707  -> (get_hint_info ()) || (get_query_stats ()) 
 let (hint_dir : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____9527  -> get_hint_dir () 
+  fun uu____9716  -> get_hint_dir () 
 let (hint_file : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____9536  -> get_hint_file () 
+  fun uu____9725  -> get_hint_file () 
 let (hint_file_for_src : Prims.string -> Prims.string) =
   fun src_filename  ->
-    let uu____9546 = hint_file ()  in
-    match uu____9546 with
+    let uu____9735 = hint_file ()  in
+    match uu____9735 with
     | FStar_Pervasives_Native.Some fn -> fn
     | FStar_Pervasives_Native.None  ->
         let file_name =
-          let uu____9557 = hint_dir ()  in
-          match uu____9557 with
+          let uu____9746 = hint_dir ()  in
+          match uu____9746 with
           | FStar_Pervasives_Native.Some dir ->
-              let uu____9565 = FStar_Util.basename src_filename  in
-              FStar_Util.concat_dir_filename dir uu____9565
-          | uu____9567 -> src_filename  in
+              let uu____9754 = FStar_Util.basename src_filename  in
+              FStar_Util.concat_dir_filename dir uu____9754
+          | uu____9756 -> src_filename  in
         FStar_Util.format1 "%s.hints" file_name
   
-let (ide : unit -> Prims.bool) = fun uu____9578  -> get_ide () 
-let (print : unit -> Prims.bool) = fun uu____9585  -> get_print () 
+let (ide : unit -> Prims.bool) = fun uu____9767  -> get_ide () 
+let (print : unit -> Prims.bool) = fun uu____9774  -> get_print () 
 let (print_in_place : unit -> Prims.bool) =
-  fun uu____9592  -> get_print_in_place () 
+  fun uu____9781  -> get_print_in_place () 
 let (initial_fuel : unit -> Prims.int) =
-  fun uu____9599  ->
-    let uu____9600 = get_initial_fuel ()  in
-    let uu____9602 = get_max_fuel ()  in Prims.min uu____9600 uu____9602
+  fun uu____9788  ->
+    let uu____9789 = get_initial_fuel ()  in
+    let uu____9791 = get_max_fuel ()  in Prims.min uu____9789 uu____9791
   
 let (initial_ifuel : unit -> Prims.int) =
-  fun uu____9610  ->
-    let uu____9611 = get_initial_ifuel ()  in
-    let uu____9613 = get_max_ifuel ()  in Prims.min uu____9611 uu____9613
+  fun uu____9799  ->
+    let uu____9800 = get_initial_ifuel ()  in
+    let uu____9802 = get_max_ifuel ()  in Prims.min uu____9800 uu____9802
   
 let (interactive : unit -> Prims.bool) =
-  fun uu____9621  -> (get_in ()) || (get_ide ()) 
-let (lax : unit -> Prims.bool) = fun uu____9628  -> get_lax () 
-let (load : unit -> Prims.string Prims.list) = fun uu____9637  -> get_load () 
-let (legacy_interactive : unit -> Prims.bool) = fun uu____9644  -> get_in () 
-let (lsp_server : unit -> Prims.bool) = fun uu____9651  -> get_lsp () 
+  fun uu____9810  -> (get_in ()) || (get_ide ()) 
+let (lax : unit -> Prims.bool) = fun uu____9817  -> get_lax () 
+let (load : unit -> Prims.string Prims.list) = fun uu____9826  -> get_load () 
+let (legacy_interactive : unit -> Prims.bool) = fun uu____9833  -> get_in () 
+let (lsp_server : unit -> Prims.bool) = fun uu____9840  -> get_lsp () 
 let (log_queries : unit -> Prims.bool) =
-  fun uu____9658  -> get_log_queries () 
+  fun uu____9847  -> get_log_queries () 
 let (keep_query_captions : unit -> Prims.bool) =
-  fun uu____9665  -> (log_queries ()) && (get_keep_query_captions ()) 
-let (log_types : unit -> Prims.bool) = fun uu____9672  -> get_log_types () 
-let (max_fuel : unit -> Prims.int) = fun uu____9679  -> get_max_fuel () 
-let (max_ifuel : unit -> Prims.int) = fun uu____9686  -> get_max_ifuel () 
-let (min_fuel : unit -> Prims.int) = fun uu____9693  -> get_min_fuel () 
-let (ml_ish : unit -> Prims.bool) = fun uu____9700  -> get_MLish () 
+  fun uu____9854  -> (log_queries ()) && (get_keep_query_captions ()) 
+let (log_types : unit -> Prims.bool) = fun uu____9861  -> get_log_types () 
+let (max_fuel : unit -> Prims.int) = fun uu____9868  -> get_max_fuel () 
+let (max_ifuel : unit -> Prims.int) = fun uu____9875  -> get_max_ifuel () 
+let (min_fuel : unit -> Prims.int) = fun uu____9882  -> get_min_fuel () 
+let (ml_ish : unit -> Prims.bool) = fun uu____9889  -> get_MLish () 
 let (set_ml_ish : unit -> unit) =
-  fun uu____9706  -> set_option "MLish" (Bool true) 
+  fun uu____9895  -> set_option "MLish" (Bool true) 
 let (no_default_includes : unit -> Prims.bool) =
-  fun uu____9715  -> get_no_default_includes () 
+  fun uu____9904  -> get_no_default_includes () 
 let (no_extract : Prims.string -> Prims.bool) =
   fun s  ->
-    let uu____9725 = get_no_extract ()  in
-    FStar_All.pipe_right uu____9725 (FStar_List.existsb (module_name_eq s))
+    let uu____9914 = get_no_extract ()  in
+    FStar_All.pipe_right uu____9914 (FStar_List.existsb (module_name_eq s))
   
 let (normalize_pure_terms_for_extraction : unit -> Prims.bool) =
-  fun uu____9740  -> get_normalize_pure_terms_for_extraction () 
+  fun uu____9929  -> get_normalize_pure_terms_for_extraction () 
 let (no_location_info : unit -> Prims.bool) =
-  fun uu____9747  -> get_no_location_info () 
-let (no_plugins : unit -> Prims.bool) = fun uu____9754  -> get_no_plugins () 
-let (no_smt : unit -> Prims.bool) = fun uu____9761  -> get_no_smt () 
+  fun uu____9936  -> get_no_location_info () 
+let (no_plugins : unit -> Prims.bool) = fun uu____9943  -> get_no_plugins () 
+let (no_smt : unit -> Prims.bool) = fun uu____9950  -> get_no_smt () 
 let (output_dir : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____9770  -> get_odir () 
-let (ugly : unit -> Prims.bool) = fun uu____9777  -> get_ugly () 
+  fun uu____9959  -> get_odir () 
+let (ugly : unit -> Prims.bool) = fun uu____9966  -> get_ugly () 
 let (print_bound_var_types : unit -> Prims.bool) =
-  fun uu____9784  -> get_print_bound_var_types () 
+  fun uu____9973  -> get_print_bound_var_types () 
 let (print_effect_args : unit -> Prims.bool) =
-  fun uu____9791  -> get_print_effect_args () 
+  fun uu____9980  -> get_print_effect_args () 
 let (print_implicits : unit -> Prims.bool) =
-  fun uu____9798  -> get_print_implicits () 
+  fun uu____9987  -> get_print_implicits () 
 let (print_real_names : unit -> Prims.bool) =
-  fun uu____9805  -> (get_prn ()) || (get_print_full_names ()) 
+  fun uu____9994  -> (get_prn ()) || (get_print_full_names ()) 
 let (print_universes : unit -> Prims.bool) =
-  fun uu____9812  -> get_print_universes () 
+  fun uu____10001  -> get_print_universes () 
 let (print_z3_statistics : unit -> Prims.bool) =
-  fun uu____9819  -> get_print_z3_statistics () 
-let (quake_lo : unit -> Prims.int) = fun uu____9826  -> get_quake_lo () 
-let (quake_hi : unit -> Prims.int) = fun uu____9833  -> get_quake_hi () 
+  fun uu____10008  -> get_print_z3_statistics () 
+let (quake_lo : unit -> Prims.int) = fun uu____10015  -> get_quake_lo () 
+let (quake_hi : unit -> Prims.int) = fun uu____10022  -> get_quake_hi () 
+let (quake_keep : unit -> Prims.bool) = fun uu____10029  -> get_quake_keep () 
 let (query_stats : unit -> Prims.bool) =
-  fun uu____9840  -> get_query_stats () 
+  fun uu____10036  -> get_query_stats () 
 let (record_hints : unit -> Prims.bool) =
-  fun uu____9847  -> get_record_hints () 
+  fun uu____10043  -> get_record_hints () 
 let (record_options : unit -> Prims.bool) =
-  fun uu____9854  -> get_record_options () 
+  fun uu____10050  -> get_record_options () 
+let (retry : unit -> Prims.bool) = fun uu____10057  -> get_retry () 
 let (reuse_hint_for : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____9863  -> get_reuse_hint_for () 
-let (silent : unit -> Prims.bool) = fun uu____9870  -> get_silent () 
+  fun uu____10066  -> get_reuse_hint_for () 
+let (silent : unit -> Prims.bool) = fun uu____10073  -> get_silent () 
 let (smtencoding_elim_box : unit -> Prims.bool) =
-  fun uu____9877  -> get_smtencoding_elim_box () 
+  fun uu____10080  -> get_smtencoding_elim_box () 
 let (smtencoding_nl_arith_native : unit -> Prims.bool) =
-  fun uu____9884  ->
-    let uu____9885 = get_smtencoding_nl_arith_repr ()  in
-    uu____9885 = "native"
+  fun uu____10087  ->
+    let uu____10088 = get_smtencoding_nl_arith_repr ()  in
+    uu____10088 = "native"
   
 let (smtencoding_nl_arith_wrapped : unit -> Prims.bool) =
-  fun uu____9895  ->
-    let uu____9896 = get_smtencoding_nl_arith_repr ()  in
-    uu____9896 = "wrapped"
+  fun uu____10098  ->
+    let uu____10099 = get_smtencoding_nl_arith_repr ()  in
+    uu____10099 = "wrapped"
   
 let (smtencoding_nl_arith_default : unit -> Prims.bool) =
-  fun uu____9906  ->
-    let uu____9907 = get_smtencoding_nl_arith_repr ()  in
-    uu____9907 = "boxwrap"
+  fun uu____10109  ->
+    let uu____10110 = get_smtencoding_nl_arith_repr ()  in
+    uu____10110 = "boxwrap"
   
 let (smtencoding_l_arith_native : unit -> Prims.bool) =
-  fun uu____9917  ->
-    let uu____9918 = get_smtencoding_l_arith_repr ()  in
-    uu____9918 = "native"
+  fun uu____10120  ->
+    let uu____10121 = get_smtencoding_l_arith_repr ()  in
+    uu____10121 = "native"
   
 let (smtencoding_l_arith_default : unit -> Prims.bool) =
-  fun uu____9928  ->
-    let uu____9929 = get_smtencoding_l_arith_repr ()  in
-    uu____9929 = "boxwrap"
+  fun uu____10131  ->
+    let uu____10132 = get_smtencoding_l_arith_repr ()  in
+    uu____10132 = "boxwrap"
   
 let (smtencoding_valid_intro : unit -> Prims.bool) =
-  fun uu____9939  -> get_smtencoding_valid_intro () 
+  fun uu____10142  -> get_smtencoding_valid_intro () 
 let (smtencoding_valid_elim : unit -> Prims.bool) =
-  fun uu____9946  -> get_smtencoding_valid_elim () 
+  fun uu____10149  -> get_smtencoding_valid_elim () 
 let (tactic_raw_binders : unit -> Prims.bool) =
-  fun uu____9953  -> get_tactic_raw_binders () 
+  fun uu____10156  -> get_tactic_raw_binders () 
 let (tactics_failhard : unit -> Prims.bool) =
-  fun uu____9960  -> get_tactics_failhard () 
+  fun uu____10163  -> get_tactics_failhard () 
 let (tactics_info : unit -> Prims.bool) =
-  fun uu____9967  -> get_tactics_info () 
+  fun uu____10170  -> get_tactics_info () 
 let (tactic_trace : unit -> Prims.bool) =
-  fun uu____9974  -> get_tactic_trace () 
+  fun uu____10177  -> get_tactic_trace () 
 let (tactic_trace_d : unit -> Prims.int) =
-  fun uu____9981  -> get_tactic_trace_d () 
+  fun uu____10184  -> get_tactic_trace_d () 
 let (tactics_nbe : unit -> Prims.bool) =
-  fun uu____9988  -> get_tactics_nbe () 
-let (tcnorm : unit -> Prims.bool) = fun uu____9995  -> get_tcnorm () 
-let (timing : unit -> Prims.bool) = fun uu____10002  -> get_timing () 
+  fun uu____10191  -> get_tactics_nbe () 
+let (tcnorm : unit -> Prims.bool) = fun uu____10198  -> get_tcnorm () 
+let (timing : unit -> Prims.bool) = fun uu____10205  -> get_timing () 
 let (trace_error : unit -> Prims.bool) =
-  fun uu____10009  -> get_trace_error () 
+  fun uu____10212  -> get_trace_error () 
 let (unthrottle_inductives : unit -> Prims.bool) =
-  fun uu____10016  -> get_unthrottle_inductives () 
+  fun uu____10219  -> get_unthrottle_inductives () 
 let (unsafe_tactic_exec : unit -> Prims.bool) =
-  fun uu____10023  -> get_unsafe_tactic_exec () 
+  fun uu____10226  -> get_unsafe_tactic_exec () 
 let (use_eq_at_higher_order : unit -> Prims.bool) =
-  fun uu____10030  -> get_use_eq_at_higher_order () 
-let (use_hints : unit -> Prims.bool) = fun uu____10037  -> get_use_hints () 
+  fun uu____10233  -> get_use_eq_at_higher_order () 
+let (use_hints : unit -> Prims.bool) = fun uu____10240  -> get_use_hints () 
 let (use_hint_hashes : unit -> Prims.bool) =
-  fun uu____10044  -> get_use_hint_hashes () 
+  fun uu____10247  -> get_use_hint_hashes () 
 let (use_native_tactics :
   unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____10053  -> get_use_native_tactics () 
+  fun uu____10256  -> get_use_native_tactics () 
 let (use_tactics : unit -> Prims.bool) =
-  fun uu____10060  -> get_use_tactics () 
+  fun uu____10263  -> get_use_tactics () 
 let (using_facts_from :
   unit -> (Prims.string Prims.list * Prims.bool) Prims.list) =
-  fun uu____10076  ->
-    let uu____10077 = get_using_facts_from ()  in
-    match uu____10077 with
+  fun uu____10279  ->
+    let uu____10280 = get_using_facts_from ()  in
+    match uu____10280 with
     | FStar_Pervasives_Native.None  -> [([], true)]
     | FStar_Pervasives_Native.Some ns -> parse_settings ns
   
 let (vcgen_optimize_bind_as_seq : unit -> Prims.bool) =
-  fun uu____10131  ->
-    let uu____10132 = get_vcgen_optimize_bind_as_seq ()  in
-    FStar_Option.isSome uu____10132
+  fun uu____10334  ->
+    let uu____10335 = get_vcgen_optimize_bind_as_seq ()  in
+    FStar_Option.isSome uu____10335
   
 let (vcgen_decorate_with_type : unit -> Prims.bool) =
-  fun uu____10143  ->
-    let uu____10144 = get_vcgen_optimize_bind_as_seq ()  in
-    match uu____10144 with
+  fun uu____10346  ->
+    let uu____10347 = get_vcgen_optimize_bind_as_seq ()  in
+    match uu____10347 with
     | FStar_Pervasives_Native.Some "with_type" -> true
-    | uu____10152 -> false
+    | uu____10355 -> false
   
 let (warn_default_effects : unit -> Prims.bool) =
-  fun uu____10163  -> get_warn_default_effects () 
+  fun uu____10366  -> get_warn_default_effects () 
 let (z3_exe : unit -> Prims.string) =
-  fun uu____10170  ->
-    let uu____10171 = get_smt ()  in
-    match uu____10171 with
+  fun uu____10373  ->
+    let uu____10374 = get_smt ()  in
+    match uu____10374 with
     | FStar_Pervasives_Native.None  -> FStar_Platform.exe "z3"
     | FStar_Pervasives_Native.Some s -> s
   
 let (z3_cliopt : unit -> Prims.string Prims.list) =
-  fun uu____10189  -> get_z3cliopt () 
-let (z3_refresh : unit -> Prims.bool) = fun uu____10196  -> get_z3refresh () 
-let (z3_rlimit : unit -> Prims.int) = fun uu____10203  -> get_z3rlimit () 
+  fun uu____10392  -> get_z3cliopt () 
+let (z3_refresh : unit -> Prims.bool) = fun uu____10399  -> get_z3refresh () 
+let (z3_rlimit : unit -> Prims.int) = fun uu____10406  -> get_z3rlimit () 
 let (z3_rlimit_factor : unit -> Prims.int) =
-  fun uu____10210  -> get_z3rlimit_factor () 
-let (z3_seed : unit -> Prims.int) = fun uu____10217  -> get_z3seed () 
+  fun uu____10413  -> get_z3rlimit_factor () 
+let (z3_seed : unit -> Prims.int) = fun uu____10420  -> get_z3seed () 
 let (use_two_phase_tc : unit -> Prims.bool) =
-  fun uu____10224  ->
+  fun uu____10427  ->
     (get_use_two_phase_tc ()) &&
-      (let uu____10226 = lax ()  in Prims.op_Negation uu____10226)
+      (let uu____10429 = lax ()  in Prims.op_Negation uu____10429)
   
 let (no_positivity : unit -> Prims.bool) =
-  fun uu____10234  -> get_no_positivity () 
+  fun uu____10437  -> get_no_positivity () 
 let (ml_no_eta_expand_coertions : unit -> Prims.bool) =
-  fun uu____10241  -> get_ml_no_eta_expand_coertions () 
+  fun uu____10444  -> get_ml_no_eta_expand_coertions () 
 let (warn_error : unit -> Prims.string) =
-  fun uu____10248  ->
-    let uu____10249 = get_warn_error ()  in
-    FStar_String.concat "" uu____10249
+  fun uu____10451  ->
+    let uu____10452 = get_warn_error ()  in
+    FStar_String.concat "" uu____10452
   
 let (use_extracted_interfaces : unit -> Prims.bool) =
-  fun uu____10260  -> get_use_extracted_interfaces () 
-let (use_nbe : unit -> Prims.bool) = fun uu____10267  -> get_use_nbe () 
+  fun uu____10463  -> get_use_extracted_interfaces () 
+let (use_nbe : unit -> Prims.bool) = fun uu____10470  -> get_use_nbe () 
 let (use_nbe_for_extraction : unit -> Prims.bool) =
-  fun uu____10274  -> get_use_nbe_for_extraction () 
+  fun uu____10477  -> get_use_nbe_for_extraction () 
 let (trivial_pre_for_unannotated_effectful_fns : unit -> Prims.bool) =
-  fun uu____10281  -> get_trivial_pre_for_unannotated_effectful_fns () 
+  fun uu____10484  -> get_trivial_pre_for_unannotated_effectful_fns () 
 let with_saved_options : 'a . (unit -> 'a) -> 'a =
   fun f  ->
-    let uu____10298 =
-      let uu____10300 = trace_error ()  in Prims.op_Negation uu____10300  in
-    if uu____10298
+    let uu____10501 =
+      let uu____10503 = trace_error ()  in Prims.op_Negation uu____10503  in
+    if uu____10501
     then
       (push ();
        (let r =
           try
-            (fun uu___798_10315  ->
+            (fun uu___822_10518  ->
                match () with
-               | () -> let uu____10320 = f ()  in FStar_Util.Inr uu____10320)
+               | () -> let uu____10523 = f ()  in FStar_Util.Inr uu____10523)
               ()
-          with | uu___797_10322 -> FStar_Util.Inl uu___797_10322  in
+          with | uu___821_10525 -> FStar_Util.Inl uu___821_10525  in
         pop ();
         (match r with
          | FStar_Util.Inr v1 -> v1
@@ -2138,28 +2176,28 @@ let (module_matches_namespace_filter :
       let m_components = path_of_text m1  in
       let rec matches_path m_components1 path =
         match (m_components1, path) with
-        | (uu____10403,[]) -> true
+        | (uu____10606,[]) -> true
         | (m2::ms,p::ps) ->
             (m2 = (FStar_String.lowercase p)) && (matches_path ms ps)
-        | uu____10436 -> false  in
-      let uu____10448 =
+        | uu____10639 -> false  in
+      let uu____10651 =
         FStar_All.pipe_right setting
           (FStar_Util.try_find
-             (fun uu____10490  ->
-                match uu____10490 with
-                | (path,uu____10501) -> matches_path m_components path))
+             (fun uu____10693  ->
+                match uu____10693 with
+                | (path,uu____10704) -> matches_path m_components path))
          in
-      match uu____10448 with
+      match uu____10651 with
       | FStar_Pervasives_Native.None  -> false
-      | FStar_Pervasives_Native.Some (uu____10520,flag) -> flag
+      | FStar_Pervasives_Native.Some (uu____10723,flag) -> flag
   
 let (matches_namespace_filter_opt :
   Prims.string ->
     Prims.string Prims.list FStar_Pervasives_Native.option -> Prims.bool)
   =
   fun m  ->
-    fun uu___13_10555  ->
-      match uu___13_10555 with
+    fun uu___14_10758  ->
+      match uu___14_10758 with
       | FStar_Pervasives_Native.None  -> false
       | FStar_Pervasives_Native.Some filter1 ->
           module_matches_namespace_filter m filter1
@@ -2167,24 +2205,24 @@ let (matches_namespace_filter_opt :
 let (should_extract : Prims.string -> Prims.bool) =
   fun m  ->
     let m1 = FStar_String.lowercase m  in
-    let uu____10585 = get_extract ()  in
-    match uu____10585 with
+    let uu____10788 = get_extract ()  in
+    match uu____10788 with
     | FStar_Pervasives_Native.Some extract_setting ->
-        ((let uu____10600 =
-            let uu____10616 = get_no_extract ()  in
-            let uu____10620 = get_extract_namespace ()  in
-            let uu____10624 = get_extract_module ()  in
-            (uu____10616, uu____10620, uu____10624)  in
-          match uu____10600 with
+        ((let uu____10803 =
+            let uu____10819 = get_no_extract ()  in
+            let uu____10823 = get_extract_namespace ()  in
+            let uu____10827 = get_extract_module ()  in
+            (uu____10819, uu____10823, uu____10827)  in
+          match uu____10803 with
           | ([],[],[]) -> ()
-          | uu____10649 ->
+          | uu____10852 ->
               failwith
                 "Incompatible options: --extract cannot be used with --no_extract, --extract_namespace or --extract_module");
          module_matches_namespace_filter m1 extract_setting)
     | FStar_Pervasives_Native.None  ->
         let should_extract_namespace m2 =
-          let uu____10678 = get_extract_namespace ()  in
-          match uu____10678 with
+          let uu____10881 = get_extract_namespace ()  in
+          match uu____10881 with
           | [] -> false
           | ns ->
               FStar_All.pipe_right ns
@@ -2193,39 +2231,39 @@ let (should_extract : Prims.string -> Prims.bool) =
                       FStar_Util.starts_with m2 (FStar_String.lowercase n1)))
            in
         let should_extract_module m2 =
-          let uu____10706 = get_extract_module ()  in
-          match uu____10706 with
+          let uu____10909 = get_extract_module ()  in
+          match uu____10909 with
           | [] -> false
           | l ->
               FStar_All.pipe_right l
                 (FStar_Util.for_some
                    (fun n1  -> (FStar_String.lowercase n1) = m2))
            in
-        (let uu____10728 = no_extract m1  in Prims.op_Negation uu____10728)
+        (let uu____10931 = no_extract m1  in Prims.op_Negation uu____10931)
           &&
-          (let uu____10731 =
-             let uu____10742 = get_extract_namespace ()  in
-             let uu____10746 = get_extract_module ()  in
-             (uu____10742, uu____10746)  in
-           (match uu____10731 with
+          (let uu____10934 =
+             let uu____10945 = get_extract_namespace ()  in
+             let uu____10949 = get_extract_module ()  in
+             (uu____10945, uu____10949)  in
+           (match uu____10934 with
             | ([],[]) -> true
-            | uu____10766 ->
+            | uu____10969 ->
                 (should_extract_namespace m1) || (should_extract_module m1)))
   
 let (should_be_already_cached : Prims.string -> Prims.bool) =
   fun m  ->
-    let uu____10786 = get_already_cached ()  in
-    match uu____10786 with
+    let uu____10989 = get_already_cached ()  in
+    match uu____10989 with
     | FStar_Pervasives_Native.None  -> false
     | FStar_Pervasives_Native.Some already_cached_setting ->
         module_matches_namespace_filter m already_cached_setting
   
 let (error_flags : unit -> error_flag Prims.list) =
   let cache = FStar_Util.smap_create (Prims.of_int (10))  in
-  fun uu____10819  ->
+  fun uu____11022  ->
     let we = warn_error ()  in
-    let uu____10822 = FStar_Util.smap_try_find cache we  in
-    match uu____10822 with
+    let uu____11025 = FStar_Util.smap_try_find cache we  in
+    match uu____11025 with
     | FStar_Pervasives_Native.None  ->
         let r = parse_warn_error we  in (FStar_Util.smap_add cache we r; r)
     | FStar_Pervasives_Native.Some r -> r
@@ -2237,11 +2275,11 @@ let (profile_enabled :
     fun phase  ->
       match modul_opt with
       | FStar_Pervasives_Native.None  ->
-          let uu____10866 = get_profile_component ()  in
-          matches_namespace_filter_opt phase uu____10866
+          let uu____11069 = get_profile_component ()  in
+          matches_namespace_filter_opt phase uu____11069
       | FStar_Pervasives_Native.Some modul ->
-          (let uu____10877 = get_profile ()  in
-           matches_namespace_filter_opt modul uu____10877) &&
-            (let uu____10884 = get_profile_component ()  in
-             matches_namespace_filter_opt phase uu____10884)
+          (let uu____11080 = get_profile ()  in
+           matches_namespace_filter_opt modul uu____11080) &&
+            (let uu____11087 = get_profile_component ()  in
+             matches_namespace_filter_opt phase uu____11087)
   

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -2674,7 +2674,7 @@ let (head_matches_delta :
                then FStar_Pervasives_Native.Some (t11, t21)
                else FStar_Pervasives_Native.None))
              in
-          let rec aux retry n_delta t11 t21 =
+          let rec aux retry1 n_delta t11 t21 =
             let r = head_matches env t11 t21  in
             (let uu____8113 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
@@ -2711,7 +2711,8 @@ let (head_matches_delta :
                     (t11, t2'))
                   in
                match uu____8150 with
-               | (t12,t22) -> aux retry (n_delta + Prims.int_one) t12 t22  in
+               | (t12,t22) -> aux retry1 (n_delta + Prims.int_one) t12 t22
+                in
              let reduce_both_and_try_again d r1 =
                let uu____8198 = FStar_TypeChecker_Common.decr_delta_depth d
                   in
@@ -2730,7 +2731,7 @@ let (head_matches_delta :
                        FStar_TypeChecker_Env.Weak;
                        FStar_TypeChecker_Env.HNF] env t21
                       in
-                   aux retry (n_delta + Prims.int_one) t12 t22
+                   aux retry1 (n_delta + Prims.int_one) t12 t22
                 in
              match r with
              | MisMatch
@@ -2749,7 +2750,7 @@ let (head_matches_delta :
                   (FStar_Syntax_Syntax.Delta_equational_at_level
                   uu____8236),uu____8237)
                  ->
-                 if Prims.op_Negation retry
+                 if Prims.op_Negation retry1
                  then fail1 n_delta r t11 t21
                  else
                    (let uu____8258 =
@@ -2773,7 +2774,7 @@ let (head_matches_delta :
                  (uu____8313,FStar_Pervasives_Native.Some
                   (FStar_Syntax_Syntax.Delta_equational_at_level uu____8314))
                  ->
-                 if Prims.op_Negation retry
+                 if Prims.op_Negation retry1
                  then fail1 n_delta r t11 t21
                  else
                    (let uu____8335 =

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -11124,14 +11124,14 @@ let (level_of_type :
   fun env  ->
     fun e  ->
       fun t  ->
-        let rec aux retry t1 =
+        let rec aux retry1 t1 =
           let uu____27920 =
             let uu____27921 = FStar_Syntax_Util.unrefine t1  in
             uu____27921.FStar_Syntax_Syntax.n  in
           match uu____27920 with
           | FStar_Syntax_Syntax.Tm_type u -> u
           | uu____27925 ->
-              if retry
+              if retry1
               then
                 let t2 =
                   FStar_TypeChecker_Normalize.normalize
@@ -11355,7 +11355,7 @@ let rec (universe_of_aux :
                FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u)
                  FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos)
       | FStar_Syntax_Syntax.Tm_app (hd1,args) ->
-          let rec type_of_head retry hd2 args1 =
+          let rec type_of_head retry1 hd2 args1 =
             let hd3 = FStar_Syntax_Subst.compress hd2  in
             match hd3.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Tm_unknown  -> failwith "Impossible"
@@ -11400,8 +11400,8 @@ let rec (universe_of_aux :
                      let uu____28769 = FStar_Syntax_Util.head_and_args hd5
                         in
                      (match uu____28769 with
-                      | (hd6,args2) -> type_of_head retry hd6 args2))
-            | uu____28826 when retry ->
+                      | (hd6,args2) -> type_of_head retry1 hd6 args2))
+            | uu____28826 when retry1 ->
                 let e1 =
                   FStar_TypeChecker_Normalize.normalize
                     [FStar_TypeChecker_Env.Beta;

--- a/ulib/FStar.Math.Lemmas.fst
+++ b/ulib/FStar.Math.Lemmas.fst
@@ -18,11 +18,11 @@ module FStar.Math.Lemmas
 open FStar.Mul
 open FStar.Math.Lib
 
-#set-options "--fuel 0 --ifuel 0 --z3rlimit 20"
+#push-options "--fuel 0 --ifuel 0"
 
 (* Lemma: definition of Euclidean division *)
 val euclidean_div_axiom: a:int -> b:pos -> Lemma
-  ((a - b * (a / b) >= 0 /\ a - b * (a / b) < b))
+  (a - b * (a / b) >= 0 /\ a - b * (a / b) < b)
 let euclidean_div_axiom a b = ()
 
 val lemma_eucl_div_bound: a:int -> b:int -> q:int -> Lemma
@@ -40,19 +40,34 @@ val lemma_mult_le_right: a:nat -> b:int -> c:int -> Lemma
   (ensures  (b * a <= c * a))
 let lemma_mult_le_right a b c = ()
 
-val lemma_mult_lt_left: a:pos -> b:pos -> c:pos -> Lemma
+val lemma_mult_lt_left: a:pos -> b:int -> c:int -> Lemma
   (requires (b < c))
   (ensures  (a * b < a * c))
 let lemma_mult_lt_left a b c = ()
 
-val lemma_mult_lt_right: a:nat -> b:int -> c:int -> Lemma
+val lemma_mult_lt_right: a:pos -> b:int -> c:int -> Lemma
   (requires (b < c))
-  (ensures  (b * a <= c * a))
+  (ensures  (b * a < c * a))
 let lemma_mult_lt_right a b c = ()
 
 let lemma_mult_lt_sqr (n:nat) (m:nat) (k:nat{n < k && m < k})
-  : Lemma (FStar.Mul.(n * m < k * k))
-  = ()
+  : Lemma (n * m < k * k) =
+  calc (<=) {
+    n * m;
+  <= { lemma_mult_le_left n m (k - 1) }
+    n * (k - 1);
+  <= { lemma_mult_le_right (k - 1) n (k - 1) }
+    (k - 1) * (k - 1);
+  <= {}
+    k*k - 1;
+  }
+
+(* Lemma: multiplication on integers is commutative *)
+val swap_mul: a:int -> b:int -> Lemma (a * b = b * a)
+let swap_mul a b = ()
+
+val lemma_cancel_mul (a b : int) (n : pos) : Lemma (requires (a * n = b * n)) (ensures (a = b))
+let lemma_cancel_mul a b n = ()
 
 (* Lemma: multiplication is right distributive over addition *)
 val distributivity_add_left: a:int -> b:int -> c:int -> Lemma
@@ -61,20 +76,20 @@ let distributivity_add_left a b c = ()
 
 (* Lemma: multiplication is left distributive over addition *)
 val distributivity_add_right: a:int -> b:int -> c:int -> Lemma
-  ((a * (b + c) = a * b + a * c))
-let distributivity_add_right a b c = ()
-
-(* Lemma: multiplication is left distributive over substraction *)
-val distributivity_sub_left: a:int -> b:int -> c:int ->
-  Lemma ((a - b) * c = a * c - b * c)
-let distributivity_sub_left a b c = ()
-
-(* Lemma: multiplication is left distributive over substraction *)
-val distributivity_sub_right: a:int -> b:int -> c:int -> Lemma
-  ((a * (b - c) = a * b - a * c))
-let distributivity_sub_right a b c = ()
+  (a * (b + c) = a * b + a * c)
+let distributivity_add_right a b c =
+  calc (==) {
+    a * (b + c);
+  == {}
+    (b + c) * a;
+  == { distributivity_add_left b c a }
+    b * a + c * a;
+  == {}
+    a * b + a * c;
+  }
 
 (* Lemma: multiplication is associative, hence parenthesizing is meaningless *)
+(* GM: This is really just an identity since the LHS is associated to the left *)
 val paren_mul_left: a:int -> b:int -> c:int -> Lemma
   (a * b * c = (a * b) * c)
 let paren_mul_left a b c = ()
@@ -110,10 +125,6 @@ val swap_add_plus_minus: a:int -> b:int -> c:int -> Lemma
   (a + b - c = (a - c) + b)
 let swap_add_plus_minus a b c = ()
 
-(* Lemma: multiplication on integers is commutative *)
-val swap_mul: a:int -> b:int -> Lemma (a * b = b * a)
-let swap_mul a b = ()
-
 (* Lemma: minus applies to the whole term *)
 val neg_mul_left: a:int -> b:int -> Lemma (-(a * b) = (-a) * b)
 let neg_mul_left a b = ()
@@ -127,21 +138,61 @@ let swap_neg_mul a b =
   neg_mul_left a b;
   neg_mul_right a b
 
+(* Lemma: multiplication is left distributive over substraction *)
+val distributivity_sub_left: a:int -> b:int -> c:int ->
+  Lemma ((a - b) * c = a * c - b * c)
+let distributivity_sub_left a b c =
+  calc (==) {
+    (a - b) * c;
+  == {}
+    (a + (-b)) * c;
+  == { distributivity_add_left a (-b) c }
+    a * c + (-b) * c;
+  == { neg_mul_left b c }
+    a * c - b * c;
+  }
+
+(* Lemma: multiplication is left distributive over substraction *)
+val distributivity_sub_right: a:int -> b:int -> c:int ->
+  Lemma ((a * (b - c) = a * b - a * c))
+let distributivity_sub_right a b c =
+  calc (==) {
+    a * (b - c);
+  == {}
+    a * (b + (-c));
+  == { distributivity_add_right a b (-c) }
+    a * b + a * (-c);
+  == { neg_mul_right a c }
+    a * b - a * c;
+  }
+
 (* Lemma: multiplication precedence on addition *)
 val mul_binds_tighter: a:int -> b:int -> c:int -> Lemma (a + (b * c) = a + b * c)
 let mul_binds_tighter a b c = ()
 
+val lemma_abs_mul : a:int -> b:int -> Lemma (abs a * abs b = abs (a * b))
+let lemma_abs_mul a b = ()
+
+val lemma_abs_bound : a:int -> b:nat -> Lemma (abs a < b <==> -b < a /\ a < b)
+let lemma_abs_bound a b = ()
+
 (* Lemma: multiplication keeps symetric bounds :
     b > 0 && d > 0 && -b < a < b && -d < c < d ==> - b * d < a * c < b * d *)
-
-#push-options "--smtencoding.elim_box true --smtencoding.l_arith_repr native --smtencoding.nl_arith_repr wrapped --z3rlimit 100"
-
 val mul_ineq1: a:int -> b:nat -> c:int -> d:nat -> Lemma
-  (requires (-b < a /\ a < b /\ -d < c /\ c < d))
-  (ensures  (-(b * d) < a * c /\ a * c < b * d))
-let mul_ineq1 a b c d = ()
-
-#pop-options
+    (requires (-b < a /\ a < b /\
+               -d < c /\ c < d))
+    (ensures  (-(b * d) < a * c /\ a * c < b * d))
+let mul_ineq1 a b c d =
+  if a = 0 || c = 0 then ()
+  else begin
+    lemma_abs_bound a b;
+    lemma_abs_bound c d;
+    lemma_abs_mul a c;
+    lemma_mult_lt_left (abs a) (abs c) d;
+    lemma_mult_lt_right d (abs a) b;
+    lemma_abs_bound (a * c) (b * d);
+    ()
+  end
 
 val nat_times_nat_is_nat: a:nat -> b:nat -> Lemma (a * b >= 0)
 let nat_times_nat_is_nat a b = ()
@@ -153,31 +204,29 @@ val nat_over_pos_is_nat: a:nat -> b:pos -> Lemma (a / b >= 0)
 let nat_over_pos_is_nat a b = ()
 
 #push-options "--fuel 1"
-
 val pow2_double_sum: n:nat -> Lemma (pow2 n + pow2 n = pow2 (n + 1))
 let pow2_double_sum n = ()
 
 val pow2_double_mult: n:nat -> Lemma (2 * pow2 n = pow2 (n + 1))
-let pow2_double_mult n = ()
+let pow2_double_mult n = pow2_double_sum n
 
 val pow2_lt_compat: n:nat -> m:nat -> Lemma
   (requires (m < n))
   (ensures  (pow2 m < pow2 n))
-  (decreases (n - m))
+  (decreases m)
 let rec pow2_lt_compat n m =
-  match n-m with
-  | 1 -> ()
-  | _ -> pow2_lt_compat (n-1) m; pow2_lt_compat n (n-1)
+  match m with
+  | 0 -> ()
+  | _ -> pow2_lt_compat (n-1) (m-1)
+#pop-options
 
 val pow2_le_compat: n:nat -> m:nat -> Lemma
   (requires (m <= n))
   (ensures  (pow2 m <= pow2 n))
-  (decreases (n - m))
 let pow2_le_compat n m =
-  match n-m with
-  | 0 -> ()
-  | _ -> pow2_lt_compat n m
+  if m < n then pow2_lt_compat n m
 
+#push-options "--fuel 1"
 val pow2_plus: n:nat -> m:nat -> Lemma
   (ensures (pow2 n * pow2 m = pow2 (n + m)))
   (decreases n)
@@ -185,20 +234,14 @@ let rec pow2_plus n m =
   match n with
   | 0 -> ()
   | _ -> pow2_plus (n - 1) m
+#pop-options
 
 (* Lemma : definition of the exponential property of pow2 *)
 val pow2_minus: n:nat -> m:nat{ n >= m } -> Lemma
   ((pow2 n) / (pow2 m) = pow2 (n - m))
 let pow2_minus n m =
-  if n = m then ()
-  else
-    begin
-    pow2_lt_compat n m;
-    pow2_plus (n - m) m;
-    slash_star_axiom (pow2 (n - m)) (pow2 m) (pow2 n)
-    end
-
-#pop-options
+  pow2_plus (n - m) m;
+  slash_star_axiom (pow2 (n - m)) (pow2 m) (pow2 n)
 
 (* Lemma: loss of precision in euclidean division *)
 val multiply_fractions (a:int) (n:nonzero) : Lemma (n * ( a / n ) <= a)
@@ -248,91 +291,40 @@ let lt_multiple_is_equal a b x n =
   assert (0 * n == 0);
   bounded_multiple_is_zero x n
 
-#push-options "--z3rlimit 10 --quake 1/3"
+val lemma_mod_plus (a:int) (k:int) (n:pos) : Lemma ((a + k * n) % n = a % n)
+let lemma_mod_plus (a:int) (k:int) (n:pos) =
+  calc (==) {
+    (a+k*n)%n - a%n;
+    == { lemma_div_mod a n; lemma_div_mod (a+k*n) n }
+    ((a + k*n) - n*((a + k*n)/n)) - (a - n*(a/n));
+    == {}
+    n*k + n*(a/n) - n*((a + k*n)/n);
+    == { distributivity_add_right n k (a/n);
+         distributivity_sub_right n (k + a/n) ((a + k*n)/n) }
+    n * (k + a/n - (a+k*n)/n);
+  };
+  lt_multiple_is_equal ((a+k*n)%n) (a%n) (k + a/n - (a+k*n)/n) n;
+  ()
 
-let lemma_mod_plus_0 (a:int) (b:int) (p:nonzero) : Lemma
-  ((a + b * p) % p - a % p = p * (b + a / p - (a + b * p) / p))
-=
-  let z: int = a + b * p in
-  lemma_div_mod a p;
-  lemma_div_mod z p
+val lemma_div_plus (a:int) (k:int) (n:pos) : Lemma ((a + k * n) / n = a / n + k)
+let lemma_div_plus (a:int) (k:int) (n:pos) =
+  calc (==) {
+    n * ((a+k*n)/n - a/n);
+    == { distributivity_sub_right n ((a+k*n)/n) (a/n) }
+    n * ((a+k*n)/n) - n*(a/n);
+    == { lemma_div_mod (a+k*n) n; lemma_div_mod a n }
+    (a + k*n - (a+k*n)%n) - (a - a%n);
+    == {}
+    k*n - (a+k*n)%n + a%n;
+    == { lemma_mod_plus a k n }
+    k*n;
+  };
+  lemma_cancel_mul ((a+k*n)/n - a/n) k n
 
-#pop-options
-
-let lemma_mod_plus_1 (a:int) (b:int) (p:pos) : Lemma
-  ((a + b * p) % p = a + b * p - p * ((a + b * p) / p))
-= lemma_div_mod (a+b*p) p;
-  lemma_mod_lt a p;
-  lemma_mod_lt (a + b * p) p
-
-val lemma_eq_trans_2: w:int -> x:int -> y:int -> z:int -> Lemma
-  (requires (w = x /\ x = y /\ y = z))
-  (ensures  (w = z))
-let lemma_eq_trans_2 w x y z = ()
-
-val lemma_mod_plus: a:int -> b:int -> p:pos -> Lemma
-  ((a + b * p) % p = a % p)
-let lemma_mod_plus a b p =
-  lemma_div_mod a p;
-  lemma_div_mod (a + b * p) p;
-  lemma_mod_lt a p;
-  lemma_mod_lt (a + b * p) p;
-  lemma_mod_plus_0 a b p;
-  lemma_mod_plus_1 a b p;
-  cut (a + b * p - p * ((a + b * p) / p) = a - p * (a / p));
-  let w = (a + b * p) % p in
-  let x = a + b * p - p * ((a + b * p) / p) in
-  let z = a % p in
-  let y = a - p * (a / p) in
-  lemma_eq_trans_2 w x y z
-
-let add_div_mod_1 (a:int) (n:pos) : Lemma ((a + n) % n == a % n /\ (a + n) / n == a / n + 1) =
-  lemma_div_mod a n;
-  lemma_div_mod (a + n) n;
-  // ((a + n) % n) == a % n + (a / n) * n + n - ((a + n) / n) * n
-  distributivity_add_left (a / n) 1 n;
-  distributivity_sub_left (a / n + 1) ((a + n) / n) n;
-  // (((a + n) % n) == a % n + (a / n + 1 - (a + n) / n) * n
-  lt_multiple_is_equal ((a + n) % n) (a % n) (a / n + 1 - (a + n) / n) n
-
-#push-options "--quake 1/3"
-
-let sub_div_mod_1 (a:int) (n:pos) : Lemma ((a - n) % n == a % n /\ (a - n) / n == a / n - 1) =
-  lemma_div_mod a n;
-  lemma_div_mod (a - n) n;
-  // ((a - n) % n) == a % n - n + (a / n) * n - ((a - n) / n) * n
-  distributivity_add_left (a / n) 1 n;
-  distributivity_sub_left (a / n - 1) ((a - n) / n) n;
-  // ((a - n) % n) == a % n + (a / n - 1 - (a - n) / n) * n
-  lt_multiple_is_equal ((a - n) % n) (a % n) (a / n - 1 - (a - n) / n) n
-
-#push-options "--z3cliopt smt.arith.nl=true --smtencoding.elim_box true --smtencoding.l_arith_repr native --z3rlimit 30"
-
-let rec lemma_div_mod_plus (a:int) (b:int) (n:pos) : Lemma
-  (requires True)
-  (ensures
-    (a + b * n) / n = a / n + b /\
-    (a + b * n) % n = a % n
-  )
-  (decreases (if b > 0 then b else -b))
-  =
-  if b = 0 then ()
-  else if b > 0 then
-  (
-    lemma_div_mod_plus a (b - 1) n;
-    sub_div_mod_1 (a + b * n) n
-  )
-  else // b < 0
-  (
-    lemma_div_mod_plus a (b + 1) n;
-    add_div_mod_1 (a + b * n) n
-  )
-
-val lemma_div_plus (a:int) (b:int) (n:pos) : Lemma ((a + b * n) / n = a / n + b)
-let lemma_div_plus a b n = lemma_div_mod_plus a b n
-
-#pop-options
-#pop-options
+val add_div_mod_1 (a:int) (n:pos) : Lemma ((a + n) % n == a % n /\ (a + n) / n == a / n + 1)
+let add_div_mod_1 a n =
+    lemma_mod_plus a 1 n;
+    lemma_div_plus a 1 n
 
 #push-options "--smtencoding.elim_box true --smtencoding.nl_arith_repr native"
 
@@ -346,99 +338,99 @@ let cancel_mul_mod (a:int) (n:pos) =
   small_mod 0 n;
   lemma_mod_plus 0 a n
 
-#push-options "--quake 1/3"
-
 val mod_add_both (a:int) (b:int) (x:int) (n:pos) : Lemma
   (requires a % n == b % n)
   (ensures (a + x) % n == (b + x) % n)
-let mod_add_both (a:int) (b:int) (x:int) (n:pos) =
-  assert (a % n == b % n);
-  lemma_div_mod a n;
-  lemma_div_mod b n;
-  lemma_div_mod (a + x) n;
-  lemma_div_mod (b + x) n;
-  assert ((a + x) % n == a + x - n * ((a + x) / n));
-  assert ((b + x) % n == b + x - n * ((b + x) / n));
-  assert ((a + x) % n - (b + x) % n == a - b + n * ((b + x) / n - (a + x) / n));
-  lemma_div_plus (b%n + x) (b/n) n;
-  lemma_div_plus (a%n + x) (a/n) n;
-  swap_mul n (b/n); swap_mul n (a/n); (* ugh *)
-  assert ((a + x) % n - (b + x) % n == a - b + n * (b/n + (b%n + x)/n - a/n - (a%n + x)/n));
-  assert ((a + x) % n - (b + x) % n == a - b + n * (b/n - a/n));
-  distributivity_sub_right n (b/n) (a/n);
-  assert ((a + x) % n - (b + x) % n == 0)
 
-#pop-options
+let mod_add_both (a:int) (b:int) (x:int) (n:pos) =
+  calc (==) {
+    (a + x) % n - (b + x) % n;
+    == {lemma_div_mod (a + x) n; lemma_div_mod (b + x) n }
+    ((a+x) - n*((a+x)/n)) - ((b+x) - n*((b+x)/n));
+    == {}
+    a - n*((a+x)/n) - b + n*((b+x)/n);
+    == { distributivity_sub_right n ((b+x)/n) ((a+x)/n) }
+    a - b + n * ((b+x)/n - (a+x)/n);
+    == { lemma_div_mod a n; lemma_div_mod b n }
+    n*(a/n) + a%n - n*(b/n) - b%n + n * ((b+x)/n - (a+x)/n);
+    == { (* a%n == b%n *) }
+    n*(a/n) - n*(b/n) + n * ((b+x)/n - (a+x)/n);
+    == { distributivity_sub_right n ((b+x)/n) ((a+x)/n) }
+    n*(a/n) - n*(b/n) + n * ((b+x)/n) - n * ((a+x)/n);
+    == { lemma_div_mod a n;
+         lemma_div_plus (a%n + x) (a/n) n;
+         swap_mul n (a/n) }
+    n*(a/n) - n*(b/n) + n * ((b+x)/n) - n * ((a%n + x)/n + a/n);
+    == { lemma_div_mod b n;
+         lemma_div_plus (b%n + x) (b/n) n;
+         swap_mul n (b/n) }
+    n*(a/n) - n*(b/n) + n * ((b%n + x)/n + b/n) - n * ((a%n + x)/n + a/n);
+    == { distributivity_add_right n (((a%n) + x)/n) (a/n);
+         distributivity_add_right n (((b%n) + x)/n) (b/n) }
+    n * ((b%n + x)/n) - n * ((a%n + x)/n);
+    == { (* a%n == b%n *) }
+    0;
+  }
 
 val lemma_mod_add_distr (a:int) (b:int) (n:pos) : Lemma ((a + b % n) % n = (a + b) % n)
 let lemma_mod_add_distr (a:int) (b:int) (n:pos) =
-  lemma_div_mod b n;
-  // (a + b) % n == (a + (b % n) + (b / n) * n) % n
-  lemma_mod_plus (a + (b % n)) (b / n) n
+  calc (==) {
+    (a + b%n) % n;
+    == { lemma_mod_plus (a + (b % n)) (b / n) n }
+    (a + b%n + n * (b/n)) % n;
+    == { lemma_div_mod b n }
+    (a + b) % n;
+  }
 
 val lemma_mod_sub_distr (a:int) (b:int) (n:pos) : Lemma ((a - b % n) % n = (a - b) % n)
 let lemma_mod_sub_distr (a:int) (b:int) (n:pos) =
-  lemma_div_mod b n;
-  distributivity_sub_left 0 (b / n) n;
-  // (a - b) % n == (a - (b % n) - (b / n) * n) % n
-  lemma_mod_plus (a - (b % n)) (-(b / n)) n
+  calc (==) {
+    (a - b%n) % n;
+    == { lemma_mod_plus (a - (b % n)) (-(b / n)) n }
+    (a - b%n + n * (-(b/n))) % n;
+    == { neg_mul_right n (b/n) }
+    (a - b%n - n * (b/n)) % n;
+    == { lemma_div_mod b n }
+    (a - b) % n;
+  }
 
 val lemma_mod_sub_0: a:pos -> Lemma ((-1) % a = a - 1)
 let lemma_mod_sub_0 a = ()
 
-val lemma_mod_sub_1: a:pos -> b:pos{a < b} -> Lemma ((-a) % b = b - a % b)
+val lemma_mod_sub_1: a:pos -> b:pos{a < b} -> Lemma ((-a) % b = b - (a%b))
 let lemma_mod_sub_1 a b =
   small_mod a b;
-  assert ((a % b) == a);
-  assert ((-a) % b == b - a)
-
-//NS: not sure why this requires 4 unfoldings
-//    it fails initially, and then succeeds on a retry with less fuel; strange
-//#reset-options "--z3rlimit 20 --initial_ifuel 0 --initial_fuel 0 --z3seed 1"
-
-let lemma_mod_mul_distr_l_0 (a:int) (b:int) (p:pos) : Lemma
-  ((((a % p) + (a / p) * p) * b) % p = ((a % p) * b + ((a / p) * b) * p) % p)
-  = ()
+  assert ((a%b) == a);
+  assert ((-a)%b == b - a)
 
 val lemma_mod_mul_distr_l (a:int) (b:int) (n:pos) : Lemma
   (requires True)
   (ensures (a * b) % n = ((a % n) * b) % n)
-  (decreases (if b >= 0 then b else -b))
-let rec lemma_mod_mul_distr_l (a:int) (b:int) (n:pos) =
-  if b = 0 then
-  (
-    assert (a * 0 == 0 /\ ((a % n) * 0) == 0);
-    small_mod 0 n
-  )
-  else if b > 0 then
-  (
-    lemma_mod_mul_distr_l a (b - 1) n;
-    distributivity_sub_right a b 1;
-    distributivity_sub_right (a % n) b 1;
-    // (a * b - a) % n == ((a % n) * b - (a % n)) % n
-    lemma_mod_sub_distr ((a % n) * b) a n;
-    // (a * b - a) % n = ((a % n) * b - a) % n
-    mod_add_both (a * b - a) ((a % n) * b - a) a n
-  )
-  else
-  (
-    lemma_mod_mul_distr_l a (b + 1) n;
-    distributivity_add_right a b 1;
-    distributivity_add_right (a % n) b 1;
-    // (a * b + a) % n == ((a % n) * b + (a % n)) % n
-    lemma_mod_add_distr ((a % n) * b) a n;
-    // (a * b + a) % n = ((a % n) * b + a) % n
-    mod_add_both (a * b + a) ((a % n) * b + a) (-a) n
-  )
 
-#push-options "--z3rlimit 10"
+let lemma_mod_mul_distr_l a b n =
+  calc (==) {
+    (a * b)  % n;
+    == { lemma_div_mod a n }
+    ((n * (a/n) + a%n) * b)  % n;
+    == { distributivity_add_left (n * (a/n)) (a%n) b }
+    (n * (a/n) * b + (a%n) * b)  % n;
+    == { paren_mul_right n (a/n) b; swap_mul ((a/n) * b) n }
+    ((a%n) * b + ((a/n) * b) * n)  % n;
+    == { lemma_mod_plus ((a%n) * b) ((a/n) * b) n }
+    ((a%n) * b)  % n;
+  }
 
 val lemma_mod_mul_distr_r (a:int) (b:int) (n:pos) : Lemma ((a * b) % n = (a * (b % n)) % n)
 let lemma_mod_mul_distr_r (a:int) (b:int) (n:pos) =
-  assert (a * (b % n) == (b % n) * a);
-  lemma_mod_mul_distr_l b a n
-
-#pop-options
+  calc (==) {
+    (a * b) % n;
+    == { swap_mul a b }
+    (b * a) % n;
+    == { lemma_mod_mul_distr_l b a n }
+    (b%n * a) % n;
+    == { swap_mul a (b%n) }
+    (a * (b%n)) % n;
+  }
 
 val lemma_mod_injective: p:pos -> a:nat -> b:nat -> Lemma
   (requires (a < p /\ b < p /\ a % p = b % p))
@@ -447,7 +439,8 @@ let lemma_mod_injective p a b = ()
 
 val lemma_mul_sub_distr: a:int -> b:int -> c:int -> Lemma
   (a * b - a * c = a * (b - c))
-let lemma_mul_sub_distr a b c = ()
+let lemma_mul_sub_distr a b c =
+  distributivity_sub_right a b c
 
 val lemma_div_exact: a:int -> p:pos -> Lemma
   (requires (a % p = 0))
@@ -461,14 +454,15 @@ let div_exact_r (a:int) (n:pos) = lemma_div_exact a n
 
 val lemma_mod_spec: a:int -> p:pos -> Lemma
   (a / p = (a - (a % p)) / p)
+
 let lemma_mod_spec a p =
-  lemma_div_mod a p;
-  assert (a = p * (a / p) + a % p);
-  assert (a % p = a - p * (a / p));
-  assert (a - (a % p) = p * (a / p));
-  lemma_mod_plus 0 (a / p) p;
-  assert ((p * (a / p)) % p = 0);
-  lemma_div_exact (p * (a / p)) p
+  calc (==) {
+    (a - a%p)/p;
+    == { lemma_div_mod a p }
+    (p*(a/p))/p;
+    == { cancel_mul_div (a/p) p }
+    a/p;
+  }
 
 val lemma_mod_spec2: a:int -> p:pos -> Lemma
   (let q:int = (a - (a % p)) / p in a = (a % p) + q * p)
@@ -486,25 +480,6 @@ val lemma_mod_plus_distr_r: a:int -> b:int -> p:pos -> Lemma
   ((a + b) % p = (a + (b % p)) % p)
 let lemma_mod_plus_distr_r a b p =
   lemma_mod_plus_distr_l b a p
-
-val lemma_mod_plus_mul_distr: a:int -> b:int -> c:int -> p:pos -> Lemma
-  (((a + b) * c) % p = (((a % p + b % p) % p) * (c % p)) % p)
-let lemma_mod_plus_mul_distr a b c p =
-  calc (==) {
-    ((a + b) * c) % p;
-    == { lemma_mod_mul_distr_l (a + b) c p }
-    (((a + b) % p) * c) % p;
-    == { swap_mul ((a + b) % p) c }
-    (c * ((a + b) % p)) % p;
-    == { lemma_mod_mul_distr_l c ((a + b) % p) p }
-    (c % p * ((a + b) % p)) % p;
-    == { lemma_mod_plus_distr_l a b p }
-    (c % p * ((a % p + b) % p)) % p;
-    == { lemma_mod_plus_distr_r (a % p) b p }
-    (c % p * ((a % p + b % p) % p)) % p;
-    == { swap_mul (c % p) ((a % p + b % p) % p) }
-    (((a % p + b % p) % p) * (c % p)) % p;
-  }
 
 val lemma_mod_mod: a:int -> b:int -> p:pos -> Lemma
   (requires (a = b % p))
@@ -608,23 +583,53 @@ let lemma_div_le a b d =
   if a / d > b / d then lemma_div_le_ a b d
 
 (* Lemma: Division distributivity under special condition *)
-#push-options "--z3cliopt smt.arith.nl=true --smtencoding.elim_box true --smtencoding.l_arith_repr native --smtencoding.nl_arith_repr native --z3rlimit 30"
-
 val division_sub_lemma (a:int) (n:pos) (b:nat) : Lemma ((a - b * n) / n = a / n - b)
-let division_sub_lemma (a:int) (n:pos) (b:nat) = lemma_div_plus a (-b) n
-
-#pop-options
-
-#push-options "--smtencoding.elim_box true --smtencoding.l_arith_repr native --smtencoding.nl_arith_repr wrapped"
+let division_sub_lemma (a:int) (n:pos) (b:nat) =
+  neg_mul_left b n;
+  lemma_div_plus a (-b) n
 
 (* Lemma: Modulo distributivity *)
-val modulo_distributivity: a:int -> b:int -> c:pos ->
-    Lemma ( (a + b) % c = (a % c + b % c) % c )
+val modulo_distributivity: a:int -> b:int -> c:pos -> Lemma ((a + b) % c == (a % c + b % c) % c)
 let modulo_distributivity a b c =
-  euclidean_division_definition a c;
-  euclidean_division_definition b c;
-  euclidean_division_definition (a % c + b % c) c;
-  division_addition_lemma (a - (a / c) * c + b - (b / c) * c) c (a / c + b / c)
+  calc (==) {
+    (a % c + b % c) % c;
+    == { lemma_div_mod (a % c + b % c) c }
+    a % c + b % c - c * ((a % c + b % c) / c);
+    == { lemma_div_mod a c; lemma_div_mod b c }
+    a % c + b % c - c * ((a - c*(a/c) + b - c*(b/c)) / c);
+    == { distributivity_add_right c (a/c) (b/c) }
+    a % c + b % c - c * ((a + b - c*(a/c + b/c)) / c);
+    == { neg_mul_right c (a/c + b/c) }
+    a % c + b % c - c * (((a + b) + c*(- (a/c) - (b/c))) / c);
+    == { division_addition_lemma (a+b) c (-a/c - b/c) }
+    a % c + b % c - c * ((a + b)/c - a/c - b/c);
+    == { distributivity_sub_right c ((a+b)/c - a/c) (b/c);
+         distributivity_sub_right c ((a+b)/c) (a/c) }
+    a % c + b % c - (c * ((a + b)/c) - c*(a/c) - c*(b/c));
+    == { (* reordering *) }
+      a % c + c * (a/c)
+    + b % c + c * (b/c)
+    - c * ((a+b) / c);
+    == { lemma_div_mod a c; lemma_div_mod b c }
+      a
+    + b
+    - c * ((a+b) / c);
+    == { lemma_div_mod (a+b) c }
+    (a + b) % c;
+  }
+
+val lemma_mod_plus_mul_distr: a:int -> b:int -> c:int -> p:pos -> Lemma
+  (((a + b) * c) % p = ((((a % p) + (b % p)) % p) * (c % p)) % p)
+let lemma_mod_plus_mul_distr a b c p =
+  calc (==) {
+    ((a + b) * c) % p;
+    == { lemma_mod_mul_distr_l (a + b) c p }
+    (((a + b) % p) * c) % p;
+    == { lemma_mod_mul_distr_r ((a + b) % p) c p }
+    (((a + b) % p) * (c % p)) % p;
+    == { modulo_distributivity a b p }
+    ((((a % p) + (b % p)) % p) * (c % p)) % p;
+  }
 
 (* Lemma: Modulo distributivity under special condition *)
 val modulo_addition_lemma (a:int) (n:pos) (b:int) : Lemma ((a + b * n) % n = a % n)
@@ -632,36 +637,45 @@ let modulo_addition_lemma (a:int) (n:pos) (b:int) = lemma_mod_plus a b n
 
 (* Lemma: Modulo distributivity under special condition *)
 val lemma_mod_sub (a:int) (n:pos) (b:int) : Lemma (ensures (a - b * n) % n = a % n)
-let lemma_mod_sub (a:int) (n:pos) (b:int) = lemma_mod_plus a (-b) n
+let lemma_mod_sub (a:int) (n:pos) (b:int) =
+  neg_mul_left b n;
+  lemma_mod_plus a (-b) n
 
 val mod_mult_exact (a:int) (n:pos) (q:pos) : Lemma
-  (requires (pos_times_pos_is_pos n q; a % (n * q) == 0))
+  (requires (a % (n * q) == 0))
   (ensures a % n == 0)
+
 let mod_mult_exact (a:int) (n:pos) (q:pos) =
-  pos_times_pos_is_pos n q;
-  lemma_div_mod a (n * q);
-  let k = a / (n * q) in
-  paren_mul_right k q n;
-  // a == (k * q) * n
-  cancel_mul_mod (k * q) n
+  calc (==) {
+    a % n;
+    == { lemma_div_mod a (n * q) }
+    ((n * q) * (a / (n * q)) + a % (n * q))  % n;
+    == { (* hyp *) }
+    ((n * q) * (a / (n * q)))  % n;
+    == { paren_mul_right n q (a / (n * q));
+         swap_mul n (q * (a / (n * q))) }
+    ((q * (a / (n * q))) * n) % n;
+    == { multiple_modulo_lemma (q * (a / (n*q))) n }
+    0;
+  }
 
 val mod_mul_div_exact (a:int) (b:pos) (n:pos) : Lemma
-  (requires (pos_times_pos_is_pos b n; a % (b * n) == 0))
+  (requires (a % (b * n) == 0))
   (ensures (a / b) % n == 0)
 let mod_mul_div_exact (a:int) (b:pos) (n:pos) =
-  pos_times_pos_is_pos b n;
-  lemma_div_mod a (b * n);
-  let k = a / (b * n) in
-  paren_mul_right k n b;
-  // a == (k * n) * b
-  cancel_mul_div (k * n) b;
-  // a / b = k * n
-  cancel_mul_mod k n
-
-#pop-options
+  calc (==) {
+    (a / b) % n;
+    == { lemma_div_mod a (b * n) (* + hyp *) }
+    (((b*n)*(a / (b*n))) / b) % n;
+    == { paren_mul_right b n (a / (b*n)) }
+    ((b*(n*(a / (b*n)))) / b) % n;
+    == { cancel_mul_div (n * (a / (b * n))) b }
+    (n*(a / (b*n))) % n;
+    == { cancel_mul_mod (a / (b*n)) n }
+    0;
+  }
 
 #push-options "--fuel 1"
-
 val mod_pow2_div2 (a:int) (m:pos) : Lemma
   (requires a % pow2 m == 0)
   (ensures (a / 2) % pow2 (m - 1) == 0)
@@ -670,80 +684,143 @@ let mod_pow2_div2 (a:int) (m:pos) : Lemma
   (ensures (a / 2) % pow2 (m - 1) == 0)
   =
   mod_mul_div_exact a 2 (pow2 (m - 1))
+#pop-options
 
-// JP: there seems to be a discrepancy in z3 behavior across platforms. This
-// goes fine on Windows / CI with rlimit=40, but on Linux systems rlimit=400 is
-// needed. Leaving the high rlimit because it doesn't seem to deteriorate the
-// total verification time too much (I see ~40 seconds on my machine).
-// GM: Noticed the same, set it to 200
-#push-options "--smtencoding.elim_box true --smtencoding.l_arith_repr native --smtencoding.nl_arith_repr boxwrap --z3rlimit 200"
+private val lemma_div_lt_cancel (a : int) (b : pos) (n : int) :
+  Lemma (requires (a < b * n))
+        (ensures (a / b < n))
+
+private let lemma_div_lt_cancel a b n =
+  (* by contradiction *)
+  if a / b >= n then begin
+    calc (>=) {
+      a;
+      >= { slash_decr_axiom a b }
+      (a / b) * b;
+      >= {}
+      n * b;
+    };
+    assert False
+  end
+
+private val lemma_mod_mult_zero (a : int) (b : pos) (c : pos) : Lemma ((a % (b * c)) / b / c == 0)
+private let lemma_mod_mult_zero a b c =
+  (* < 1 *)
+  lemma_mod_lt a (b * c);
+  lemma_div_lt_cancel (a % (b * c)) b c;
+  lemma_div_lt_cancel ((a % (b * c)) / b) c 1;
+
+  (* >= 0 *)
+  nat_over_pos_is_nat (a % (b * c)) b;
+  nat_over_pos_is_nat ((a % (b * c)) / b) c;
+  ()
 
 (* Lemma: Divided by a product is equivalent to being divided one by one *)
 val division_multiplication_lemma (a:int) (b:pos) (c:pos) : Lemma
-  (pos_times_pos_is_pos b c; a / (b * c) = (a / b) / c)
+  (a / (b * c) = (a / b) / c)
 let division_multiplication_lemma (a:int) (b:pos) (c:pos) =
-  pos_times_pos_is_pos b c;
-  lemma_div_mod a b;
-  lemma_div_mod (a / b) c;
-  lemma_div_mod a (b * c);
-  let k1 = a / b - ((a / b) / c) * c in // k1 = (a / b) % c
-  let k2 = a - (a / (b * c)) * (b * c) in // k2 = a % (b * c)
-  distributivity_sub_left (a / b) (((a / b) / c) * c) b;
-  paren_mul_right ((a / b) / c) c b;
-  swap_mul b c;
-  // k1 * b == (a / b) * b - ((a / b) / c) * (b * c)
-  // k1 * b - k2 == (a / (b * c) - (a / b) / c) * (b * c) - a % b
-  lemma_mult_le_right b 0 k1;
-  lemma_mult_le_right b k1 (c - 1);
-  distributivity_sub_left c 1 b;
-  // 0 <= k1 <= (c - 1)
-  // 0 <= k1 * b <= (c - 1) * b
-  // 0 <= k2 < b * c
-  // 1 - b * c <= k1 * b - k2 <= b * c - b
-  distributivity_sub_left (a / (b * c)) ((a / b) / c) (b * c);
-  bounded_multiple_is_zero (a / (b * c) - (a / b) / c) (b * c)
+  calc (==) {
+    a / b / c;
+    == { lemma_div_mod a (b * c) }
+    ((b * c) * (a / (b * c)) + a % (b * c)) / b / c;
+    == { paren_mul_right b c (a / (b * c)) }
+    (b * (c * (a / (b * c))) + a % (b * c)) / b / c;
+    == { lemma_div_plus (a % (b * c)) (c * (a / (b * c))) b }
+    (c * (a / (b * c)) + ((a % (b * c)) / b)) / c;
+    == { lemma_div_plus ((a % (b * c)) / b) (a / (b * c)) c }
+    (a / (b * c)) + (a % (b * c)) / b / c;
+    == { lemma_mod_mult_zero a b c }
+    a / (b * c);
+  }
 
+private val cancel_fraction (a:int) (b:pos) (c:pos) : Lemma ((a * c) / (b * c) == a / b)
+private let cancel_fraction a b c =
+  calc (==) {
+    (a * c) / (b * c);
+    == { swap_mul b c }
+    (a * c) / (c * b);
+    == { division_multiplication_lemma (a * c) c b }
+    ((a * c) / c) / b;
+    == { cancel_mul_div a c }
+    a / b;
+  }
+
+val modulo_scale_lemma : a:int -> b:pos -> c:pos -> Lemma ((a * b) % (b * c) == (a % c) * b)
+let modulo_scale_lemma a b c =
+  calc (==) {
+    (a * b) % (b * c);
+    == { lemma_div_mod (a * b) (b * c) }
+    a * b - (b * c) * ((a * b) / (b * c));
+    == { cancel_fraction a c b }
+    a * b - (b * c) * (a / c);
+    == { paren_mul_right b c (a / c) }
+    a * b - b * (c * (a / c));
+    == { swap_mul b (c * (a / c)); distributivity_sub_left a (c * (a / c)) b }
+    (a - c * (a / c)) * b;
+    == { lemma_div_mod a c }
+    (a % c) * b;
+  }
 
 let lemma_mul_pos_pos_is_pos (x:pos) (y:pos) : Lemma (x*y > 0) = ()
 let lemma_mul_nat_pos_is_nat (x:nat) (y:pos) : Lemma (x*y >= 0) = ()
 
-#push-options "--z3rlimit 400"
-
 let modulo_division_lemma_0 (a:nat) (b:pos) (c:pos) : Lemma
   (a / (b*c) <= a /\ (a - (a / (b * c)) * (b * c)) / b = a / b - ((a / (b * c)) * c))
   = slash_decr_axiom a (b*c);
-    cut ( (a / (b*c)) * (b * c) = ((a / (b * c)) * c) * b);
+    calc (==) {
+      (a / (b*c)) * (b * c);
+      == { swap_mul b c }
+      (a / (b*c)) * (c * b);
+      == { paren_mul_right (a / (b*c)) c b }
+      ((a / (b*c)) * c) * b;
+    };
+    cut ((a / (b*c)) * (b * c) = ((a / (b * c)) * c) * b);
     lemma_div_mod a (b*c);
-    division_sub_lemma a b ((a / (b*c)) * c)
-
-#pop-options
+    division_sub_lemma a b ((a / (b*c)) * c);
+    ()
 
 val modulo_division_lemma: a:nat -> b:pos -> c:pos ->
-  Lemma ( (a % (b * c)) / b = (a / b) % c )
+    Lemma ((a % (b * c)) / b = (a / b) % c)
+
 let modulo_division_lemma a b c =
-  division_addition_lemma (a - (a / (b * c)) * (b * c)) b ((a / (b * c)) * c);
-  let x = (a - (a / (b * c)) * (b * c)) in
-  let y = ((a / (b * c)) * c) in
-  cut ((x + y * b) % b = x % b);
-  lemma_mul_pos_pos_is_pos b c;
-  let bc:pos = b * c in
-  let a_bc = a/bc in
-  distributivity_sub_left a a_bc bc;
-  paren_mul_right (a / (b * c)) c b;
-  paren_mul_left (a / (b * c)) c b;
-  modulo_division_lemma_0 a b c;
-  euclidean_division_definition a (b * c);
-  division_multiplication_lemma a b c;
-  euclidean_division_definition (a / b) c
+  calc (==) {
+    (a % (b * c)) / b;
+    == { lemma_div_mod a (b * c) }
+    (a - (b * c) * (a / (b * c))) / b;
+    == { paren_mul_right b c ((a / (b * c))); neg_mul_right b (c * (a / (b * c))) }
+    (a + b * (-(c * (a / (b * c))))) / b;
+    == { lemma_div_plus a (-(c * (a / (b * c)))) b }
+    (a / b) - c * (a / (b * c));
+    == { division_multiplication_lemma a b c }
+    (a / b) - c * ((a / b) / c);
+    == { lemma_div_mod (a/b) c }
+    (a / b) % c;
+  }
 
 val modulo_modulo_lemma (a:int) (b:pos) (c:pos) : Lemma
-  (pos_times_pos_is_pos b c; (a % (b * c)) % b = a % b)
+  ((a % (b * c)) % b = a % b)
+
 let modulo_modulo_lemma (a:int) (b:pos) (c:pos) =
   pos_times_pos_is_pos b c;
-  lemma_div_mod a (b * c);
-  paren_mul_right (a / (b * c)) c b;
-  swap_mul b c;
-  lemma_mod_plus (a % (b * c)) ((a / (b * c)) * c) b
+  calc (==) {
+    (a % (b * c)) % b;
+    == { calc (==) {
+             a % (b * c);
+             == { lemma_div_mod a (b * c) }
+             a - (b * c) * (a / (b * c));
+             == { paren_mul_right b c (a / (b * c)) }
+             a - b * (c * (a / (b * c)));
+         }}
+    (a - b * (c * (a / (b * c)))) % b;
+    == { () }
+    (a + (- (b * (c * (a / (b * c)))))) % b;
+    == { neg_mul_right b (c * (a / (b * c))) }
+    (a + (b * (-c * (a / (b * c))))) % b;
+    == { () }
+    (a + (-c * (a / (b * c))) * b) % b;
+    == { lemma_mod_plus a (-c * (a / (b * c))) b}
+    a % b;
+  }
 
 val pow2_multiplication_division_lemma_1: a:int -> b:nat -> c:nat{c >= b} ->
   Lemma ( (a * pow2 c) / pow2 b = a * pow2 (c - b))
@@ -771,23 +848,16 @@ let pow2_multiplication_modulo_lemma_1 a b c =
 val pow2_multiplication_modulo_lemma_2: a:int -> b:nat -> c:nat{c <= b} ->
   Lemma ( (a * pow2 c) % pow2 b = (a % pow2 (b - c)) * pow2 c )
 
-// GM, 2019-06-25: Not sure why validity makes a difference here, it's probably
-// just noise.
-#push-options "--z3rlimit 500 --smtencoding.valid_intro true --smtencoding.valid_elim true"
-
 let pow2_multiplication_modulo_lemma_2 a b c =
-  euclidean_division_definition a (pow2 (b - c));
-  let q = pow2 (b - c) in
-  let r = a % pow2 (b - c) in
-  assert(a = q * (a / q) + a % q);
-  pow2_plus (b - c) c;
-  paren_mul_right (a / pow2 (b - c)) (pow2 (b - c)) (pow2 c);
-  paren_mul_left (a / pow2 (b - c)) (pow2 (b - c)) (pow2 c);
-  modulo_addition_lemma ((a % pow2 (b - c)) * pow2 c) (pow2 b) (a / pow2 (b - c));
-  multiplication_order_lemma (pow2 (b - c)) (a % pow2 (b - c)) (pow2 c);
-  small_modulo_lemma_1 ((a % pow2 (b - c)) * pow2 c) (pow2 b)
-
-#pop-options
+  calc (==) {
+    (a * pow2 c) % pow2 b;
+    == {}
+    (a * pow2 c) % pow2 (c + (b-c));
+    == { pow2_plus c (b-c) }
+    (a * pow2 c) % (pow2 c * pow2 (b-c));
+    == { modulo_scale_lemma a (pow2 c) (pow2 (b-c)) }
+    (a % pow2 (b - c)) * pow2 c;
+  }
 
 val pow2_modulo_division_lemma_1: a:nat -> b:nat -> c:nat{c >= b} ->
   Lemma ( (a % pow2 c) / pow2 b = (a / pow2 b) % (pow2 (c - b)) )

--- a/ulib/FStar.Math.Lemmas.fst
+++ b/ulib/FStar.Math.Lemmas.fst
@@ -338,40 +338,6 @@ let cancel_mul_mod (a:int) (n:pos) =
   small_mod 0 n;
   lemma_mod_plus 0 a n
 
-val mod_add_both (a:int) (b:int) (x:int) (n:pos) : Lemma
-  (requires a % n == b % n)
-  (ensures (a + x) % n == (b + x) % n)
-
-let mod_add_both (a:int) (b:int) (x:int) (n:pos) =
-  calc (==) {
-    (a + x) % n - (b + x) % n;
-    == {lemma_div_mod (a + x) n; lemma_div_mod (b + x) n }
-    ((a+x) - n*((a+x)/n)) - ((b+x) - n*((b+x)/n));
-    == {}
-    a - n*((a+x)/n) - b + n*((b+x)/n);
-    == { distributivity_sub_right n ((b+x)/n) ((a+x)/n) }
-    a - b + n * ((b+x)/n - (a+x)/n);
-    == { lemma_div_mod a n; lemma_div_mod b n }
-    n*(a/n) + a%n - n*(b/n) - b%n + n * ((b+x)/n - (a+x)/n);
-    == { (* a%n == b%n *) }
-    n*(a/n) - n*(b/n) + n * ((b+x)/n - (a+x)/n);
-    == { distributivity_sub_right n ((b+x)/n) ((a+x)/n) }
-    n*(a/n) - n*(b/n) + n * ((b+x)/n) - n * ((a+x)/n);
-    == { lemma_div_mod a n;
-         lemma_div_plus (a%n + x) (a/n) n;
-         swap_mul n (a/n) }
-    n*(a/n) - n*(b/n) + n * ((b+x)/n) - n * ((a%n + x)/n + a/n);
-    == { lemma_div_mod b n;
-         lemma_div_plus (b%n + x) (b/n) n;
-         swap_mul n (b/n) }
-    n*(a/n) - n*(b/n) + n * ((b%n + x)/n + b/n) - n * ((a%n + x)/n + a/n);
-    == { distributivity_add_right n (((a%n) + x)/n) (a/n);
-         distributivity_add_right n (((b%n) + x)/n) (b/n) }
-    n * ((b%n + x)/n) - n * ((a%n + x)/n);
-    == { (* a%n == b%n *) }
-    0;
-  }
-
 val lemma_mod_add_distr (a:int) (b:int) (n:pos) : Lemma ((a + b % n) % n = (a + b) % n)
 let lemma_mod_add_distr (a:int) (b:int) (n:pos) =
   calc (==) {
@@ -886,6 +852,20 @@ val modulo_sub : p:pos -> a:int -> b:int -> c:int -> Lemma
 
 let modulo_sub p a b c =
   modulo_add p (-a) (a + b) (a + c)
+
+val mod_add_both (a:int) (b:int) (x:int) (n:pos) : Lemma
+  (requires a % n == b % n)
+  (ensures (a + x) % n == (b + x) % n)
+let mod_add_both (a:int) (b:int) (x:int) (n:pos) =
+  calc (==) {
+    (a + x) % n;
+    == { modulo_distributivity a x n }
+    ((a % n) + (x % n)) % n;
+    == { (* hyp *) }
+    ((b % n) + (x % n)) % n;
+    == { modulo_distributivity b x n }
+    (b + x) % n;
+  }
 
 val lemma_mod_plus_injective (n:pos) (a:int) (b:nat) (c:nat) : Lemma
   (requires b < n /\ c < n /\ (a + b) % n = (a + c) % n)

--- a/ulib/FStar.Math.Lemmas.fst
+++ b/ulib/FStar.Math.Lemmas.fst
@@ -365,9 +365,17 @@ let lemma_mod_sub_0 a = ()
 
 val lemma_mod_sub_1: a:pos -> b:pos{a < b} -> Lemma ((-a) % b = b - (a%b))
 let lemma_mod_sub_1 a b =
-  small_mod a b;
-  assert ((a%b) == a);
-  assert ((-a)%b == b - a)
+  calc (==) {
+    (-a) % b;
+    == { lemma_mod_plus (-a) 1 b }
+    ((-a) + 1*b) % b;
+    == {}
+    (b - a) % b;
+    == { small_mod (b-a) b }
+    b - a;
+    == { small_mod a b }
+    b - a%b;
+  }
 
 val lemma_mod_mul_distr_l (a:int) (b:int) (n:pos) : Lemma
   (requires True)

--- a/ulib/FStar.Math.Lemmas.fst
+++ b/ulib/FStar.Math.Lemmas.fst
@@ -467,7 +467,13 @@ let lemma_mod_spec a p =
 val lemma_mod_spec2: a:int -> p:pos -> Lemma
   (let q:int = (a - (a % p)) / p in a = (a % p) + q * p)
 let lemma_mod_spec2 a p =
-  lemma_mod_spec a p
+  calc (==) {
+    (a % p) + ((a - (a % p)) / p) * p;
+    == { lemma_mod_spec a p }
+    (a % p) + (a / p) * p;
+    == { lemma_div_mod a p }
+    a;
+  }
 
 val lemma_mod_plus_distr_l: a:int -> b:int -> p:pos -> Lemma
   ((a + b) % p = ((a % p) + b) % p)

--- a/ulib/FStar.Math.Lemmas.fst
+++ b/ulib/FStar.Math.Lemmas.fst
@@ -598,30 +598,11 @@ let division_sub_lemma (a:int) (n:pos) (b:nat) =
 val modulo_distributivity: a:int -> b:int -> c:pos -> Lemma ((a + b) % c == (a % c + b % c) % c)
 let modulo_distributivity a b c =
   calc (==) {
-    (a % c + b % c) % c;
-    == { lemma_div_mod (a % c + b % c) c }
-    a % c + b % c - c * ((a % c + b % c) / c);
-    == { lemma_div_mod a c; lemma_div_mod b c }
-    a % c + b % c - c * ((a - c*(a/c) + b - c*(b/c)) / c);
-    == { distributivity_add_right c (a/c) (b/c) }
-    a % c + b % c - c * ((a + b - c*(a/c + b/c)) / c);
-    == { neg_mul_right c (a/c + b/c) }
-    a % c + b % c - c * (((a + b) + c*(- (a/c) - (b/c))) / c);
-    == { division_addition_lemma (a+b) c (-a/c - b/c) }
-    a % c + b % c - c * ((a + b)/c - a/c - b/c);
-    == { distributivity_sub_right c ((a+b)/c - a/c) (b/c);
-         distributivity_sub_right c ((a+b)/c) (a/c) }
-    a % c + b % c - (c * ((a + b)/c) - c*(a/c) - c*(b/c));
-    == { (* reordering *) }
-      a % c + c * (a/c)
-    + b % c + c * (b/c)
-    - c * ((a+b) / c);
-    == { lemma_div_mod a c; lemma_div_mod b c }
-      a
-    + b
-    - c * ((a+b) / c);
-    == { lemma_div_mod (a+b) c }
     (a + b) % c;
+    == { lemma_mod_plus_distr_l a b c }
+    ((a % c) + b) % c;
+    == { lemma_mod_plus_distr_r (a % c) b c }
+    ((a % c) + (b % c)) % c;
   }
 
 val lemma_mod_plus_mul_distr: a:int -> b:int -> c:int -> p:pos -> Lemma


### PR DESCRIPTION
This introduces a `--retry` option as discussed in #1942 

1- Change the behaviour of `--quake` to abort as early as possible. That is, when successes have met the low bar, or when it's impossible for them to meet it.
2- Add a `--retry N` option that is an alias for `--quake 1/N`
3- Add an optional `/k` suffix to the argument of `--quake` to *not* abort early (mimicking the previous behaviour)
4- Some tweaking of error and debug messages so there's no confusion between `--quake` and `--retry`. Internally they are pretty much the same thing, but the user does not need to care about that (but should know that using one disables the other).

Tagging @nikswamy and @aseemr in case they have comments on the feature and/or output messages (I'm pretty confident in the code itself).

Fixes #1942 