### PR TITLE
Reducing build output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,45 +1,47 @@
 .PHONY: all package clean 0 1 2 3 hints
 
+include src/Makefile.common
+
 all:
-	$(MAKE) -C src/ocaml-output
-	$(MAKE) -C ulib
-	$(MAKE) -C ulib/ml
+	$(Q)+$(MAKE) -C src/ocaml-output
+	$(Q)+$(MAKE) -C ulib
+	$(Q)+$(MAKE) -C ulib/ml
 
 package:
-	git clean -ffdx .
-	$(MAKE) -C src/ocaml-output package
+	$(Q)git clean -ffdx .
+	$(Q)+$(MAKE) -C src/ocaml-output package
 
 clean:
-	$(MAKE) -C ulib clean
-	$(MAKE) -C src/ocaml-output clean
+	$(Q)+$(MAKE) -C ulib clean
+	$(Q)+$(MAKE) -C src/ocaml-output clean
 
 # Shortcuts for developers
 
 # Build the F# version
 0:
-	$(MAKE) -C src/
+	$(Q)+$(MAKE) -C src/
 
 # Build the OCaml snapshot. NOTE: This will not build the standard library,
 # nor tests, and native tactics will not run
 1:
-	$(MAKE) -C src/ocaml-output ../../bin/fstar.exe
+	$(Q)+$(MAKE) -C src/ocaml-output ../../bin/fstar.exe
 
 # Bootstrap just the compiler, not the library and tests;
 # fastest way to incrementally build a patch to the compiler
 boot:
-	$(MAKE) -C src/ ocaml
-	$(MAKE) -C src/ocaml-output ../../bin/fstar.exe
+	$(Q)+$(MAKE) -C src/ ocaml
+	$(Q)+$(MAKE) -C src/ocaml-output ../../bin/fstar.exe
 
 # Generate a new OCaml snapshot
 2:
-	$(MAKE) -C src fstar-ocaml
+	$(Q)+$(MAKE) -C src fstar-ocaml
 
 # Build the snapshot and then regen, i.e. 1 + 2
 3:
-	$(MAKE) -C src ocaml-fstar-ocaml
+	$(Q)+$(MAKE) -C src ocaml-fstar-ocaml
 
 # Regenerate all hints for the standard library and regression test suite
 hints:
-	OTHERFLAGS=--record_hints $(MAKE) -C ulib/
-	OTHERFLAGS=--record_hints $(MAKE) -C ulib/ml
-	OTHERFLAGS=--record_hints $(MAKE) -C src/ uregressions
+	$(Q)OTHERFLAGS=--record_hints +$(MAKE) -C ulib/
+	$(Q)OTHERFLAGS=--record_hints +$(MAKE) -C ulib/ml
+	$(Q)OTHERFLAGS=--record_hints +$(MAKE) -C src/ uregressions

--- a/examples/Makefile.common
+++ b/examples/Makefile.common
@@ -1,6 +1,7 @@
 FSTAR_HOME?=..
 include $(FSTAR_HOME)/ulib/gmake/z3.mk
 include $(FSTAR_HOME)/ulib/gmake/fstar.mk
+include $(FSTAR_HOME)/src/Makefile.common
 FSTAR=$(FSTAR_HOME)/bin/fstar.exe
 
 #################################################################################
@@ -37,7 +38,7 @@ MAYBE_ADMIT = $(if $(ADMIT),--admit_smt_queries true)
 # YOU SHOULDN'T NEED TO TOUCH THE REST
 ################################################################################
 
-MY_FSTAR=$(FSTAR) --cache_checked_modules                   \
+MY_FSTAR=$(Q)$(FSTAR) $(SIL) --cache_checked_modules        \
 		  --odir $(OUTPUT_DIRECTORY)                \
 		  --cache_dir $(CACHE_DIR)                  \
 		  $(addprefix --include , $(INCLUDE_PATHS)) \
@@ -55,7 +56,7 @@ MY_FSTAR=$(FSTAR) --cache_checked_modules                   \
 # the dependency analysis failed.
 #--------------------------------------------------------------------------------
 .depend: $(FSTAR_FILES)
-	$(MY_FSTAR) --dep full $(FSTAR_FILES) > ._depend
+	$(Q)$(MY_FSTAR) --dep full $(FSTAR_FILES) > ._depend
 	mv ._depend .depend
 
 depend: .depend
@@ -65,13 +66,15 @@ include .depend
 
 # a.fst.checked is the binary, checked version of a.fst
 %.fst.checked:
-	$(MY_FSTAR) $<
-	touch -c $@
+	@echo "[CHECK     $(basename $(notdir $@))]"
+	$(Q)$(MY_FSTAR) $<
+	@touch -c $@
 
 # a.fsti.checked is the binary, checked version of a.fsti
 %.fsti.checked:
-	$(MY_FSTAR) $<
-	touch -c $@
+	@echo "[CHECK     $(basename $(notdir $@))]"
+	$(Q)$(MY_FSTAR) $<
+	@touch -c $@
 
 clean:
 	rm -rf $(CACHE_DIR)

--- a/examples/Makefile.include
+++ b/examples/Makefile.include
@@ -17,7 +17,7 @@ endif
 # we ignore the return result in benchmark runs because we can have micro-benchmarks which
 # produce error asserts when executed with '--admit_smt_queries true'
 %.uver: %.fst
-	$(BENCHMARK_PRE) $(FSTAR) --use_extracted_interfaces true $^
+	$(Q)$(BENCHMARK_PRE) $(FSTAR) --use_extracted_interfaces true $^
 
 %.fail-uver: %.fst
 	(! $(FSTAR) $^ >/dev/null 2>&1) || (echo "NEGATIVE TEST FAILED ($@)!" ; false)

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,7 @@ MAKEFLAGS += --no-builtin-rules
 # --------------------------------------------------------------------
 # An artefact of the build process is that parse.fsi is auto-generated
 fstar-in-fsharp: nuget-restore
-	$(MAKE) -C VS install-packages
+	+$(MAKE) -C VS install-packages
 	$(MSBUILD) VS/FStar.sln
 	$(DOS2UNIX) parser/parse.fsi
 	chmod a+x $(BIN)/tests.exe
@@ -46,51 +46,47 @@ $(FSYACC) $(FSLEX): nuget-restore
 ALL_BOOT=$(addprefix boot/FStar., Util.fsti List.fsti			\
 			          Compiler.Bytes.fsti String.fsti	\
 			          BigInt.fsti Pprint.fsti		\
-			          Parser.Parse.fsti			\
 			          Tactics.Interpreter.fst		\
+			          Parser.Parse.fsti			\
 			          Tactics.Interpreter.fsti \
 			          Tests.Test.fst \
 			          StringBuffer.fsti)
 
-boot/%.fsti: basic/boot/%.fsi | boot_dir
-	cp $^ $@
-	$(SED) -i.bak 's/<.* when .* : equality>//g' $@
-	$(SED) -i.bak '/\/\/ *JUST *FSHARP */d' $@
-	touch -r $^ $@
-
-boot/%.fsti: prettyprint/boot/%.fsi | boot_dir
-	cp $^ $@
-	$(SED) -i.bak '/\/\/ *JUST *FSHARP */d' $@
-	touch -r $^ $@
-
-#fix up a use of polymorphic recursion in F#, which has a different syntax than F*
-boot/FStar.Tactics.Interpreter.fst: tactics/boot/FStar.Tactics.Interpreter.fs | boot_dir
-	cp $^ $@
-	$(SED) -i.bak '/\/\/ *JUST *FSHARP */d' $@
-	$(SED) -i.bak 's,^ *// *IN *F\* *:,,g' $@
-	touch -r $^ $@
-
-boot/FStar.Tests.Test.fst: tests/boot/FStar.Tests.Test.fs | boot_dir
-	cp $^ $@
-	$(SED) -i.bak '/\/\/ *JUST *FSHARP */d' $@
-	touch -r $^ $@
-
-boot/FStar.Parser.Parse.fsti: parser/parse.fsi | boot_dir
-	echo "#light \"off\"" > $@
-	$(HEAD) -n12 $^ >> $@
-	touch -r parser/parse.mly $@
+define from_boot_file
+	@echo "[BOOT      $(basename $(notdir $@))]"
+	$(Q)cp $^ $@
+	$(Q)$(SED) -i.bak '/\/\/ *JUST *FSHARP */d' $@
+	$(Q)$(SED) -i.bak 's,^ *// *IN *F\* *:,,g' $@
+	$(Q)touch -r $^ $@
+endef
 
 boot/%.fst: basic/boot/%.fs | boot_dir
-	cp $^ $@
-	touch -r $^ $@
+	$(call from_boot_file)
+
+boot/%.fsti: basic/boot/%.fsi | boot_dir
+	$(call from_boot_file)
+
+boot/%.fsti: prettyprint/boot/%.fsi | boot_dir
+	$(call from_boot_file)
+
+boot/FStar.Tactics.Interpreter.fst: tactics/boot/FStar.Tactics.Interpreter.fs | boot_dir
+	$(call from_boot_file)
+
+boot/FStar.Tests.Test.fst: tests/boot/FStar.Tests.Test.fs | boot_dir
+	$(call from_boot_file)
+
+# GM: What's going on here?
+boot/FStar.Parser.Parse.fsti: parser/parse.fsi | boot_dir
+	@echo "[BOOT      $(basename $(notdir $@))]"
+	$(Q)echo "#light \"off\"" > $@
+	$(Q)$(HEAD) -n12 $^ >> $@
+	$(Q)touch -r parser/parse.mly $@
 
 boot/FStar.Parser.Parse.fst: parser/parse.fs | boot_dir
-	cp $^ $@
-	touch -r $^ $@
+	$(call from_boot_file)
 
 boot/FStar.Tactics.Interpreter.fsti: tactics/boot/FStar.Tactics.Interpreter.fsi | boot_dir
-	cp $^ $@
-	touch -r $^ $@
+	$(call from_boot_file)
 
 boot_dir:
 	mkdir -p boot
@@ -107,7 +103,7 @@ clean_boot:
 # And ocaml-output/Makefile, to actually build the compiler in OCaml
 # --------------------------------------------------------------------------------
 ocaml: boot
-	+$(MAKE) -f Makefile.boot all-ml
+	$(Q)+$(MAKE) -f Makefile.boot all-ml
 
 boot-ocaml:
 	+$(MAKE) -C ocaml-output all
@@ -128,10 +124,10 @@ clean_extracted:
 	rm -f ocaml-output/FStar_*.ml
 
 rebuild:
-	$(MAKE) ocaml
-	$(MAKE) -C ../ulib clean_ocaml
-	$(MAKE) -C ocaml-output
-	$(MAKE) -C ../ulib install-fstarlib install-fstar-tactics
+	+$(MAKE) ocaml
+	+$(MAKE) -C ../ulib clean_ocaml
+	+$(MAKE) -C ocaml-output
+	+$(MAKE) -C ../ulib install-fstarlib install-fstar-tactics
 # --------------------------------------------------------------------
 # Testing
 # --------------------------------------------------------------------
@@ -194,10 +190,10 @@ uexamples: fstarlib
 
 # Interactive mode regressions
 interactive-test:
-	$(MAKE) -C tests/interactive
+	+$(MAKE) -C tests/interactive
 
 prettyprinting-tests:
-	$(MAKE) -C tests/prettyprinting
+	+$(MAKE) -C tests/prettyprinting
 
 ulong:
 	+$(MAKE) utest-prelude

--- a/src/Makefile.boot
+++ b/src/Makefile.boot
@@ -46,13 +46,15 @@ EXTRACT = $(addprefix --extract_module , $(EXTRACT_MODULES))		\
 # ensures that if this rule is successful then %.checked.lax is more
 # recent than its dependences.
 %.checked.lax:
-	$(FSTAR_C) $< --already_cached "* -$(basename $(notdir $<))"
-	touch $@
+	@echo "[LAXCHECK  $(basename $(basename $(notdir $@)))]"
+	$(Q)$(FSTAR_C) $(SIL) $< --already_cached "* -$(basename $(notdir $<))"
+	$(Q)@touch $@
 
 # And then, in a separate invocation, from each .checked.lax we
 # extract an .ml file
 ocaml-output/%.ml:
-	$(BENCHMARK_PRE) $(FSTAR_C) $(notdir $(subst .checked.lax,,$<)) \
+	@echo "[EXTRACT   $(basename $(notdir $@))]"
+	$(Q)$(BENCHMARK_PRE) $(FSTAR_C) $(SIL) $(notdir $(subst .checked.lax,,$<)) \
                    --codegen OCaml \
                    --extract_module $(basename $(notdir $(subst .checked.lax,,$<)))
 
@@ -69,12 +71,13 @@ ocaml-output/%.ml:
 # the dependency analysis failed.
 
 .depend:
-	$(FSTAR_C) --dep full                 \
-		   fstar/FStar.Main.fs	      \
-		   boot/FStar.Tests.Test.fst  \
-		   $(EXTRACT)		      > ._depend
-	mv ._depend .depend
-	mkdir -p $(CACHE_DIR)
+	@echo "[DEPEND]"
+	$(Q)$(FSTAR_C) $(SIL) --dep full	\
+		fstar/FStar.Main.fs		\
+		boot/FStar.Tests.Test.fst	\
+		$(EXTRACT)			> ._depend
+	$(Q)mv ._depend .depend
+	$(Q)mkdir -p $(CACHE_DIR)
 
 depend: .depend
 

--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -1,0 +1,6 @@
+Q?=@
+SIL?=--silent
+ifneq ($(V),)
+	Q=
+	SIL=
+endif

--- a/src/Makefile.config
+++ b/src/Makefile.config
@@ -1,4 +1,5 @@
 FSTAR_HOME=..
+include Makefile.common
 include $(FSTAR_HOME)/ulib/gmake/z3.mk    # This pins $(Z3) ...
 include $(FSTAR_HOME)/ulib/gmake/fstar.mk # and $(FSTAR) for all sub-make calls
 

--- a/src/basic/boot/FStar.List.fsi
+++ b/src/basic/boot/FStar.List.fsi
@@ -23,7 +23,6 @@ val isEmpty : (list<'a>) -> Tot<bool>
 val hd : (list<'a>) -> 'a
 val length : (list<'a>) -> Tot<nat>
 val nth : (list<'a>) -> int -> 'a
-val count<'a when 'a : equality> : 'a -> (list<'a>) -> Tot<nat>
 val rev_acc : (list<'a>) -> (list<'a>) -> Tot<(list<'a>)>
 val rev : (list<'a>) -> Tot<(list<'a>)>
 val append : (list<'a>) -> (list<'a>) -> Tot<(list<'a>)>
@@ -44,7 +43,6 @@ val fold_right2 : ('a -> 'b -> 'c -> 'c) -> list<'a> -> list<'b> -> 'c -> 'c
 val rev_map_onto : ('a -> 'b) -> (list<'a>) -> (list<'b>) -> (list<'b>)
 val init : (list<'a>) -> list<'a>
 val last : (list<'a>) -> option<'a>
-val mem<'a when 'a : equality>  : 'a -> (list<'a>) -> Tot<bool>
 val existsb : f:('a -> bool) -> (list<'a>) -> Tot<bool>
 val existsML : f:('a -> bool) -> (list<'a>) -> bool
 val find : f:('a -> bool) -> (list<'a>) -> Tot<(option<'a>)>
@@ -56,7 +54,6 @@ val tryFind : ('a -> bool) -> (list<'a>) -> (option<'a>)
 val tryPick : ('a -> (option<'b>)) -> (list<'a>) -> (option<'b>)
 val choose : ('a -> (option<'b>)) -> (list<'a>) -> (list<'b>)
 val partition : ('a -> bool) -> (list<'a>) -> ((list<'a>) * (list<'a>))
-val assoc<'a, 'b when 'a : equality>  : 'a -> (list<('a * 'b)>) -> Tot<(option<'b>)>
 val splitAt : int -> list<'a> -> list<'a> * list<'a>
 val split : (list<('a * 'b)>) -> Tot<((list<'a>) * (list<'b>))>
 val unzip3 : (list<('a * 'b * 'c)>) -> Tot<((list<'a>) * (list<'b>) * (list<'c>))>
@@ -68,8 +65,32 @@ val tail : (list<'_1225>) -> (list<'_1225>)
 val tl : list<'_1230> -> list<'_1230>
 val rev_append : (list<'_5110>) -> (list<'_5110>) -> Tot<(list<'_5110>)>
 val concat : (list<(list<'_6116>)>) -> Tot<(list<'_6116>)>
-val contains<'_17778 when '_17778 : equality>  : '_17778 -> (list<'_17778>) -> Tot<bool>
 val unzip : (list<('_36948 * '_36947)>) -> Tot<((list<'_36948>) * (list<'_36947>))>
-val unique<'a when 'a : equality> : list<'a> -> list<'a>
 val filter_map: ('a -> option<'b>) -> list<'a> -> list<'b>
-val index<'a when 'a : equality> : ('a -> bool) -> list<'a> -> int
+
+
+(* Functions with eqtypes, they require the annotation for F#, we delete it for F* *)
+
+val count
+    <'a when 'a : equality> // JUST FSHARP
+    : 'a -> (list<'a>) -> Tot<nat>
+
+val mem
+    <'a when 'a : equality> // JUST FSHARP
+    : 'a -> (list<'a>) -> Tot<bool>
+
+val assoc
+    <'a, 'b when 'a : equality> // JUST FSHARP
+    : 'a -> (list<('a * 'b)>) -> Tot<(option<'b>)>
+
+val contains
+    <'a when 'a : equality> // JUST FSHARP
+    : 'a -> (list<'a>) -> Tot<bool>
+
+val unique
+    <'a when 'a : equality> // JUST FSHARP
+    : list<'a> -> list<'a>
+
+val index
+    <'a when 'a : equality> // JUST FSHARP
+    : ('a -> bool) -> list<'a> -> int

--- a/src/ocaml-output/Makefile
+++ b/src/ocaml-output/Makefile
@@ -6,6 +6,8 @@ else
 HAS_VALID_MENHIR := 0
 endif
 
+include ../Makefile.common
+
 MENHIR=menhir #--explain --infer -la 1 --table
 OCAMLLEX=ocamllex
 FSTAR_OCAMLBUILD_EXTRAS ?= -cflag -g
@@ -63,42 +65,43 @@ endif
 # This is about the F# parser, which we sed-transform from the parse.mly
 # obtained via the rule above.
 ../parser/parse.fsy: parse.mly
-	echo "%{" > $@
-	echo "#light \"off\"" >> $@
-	echo "// (c) Microsoft Corporation. All rights reserved" >> $@
-	echo "open Prims" >> $@
-	echo "open FStar" >> $@
-	echo "open FStar.Errors" >> $@
-	echo "open FStar.List" >> $@
-	echo "open FStar.Util" >> $@
-	echo "open FStar.Range" >> $@
-	echo "open FStar.Options" >> $@
-	echo "open FStar.Parser.Const" >> $@
-	echo "open FStar.Parser.AST" >> $@
-	echo "open FStar.Parser.Util" >> $@
-	echo "open FStar.Const" >> $@
-	echo "open FStar.Ident" >> $@
-	echo "open FStar.String" >> $@
+	$(Q)echo "%{" > $@
+	$(Q)echo "#light \"off\"" >> $@
+	$(Q)echo "// (c) Microsoft Corporation. All rights reserved" >> $@
+	$(Q)echo "open Prims" >> $@
+	$(Q)echo "open FStar" >> $@
+	$(Q)echo "open FStar.Errors" >> $@
+	$(Q)echo "open FStar.List" >> $@
+	$(Q)echo "open FStar.Util" >> $@
+	$(Q)echo "open FStar.Range" >> $@
+	$(Q)echo "open FStar.Options" >> $@
+	$(Q)echo "open FStar.Parser.Const" >> $@
+	$(Q)echo "open FStar.Parser.AST" >> $@
+	$(Q)echo "open FStar.Parser.Util" >> $@
+	$(Q)echo "open FStar.Const" >> $@
+	$(Q)echo "open FStar.Ident" >> $@
+	$(Q)echo "open FStar.String" >> $@
 	@# TODO : fsyacc seems to complain as soon as there is an arrow -> in a %type declaration...
-	cat parse.mly | sed -e '/%{/d' \
+	$(Q)cat parse.mly | sed -e '/%{/d' \
 	                    -e '/^open /d' \
 	                    -e '/%token/s/[a-zA-Z0-9_]*\.//g' \
 	                    -e '/%type/s/[a-zA-Z0-9_]*\.//g' \
 	                    -e '/%token.*->.*/d' \
 	                    -e '/%type.*->.*/d' \
-	              | cat -s >> $@
+	                  | cat -s >> $@
 
 # https://stackoverflow.com/questions/38294095/ocaml-how-to-solve-findlib-warnings-of-multiple-cmis
 FSTAR_MAIN_NATIVE=_build/src/fstar/ml/main.native
 $(FSTAR_MAIN_NATIVE): export OCAMLFIND_IGNORE_DUPS_IN = $(shell ocamlfind query compiler-libs)
 $(FSTAR_MAIN_NATIVE): $(GENERATED_FILES)
-	$(OCAMLBUILD) $(notdir $(FSTAR_MAIN_NATIVE)) src/ocaml-output/FStar_Syntax_Syntax.inferred.mli
+	@echo "[OCAMLBUILD]"
+	$(Q)$(OCAMLBUILD) $(notdir $(FSTAR_MAIN_NATIVE)) src/ocaml-output/FStar_Syntax_Syntax.inferred.mli
 
 ../../bin/fstar.exe: $(FSTAR_MAIN_NATIVE)
-	cp $^ $@
+	$(Q)cp $^ $@
 
 ../../bin/fstar.ocaml: $(FSTAR_MAIN_NATIVE)
-	cp $^ $@
+	$(Q)cp $^ $@
 
 install-compiler-lib: $(FSTAR_MAIN_NATIVE)
 	mkdir -p ../../bin/fstar-compiler-lib/
@@ -112,38 +115,39 @@ install-compiler-lib: $(FSTAR_MAIN_NATIVE)
 FStar_Parser_Parse.ml: parse.mly
 	@# We are opening the same module twice but we need these modules
 	@# open for the definition of tokens
-	echo "open Prims" > $@
-	echo "open FStar_Errors" >> $@
-	echo "open FStar_List" >> $@
-	echo "open FStar_Util" >> $@
-	echo "open FStar_Range" >> $@
-	echo "open FStar_Options" >> $@
-	echo "open FStar_Syntax_Syntax" >> $@
-	echo "open FStar_Parser_Const" >> $@
-	echo "open FStar_Syntax_Util" >> $@
-	echo "open FStar_Parser_AST" >> $@
-	echo "open FStar_Parser_Util" >> $@
-	echo "open FStar_Const" >> $@
-	echo "open FStar_Ident" >> $@
-	echo "open FStar_String" >> $@
+	$(Q)echo "open Prims" > $@
+	$(Q)echo "open FStar_Errors" >> $@
+	$(Q)echo "open FStar_List" >> $@
+	$(Q)echo "open FStar_Util" >> $@
+	$(Q)echo "open FStar_Range" >> $@
+	$(Q)echo "open FStar_Options" >> $@
+	$(Q)echo "open FStar_Syntax_Syntax" >> $@
+	$(Q)echo "open FStar_Parser_Const" >> $@
+	$(Q)echo "open FStar_Syntax_Util" >> $@
+	$(Q)echo "open FStar_Parser_AST" >> $@
+	$(Q)echo "open FStar_Parser_Util" >> $@
+	$(Q)echo "open FStar_Const" >> $@
+	$(Q)echo "open FStar_Ident" >> $@
+	$(Q)echo "open FStar_String" >> $@
 	@# TODO: create a proper OCamlbuild rule for this production so that
 	@# OCamlbuild knows how to generate parse.mly first (possibly using
 	@# menhir) and removes the production as needed.
-	ocamlyacc parse.mly 2> yac-log
-	cat yac-log
+	@echo "[OCAMLYACC]"
+	$(Q)ocamlyacc parse.mly 2> yac-log
+	$(Q)cat yac-log
 	@if [ "0$$(grep "shift/reduce" yac-log | sed 's/^\([0-9]\+\).*/\1/')" -gt 6 ]; then \
-	  echo "shift-reduce conflicts have increased; please fix" && exit 255; \
+	  @echo "shift-reduce conflicts have increased; please fix" && exit 255; \
 	fi
 	@if grep -q "reduce/reduce" yac-log ; then \
-	  echo "A reduce-reduce conflict was introduced; please fix" && exit 255; \
+	  @echo "A reduce-reduce conflict was introduced; please fix" && exit 255; \
 	fi
-	cat parse.ml >> $@
-	rm parse.ml parse.mli
+	$(Q)cat parse.ml >> $@
+	$(Q)rm parse.ml parse.mli
 
 ../../bin/tests.exe: export OCAMLFIND_IGNORE_DUPS_IN = $(shell ocamlfind query compiler-libs)
 ../../bin/tests.exe: ../../bin/fstar.exe
-	$(OCAMLBUILD) FStar_Tests_Main.native
-	cp -f _build/src/tests/ml/FStar_Tests_Main.native $@
+	$(Q)$(OCAMLBUILD) FStar_Tests_Main.native
+	$(Q)cp -f _build/src/tests/ml/FStar_Tests_Main.native $@
 
 # always bump version for a release; always bump it when recompiling so that one
 # can easily help debugging
@@ -164,14 +168,14 @@ COMMITDATE = $(shell git log --pretty=format:%ci -n 1 2>/dev/null || echo unset)
 
 .PHONY: FStar_Version.ml
 FStar_Version.ml:
-	echo 'open FStar_Util' > $@
-	echo 'let dummy () = ();;' >> $@
-	echo 'FStar_Options._version := "$(VERSION)";;' >> $@
-	echo 'FStar_Options._platform := "$(PLATFORM)";;' >> $@
-	echo 'FStar_Options._compiler := "$(COMPILER)";;' >> $@
-	# We deliberately use commitdate instead of date, so that rebuilds are no-ops
-	echo 'FStar_Options._date := "$(COMMITDATE)";;' >> $@
-	echo 'FStar_Options._commit:= "$(COMMIT)";;' >> $@
+	$(Q)echo 'open FStar_Util' > $@
+	$(Q)echo 'let dummy () = ();;' >> $@
+	$(Q)echo 'FStar_Options._version := "$(VERSION)";;' >> $@
+	$(Q)echo 'FStar_Options._platform := "$(PLATFORM)";;' >> $@
+	$(Q)echo 'FStar_Options._compiler := "$(COMPILER)";;' >> $@
+	@# We deliberately use commitdate instead of date, so that rebuilds are no-ops
+	$(Q)echo 'FStar_Options._date := "$(COMMITDATE)";;' >> $@
+	$(Q)echo 'FStar_Options._commit:= "$(COMMIT)";;' >> $@
 
 
 # ------------------------------------------------------------------------------

--- a/ulib/Makefile.verify
+++ b/ulib/Makefile.verify
@@ -21,6 +21,7 @@ CACHE_DIR=--cache_dir .cache --hint_dir .cache
 
 OTHERFLAGS+=$(USE_EXTRACTED_INTERFACES)
 
+include $(FSTAR_HOME)/src/Makefile.common
 include gmake/z3.mk
 include gmake/fstar.mk
 include gmake/Makefile.tmpl
@@ -42,7 +43,8 @@ verify-core: $(filter-out $(addprefix %, $(addsuffix .checked, $(notdir $(EXTRA)
 verify-extra: $(filter $(addprefix %, $(addsuffix .checked, $(notdir $(EXTRA)))), $(ALL_CHECKED_FILES))
 
 %.checked:
-	$(MY_FSTAR) $<
+	@echo "[CHECK     $(basename $(notdir $@))]"
+	$(Q)$(MY_FSTAR) $(SIL) $<
 
 # Benchmarking rules
 #


### PR DESCRIPTION
This PR introduces some changes to our `Makefile`s to make output less verbose. There's much more that can be done, this is just a start. If there's consensus that this is desirable I can continue pushing on it.

The main change is reducing the output of F* invocations, but the command themselves and the
```
Verified module: M
All verification conditions discharged successfully
```
messages output by F*. So what before was:
```
make: Entering directory '/home/guido/r/fstar/guido_make/examples/typeclasses'
../../bin/fstar.exe  --cache_checked_modules --odir _output --cache_dir _cache  --warn_error -271 --use_extracted_interfaces true --use_hints  --dep full EnumEq.fst Inlining.fst Enum.fst Monad.fst OpenIface.fst Loop.fst Eq.fst Add.fst Functor.fst Tests.fst Big.fst Num.fst > ._depend
### Tons of Warning 321
mv ._depend .depend
../../bin/fstar.exe  --cache_checked_modules --odir _output --cache_dir _cache  --warn_error -271 --use_extracted_interfaces true --use_hints  Functor.fst
../../bin/fstar.exe  --cache_checked_modules --odir _output --cache_dir _cache  --warn_error -271 --use_extracted_interfaces true --use_hints  Big.fst
../../bin/fstar.exe  --cache_checked_modules --odir _output --cache_dir _cache  --warn_error -271 --use_extracted_interfaces true --use_hints  Eq.fst
../../bin/fstar.exe  --cache_checked_modules --odir _output --cache_dir _cache  --warn_error -271 --use_extracted_interfaces true --use_hints  Inlining.fst
Verified module: Functor
All verification conditions discharged successfully
../../bin/fstar.exe  --cache_checked_modules --odir _output --cache_dir _cache  --warn_error -271 --use_extracted_interfaces true --use_hints  Add.fst
Verified module: Inlining
All verification conditions discharged successfully
../../bin/fstar.exe  --cache_checked_modules --odir _output --cache_dir _cache  --warn_error -271 --use_extracted_interfaces true --use_hints  Enum.fst
Verified module: Add
All verification conditions discharged successfully
Verified module: Eq
All verification conditions discharged successfully
../../bin/fstar.exe  --cache_checked_modules --odir _output --cache_dir _cache  --warn_error -271 --use_extracted_interfaces true --use_hints  Loop.fst
../../bin/fstar.exe  --cache_checked_modules --odir _output --cache_dir _cache  --warn_error -271 --use_extracted_interfaces true --use_hints  Monad.fst
proof-state: State dump @ depth 0 (at the time of failure):
Location: FStar.Tactics.Derived.fst(289,4-291,16)
Goal 1/1:
(a: Type) |- _ : Loop.c a

Verified module: Loop
All verification conditions discharged successfully
../../bin/fstar.exe  --cache_checked_modules --odir _output --cache_dir _cache  --warn_error -271 --use_extracted_interfaces true --use_hints  Num.fst
Verified module: Num
All verification conditions discharged successfully
../../bin/fstar.exe  --cache_checked_modules --odir _output --cache_dir _cache  --warn_error -271 --use_extracted_interfaces true --use_hints  Tests.fst
Verified module: Monad
All verification conditions discharged successfully
Verified module: Enum
All verification conditions discharged successfully
../../bin/fstar.exe  --cache_checked_modules --odir _output --cache_dir _cache  --warn_error -271 --use_extracted_interfaces true --use_hints  EnumEq.fst
../../bin/fstar.exe  --cache_checked_modules --odir _output --cache_dir _cache  --warn_error -271 --use_extracted_interfaces true --use_hints  EnumEq.fsti
Verified i'face (or impl+i'face): EnumEq
All verification conditions discharged successfully
../../bin/fstar.exe  --cache_checked_modules --odir _output --cache_dir _cache  --warn_error -271 --use_extracted_interfaces true --use_hints  OpenIface.fst
Verified module: EnumEq
All verification conditions discharged successfully
Verified module: Tests
All verification conditions discharged successfully
Verified module: OpenIface
All verification conditions discharged successfully
Verified module: Big
All verification conditions discharged successfully
make: Leaving directory '/home/guido/r/fstar/guido_make/examples/typeclasses'

```
is now:
```
$ make -C examples/typeclasses -j4
make: Entering directory '/home/guido/r/fstar/guido_make/examples/typeclasses'
### Tons of Warning 321
mv ._depend .depend
[CHECK     Functor.fst]
[CHECK     Big.fst]
[CHECK     Eq.fst]
[CHECK     Inlining.fst]
[CHECK     Add.fst]
[CHECK     Enum.fst]
[CHECK     Loop.fst]
[CHECK     Monad.fst]
proof-state: State dump @ depth 0 (at the time of failure):
Location: FStar.Tactics.Derived.fst(289,4-291,16)
Goal 1/1:
(a: Type) |- _ : Loop.c a

[CHECK     Num.fst]
[CHECK     Tests.fst]
[CHECK     EnumEq.fst]
[CHECK     EnumEq.fsti]
[CHECK     OpenIface.fst]
make: Leaving directory '/home/guido/r/fstar/guido_make/examples/typeclasses'
```

The old behaviour can always be obtained by passing `V=1` to the `make` invocation (or by `export V=1`). 

The output for `ulib/` does not change much since I did not want to modify the `ulib/gmake/Makefile.tmpl` file which is meant for users afaict. Maybe we should not be using it ourselves?