### PR TITLE
Improving build dependencies

### DIFF
--- a/examples/Makefile.common
+++ b/examples/Makefile.common
@@ -69,13 +69,11 @@ include .depend
 %.fst.checked:
 	@echo "[CHECK     $(basename $(notdir $@))]"
 	$(Q)$(MY_FSTAR) $<
-	@touch -c $@
 
 # a.fsti.checked is the binary, checked version of a.fsti
 %.fsti.checked:
 	@echo "[CHECK     $(basename $(notdir $@))]"
 	$(Q)$(MY_FSTAR) $<
-	@touch -c $@
 
 clean:
 	rm -rf $(CACHE_DIR)

--- a/examples/data_structures/Makefile
+++ b/examples/data_structures/Makefile
@@ -37,14 +37,12 @@ $(CACHE_DIR) $(OUT_DIR):
 	mkdir -p $@
 
 $(CACHE_DIR)/%.checked: | $(CACHE_DIR) .depend
-	$(FSTAR) $< && \
-	touch -c $@
+	$(FSTAR) $<
 
 $(OUT_DIR)/%.ml: | $(OUT_DIR) .depend
 	$(FSTAR) --codegen OCaml \
 	  --extract_module $(basename $(notdir $(subst .checked,,$<))) \
-	  $(notdir $(subst .checked,,$<)) && \
-	touch $@
+	  $(notdir $(subst .checked,,$<))
 
 %.cmx:
 	$(OCAMLOPT) -I $(OUT_DIR) -c $< -o $@

--- a/examples/demos/low-star/Makefile
+++ b/examples/demos/low-star/Makefile
@@ -15,7 +15,6 @@ depend: .depend
 
 %.checked:
 	$(FSTAR) $<
-	touch -c $@
 
 %.fst-in:
 	@echo $(FSTAR_FLAGS) --max_fuel 0 --max_ifuel 0

--- a/examples/dependencies/Makefile
+++ b/examples/dependencies/Makefile
@@ -27,8 +27,7 @@ all:
 include .depend
 
 $(CACHE_DIR)/%.checked: | .depend
-	$(FSTAR) $< $(ENABLE_HINTS) --hint_file $(HINT_DIR)/$(notdir $<).hints && \
-	touch $@
+	$(FSTAR) $< $(ENABLE_HINTS) --hint_file $(HINT_DIR)/$(notdir $<).hints
 
 # 2. Compile all .ml files to .cmx and link them to get an executable
 $(OUT_DIR):
@@ -37,8 +36,7 @@ $(OUT_DIR):
 $(OUT_DIR)/%.ml: | .depend
 	$(FSTAR) --codegen OCaml \
 	  --extract_module $(basename $(notdir $(subst .checked,,$<))) \
-	  $(notdir $(subst .checked,,$<)) && \
-	touch $@
+	  $(notdir $(subst .checked,,$<))
 
 %.cmx:
 	$(OCAMLOPT) -I $(OUT_DIR) -c $< -o $@

--- a/examples/native_tactics/Makefile
+++ b/examples/native_tactics/Makefile
@@ -58,7 +58,6 @@ all: $(addsuffix .sep.test, $(TAC_MODULES)) $(addsuffix .test, $(ALL))
 
 %.ml: %.fst
 	$(FSTAR) $*.fst --cache_checked_modules --codegen Plugin --extract $*
-	touch $@
 
 %.clean:
 	rm -f Registers_List.ml Registers.List.ml Registers_List.cmxs

--- a/examples/native_tactics/Makefile.bench
+++ b/examples/native_tactics/Makefile.bench
@@ -77,7 +77,6 @@ prep: $(addsuffix .fst.checked , Registers.List Registers.Fun Imp.List Imp.Fun) 
 
 %.ml: %.fst.checked
 	$(FSTAR) $*.fst --codegen Plugin --extract $*
-	touch $@
 
 %.Load.run: %.Load.fst
 	$(FSTAR) $< --load Registers.List --load Registers.Fun  --warn_error -266 | grep Checked

--- a/examples/rbtree/Makefile
+++ b/examples/rbtree/Makefile
@@ -37,14 +37,12 @@ $(CACHE_DIR) $(OUT_DIR):
 	mkdir -p $@
 
 $(CACHE_DIR)/%.checked: | $(CACHE_DIR) .depend
-	$(FSTAR) $< && \
-	touch -c $@
+	$(FSTAR) $<
 
 $(OUT_DIR)/%.ml: | $(OUT_DIR) .depend
 	$(FSTAR) --codegen OCaml \
 	  --extract_module $(basename $(notdir $(subst .checked,,$<))) \
-	  $(notdir $(subst .checked,,$<)) && \
-	touch $@
+	  $(notdir $(subst .checked,,$<))
 
 %.cmx:
 	$(OCAMLOPT) -I $(OUT_DIR) -c $< -o $@

--- a/examples/sample_project/Makefile
+++ b/examples/sample_project/Makefile
@@ -24,7 +24,6 @@ all: verify-all
 # a.fst.checked is the binary, checked version of a.fst
 %.checked: %
 	$(FSTAR) $*
-	touch $@
 
 # The _tags file is a directive to ocamlbuild
 # The extracted ML files are precious, because you may want to examine them,

--- a/src/Makefile.boot
+++ b/src/Makefile.boot
@@ -43,14 +43,9 @@ EXTRACT = $(addprefix --extract_module , $(EXTRACT_MODULES))		\
 	  $(addprefix --no_extract , $(NO_EXTRACT))
 
 # We first lax type-check each file, producing a .checked.lax file
-# We touch the file, because if F* determined that the .checked.lax
-# file was already up to date, it doesn't touch it. Touching it here
-# ensures that if this rule is successful then %.checked.lax is more
-# recent than its dependences.
 %.checked.lax:
 	@echo "[LAXCHECK  $(basename $(basename $(notdir $@)))]"
 	$(Q)$(FSTAR_C) $(SIL) $< --already_cached "* -$(basename $(notdir $<))"
-	$(Q)@touch -c $@
 
 # And then, in a separate invocation, from each .checked.lax we
 # extract an .ml file

--- a/src/basic/FStar.Options.fs
+++ b/src/basic/FStar.Options.fs
@@ -1442,13 +1442,18 @@ let module_name_of_file_name f =
     let f = String.substring f 0 (String.length f - String.length (get_file_extension f) - 1) in
     String.lowercase f
 
-let should_verify m =
-  if get_lax () then
-    false
-  else let l = get_verify_module () in
-       List.contains (String.lowercase m) l
+let should_check m =
+  let l = get_verify_module () in
+  List.contains (String.lowercase m) l
 
-let should_verify_file fn = should_verify (module_name_of_file_name fn)
+let should_verify m =
+  not (get_lax ()) && should_check m
+
+let should_check_file fn =
+    should_check (module_name_of_file_name fn)
+
+let should_verify_file fn =
+    should_verify (module_name_of_file_name fn)
 
 let module_name_eq m1 m2 = String.lowercase m1 = String.lowercase m2
 

--- a/src/basic/FStar.Options.fsi
+++ b/src/basic/FStar.Options.fsi
@@ -195,8 +195,10 @@ val set_options                 : string -> parse_cmdline_res
 val should_be_already_cached    : string  -> bool
 val should_print_message        : string  -> bool
 val should_extract              : string  -> bool
-val should_verify               : string  -> bool
-val should_verify_file          : string  -> bool
+val should_check                : string  -> bool (* Should check this module, lax or not. *)
+val should_check_file           : string  -> bool (* Should check this file, lax or not. *)
+val should_verify               : string  -> bool (* Should check this module with verification enabled. *)
+val should_verify_file          : string  -> bool (* Should check this file with verification enabled. *)
 val silent                      : unit    -> bool
 val smtencoding_elim_box        : unit    -> bool
 val smtencoding_nl_arith_default: unit    -> bool

--- a/src/basic/boot/FStar.Util.fsi
+++ b/src/basic/boot/FStar.Util.fsi
@@ -425,6 +425,7 @@ val load_2values_from_file: string -> option<('a * 'b)>
 val print_exn: exn -> string
 val digest_of_file: string -> string
 val digest_of_string: string -> string
+val touch_file: string -> unit (* Precondition: file exists *)
 
 val ensure_decimal: string -> string
 val measure_execution_time: string -> (unit -> 'a) -> 'a

--- a/src/basic/boot/NotFStar.Util.fs
+++ b/src/basic/boot/NotFStar.Util.fs
@@ -930,7 +930,9 @@ let load_2values_from_file (fname:string) =
     printfn "Failed to load file because: %A" e;
     None
 
-
+(* Precondition: file exists *)
+let touch_file (fname:string) : unit =
+  File.SetLastWriteTime (fname, DateTime.Now)
 
 let print_exn (e: exn): string =
   e.Message

--- a/src/basic/ml/FStar_Util.ml
+++ b/src/basic/ml/FStar_Util.ml
@@ -1024,6 +1024,11 @@ let digest_of_file =
 let digest_of_string (s:string) =
   BatDigest.to_hex (BatDigest.string s)
 
+(* Precondition: file exists *)
+let touch_file (fname:string) : unit =
+  (* Sets access and modification times to current time *)
+  Unix.utimes fname 0.0 0.0
+
 let ensure_decimal s = Z.to_string (Z.of_string s)
 
 let measure_execution_time tag f =

--- a/src/fstar/FStar.CheckedFiles.fs
+++ b/src/fstar/FStar.CheckedFiles.fs
@@ -383,7 +383,7 @@ let load_module_from_cache =
       | Inr tc_result ->
         if Options.debug_at_level_no_module (Options.Other "CheckedFiles") then
           BU.print1 "Successfully loaded module from checked file %s\n" cache_file;
-        Some tc_result
+        Some (tc_result, cache_file)
       (* | _ -> failwith "load_checked_file_tc_result must have an Invalid or Valid entry" *)
     in
     Profiling.profile

--- a/src/fstar/FStar.CheckedFiles.fsi
+++ b/src/fstar/FStar.CheckedFiles.fsi
@@ -55,6 +55,7 @@ val load_parsing_data_from_cache: file_name:string -> option<Parser.Dep.parsing_
 (* Loading and storing cache files                                     *)
 (***********************************************************************)
 
-val load_module_from_cache: (uenv -> string -> option<tc_result>)
+(* Returns tc_result and path of .checked file loaded *)
+val load_module_from_cache: (uenv -> string -> option<(tc_result * string)>)
 
 val store_module_to_cache: uenv -> file_name:string -> Dep.parsing_data -> tc_result -> unit 

--- a/src/fstar/FStar.Universal.fs
+++ b/src/fstar/FStar.Universal.fs
@@ -379,9 +379,10 @@ let tc_one_file
 
         (* If we were called to verify (or lax check) this file, and we found
          * a good, non-stale checked file, update the timestamp as if we had
-         * built it again. This simplifies Makefile logic a lot. See
+         * built it again. This simplifies Makefile logic a lot. However if we're
+         * called to extract, leave the .checked file as-is. See
          * issue #1978 (starting from "Also, separate issue: ..."). *)
-        if Options.should_check_file fn then begin
+        if Options.should_check_file fn && Option.isNone (Options.codegen ()) then begin
             if Options.debug_at_level_no_module (Options.Other "CheckedFiles") then
               BU.print1 "Updating timestamp on checked file %s\n" checked_fname;
             BU.touch_file checked_fname

--- a/src/fstar/FStar.Universal.fs
+++ b/src/fstar/FStar.Universal.fs
@@ -360,13 +360,14 @@ let tc_one_file
                  BU.format1 "Cross-module inlining expects all modules to be checked first; %s was not checked"
                             fn);
 
-
         let tc_result, mllib, env = tc_source_file () in
+
         if FStar.Errors.get_err_count() = 0
         && (Options.lax()  //we'll write out a .checked.lax file
             || Options.should_verify tc_result.checked_module.name.str) //we'll write out a .checked file
         //but we will not write out a .checked file for an unverified dependence
         //of some file that should be checked
+        //(i.e. we DO write .checked.lax files for dependencies even if not provided as an argument)
         then Ch.store_module_to_cache env fn parsing_data tc_result;
         tc_result, mllib, env
 

--- a/src/ocaml-output/FStar_CheckedFiles.ml
+++ b/src/ocaml-output/FStar_CheckedFiles.ml
@@ -433,12 +433,12 @@ let (load_parsing_data_from_cache :
   
 let (load_module_from_cache :
   FStar_Extraction_ML_UEnv.uenv ->
-    Prims.string -> tc_result FStar_Pervasives_Native.option)
+    Prims.string -> (tc_result * Prims.string) FStar_Pervasives_Native.option)
   =
   let already_failed = FStar_Util.mk_ref false  in
   fun env  ->
     fun fn  ->
-      let load_it uu____1550 =
+      let load_it uu____1560 =
         let cache_file = FStar_Parser_Dep.cache_file_name fn  in
         let fail1 msg cache_file1 =
           let suppress_warning =
@@ -448,42 +448,42 @@ let (load_module_from_cache :
           if Prims.op_Negation suppress_warning
           then
             (FStar_ST.op_Colon_Equals already_failed true;
-             (let uu____1615 =
-                let uu____1616 =
+             (let uu____1625 =
+                let uu____1626 =
                   FStar_Range.mk_pos Prims.int_zero Prims.int_zero  in
-                let uu____1619 =
+                let uu____1629 =
                   FStar_Range.mk_pos Prims.int_zero Prims.int_zero  in
-                FStar_Range.mk_range fn uu____1616 uu____1619  in
-              let uu____1622 =
-                let uu____1628 =
+                FStar_Range.mk_range fn uu____1626 uu____1629  in
+              let uu____1632 =
+                let uu____1638 =
                   FStar_Util.format3
                     "Unable to load %s since %s; will recheck %s (suppressing this warning for further modules)"
                     cache_file1 msg fn
                    in
-                (FStar_Errors.Warning_CachedFile, uu____1628)  in
-              FStar_Errors.log_issue uu____1615 uu____1622))
+                (FStar_Errors.Warning_CachedFile, uu____1638)  in
+              FStar_Errors.log_issue uu____1625 uu____1632))
           else ()  in
-        let uu____1634 =
-          let uu____1640 =
+        let uu____1644 =
+          let uu____1650 =
             FStar_TypeChecker_Env.dep_graph
               env.FStar_Extraction_ML_UEnv.env_tcenv
              in
-          load_checked_file_with_tc_result uu____1640 fn cache_file  in
-        match uu____1634 with
+          load_checked_file_with_tc_result uu____1650 fn cache_file  in
+        match uu____1644 with
         | FStar_Util.Inl msg ->
             (fail1 msg cache_file; FStar_Pervasives_Native.None)
         | FStar_Util.Inr tc_result ->
-            ((let uu____1650 =
+            ((let uu____1670 =
                 FStar_Options.debug_at_level_no_module
                   (FStar_Options.Other "CheckedFiles")
                  in
-              if uu____1650
+              if uu____1670
               then
                 FStar_Util.print1
                   "Successfully loaded module from checked file %s\n"
                   cache_file
               else ());
-             FStar_Pervasives_Native.Some tc_result)
+             FStar_Pervasives_Native.Some (tc_result, cache_file))
          in
       FStar_Profiling.profile load_it FStar_Pervasives_Native.None
         "FStar.CheckedFiles"
@@ -504,53 +504,53 @@ let (store_module_to_cache :
     fun fn  ->
       fun parsing_data  ->
         fun tc_result  ->
-          let uu____1702 =
+          let uu____1733 =
             (FStar_Options.cache_checked_modules ()) &&
-              (let uu____1705 = FStar_Options.cache_off ()  in
-               Prims.op_Negation uu____1705)
+              (let uu____1736 = FStar_Options.cache_off ()  in
+               Prims.op_Negation uu____1736)
              in
-          if uu____1702
+          if uu____1733
           then
             let cache_file = FStar_Parser_Dep.cache_file_name fn  in
             let digest =
-              let uu____1724 =
+              let uu____1755 =
                 FStar_TypeChecker_Env.dep_graph
                   env.FStar_Extraction_ML_UEnv.env_tcenv
                  in
-              hash_dependences uu____1724 fn  in
+              hash_dependences uu____1755 fn  in
             match digest with
             | FStar_Util.Inr hashes ->
                 let tc_result1 =
-                  let uu___221_1744 = tc_result  in
+                  let uu___221_1775 = tc_result  in
                   {
-                    checked_module = (uu___221_1744.checked_module);
-                    mii = (uu___221_1744.mii);
-                    smt_decls = (uu___221_1744.smt_decls);
+                    checked_module = (uu___221_1775.checked_module);
+                    mii = (uu___221_1775.mii);
+                    smt_decls = (uu___221_1775.smt_decls);
                     tc_time = Prims.int_zero;
                     extraction_time = Prims.int_zero
                   }  in
                 let stage1 =
-                  let uu____1748 = FStar_Util.digest_of_file fn  in
+                  let uu____1779 = FStar_Util.digest_of_file fn  in
                   {
                     version = cache_version_number;
-                    digest = uu____1748;
+                    digest = uu____1779;
                     parsing_data
                   }  in
                 let stage2 = { deps_dig = hashes; tc_res = tc_result1 }  in
                 store_values_to_cache cache_file stage1 stage2
             | FStar_Util.Inl msg ->
-                let uu____1762 =
-                  let uu____1763 =
+                let uu____1793 =
+                  let uu____1794 =
                     FStar_Range.mk_pos Prims.int_zero Prims.int_zero  in
-                  let uu____1766 =
+                  let uu____1797 =
                     FStar_Range.mk_pos Prims.int_zero Prims.int_zero  in
-                  FStar_Range.mk_range fn uu____1763 uu____1766  in
-                let uu____1769 =
-                  let uu____1775 =
+                  FStar_Range.mk_range fn uu____1794 uu____1797  in
+                let uu____1800 =
+                  let uu____1806 =
                     FStar_Util.format2 "%s was not written since %s"
                       cache_file msg
                      in
-                  (FStar_Errors.Warning_FileNotWritten, uu____1775)  in
-                FStar_Errors.log_issue uu____1762 uu____1769
+                  (FStar_Errors.Warning_FileNotWritten, uu____1806)  in
+                FStar_Errors.log_issue uu____1793 uu____1800
           else ()
   

--- a/src/ocaml-output/FStar_Options.ml
+++ b/src/ocaml-output/FStar_Options.ml
@@ -1615,18 +1615,23 @@ let (module_name_of_file_name : Prims.string -> Prims.string) =
       FStar_String.substring f1 Prims.int_zero uu____8507  in
     FStar_String.lowercase f2
   
+let (should_check : Prims.string -> Prims.bool) =
+  fun m  ->
+    let l = get_verify_module ()  in
+    FStar_List.contains (FStar_String.lowercase m) l
+  
 let (should_verify : Prims.string -> Prims.bool) =
   fun m  ->
-    let uu____8526 = get_lax ()  in
-    if uu____8526
-    then false
-    else
-      (let l = get_verify_module ()  in
-       FStar_List.contains (FStar_String.lowercase m) l)
+    (let uu____8542 = get_lax ()  in Prims.op_Negation uu____8542) &&
+      (should_check m)
+  
+let (should_check_file : Prims.string -> Prims.bool) =
+  fun fn  ->
+    let uu____8553 = module_name_of_file_name fn  in should_check uu____8553
   
 let (should_verify_file : Prims.string -> Prims.bool) =
   fun fn  ->
-    let uu____8547 = module_name_of_file_name fn  in should_verify uu____8547
+    let uu____8564 = module_name_of_file_name fn  in should_verify uu____8564
   
 let (module_name_eq : Prims.string -> Prims.string -> Prims.bool) =
   fun m1  ->
@@ -1634,73 +1639,73 @@ let (module_name_eq : Prims.string -> Prims.string -> Prims.bool) =
   
 let (dont_gen_projectors : Prims.string -> Prims.bool) =
   fun m  ->
-    let uu____8575 = get___temp_no_proj ()  in
-    FStar_All.pipe_right uu____8575 (FStar_List.existsb (module_name_eq m))
+    let uu____8592 = get___temp_no_proj ()  in
+    FStar_All.pipe_right uu____8592 (FStar_List.existsb (module_name_eq m))
   
 let (should_print_message : Prims.string -> Prims.bool) =
   fun m  ->
-    let uu____8593 = should_verify m  in
-    if uu____8593 then m <> "Prims" else false
+    let uu____8610 = should_verify m  in
+    if uu____8610 then m <> "Prims" else false
   
 let (include_path : unit -> Prims.string Prims.list) =
-  fun uu____8610  ->
+  fun uu____8627  ->
     let cache_dir =
-      let uu____8615 = get_cache_dir ()  in
-      match uu____8615 with
+      let uu____8632 = get_cache_dir ()  in
+      match uu____8632 with
       | FStar_Pervasives_Native.None  -> []
       | FStar_Pervasives_Native.Some c -> [c]  in
-    let uu____8629 = get_no_default_includes ()  in
-    if uu____8629
+    let uu____8646 = get_no_default_includes ()  in
+    if uu____8646
     then
-      let uu____8635 = get_include ()  in
-      FStar_List.append cache_dir uu____8635
+      let uu____8652 = get_include ()  in
+      FStar_List.append cache_dir uu____8652
     else
       (let lib_paths =
-         let uu____8646 = FStar_Util.expand_environment_variable "FSTAR_LIB"
+         let uu____8663 = FStar_Util.expand_environment_variable "FSTAR_LIB"
             in
-         match uu____8646 with
+         match uu____8663 with
          | FStar_Pervasives_Native.None  ->
              let fstar_home = FStar_String.op_Hat fstar_bin_directory "/.."
                 in
              let defs = universe_include_path_base_dirs  in
-             let uu____8662 =
+             let uu____8679 =
                FStar_All.pipe_right defs
                  (FStar_List.map (fun x  -> FStar_String.op_Hat fstar_home x))
                 in
-             FStar_All.pipe_right uu____8662
+             FStar_All.pipe_right uu____8679
                (FStar_List.filter FStar_Util.file_exists)
          | FStar_Pervasives_Native.Some s -> [s]  in
-       let uu____8689 =
-         let uu____8693 =
-           let uu____8697 = get_include ()  in
-           FStar_List.append uu____8697 ["."]  in
-         FStar_List.append lib_paths uu____8693  in
-       FStar_List.append cache_dir uu____8689)
+       let uu____8706 =
+         let uu____8710 =
+           let uu____8714 = get_include ()  in
+           FStar_List.append uu____8714 ["."]  in
+         FStar_List.append lib_paths uu____8710  in
+       FStar_List.append cache_dir uu____8706)
   
 let (find_file : Prims.string -> Prims.string FStar_Pervasives_Native.option)
   =
   let file_map = FStar_Util.smap_create (Prims.of_int (100))  in
   fun filename  ->
-    let uu____8728 = FStar_Util.smap_try_find file_map filename  in
-    match uu____8728 with
+    let uu____8745 = FStar_Util.smap_try_find file_map filename  in
+    match uu____8745 with
     | FStar_Pervasives_Native.Some f -> f
     | FStar_Pervasives_Native.None  ->
         let result =
           try
-            (fun uu___616_8759  ->
+            (fun uu___617_8776  ->
                match () with
                | () ->
-                   let uu____8763 = FStar_Util.is_path_absolute filename  in
-                   if uu____8763
+                   let uu____8780 = FStar_Util.is_path_absolute filename  in
+                   if uu____8780
                    then
                      (if FStar_Util.file_exists filename
                       then FStar_Pervasives_Native.Some filename
                       else FStar_Pervasives_Native.None)
                    else
-                     (let uu____8779 =
-                        let uu____8783 = include_path ()  in
-                        FStar_List.rev uu____8783  in
-                      FStar_Util.find_map uu____8779
+                     (let uu____8796 =
+                        let uu____8800 = include_path ()  in
+                        FStar_List.rev uu____8800  in
+                      FStar_Util.find_map uu____8796
                         (fun p  ->
                            let path =
                              if p = "."
@@ -1709,81 +1714,81 @@ let (find_file : Prims.string -> Prims.string FStar_Pervasives_Native.option)
                            if FStar_Util.file_exists path
                            then FStar_Pervasives_Native.Some path
                            else FStar_Pervasives_Native.None))) ()
-          with | uu___615_8811 -> FStar_Pervasives_Native.None  in
+          with | uu___616_8828 -> FStar_Pervasives_Native.None  in
         (if FStar_Option.isSome result
          then FStar_Util.smap_add file_map filename result
          else ();
          result)
   
 let (prims : unit -> Prims.string) =
-  fun uu____8830  ->
-    let uu____8831 = get_prims ()  in
-    match uu____8831 with
+  fun uu____8847  ->
+    let uu____8848 = get_prims ()  in
+    match uu____8848 with
     | FStar_Pervasives_Native.None  ->
         let filename = "prims.fst"  in
-        let uu____8840 = find_file filename  in
-        (match uu____8840 with
+        let uu____8857 = find_file filename  in
+        (match uu____8857 with
          | FStar_Pervasives_Native.Some result -> result
          | FStar_Pervasives_Native.None  ->
-             let uu____8849 =
+             let uu____8866 =
                FStar_Util.format1
                  "unable to find required file \"%s\" in the module search path.\n"
                  filename
                 in
-             failwith uu____8849)
+             failwith uu____8866)
     | FStar_Pervasives_Native.Some x -> x
   
 let (prims_basename : unit -> Prims.string) =
-  fun uu____8862  ->
-    let uu____8863 = prims ()  in FStar_Util.basename uu____8863
+  fun uu____8879  ->
+    let uu____8880 = prims ()  in FStar_Util.basename uu____8880
   
 let (pervasives : unit -> Prims.string) =
-  fun uu____8871  ->
+  fun uu____8888  ->
     let filename = "FStar.Pervasives.fsti"  in
-    let uu____8875 = find_file filename  in
-    match uu____8875 with
+    let uu____8892 = find_file filename  in
+    match uu____8892 with
     | FStar_Pervasives_Native.Some result -> result
     | FStar_Pervasives_Native.None  ->
-        let uu____8884 =
+        let uu____8901 =
           FStar_Util.format1
             "unable to find required file \"%s\" in the module search path.\n"
             filename
            in
-        failwith uu____8884
+        failwith uu____8901
   
 let (pervasives_basename : unit -> Prims.string) =
-  fun uu____8894  ->
-    let uu____8895 = pervasives ()  in FStar_Util.basename uu____8895
+  fun uu____8911  ->
+    let uu____8912 = pervasives ()  in FStar_Util.basename uu____8912
   
 let (pervasives_native_basename : unit -> Prims.string) =
-  fun uu____8903  ->
+  fun uu____8920  ->
     let filename = "FStar.Pervasives.Native.fst"  in
-    let uu____8907 = find_file filename  in
-    match uu____8907 with
+    let uu____8924 = find_file filename  in
+    match uu____8924 with
     | FStar_Pervasives_Native.Some result -> FStar_Util.basename result
     | FStar_Pervasives_Native.None  ->
-        let uu____8916 =
+        let uu____8933 =
           FStar_Util.format1
             "unable to find required file \"%s\" in the module search path.\n"
             filename
            in
-        failwith uu____8916
+        failwith uu____8933
   
 let (prepend_output_dir : Prims.string -> Prims.string) =
   fun fname  ->
-    let uu____8929 = get_odir ()  in
-    match uu____8929 with
+    let uu____8946 = get_odir ()  in
+    match uu____8946 with
     | FStar_Pervasives_Native.None  -> fname
     | FStar_Pervasives_Native.Some x -> FStar_Util.join_paths x fname
   
 let (prepend_cache_dir : Prims.string -> Prims.string) =
   fun fpath  ->
-    let uu____8947 = get_cache_dir ()  in
-    match uu____8947 with
+    let uu____8964 = get_cache_dir ()  in
+    match uu____8964 with
     | FStar_Pervasives_Native.None  -> fpath
     | FStar_Pervasives_Native.Some x ->
-        let uu____8956 = FStar_Util.basename fpath  in
-        FStar_Util.join_paths x uu____8956
+        let uu____8973 = FStar_Util.basename fpath  in
+        FStar_Util.join_paths x uu____8973
   
 let (path_of_text : Prims.string -> Prims.string Prims.list) =
   fun text  -> FStar_String.split [46] text 
@@ -1794,8 +1799,8 @@ let (parse_settings :
   fun ns  ->
     let cache = FStar_Util.smap_create (Prims.of_int (31))  in
     let with_cache f s =
-      let uu____9078 = FStar_Util.smap_try_find cache s  in
-      match uu____9078 with
+      let uu____9095 = FStar_Util.smap_try_find cache s  in
+      match uu____9095 with
       | FStar_Pervasives_Native.Some s1 -> s1
       | FStar_Pervasives_Native.None  ->
           let res = f s  in (FStar_Util.smap_add cache s res; res)
@@ -1810,8 +1815,8 @@ let (parse_settings :
           if FStar_Util.starts_with s "-"
           then
             (let path =
-               let uu____9232 = FStar_Util.substring_from s Prims.int_one  in
-               path_of_text uu____9232  in
+               let uu____9249 = FStar_Util.substring_from s Prims.int_one  in
+               path_of_text uu____9249  in
              (path, false))
           else
             (let s1 =
@@ -1820,7 +1825,7 @@ let (parse_settings :
                else s  in
              ((path_of_text s1), true))
        in
-    let uu____9255 =
+    let uu____9272 =
       FStar_All.pipe_right ns
         (FStar_List.collect
            (fun s  ->
@@ -1831,37 +1836,37 @@ let (parse_settings :
                 with_cache
                   (fun s2  ->
                      let s3 = FStar_Util.replace_char s2 32 44  in
-                     let uu____9329 =
-                       let uu____9333 =
+                     let uu____9346 =
+                       let uu____9350 =
                          FStar_All.pipe_right (FStar_Util.splitlines s3)
                            (FStar_List.concatMap
                               (fun s4  -> FStar_Util.split s4 ","))
                           in
-                       FStar_All.pipe_right uu____9333
+                       FStar_All.pipe_right uu____9350
                          (FStar_List.filter (fun s4  -> s4 <> ""))
                         in
-                     FStar_All.pipe_right uu____9329
+                     FStar_All.pipe_right uu____9346
                        (FStar_List.map parse_one_setting)) s1))
        in
-    FStar_All.pipe_right uu____9255 FStar_List.rev
+    FStar_All.pipe_right uu____9272 FStar_List.rev
   
 let (__temp_no_proj : Prims.string -> Prims.bool) =
   fun s  ->
-    let uu____9420 = get___temp_no_proj ()  in
-    FStar_All.pipe_right uu____9420 (FStar_List.contains s)
+    let uu____9437 = get___temp_no_proj ()  in
+    FStar_All.pipe_right uu____9437 (FStar_List.contains s)
   
 let (__temp_fast_implicits : unit -> Prims.bool) =
-  fun uu____9435  -> lookup_opt "__temp_fast_implicits" as_bool 
+  fun uu____9452  -> lookup_opt "__temp_fast_implicits" as_bool 
 let (admit_smt_queries : unit -> Prims.bool) =
-  fun uu____9444  -> get_admit_smt_queries () 
+  fun uu____9461  -> get_admit_smt_queries () 
 let (admit_except : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____9453  -> get_admit_except () 
+  fun uu____9470  -> get_admit_except () 
 let (cache_checked_modules : unit -> Prims.bool) =
-  fun uu____9460  -> get_cache_checked_modules () 
-let (cache_off : unit -> Prims.bool) = fun uu____9467  -> get_cache_off () 
+  fun uu____9477  -> get_cache_checked_modules () 
+let (cache_off : unit -> Prims.bool) = fun uu____9484  -> get_cache_off () 
 let (print_cache_version : unit -> Prims.bool) =
-  fun uu____9474  -> get_print_cache_version () 
-let (cmi : unit -> Prims.bool) = fun uu____9481  -> get_cmi () 
+  fun uu____9491  -> get_print_cache_version () 
+let (cmi : unit -> Prims.bool) = fun uu____9498  -> get_cmi () 
 type codegen_t =
   | OCaml 
   | FSharp 
@@ -1869,44 +1874,44 @@ type codegen_t =
   | Plugin 
 let (uu___is_OCaml : codegen_t -> Prims.bool) =
   fun projectee  ->
-    match projectee with | OCaml  -> true | uu____9491 -> false
+    match projectee with | OCaml  -> true | uu____9508 -> false
   
 let (uu___is_FSharp : codegen_t -> Prims.bool) =
   fun projectee  ->
-    match projectee with | FSharp  -> true | uu____9502 -> false
+    match projectee with | FSharp  -> true | uu____9519 -> false
   
 let (uu___is_Kremlin : codegen_t -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Kremlin  -> true | uu____9513 -> false
+    match projectee with | Kremlin  -> true | uu____9530 -> false
   
 let (uu___is_Plugin : codegen_t -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Plugin  -> true | uu____9524 -> false
+    match projectee with | Plugin  -> true | uu____9541 -> false
   
 let (codegen : unit -> codegen_t FStar_Pervasives_Native.option) =
-  fun uu____9533  ->
-    let uu____9534 = get_codegen ()  in
-    FStar_Util.map_opt uu____9534
-      (fun uu___13_9540  ->
-         match uu___13_9540 with
+  fun uu____9550  ->
+    let uu____9551 = get_codegen ()  in
+    FStar_Util.map_opt uu____9551
+      (fun uu___13_9557  ->
+         match uu___13_9557 with
          | "OCaml" -> OCaml
          | "FSharp" -> FSharp
          | "Kremlin" -> Kremlin
          | "Plugin" -> Plugin
-         | uu____9546 -> failwith "Impossible")
+         | uu____9563 -> failwith "Impossible")
   
 let (codegen_libs : unit -> Prims.string Prims.list Prims.list) =
-  fun uu____9559  ->
-    let uu____9560 = get_codegen_lib ()  in
-    FStar_All.pipe_right uu____9560
+  fun uu____9576  ->
+    let uu____9577 = get_codegen_lib ()  in
+    FStar_All.pipe_right uu____9577
       (FStar_List.map (fun x  -> FStar_Util.split x "."))
   
 let (debug_any : unit -> Prims.bool) =
-  fun uu____9586  -> let uu____9587 = get_debug ()  in uu____9587 <> [] 
+  fun uu____9603  -> let uu____9604 = get_debug ()  in uu____9604 <> [] 
 let (debug_module : Prims.string -> Prims.bool) =
   fun modul  ->
-    let uu____9604 = get_debug ()  in
-    FStar_All.pipe_right uu____9604
+    let uu____9621 = get_debug ()  in
+    FStar_All.pipe_right uu____9621
       (FStar_List.existsb (module_name_eq modul))
   
 let (debug_at_level_no_module : debug_level_t -> Prims.bool) =
@@ -1916,263 +1921,263 @@ let (debug_at_level : Prims.string -> debug_level_t -> Prims.bool) =
     fun level  -> (debug_module modul) && (debug_at_level_no_module level)
   
 let (profile_group_by_decls : unit -> Prims.bool) =
-  fun uu____9640  -> get_profile_group_by_decl () 
+  fun uu____9657  -> get_profile_group_by_decl () 
 let (defensive : unit -> Prims.bool) =
-  fun uu____9647  -> let uu____9648 = get_defensive ()  in uu____9648 <> "no" 
+  fun uu____9664  -> let uu____9665 = get_defensive ()  in uu____9665 <> "no" 
 let (defensive_fail : unit -> Prims.bool) =
-  fun uu____9658  ->
-    let uu____9659 = get_defensive ()  in uu____9659 = "fail"
+  fun uu____9675  ->
+    let uu____9676 = get_defensive ()  in uu____9676 = "fail"
   
 let (dep : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____9671  -> get_dep () 
+  fun uu____9688  -> get_dep () 
 let (detail_errors : unit -> Prims.bool) =
-  fun uu____9678  -> get_detail_errors () 
+  fun uu____9695  -> get_detail_errors () 
 let (detail_hint_replay : unit -> Prims.bool) =
-  fun uu____9685  -> get_detail_hint_replay () 
+  fun uu____9702  -> get_detail_hint_replay () 
 let (dump_module : Prims.string -> Prims.bool) =
   fun s  ->
-    let uu____9695 = get_dump_module ()  in
-    FStar_All.pipe_right uu____9695 (FStar_List.existsb (module_name_eq s))
+    let uu____9712 = get_dump_module ()  in
+    FStar_All.pipe_right uu____9712 (FStar_List.existsb (module_name_eq s))
   
 let (eager_subtyping : unit -> Prims.bool) =
-  fun uu____9710  -> get_eager_subtyping () 
+  fun uu____9727  -> get_eager_subtyping () 
 let (expose_interfaces : unit -> Prims.bool) =
-  fun uu____9717  -> get_expose_interfaces () 
+  fun uu____9734  -> get_expose_interfaces () 
 let (fs_typ_app : Prims.string -> Prims.bool) =
   fun filename  ->
-    let uu____9727 = FStar_ST.op_Bang light_off_files  in
-    FStar_List.contains filename uu____9727
+    let uu____9744 = FStar_ST.op_Bang light_off_files  in
+    FStar_List.contains filename uu____9744
   
-let (full_context_dependency : unit -> Prims.bool) = fun uu____9763  -> true 
+let (full_context_dependency : unit -> Prims.bool) = fun uu____9780  -> true 
 let (hide_uvar_nums : unit -> Prims.bool) =
-  fun uu____9771  -> get_hide_uvar_nums () 
+  fun uu____9788  -> get_hide_uvar_nums () 
 let (hint_info : unit -> Prims.bool) =
-  fun uu____9778  -> (get_hint_info ()) || (get_query_stats ()) 
+  fun uu____9795  -> (get_hint_info ()) || (get_query_stats ()) 
 let (hint_dir : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____9787  -> get_hint_dir () 
+  fun uu____9804  -> get_hint_dir () 
 let (hint_file : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____9796  -> get_hint_file () 
+  fun uu____9813  -> get_hint_file () 
 let (hint_file_for_src : Prims.string -> Prims.string) =
   fun src_filename  ->
-    let uu____9806 = hint_file ()  in
-    match uu____9806 with
+    let uu____9823 = hint_file ()  in
+    match uu____9823 with
     | FStar_Pervasives_Native.Some fn -> fn
     | FStar_Pervasives_Native.None  ->
         let file_name =
-          let uu____9817 = hint_dir ()  in
-          match uu____9817 with
+          let uu____9834 = hint_dir ()  in
+          match uu____9834 with
           | FStar_Pervasives_Native.Some dir ->
-              let uu____9825 = FStar_Util.basename src_filename  in
-              FStar_Util.concat_dir_filename dir uu____9825
-          | uu____9827 -> src_filename  in
+              let uu____9842 = FStar_Util.basename src_filename  in
+              FStar_Util.concat_dir_filename dir uu____9842
+          | uu____9844 -> src_filename  in
         FStar_Util.format1 "%s.hints" file_name
   
-let (ide : unit -> Prims.bool) = fun uu____9838  -> get_ide () 
-let (print : unit -> Prims.bool) = fun uu____9845  -> get_print () 
+let (ide : unit -> Prims.bool) = fun uu____9855  -> get_ide () 
+let (print : unit -> Prims.bool) = fun uu____9862  -> get_print () 
 let (print_in_place : unit -> Prims.bool) =
-  fun uu____9852  -> get_print_in_place () 
+  fun uu____9869  -> get_print_in_place () 
 let (initial_fuel : unit -> Prims.int) =
-  fun uu____9859  ->
-    let uu____9860 = get_initial_fuel ()  in
-    let uu____9862 = get_max_fuel ()  in Prims.min uu____9860 uu____9862
+  fun uu____9876  ->
+    let uu____9877 = get_initial_fuel ()  in
+    let uu____9879 = get_max_fuel ()  in Prims.min uu____9877 uu____9879
   
 let (initial_ifuel : unit -> Prims.int) =
-  fun uu____9870  ->
-    let uu____9871 = get_initial_ifuel ()  in
-    let uu____9873 = get_max_ifuel ()  in Prims.min uu____9871 uu____9873
+  fun uu____9887  ->
+    let uu____9888 = get_initial_ifuel ()  in
+    let uu____9890 = get_max_ifuel ()  in Prims.min uu____9888 uu____9890
   
 let (interactive : unit -> Prims.bool) =
-  fun uu____9881  -> (get_in ()) || (get_ide ()) 
-let (lax : unit -> Prims.bool) = fun uu____9888  -> get_lax () 
-let (load : unit -> Prims.string Prims.list) = fun uu____9897  -> get_load () 
-let (legacy_interactive : unit -> Prims.bool) = fun uu____9904  -> get_in () 
-let (lsp_server : unit -> Prims.bool) = fun uu____9911  -> get_lsp () 
+  fun uu____9898  -> (get_in ()) || (get_ide ()) 
+let (lax : unit -> Prims.bool) = fun uu____9905  -> get_lax () 
+let (load : unit -> Prims.string Prims.list) = fun uu____9914  -> get_load () 
+let (legacy_interactive : unit -> Prims.bool) = fun uu____9921  -> get_in () 
+let (lsp_server : unit -> Prims.bool) = fun uu____9928  -> get_lsp () 
 let (log_queries : unit -> Prims.bool) =
-  fun uu____9918  -> get_log_queries () 
+  fun uu____9935  -> get_log_queries () 
 let (keep_query_captions : unit -> Prims.bool) =
-  fun uu____9925  -> (log_queries ()) && (get_keep_query_captions ()) 
-let (log_types : unit -> Prims.bool) = fun uu____9932  -> get_log_types () 
-let (max_fuel : unit -> Prims.int) = fun uu____9939  -> get_max_fuel () 
-let (max_ifuel : unit -> Prims.int) = fun uu____9946  -> get_max_ifuel () 
-let (min_fuel : unit -> Prims.int) = fun uu____9953  -> get_min_fuel () 
-let (ml_ish : unit -> Prims.bool) = fun uu____9960  -> get_MLish () 
+  fun uu____9942  -> (log_queries ()) && (get_keep_query_captions ()) 
+let (log_types : unit -> Prims.bool) = fun uu____9949  -> get_log_types () 
+let (max_fuel : unit -> Prims.int) = fun uu____9956  -> get_max_fuel () 
+let (max_ifuel : unit -> Prims.int) = fun uu____9963  -> get_max_ifuel () 
+let (min_fuel : unit -> Prims.int) = fun uu____9970  -> get_min_fuel () 
+let (ml_ish : unit -> Prims.bool) = fun uu____9977  -> get_MLish () 
 let (set_ml_ish : unit -> unit) =
-  fun uu____9966  -> set_option "MLish" (Bool true) 
+  fun uu____9983  -> set_option "MLish" (Bool true) 
 let (no_default_includes : unit -> Prims.bool) =
-  fun uu____9975  -> get_no_default_includes () 
+  fun uu____9992  -> get_no_default_includes () 
 let (no_extract : Prims.string -> Prims.bool) =
   fun s  ->
-    let uu____9985 = get_no_extract ()  in
-    FStar_All.pipe_right uu____9985 (FStar_List.existsb (module_name_eq s))
+    let uu____10002 = get_no_extract ()  in
+    FStar_All.pipe_right uu____10002 (FStar_List.existsb (module_name_eq s))
   
 let (normalize_pure_terms_for_extraction : unit -> Prims.bool) =
-  fun uu____10000  -> get_normalize_pure_terms_for_extraction () 
+  fun uu____10017  -> get_normalize_pure_terms_for_extraction () 
 let (no_load_fstartaclib : unit -> Prims.bool) =
-  fun uu____10007  -> get_no_load_fstartaclib () 
+  fun uu____10024  -> get_no_load_fstartaclib () 
 let (no_location_info : unit -> Prims.bool) =
-  fun uu____10014  -> get_no_location_info () 
-let (no_plugins : unit -> Prims.bool) = fun uu____10021  -> get_no_plugins () 
-let (no_smt : unit -> Prims.bool) = fun uu____10028  -> get_no_smt () 
+  fun uu____10031  -> get_no_location_info () 
+let (no_plugins : unit -> Prims.bool) = fun uu____10038  -> get_no_plugins () 
+let (no_smt : unit -> Prims.bool) = fun uu____10045  -> get_no_smt () 
 let (output_dir : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____10037  -> get_odir () 
-let (ugly : unit -> Prims.bool) = fun uu____10044  -> get_ugly () 
+  fun uu____10054  -> get_odir () 
+let (ugly : unit -> Prims.bool) = fun uu____10061  -> get_ugly () 
 let (print_bound_var_types : unit -> Prims.bool) =
-  fun uu____10051  -> get_print_bound_var_types () 
+  fun uu____10068  -> get_print_bound_var_types () 
 let (print_effect_args : unit -> Prims.bool) =
-  fun uu____10058  -> get_print_effect_args () 
+  fun uu____10075  -> get_print_effect_args () 
 let (print_implicits : unit -> Prims.bool) =
-  fun uu____10065  -> get_print_implicits () 
+  fun uu____10082  -> get_print_implicits () 
 let (print_real_names : unit -> Prims.bool) =
-  fun uu____10072  -> (get_prn ()) || (get_print_full_names ()) 
+  fun uu____10089  -> (get_prn ()) || (get_print_full_names ()) 
 let (print_universes : unit -> Prims.bool) =
-  fun uu____10079  -> get_print_universes () 
+  fun uu____10096  -> get_print_universes () 
 let (print_z3_statistics : unit -> Prims.bool) =
-  fun uu____10086  -> get_print_z3_statistics () 
-let (quake_lo : unit -> Prims.int) = fun uu____10093  -> get_quake_lo () 
-let (quake_hi : unit -> Prims.int) = fun uu____10100  -> get_quake_hi () 
-let (quake_keep : unit -> Prims.bool) = fun uu____10107  -> get_quake_keep () 
+  fun uu____10103  -> get_print_z3_statistics () 
+let (quake_lo : unit -> Prims.int) = fun uu____10110  -> get_quake_lo () 
+let (quake_hi : unit -> Prims.int) = fun uu____10117  -> get_quake_hi () 
+let (quake_keep : unit -> Prims.bool) = fun uu____10124  -> get_quake_keep () 
 let (query_stats : unit -> Prims.bool) =
-  fun uu____10114  -> get_query_stats () 
+  fun uu____10131  -> get_query_stats () 
 let (record_hints : unit -> Prims.bool) =
-  fun uu____10121  -> get_record_hints () 
+  fun uu____10138  -> get_record_hints () 
 let (record_options : unit -> Prims.bool) =
-  fun uu____10128  -> get_record_options () 
-let (retry : unit -> Prims.bool) = fun uu____10135  -> get_retry () 
+  fun uu____10145  -> get_record_options () 
+let (retry : unit -> Prims.bool) = fun uu____10152  -> get_retry () 
 let (reuse_hint_for : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____10144  -> get_reuse_hint_for () 
-let (silent : unit -> Prims.bool) = fun uu____10151  -> get_silent () 
+  fun uu____10161  -> get_reuse_hint_for () 
+let (silent : unit -> Prims.bool) = fun uu____10168  -> get_silent () 
 let (smtencoding_elim_box : unit -> Prims.bool) =
-  fun uu____10158  -> get_smtencoding_elim_box () 
+  fun uu____10175  -> get_smtencoding_elim_box () 
 let (smtencoding_nl_arith_native : unit -> Prims.bool) =
-  fun uu____10165  ->
-    let uu____10166 = get_smtencoding_nl_arith_repr ()  in
-    uu____10166 = "native"
+  fun uu____10182  ->
+    let uu____10183 = get_smtencoding_nl_arith_repr ()  in
+    uu____10183 = "native"
   
 let (smtencoding_nl_arith_wrapped : unit -> Prims.bool) =
-  fun uu____10176  ->
-    let uu____10177 = get_smtencoding_nl_arith_repr ()  in
-    uu____10177 = "wrapped"
+  fun uu____10193  ->
+    let uu____10194 = get_smtencoding_nl_arith_repr ()  in
+    uu____10194 = "wrapped"
   
 let (smtencoding_nl_arith_default : unit -> Prims.bool) =
-  fun uu____10187  ->
-    let uu____10188 = get_smtencoding_nl_arith_repr ()  in
-    uu____10188 = "boxwrap"
+  fun uu____10204  ->
+    let uu____10205 = get_smtencoding_nl_arith_repr ()  in
+    uu____10205 = "boxwrap"
   
 let (smtencoding_l_arith_native : unit -> Prims.bool) =
-  fun uu____10198  ->
-    let uu____10199 = get_smtencoding_l_arith_repr ()  in
-    uu____10199 = "native"
+  fun uu____10215  ->
+    let uu____10216 = get_smtencoding_l_arith_repr ()  in
+    uu____10216 = "native"
   
 let (smtencoding_l_arith_default : unit -> Prims.bool) =
-  fun uu____10209  ->
-    let uu____10210 = get_smtencoding_l_arith_repr ()  in
-    uu____10210 = "boxwrap"
+  fun uu____10226  ->
+    let uu____10227 = get_smtencoding_l_arith_repr ()  in
+    uu____10227 = "boxwrap"
   
 let (smtencoding_valid_intro : unit -> Prims.bool) =
-  fun uu____10220  -> get_smtencoding_valid_intro () 
+  fun uu____10237  -> get_smtencoding_valid_intro () 
 let (smtencoding_valid_elim : unit -> Prims.bool) =
-  fun uu____10227  -> get_smtencoding_valid_elim () 
+  fun uu____10244  -> get_smtencoding_valid_elim () 
 let (tactic_raw_binders : unit -> Prims.bool) =
-  fun uu____10234  -> get_tactic_raw_binders () 
+  fun uu____10251  -> get_tactic_raw_binders () 
 let (tactics_failhard : unit -> Prims.bool) =
-  fun uu____10241  -> get_tactics_failhard () 
+  fun uu____10258  -> get_tactics_failhard () 
 let (tactics_info : unit -> Prims.bool) =
-  fun uu____10248  -> get_tactics_info () 
+  fun uu____10265  -> get_tactics_info () 
 let (tactic_trace : unit -> Prims.bool) =
-  fun uu____10255  -> get_tactic_trace () 
+  fun uu____10272  -> get_tactic_trace () 
 let (tactic_trace_d : unit -> Prims.int) =
-  fun uu____10262  -> get_tactic_trace_d () 
+  fun uu____10279  -> get_tactic_trace_d () 
 let (tactics_nbe : unit -> Prims.bool) =
-  fun uu____10269  -> get_tactics_nbe () 
-let (tcnorm : unit -> Prims.bool) = fun uu____10276  -> get_tcnorm () 
-let (timing : unit -> Prims.bool) = fun uu____10283  -> get_timing () 
+  fun uu____10286  -> get_tactics_nbe () 
+let (tcnorm : unit -> Prims.bool) = fun uu____10293  -> get_tcnorm () 
+let (timing : unit -> Prims.bool) = fun uu____10300  -> get_timing () 
 let (trace_error : unit -> Prims.bool) =
-  fun uu____10290  -> get_trace_error () 
+  fun uu____10307  -> get_trace_error () 
 let (unthrottle_inductives : unit -> Prims.bool) =
-  fun uu____10297  -> get_unthrottle_inductives () 
+  fun uu____10314  -> get_unthrottle_inductives () 
 let (unsafe_tactic_exec : unit -> Prims.bool) =
-  fun uu____10304  -> get_unsafe_tactic_exec () 
+  fun uu____10321  -> get_unsafe_tactic_exec () 
 let (use_eq_at_higher_order : unit -> Prims.bool) =
-  fun uu____10311  -> get_use_eq_at_higher_order () 
-let (use_hints : unit -> Prims.bool) = fun uu____10318  -> get_use_hints () 
+  fun uu____10328  -> get_use_eq_at_higher_order () 
+let (use_hints : unit -> Prims.bool) = fun uu____10335  -> get_use_hints () 
 let (use_hint_hashes : unit -> Prims.bool) =
-  fun uu____10325  -> get_use_hint_hashes () 
+  fun uu____10342  -> get_use_hint_hashes () 
 let (use_native_tactics :
   unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____10334  -> get_use_native_tactics () 
+  fun uu____10351  -> get_use_native_tactics () 
 let (use_tactics : unit -> Prims.bool) =
-  fun uu____10341  -> get_use_tactics () 
+  fun uu____10358  -> get_use_tactics () 
 let (using_facts_from :
   unit -> (Prims.string Prims.list * Prims.bool) Prims.list) =
-  fun uu____10357  ->
-    let uu____10358 = get_using_facts_from ()  in
-    match uu____10358 with
+  fun uu____10374  ->
+    let uu____10375 = get_using_facts_from ()  in
+    match uu____10375 with
     | FStar_Pervasives_Native.None  -> [([], true)]
     | FStar_Pervasives_Native.Some ns -> parse_settings ns
   
 let (vcgen_optimize_bind_as_seq : unit -> Prims.bool) =
-  fun uu____10412  ->
-    let uu____10413 = get_vcgen_optimize_bind_as_seq ()  in
-    FStar_Option.isSome uu____10413
+  fun uu____10429  ->
+    let uu____10430 = get_vcgen_optimize_bind_as_seq ()  in
+    FStar_Option.isSome uu____10430
   
 let (vcgen_decorate_with_type : unit -> Prims.bool) =
-  fun uu____10424  ->
-    let uu____10425 = get_vcgen_optimize_bind_as_seq ()  in
-    match uu____10425 with
+  fun uu____10441  ->
+    let uu____10442 = get_vcgen_optimize_bind_as_seq ()  in
+    match uu____10442 with
     | FStar_Pervasives_Native.Some "with_type" -> true
-    | uu____10433 -> false
+    | uu____10450 -> false
   
 let (warn_default_effects : unit -> Prims.bool) =
-  fun uu____10444  -> get_warn_default_effects () 
+  fun uu____10461  -> get_warn_default_effects () 
 let (z3_exe : unit -> Prims.string) =
-  fun uu____10451  ->
-    let uu____10452 = get_smt ()  in
-    match uu____10452 with
+  fun uu____10468  ->
+    let uu____10469 = get_smt ()  in
+    match uu____10469 with
     | FStar_Pervasives_Native.None  -> FStar_Platform.exe "z3"
     | FStar_Pervasives_Native.Some s -> s
   
 let (z3_cliopt : unit -> Prims.string Prims.list) =
-  fun uu____10470  -> get_z3cliopt () 
-let (z3_refresh : unit -> Prims.bool) = fun uu____10477  -> get_z3refresh () 
-let (z3_rlimit : unit -> Prims.int) = fun uu____10484  -> get_z3rlimit () 
+  fun uu____10487  -> get_z3cliopt () 
+let (z3_refresh : unit -> Prims.bool) = fun uu____10494  -> get_z3refresh () 
+let (z3_rlimit : unit -> Prims.int) = fun uu____10501  -> get_z3rlimit () 
 let (z3_rlimit_factor : unit -> Prims.int) =
-  fun uu____10491  -> get_z3rlimit_factor () 
-let (z3_seed : unit -> Prims.int) = fun uu____10498  -> get_z3seed () 
+  fun uu____10508  -> get_z3rlimit_factor () 
+let (z3_seed : unit -> Prims.int) = fun uu____10515  -> get_z3seed () 
 let (use_two_phase_tc : unit -> Prims.bool) =
-  fun uu____10505  ->
+  fun uu____10522  ->
     (get_use_two_phase_tc ()) &&
-      (let uu____10507 = lax ()  in Prims.op_Negation uu____10507)
+      (let uu____10524 = lax ()  in Prims.op_Negation uu____10524)
   
 let (no_positivity : unit -> Prims.bool) =
-  fun uu____10515  -> get_no_positivity () 
+  fun uu____10532  -> get_no_positivity () 
 let (ml_no_eta_expand_coertions : unit -> Prims.bool) =
-  fun uu____10522  -> get_ml_no_eta_expand_coertions () 
+  fun uu____10539  -> get_ml_no_eta_expand_coertions () 
 let (warn_error : unit -> Prims.string) =
-  fun uu____10529  ->
-    let uu____10530 = get_warn_error ()  in
-    FStar_String.concat "" uu____10530
+  fun uu____10546  ->
+    let uu____10547 = get_warn_error ()  in
+    FStar_String.concat "" uu____10547
   
 let (use_extracted_interfaces : unit -> Prims.bool) =
-  fun uu____10541  -> get_use_extracted_interfaces () 
-let (use_nbe : unit -> Prims.bool) = fun uu____10548  -> get_use_nbe () 
+  fun uu____10558  -> get_use_extracted_interfaces () 
+let (use_nbe : unit -> Prims.bool) = fun uu____10565  -> get_use_nbe () 
 let (use_nbe_for_extraction : unit -> Prims.bool) =
-  fun uu____10555  -> get_use_nbe_for_extraction () 
+  fun uu____10572  -> get_use_nbe_for_extraction () 
 let (trivial_pre_for_unannotated_effectful_fns : unit -> Prims.bool) =
-  fun uu____10562  -> get_trivial_pre_for_unannotated_effectful_fns () 
+  fun uu____10579  -> get_trivial_pre_for_unannotated_effectful_fns () 
 let with_saved_options : 'a . (unit -> 'a) -> 'a =
   fun f  ->
-    let uu____10579 =
-      let uu____10581 = trace_error ()  in Prims.op_Negation uu____10581  in
-    if uu____10579
+    let uu____10596 =
+      let uu____10598 = trace_error ()  in Prims.op_Negation uu____10598  in
+    if uu____10596
     then
       (push ();
        (let r =
           try
-            (fun uu___827_10596  ->
+            (fun uu___828_10613  ->
                match () with
-               | () -> let uu____10601 = f ()  in FStar_Util.Inr uu____10601)
+               | () -> let uu____10618 = f ()  in FStar_Util.Inr uu____10618)
               ()
-          with | uu___826_10603 -> FStar_Util.Inl uu___826_10603  in
+          with | uu___827_10620 -> FStar_Util.Inl uu___827_10620  in
         pop ();
         (match r with
          | FStar_Util.Inr v1 -> v1
@@ -2188,28 +2193,28 @@ let (module_matches_namespace_filter :
       let m_components = path_of_text m1  in
       let rec matches_path m_components1 path =
         match (m_components1, path) with
-        | (uu____10684,[]) -> true
+        | (uu____10701,[]) -> true
         | (m2::ms,p::ps) ->
             (m2 = (FStar_String.lowercase p)) && (matches_path ms ps)
-        | uu____10717 -> false  in
-      let uu____10729 =
+        | uu____10734 -> false  in
+      let uu____10746 =
         FStar_All.pipe_right setting
           (FStar_Util.try_find
-             (fun uu____10771  ->
-                match uu____10771 with
-                | (path,uu____10782) -> matches_path m_components path))
+             (fun uu____10788  ->
+                match uu____10788 with
+                | (path,uu____10799) -> matches_path m_components path))
          in
-      match uu____10729 with
+      match uu____10746 with
       | FStar_Pervasives_Native.None  -> false
-      | FStar_Pervasives_Native.Some (uu____10801,flag) -> flag
+      | FStar_Pervasives_Native.Some (uu____10818,flag) -> flag
   
 let (matches_namespace_filter_opt :
   Prims.string ->
     Prims.string Prims.list FStar_Pervasives_Native.option -> Prims.bool)
   =
   fun m  ->
-    fun uu___14_10836  ->
-      match uu___14_10836 with
+    fun uu___14_10853  ->
+      match uu___14_10853 with
       | FStar_Pervasives_Native.None  -> false
       | FStar_Pervasives_Native.Some filter1 ->
           module_matches_namespace_filter m filter1
@@ -2217,24 +2222,24 @@ let (matches_namespace_filter_opt :
 let (should_extract : Prims.string -> Prims.bool) =
   fun m  ->
     let m1 = FStar_String.lowercase m  in
-    let uu____10866 = get_extract ()  in
-    match uu____10866 with
+    let uu____10883 = get_extract ()  in
+    match uu____10883 with
     | FStar_Pervasives_Native.Some extract_setting ->
-        ((let uu____10881 =
-            let uu____10897 = get_no_extract ()  in
-            let uu____10901 = get_extract_namespace ()  in
-            let uu____10905 = get_extract_module ()  in
-            (uu____10897, uu____10901, uu____10905)  in
-          match uu____10881 with
+        ((let uu____10898 =
+            let uu____10914 = get_no_extract ()  in
+            let uu____10918 = get_extract_namespace ()  in
+            let uu____10922 = get_extract_module ()  in
+            (uu____10914, uu____10918, uu____10922)  in
+          match uu____10898 with
           | ([],[],[]) -> ()
-          | uu____10930 ->
+          | uu____10947 ->
               failwith
                 "Incompatible options: --extract cannot be used with --no_extract, --extract_namespace or --extract_module");
          module_matches_namespace_filter m1 extract_setting)
     | FStar_Pervasives_Native.None  ->
         let should_extract_namespace m2 =
-          let uu____10959 = get_extract_namespace ()  in
-          match uu____10959 with
+          let uu____10976 = get_extract_namespace ()  in
+          match uu____10976 with
           | [] -> false
           | ns ->
               FStar_All.pipe_right ns
@@ -2243,39 +2248,39 @@ let (should_extract : Prims.string -> Prims.bool) =
                       FStar_Util.starts_with m2 (FStar_String.lowercase n1)))
            in
         let should_extract_module m2 =
-          let uu____10987 = get_extract_module ()  in
-          match uu____10987 with
+          let uu____11004 = get_extract_module ()  in
+          match uu____11004 with
           | [] -> false
           | l ->
               FStar_All.pipe_right l
                 (FStar_Util.for_some
                    (fun n1  -> (FStar_String.lowercase n1) = m2))
            in
-        (let uu____11009 = no_extract m1  in Prims.op_Negation uu____11009)
+        (let uu____11026 = no_extract m1  in Prims.op_Negation uu____11026)
           &&
-          (let uu____11012 =
-             let uu____11023 = get_extract_namespace ()  in
-             let uu____11027 = get_extract_module ()  in
-             (uu____11023, uu____11027)  in
-           (match uu____11012 with
+          (let uu____11029 =
+             let uu____11040 = get_extract_namespace ()  in
+             let uu____11044 = get_extract_module ()  in
+             (uu____11040, uu____11044)  in
+           (match uu____11029 with
             | ([],[]) -> true
-            | uu____11047 ->
+            | uu____11064 ->
                 (should_extract_namespace m1) || (should_extract_module m1)))
   
 let (should_be_already_cached : Prims.string -> Prims.bool) =
   fun m  ->
-    let uu____11067 = get_already_cached ()  in
-    match uu____11067 with
+    let uu____11084 = get_already_cached ()  in
+    match uu____11084 with
     | FStar_Pervasives_Native.None  -> false
     | FStar_Pervasives_Native.Some already_cached_setting ->
         module_matches_namespace_filter m already_cached_setting
   
 let (error_flags : unit -> error_flag Prims.list) =
   let cache = FStar_Util.smap_create (Prims.of_int (10))  in
-  fun uu____11100  ->
+  fun uu____11117  ->
     let we = warn_error ()  in
-    let uu____11103 = FStar_Util.smap_try_find cache we  in
-    match uu____11103 with
+    let uu____11120 = FStar_Util.smap_try_find cache we  in
+    match uu____11120 with
     | FStar_Pervasives_Native.None  ->
         let r = parse_warn_error we  in (FStar_Util.smap_add cache we r; r)
     | FStar_Pervasives_Native.Some r -> r
@@ -2287,11 +2292,11 @@ let (profile_enabled :
     fun phase  ->
       match modul_opt with
       | FStar_Pervasives_Native.None  ->
-          let uu____11147 = get_profile_component ()  in
-          matches_namespace_filter_opt phase uu____11147
+          let uu____11164 = get_profile_component ()  in
+          matches_namespace_filter_opt phase uu____11164
       | FStar_Pervasives_Native.Some modul ->
-          (let uu____11158 = get_profile ()  in
-           matches_namespace_filter_opt modul uu____11158) &&
-            (let uu____11165 = get_profile_component ()  in
-             matches_namespace_filter_opt phase uu____11165)
+          (let uu____11175 = get_profile ()  in
+           matches_namespace_filter_opt modul uu____11175) &&
+            (let uu____11182 = get_profile_component ()  in
+             matches_namespace_filter_opt phase uu____11182)
   

--- a/src/ocaml-output/FStar_Parser_Dep.ml
+++ b/src/ocaml-output/FStar_Parser_Dep.ml
@@ -551,28 +551,32 @@ let (cache_file_name : Prims.string -> Prims.string) =
               (FStar_Errors.Warning_UnexpectedCheckedFile, uu____1803)  in
             FStar_Errors.log_issue FStar_Range.dummyRange uu____1797
           else ());
-         path)
+         (let uu____1811 =
+            (FStar_Util.file_exists expected_cache_file) &&
+              (FStar_Util.paths_to_same_file path expected_cache_file)
+             in
+          if uu____1811 then expected_cache_file else path))
     | FStar_Pervasives_Native.None  ->
-        let uu____1812 =
+        let uu____1818 =
           FStar_All.pipe_right mname FStar_Options.should_be_already_cached
            in
-        if uu____1812
+        if uu____1818
         then
-          let uu____1818 =
-            let uu____1824 =
+          let uu____1824 =
+            let uu____1830 =
               FStar_Util.format1
                 "Expected %s to be already checked but could not find it"
                 mname
                in
-            (FStar_Errors.Error_AlreadyCachedAssertionFailure, uu____1824)
+            (FStar_Errors.Error_AlreadyCachedAssertionFailure, uu____1830)
              in
-          FStar_Errors.raise_err uu____1818
+          FStar_Errors.raise_err uu____1824
         else FStar_Options.prepend_cache_dir cache_fn
      in
   let memo = FStar_Util.smap_create (Prims.of_int (100))  in
   let memo1 f x =
-    let uu____1860 = FStar_Util.smap_try_find memo x  in
-    match uu____1860 with
+    let uu____1866 = FStar_Util.smap_try_find memo x  in
+    match uu____1866 with
     | FStar_Pervasives_Native.Some res -> res
     | FStar_Pervasives_Native.None  ->
         let res = f x  in (FStar_Util.smap_add memo x res; res)
@@ -581,8 +585,8 @@ let (cache_file_name : Prims.string -> Prims.string) =
 let (parsing_data_of : deps -> Prims.string -> parsing_data) =
   fun deps  ->
     fun fn  ->
-      let uu____1887 = FStar_Util.smap_try_find deps.parse_results fn  in
-      FStar_All.pipe_right uu____1887 FStar_Util.must
+      let uu____1893 = FStar_Util.smap_try_find deps.parse_results fn  in
+      FStar_All.pipe_right uu____1893 FStar_Util.must
   
 let (file_of_dep_aux :
   Prims.bool ->
@@ -597,111 +601,111 @@ let (file_of_dep_aux :
               (FStar_Util.for_some
                  (fun fn  ->
                     (is_implementation fn) &&
-                      (let uu____1941 = lowercase_module_name fn  in
-                       key = uu____1941)))
+                      (let uu____1947 = lowercase_module_name fn  in
+                       key = uu____1947)))
              in
           let maybe_use_cache_of f =
             if use_checked_file then cache_file_name f else f  in
           match d with
           | UseInterface key ->
-              let uu____1960 = interface_of_internal file_system_map key  in
-              (match uu____1960 with
+              let uu____1966 = interface_of_internal file_system_map key  in
+              (match uu____1966 with
                | FStar_Pervasives_Native.None  ->
-                   let uu____1967 =
-                     let uu____1973 =
+                   let uu____1973 =
+                     let uu____1979 =
                        FStar_Util.format1
                          "Expected an interface for module %s, but couldn't find one"
                          key
                         in
-                     (FStar_Errors.Fatal_MissingInterface, uu____1973)  in
-                   FStar_Errors.raise_err uu____1967
+                     (FStar_Errors.Fatal_MissingInterface, uu____1979)  in
+                   FStar_Errors.raise_err uu____1973
                | FStar_Pervasives_Native.Some f -> f)
           | PreferInterface key when has_interface file_system_map key ->
-              let uu____1983 =
+              let uu____1989 =
                 (cmd_line_has_impl key) &&
-                  (let uu____1986 = FStar_Options.dep ()  in
-                   FStar_Option.isNone uu____1986)
+                  (let uu____1992 = FStar_Options.dep ()  in
+                   FStar_Option.isNone uu____1992)
                  in
-              if uu____1983
+              if uu____1989
               then
-                let uu____1993 = FStar_Options.expose_interfaces ()  in
-                (if uu____1993
+                let uu____1999 = FStar_Options.expose_interfaces ()  in
+                (if uu____1999
                  then
-                   let uu____1997 =
-                     let uu____1999 =
+                   let uu____2003 =
+                     let uu____2005 =
                        implementation_of_internal file_system_map key  in
-                     FStar_Option.get uu____1999  in
-                   maybe_use_cache_of uu____1997
+                     FStar_Option.get uu____2005  in
+                   maybe_use_cache_of uu____2003
                  else
-                   (let uu____2006 =
-                      let uu____2012 =
-                        let uu____2014 =
-                          let uu____2016 =
+                   (let uu____2012 =
+                      let uu____2018 =
+                        let uu____2020 =
+                          let uu____2022 =
                             implementation_of_internal file_system_map key
                              in
-                          FStar_Option.get uu____2016  in
-                        let uu____2021 =
-                          let uu____2023 =
+                          FStar_Option.get uu____2022  in
+                        let uu____2027 =
+                          let uu____2029 =
                             interface_of_internal file_system_map key  in
-                          FStar_Option.get uu____2023  in
+                          FStar_Option.get uu____2029  in
                         FStar_Util.format3
                           "You may have a cyclic dependence on module %s: use --dep full to confirm. Alternatively, invoking fstar with %s on the command line breaks the abstraction imposed by its interface %s; if you really want this behavior add the option '--expose_interfaces'"
-                          key uu____2014 uu____2021
+                          key uu____2020 uu____2027
                          in
                       (FStar_Errors.Fatal_MissingExposeInterfacesOption,
-                        uu____2012)
+                        uu____2018)
                        in
-                    FStar_Errors.raise_err uu____2006))
+                    FStar_Errors.raise_err uu____2012))
               else
-                (let uu____2033 =
-                   let uu____2035 = interface_of_internal file_system_map key
+                (let uu____2039 =
+                   let uu____2041 = interface_of_internal file_system_map key
                       in
-                   FStar_Option.get uu____2035  in
-                 maybe_use_cache_of uu____2033)
+                   FStar_Option.get uu____2041  in
+                 maybe_use_cache_of uu____2039)
           | PreferInterface key ->
-              let uu____2042 = implementation_of_internal file_system_map key
+              let uu____2048 = implementation_of_internal file_system_map key
                  in
-              (match uu____2042 with
+              (match uu____2048 with
                | FStar_Pervasives_Native.None  ->
-                   let uu____2048 =
-                     let uu____2054 =
+                   let uu____2054 =
+                     let uu____2060 =
                        FStar_Util.format1
                          "Expected an implementation of module %s, but couldn't find one"
                          key
                         in
-                     (FStar_Errors.Fatal_MissingImplementation, uu____2054)
+                     (FStar_Errors.Fatal_MissingImplementation, uu____2060)
                       in
-                   FStar_Errors.raise_err uu____2048
+                   FStar_Errors.raise_err uu____2054
                | FStar_Pervasives_Native.Some f -> maybe_use_cache_of f)
           | UseImplementation key ->
-              let uu____2064 = implementation_of_internal file_system_map key
+              let uu____2070 = implementation_of_internal file_system_map key
                  in
-              (match uu____2064 with
+              (match uu____2070 with
                | FStar_Pervasives_Native.None  ->
-                   let uu____2070 =
-                     let uu____2076 =
+                   let uu____2076 =
+                     let uu____2082 =
                        FStar_Util.format1
                          "Expected an implementation of module %s, but couldn't find one"
                          key
                         in
-                     (FStar_Errors.Fatal_MissingImplementation, uu____2076)
+                     (FStar_Errors.Fatal_MissingImplementation, uu____2082)
                       in
-                   FStar_Errors.raise_err uu____2070
+                   FStar_Errors.raise_err uu____2076
                | FStar_Pervasives_Native.Some f -> maybe_use_cache_of f)
           | FriendImplementation key ->
-              let uu____2086 = implementation_of_internal file_system_map key
+              let uu____2092 = implementation_of_internal file_system_map key
                  in
-              (match uu____2086 with
+              (match uu____2092 with
                | FStar_Pervasives_Native.None  ->
-                   let uu____2092 =
-                     let uu____2098 =
+                   let uu____2098 =
+                     let uu____2104 =
                        FStar_Util.format1
                          "Expected an implementation of module %s, but couldn't find one"
                          key
                         in
-                     (FStar_Errors.Fatal_MissingImplementation, uu____2098)
+                     (FStar_Errors.Fatal_MissingImplementation, uu____2104)
                       in
-                   FStar_Errors.raise_err uu____2092
+                   FStar_Errors.raise_err uu____2098
                | FStar_Pervasives_Native.Some f -> maybe_use_cache_of f)
   
 let (file_of_dep :
@@ -716,16 +720,16 @@ let (dependences_of :
     fun deps  ->
       fun all_cmd_line_files  ->
         fun fn  ->
-          let uu____2159 = deps_try_find deps fn  in
-          match uu____2159 with
+          let uu____2165 = deps_try_find deps fn  in
+          match uu____2165 with
           | FStar_Pervasives_Native.None  -> empty_dependences ()
           | FStar_Pervasives_Native.Some
-              { edges = deps1; color = uu____2167;_} ->
-              let uu____2168 =
+              { edges = deps1; color = uu____2173;_} ->
+              let uu____2174 =
                 FStar_List.map
                   (file_of_dep file_system_map all_cmd_line_files) deps1
                  in
-              FStar_All.pipe_right uu____2168
+              FStar_All.pipe_right uu____2174
                 (FStar_List.filter (fun k  -> k <> fn))
   
 let (print_graph : dependence_graph -> unit) =
@@ -736,45 +740,45 @@ let (print_graph : dependence_graph -> unit) =
       "With GraphViz installed, try: fdp -Tpng -odep.png dep.graph";
     FStar_Util.print_endline
       "Hint: cat dep.graph | grep -v _ | grep -v prims";
-    (let uu____2196 =
-       let uu____2198 =
-         let uu____2200 =
-           let uu____2202 =
-             let uu____2206 =
-               let uu____2210 = deps_keys graph  in
-               FStar_List.unique uu____2210  in
+    (let uu____2202 =
+       let uu____2204 =
+         let uu____2206 =
+           let uu____2208 =
+             let uu____2212 =
+               let uu____2216 = deps_keys graph  in
+               FStar_List.unique uu____2216  in
              FStar_List.collect
                (fun k  ->
                   let deps =
-                    let uu____2224 =
-                      let uu____2225 = deps_try_find graph k  in
-                      FStar_Util.must uu____2225  in
-                    uu____2224.edges  in
+                    let uu____2230 =
+                      let uu____2231 = deps_try_find graph k  in
+                      FStar_Util.must uu____2231  in
+                    uu____2230.edges  in
                   let r s = FStar_Util.replace_char s 46 95  in
                   let print7 dep1 =
-                    let uu____2246 =
-                      let uu____2248 = lowercase_module_name k  in
-                      r uu____2248  in
-                    FStar_Util.format2 "  \"%s\" -> \"%s\"" uu____2246
+                    let uu____2252 =
+                      let uu____2254 = lowercase_module_name k  in
+                      r uu____2254  in
+                    FStar_Util.format2 "  \"%s\" -> \"%s\"" uu____2252
                       (r (module_name_of_dep dep1))
                      in
-                  FStar_List.map print7 deps) uu____2206
+                  FStar_List.map print7 deps) uu____2212
               in
-           FStar_String.concat "\n" uu____2202  in
-         FStar_String.op_Hat uu____2200 "\n}\n"  in
-       FStar_String.op_Hat "digraph {\n" uu____2198  in
-     FStar_Util.write_file "dep.graph" uu____2196)
+           FStar_String.concat "\n" uu____2208  in
+         FStar_String.op_Hat uu____2206 "\n}\n"  in
+       FStar_String.op_Hat "digraph {\n" uu____2204  in
+     FStar_Util.write_file "dep.graph" uu____2202)
   
 let (build_inclusion_candidates_list :
   unit -> (Prims.string * Prims.string) Prims.list) =
-  fun uu____2269  ->
+  fun uu____2275  ->
     let include_directories = FStar_Options.include_path ()  in
     let include_directories1 =
       FStar_List.map FStar_Util.normalize_file_path include_directories  in
     let include_directories2 = FStar_List.unique include_directories1  in
     let cwd =
-      let uu____2295 = FStar_Util.getcwd ()  in
-      FStar_Util.normalize_file_path uu____2295  in
+      let uu____2301 = FStar_Util.getcwd ()  in
+      FStar_Util.normalize_file_path uu____2301  in
     FStar_List.concatMap
       (fun d  ->
          if FStar_Util.is_directory d
@@ -783,8 +787,8 @@ let (build_inclusion_candidates_list :
            FStar_List.filter_map
              (fun f  ->
                 let f1 = FStar_Util.basename f  in
-                let uu____2335 = check_and_strip_suffix f1  in
-                FStar_All.pipe_right uu____2335
+                let uu____2341 = check_and_strip_suffix f1  in
+                FStar_All.pipe_right uu____2341
                   (FStar_Util.map_option
                      (fun longname  ->
                         let full_path =
@@ -792,22 +796,22 @@ let (build_inclusion_candidates_list :
                            in
                         (longname, full_path)))) files
          else
-           (let uu____2372 =
-              let uu____2378 =
+           (let uu____2378 =
+              let uu____2384 =
                 FStar_Util.format1 "not a valid include directory: %s\n" d
                  in
-              (FStar_Errors.Fatal_NotValidIncludeDirectory, uu____2378)  in
-            FStar_Errors.raise_err uu____2372)) include_directories2
+              (FStar_Errors.Fatal_NotValidIncludeDirectory, uu____2384)  in
+            FStar_Errors.raise_err uu____2378)) include_directories2
   
 let (build_map : Prims.string Prims.list -> files_for_module_name) =
   fun filenames  ->
     let map1 = FStar_Util.smap_create (Prims.of_int (41))  in
     let add_entry key full_path =
-      let uu____2441 = FStar_Util.smap_try_find map1 key  in
-      match uu____2441 with
+      let uu____2447 = FStar_Util.smap_try_find map1 key  in
+      match uu____2447 with
       | FStar_Pervasives_Native.Some (intf,impl) ->
-          let uu____2488 = is_interface full_path  in
-          if uu____2488
+          let uu____2494 = is_interface full_path  in
+          if uu____2494
           then
             FStar_Util.smap_add map1 key
               ((FStar_Pervasives_Native.Some full_path), impl)
@@ -815,8 +819,8 @@ let (build_map : Prims.string Prims.list -> files_for_module_name) =
             FStar_Util.smap_add map1 key
               (intf, (FStar_Pervasives_Native.Some full_path))
       | FStar_Pervasives_Native.None  ->
-          let uu____2537 = is_interface full_path  in
-          if uu____2537
+          let uu____2543 = is_interface full_path  in
+          if uu____2543
           then
             FStar_Util.smap_add map1 key
               ((FStar_Pervasives_Native.Some full_path),
@@ -826,16 +830,16 @@ let (build_map : Prims.string Prims.list -> files_for_module_name) =
               (FStar_Pervasives_Native.None,
                 (FStar_Pervasives_Native.Some full_path))
        in
-    (let uu____2579 = build_inclusion_candidates_list ()  in
+    (let uu____2585 = build_inclusion_candidates_list ()  in
      FStar_List.iter
-       (fun uu____2597  ->
-          match uu____2597 with
+       (fun uu____2603  ->
+          match uu____2603 with
           | (longname,full_path) ->
               add_entry (FStar_String.lowercase longname) full_path)
-       uu____2579);
+       uu____2585);
     FStar_List.iter
       (fun f  ->
-         let uu____2616 = lowercase_module_name f  in add_entry uu____2616 f)
+         let uu____2622 = lowercase_module_name f  in add_entry uu____2622 f)
       filenames;
     map1
   
@@ -850,7 +854,7 @@ let (enter_namespace :
         let prefix2 = FStar_String.op_Hat prefix1 "."  in
         FStar_Util.smap_iter original_map
           (fun k  ->
-             fun uu____2664  ->
+             fun uu____2670  ->
                if FStar_Util.starts_with k prefix2
                then
                  let suffix =
@@ -858,9 +862,9 @@ let (enter_namespace :
                      ((FStar_String.length k) - (FStar_String.length prefix2))
                     in
                  let filename =
-                   let uu____2690 = FStar_Util.smap_try_find original_map k
+                   let uu____2696 = FStar_Util.smap_try_find original_map k
                       in
-                   FStar_Util.must uu____2690  in
+                   FStar_Util.must uu____2696  in
                  (FStar_Util.smap_add working_map suffix filename;
                   FStar_ST.op_Colon_Equals found true)
                else ());
@@ -872,87 +876,87 @@ let (string_of_lid : FStar_Ident.lident -> Prims.bool -> Prims.string) =
       let suffix =
         if last1 then [(l.FStar_Ident.ident).FStar_Ident.idText] else []  in
       let names =
-        let uu____2810 =
+        let uu____2816 =
           FStar_List.map (fun x  -> x.FStar_Ident.idText) l.FStar_Ident.ns
            in
-        FStar_List.append uu____2810 suffix  in
+        FStar_List.append uu____2816 suffix  in
       FStar_String.concat "." names
   
 let (lowercase_join_longident :
   FStar_Ident.lident -> Prims.bool -> Prims.string) =
   fun l  ->
     fun last1  ->
-      let uu____2833 = string_of_lid l last1  in
-      FStar_String.lowercase uu____2833
+      let uu____2839 = string_of_lid l last1  in
+      FStar_String.lowercase uu____2839
   
 let (namespace_of_lid : FStar_Ident.lident -> Prims.string) =
   fun l  ->
-    let uu____2842 = FStar_List.map FStar_Ident.text_of_id l.FStar_Ident.ns
+    let uu____2848 = FStar_List.map FStar_Ident.text_of_id l.FStar_Ident.ns
        in
-    FStar_String.concat "_" uu____2842
+    FStar_String.concat "_" uu____2848
   
 let (check_module_declaration_against_filename :
   FStar_Ident.lident -> Prims.string -> unit) =
   fun lid  ->
     fun filename  ->
       let k' = lowercase_join_longident lid true  in
-      let uu____2864 =
-        let uu____2866 =
-          let uu____2868 =
-            let uu____2870 =
-              let uu____2874 = FStar_Util.basename filename  in
-              check_and_strip_suffix uu____2874  in
-            FStar_Util.must uu____2870  in
-          FStar_String.lowercase uu____2868  in
-        uu____2866 <> k'  in
-      if uu____2864
+      let uu____2870 =
+        let uu____2872 =
+          let uu____2874 =
+            let uu____2876 =
+              let uu____2880 = FStar_Util.basename filename  in
+              check_and_strip_suffix uu____2880  in
+            FStar_Util.must uu____2876  in
+          FStar_String.lowercase uu____2874  in
+        uu____2872 <> k'  in
+      if uu____2870
       then
-        let uu____2879 = FStar_Ident.range_of_lid lid  in
-        let uu____2880 =
-          let uu____2886 =
-            let uu____2888 = string_of_lid lid true  in
+        let uu____2885 = FStar_Ident.range_of_lid lid  in
+        let uu____2886 =
+          let uu____2892 =
+            let uu____2894 = string_of_lid lid true  in
             FStar_Util.format2
               "The module declaration \"module %s\" found in file %s does not match its filename. Dependencies will be incorrect and the module will not be verified.\n"
-              uu____2888 filename
+              uu____2894 filename
              in
-          (FStar_Errors.Error_ModuleFileNameMismatch, uu____2886)  in
-        FStar_Errors.log_issue uu____2879 uu____2880
+          (FStar_Errors.Error_ModuleFileNameMismatch, uu____2892)  in
+        FStar_Errors.log_issue uu____2885 uu____2886
       else ()
   
 exception Exit 
 let (uu___is_Exit : Prims.exn -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Exit  -> true | uu____2904 -> false
+    match projectee with | Exit  -> true | uu____2910 -> false
   
 let (core_modules : Prims.string Prims.list) =
-  let uu____2910 =
-    let uu____2914 = FStar_Options.prims_basename ()  in
-    let uu____2916 =
-      let uu____2920 = FStar_Options.pervasives_basename ()  in
-      let uu____2922 =
-        let uu____2926 = FStar_Options.pervasives_native_basename ()  in
-        [uu____2926]  in
-      uu____2920 :: uu____2922  in
-    uu____2914 :: uu____2916  in
-  FStar_All.pipe_right uu____2910 (FStar_List.map module_name_of_file) 
+  let uu____2916 =
+    let uu____2920 = FStar_Options.prims_basename ()  in
+    let uu____2922 =
+      let uu____2926 = FStar_Options.pervasives_basename ()  in
+      let uu____2928 =
+        let uu____2932 = FStar_Options.pervasives_native_basename ()  in
+        [uu____2932]  in
+      uu____2926 :: uu____2928  in
+    uu____2920 :: uu____2922  in
+  FStar_All.pipe_right uu____2916 (FStar_List.map module_name_of_file) 
 let (hard_coded_dependencies :
   Prims.string -> (FStar_Ident.lident * open_kind) Prims.list) =
   fun full_filename  ->
     let filename = FStar_Util.basename full_filename  in
-    let uu____2956 =
-      let uu____2958 = module_name_of_file filename  in
-      FStar_List.mem uu____2958 core_modules  in
-    if uu____2956
+    let uu____2962 =
+      let uu____2964 = module_name_of_file filename  in
+      FStar_List.mem uu____2964 core_modules  in
+    if uu____2962
     then []
     else
       (let implicit_deps =
          [(FStar_Parser_Const.fstar_ns_lid, Open_namespace);
          (FStar_Parser_Const.prims_lid, Open_module);
          (FStar_Parser_Const.pervasives_lid, Open_module)]  in
-       let uu____2997 =
-         let uu____3000 = lowercase_module_name full_filename  in
-         namespace_of_module uu____3000  in
-       match uu____2997 with
+       let uu____3003 =
+         let uu____3006 = lowercase_module_name full_filename  in
+         namespace_of_module uu____3006  in
+       match uu____3003 with
        | FStar_Pervasives_Native.None  -> implicit_deps
        | FStar_Pervasives_Native.Some ns ->
            FStar_List.append implicit_deps [(ns, Open_namespace)])
@@ -962,7 +966,7 @@ let (dep_subsumed_by : dependence -> dependence -> Prims.bool) =
     fun d'  ->
       match (d, d') with
       | (PreferInterface l',FriendImplementation l) -> l = l'
-      | uu____3039 -> d = d'
+      | uu____3045 -> d = d'
   
 let (collect_one :
   files_for_module_name ->
@@ -979,37 +983,37 @@ let (collect_one :
           let has_inline_for_extraction = FStar_Util.mk_ref false  in
           let mo_roots =
             let mname = lowercase_module_name filename1  in
-            let uu____3157 =
+            let uu____3163 =
               (is_interface filename1) &&
                 (has_implementation original_map1 mname)
                in
-            if uu____3157 then [UseImplementation mname] else []  in
+            if uu____3163 then [UseImplementation mname] else []  in
           let auto_open =
-            let uu____3167 = hard_coded_dependencies filename1  in
-            FStar_All.pipe_right uu____3167
+            let uu____3173 = hard_coded_dependencies filename1  in
+            FStar_All.pipe_right uu____3173
               (FStar_List.map
-                 (fun uu____3189  ->
-                    match uu____3189 with
+                 (fun uu____3195  ->
+                    match uu____3195 with
                     | (lid,k) -> P_open_module_or_namespace (k, lid)))
              in
           let working_map = FStar_Util.smap_copy original_map1  in
-          let set_interface_inlining uu____3224 =
-            let uu____3225 = is_interface filename1  in
-            if uu____3225
+          let set_interface_inlining uu____3230 =
+            let uu____3231 = is_interface filename1  in
+            if uu____3231
             then FStar_ST.op_Colon_Equals has_inline_for_extraction true
             else ()  in
           let add_dep deps1 d =
-            let uu____3347 =
-              let uu____3349 =
-                let uu____3351 = FStar_ST.op_Bang deps1  in
-                FStar_List.existsML (dep_subsumed_by d) uu____3351  in
-              Prims.op_Negation uu____3349  in
-            if uu____3347
+            let uu____3353 =
+              let uu____3355 =
+                let uu____3357 = FStar_ST.op_Bang deps1  in
+                FStar_List.existsML (dep_subsumed_by d) uu____3357  in
+              Prims.op_Negation uu____3355  in
+            if uu____3353
             then
-              let uu____3378 =
-                let uu____3381 = FStar_ST.op_Bang deps1  in d :: uu____3381
+              let uu____3384 =
+                let uu____3387 = FStar_ST.op_Bang deps1  in d :: uu____3387
                  in
-              FStar_ST.op_Colon_Equals deps1 uu____3378
+              FStar_ST.op_Colon_Equals deps1 uu____3384
             else ()  in
           let dep_edge module_name is_friend =
             if is_friend
@@ -1017,33 +1021,33 @@ let (collect_one :
             else PreferInterface module_name  in
           let add_dependence_edge original_or_working_map lid is_friend =
             let key = lowercase_join_longident lid true  in
-            let uu____3472 = resolve_module_name original_or_working_map key
+            let uu____3478 = resolve_module_name original_or_working_map key
                in
-            match uu____3472 with
+            match uu____3478 with
             | FStar_Pervasives_Native.Some module_name ->
                 (add_dep deps (dep_edge module_name is_friend); true)
-            | uu____3482 -> false  in
+            | uu____3488 -> false  in
           let record_open_module let_open lid =
-            let uu____3501 =
+            let uu____3507 =
               (let_open && (add_dependence_edge working_map lid false)) ||
                 ((Prims.op_Negation let_open) &&
                    (add_dependence_edge original_map1 lid false))
                in
-            if uu____3501
+            if uu____3507
             then true
             else
               (if let_open
                then
-                 (let uu____3512 = FStar_Ident.range_of_lid lid  in
-                  let uu____3513 =
-                    let uu____3519 =
-                      let uu____3521 = string_of_lid lid true  in
-                      FStar_Util.format1 "Module not found: %s" uu____3521
+                 (let uu____3518 = FStar_Ident.range_of_lid lid  in
+                  let uu____3519 =
+                    let uu____3525 =
+                      let uu____3527 = string_of_lid lid true  in
+                      FStar_Util.format1 "Module not found: %s" uu____3527
                        in
                     (FStar_Errors.Warning_ModuleOrFileNotFoundWarning,
-                      uu____3519)
+                      uu____3525)
                      in
-                  FStar_Errors.log_issue uu____3512 uu____3513)
+                  FStar_Errors.log_issue uu____3518 uu____3519)
                else ();
                false)
              in
@@ -1052,92 +1056,92 @@ let (collect_one :
             let r = enter_namespace original_map1 working_map key  in
             if Prims.op_Negation r
             then
-              let uu____3541 = FStar_Ident.range_of_lid lid  in
-              let uu____3542 =
-                let uu____3548 =
-                  let uu____3550 = string_of_lid lid true  in
+              let uu____3547 = FStar_Ident.range_of_lid lid  in
+              let uu____3548 =
+                let uu____3554 =
+                  let uu____3556 = string_of_lid lid true  in
                   FStar_Util.format1
                     "No modules in namespace %s and no file with that name either"
-                    uu____3550
+                    uu____3556
                    in
                 (FStar_Errors.Warning_ModuleOrFileNotFoundWarning,
-                  uu____3548)
+                  uu____3554)
                  in
-              FStar_Errors.log_issue uu____3541 uu____3542
+              FStar_Errors.log_issue uu____3547 uu____3548
             else ()  in
           let record_open let_open lid =
-            let uu____3570 = record_open_module let_open lid  in
-            if uu____3570
+            let uu____3576 = record_open_module let_open lid  in
+            if uu____3576
             then ()
             else
               if Prims.op_Negation let_open
               then record_open_namespace lid
               else ()
              in
-          let record_open_module_or_namespace uu____3587 =
-            match uu____3587 with
+          let record_open_module_or_namespace uu____3593 =
+            match uu____3593 with
             | (lid,kind) ->
                 (match kind with
                  | Open_namespace  -> record_open_namespace lid
                  | Open_module  ->
-                     let uu____3594 = record_open_module false lid  in ())
+                     let uu____3600 = record_open_module false lid  in ())
              in
           let record_module_alias ident lid =
             let key =
-              let uu____3611 = FStar_Ident.text_of_id ident  in
-              FStar_String.lowercase uu____3611  in
+              let uu____3617 = FStar_Ident.text_of_id ident  in
+              FStar_String.lowercase uu____3617  in
             let alias = lowercase_join_longident lid true  in
-            let uu____3616 = FStar_Util.smap_try_find original_map1 alias  in
-            match uu____3616 with
+            let uu____3622 = FStar_Util.smap_try_find original_map1 alias  in
+            match uu____3622 with
             | FStar_Pervasives_Native.Some deps_of_aliased_module ->
                 (FStar_Util.smap_add working_map key deps_of_aliased_module;
-                 (let uu____3673 =
-                    let uu____3674 = lowercase_join_longident lid true  in
-                    dep_edge uu____3674 false  in
-                  add_dep deps uu____3673);
+                 (let uu____3679 =
+                    let uu____3680 = lowercase_join_longident lid true  in
+                    dep_edge uu____3680 false  in
+                  add_dep deps uu____3679);
                  true)
             | FStar_Pervasives_Native.None  ->
-                ((let uu____3690 = FStar_Ident.range_of_lid lid  in
-                  let uu____3691 =
-                    let uu____3697 =
+                ((let uu____3696 = FStar_Ident.range_of_lid lid  in
+                  let uu____3697 =
+                    let uu____3703 =
                       FStar_Util.format1
                         "module not found in search path: %s\n" alias
                        in
                     (FStar_Errors.Warning_ModuleOrFileNotFoundWarning,
-                      uu____3697)
+                      uu____3703)
                      in
-                  FStar_Errors.log_issue uu____3690 uu____3691);
+                  FStar_Errors.log_issue uu____3696 uu____3697);
                  false)
              in
           let add_dep_on_module module_name is_friend =
-            let uu____3715 =
+            let uu____3721 =
               add_dependence_edge working_map module_name is_friend  in
-            if uu____3715
+            if uu____3721
             then ()
             else
-              (let uu____3720 =
+              (let uu____3726 =
                  FStar_Options.debug_at_level_no_module
                    (FStar_Options.Other "Dep")
                   in
-               if uu____3720
+               if uu____3726
                then
-                 let uu____3724 = FStar_Ident.range_of_lid module_name  in
-                 let uu____3725 =
-                   let uu____3731 =
-                     let uu____3733 = FStar_Ident.string_of_lid module_name
+                 let uu____3730 = FStar_Ident.range_of_lid module_name  in
+                 let uu____3731 =
+                   let uu____3737 =
+                     let uu____3739 = FStar_Ident.string_of_lid module_name
                         in
                      FStar_Util.format1 "Unbound module reference %s"
-                       uu____3733
+                       uu____3739
                       in
-                   (FStar_Errors.Warning_UnboundModuleReference, uu____3731)
+                   (FStar_Errors.Warning_UnboundModuleReference, uu____3737)
                     in
-                 FStar_Errors.log_issue uu____3724 uu____3725
+                 FStar_Errors.log_issue uu____3730 uu____3731
                else ())
              in
           let record_lid lid =
             match lid.FStar_Ident.ns with
             | [] -> ()
-            | uu____3745 ->
+            | uu____3751 ->
                 let module_name = FStar_Ident.lid_of_ids lid.FStar_Ident.ns
                    in
                 add_dep_on_module module_name false
@@ -1145,9 +1149,9 @@ let (collect_one :
           let begin_module lid =
             if (FStar_List.length lid.FStar_Ident.ns) > Prims.int_zero
             then
-              let uu____3758 =
-                let uu____3760 = namespace_of_lid lid  in
-                enter_namespace original_map1 working_map uu____3760  in
+              let uu____3764 =
+                let uu____3766 = namespace_of_lid lid  in
+                enter_namespace original_map1 working_map uu____3766  in
               ()
             else ()  in
           (match pd with
@@ -1162,65 +1166,65 @@ let (collect_one :
                            record_open_module_or_namespace (lid, k)
                        | P_dep (b,lid) -> add_dep_on_module lid b
                        | P_alias (id1,lid) ->
-                           let uu____3786 = record_module_alias id1 lid  in
+                           let uu____3792 = record_module_alias id1 lid  in
                            ()
                        | P_lid lid -> record_lid lid
                        | P_inline_for_extraction  ->
                            set_interface_inlining ())));
-          (let uu____3789 = FStar_ST.op_Bang deps  in
-           let uu____3815 = FStar_ST.op_Bang has_inline_for_extraction  in
-           (uu____3789, uu____3815, mo_roots))
+          (let uu____3795 = FStar_ST.op_Bang deps  in
+           let uu____3821 = FStar_ST.op_Bang has_inline_for_extraction  in
+           (uu____3795, uu____3821, mo_roots))
            in
         let data_from_cache =
           FStar_All.pipe_right filename get_parsing_data_from_cache  in
-        let uu____3849 =
+        let uu____3855 =
           FStar_All.pipe_right data_from_cache FStar_Util.is_some  in
-        if uu____3849
+        if uu____3855
         then
-          ((let uu____3869 =
+          ((let uu____3875 =
               FStar_Options.debug_at_level_no_module
                 (FStar_Options.Other "Dep")
                in
-            if uu____3869
+            if uu____3875
             then
               FStar_Util.print1
                 "Reading the parsing data for %s from its checked file\n"
                 filename
             else ());
-           (let uu____3876 =
-              let uu____3888 =
+           (let uu____3882 =
+              let uu____3894 =
                 FStar_All.pipe_right data_from_cache FStar_Util.must  in
-              from_parsing_data uu____3888 original_map filename  in
-            match uu____3876 with
+              from_parsing_data uu____3894 original_map filename  in
+            match uu____3882 with
             | (deps,has_inline_for_extraction,mo_roots) ->
-                let uu____3917 =
+                let uu____3923 =
                   FStar_All.pipe_right data_from_cache FStar_Util.must  in
-                (uu____3917, deps, has_inline_for_extraction, mo_roots)))
+                (uu____3923, deps, has_inline_for_extraction, mo_roots)))
         else
           (let num_of_toplevelmods = FStar_Util.mk_ref Prims.int_zero  in
            let pd = FStar_Util.mk_ref []  in
            let add_to_parsing_data elt =
-             let uu____3946 =
-               let uu____3948 =
-                 let uu____3950 = FStar_ST.op_Bang pd  in
+             let uu____3952 =
+               let uu____3954 =
+                 let uu____3956 = FStar_ST.op_Bang pd  in
                  FStar_List.existsML (fun e  -> parsing_data_elt_eq e elt)
-                   uu____3950
+                   uu____3956
                   in
-               Prims.op_Negation uu____3948  in
-             if uu____3946
+               Prims.op_Negation uu____3954  in
+             if uu____3952
              then
-               let uu____3979 =
-                 let uu____3982 = FStar_ST.op_Bang pd  in elt :: uu____3982
+               let uu____3985 =
+                 let uu____3988 = FStar_ST.op_Bang pd  in elt :: uu____3988
                   in
-               FStar_ST.op_Colon_Equals pd uu____3979
+               FStar_ST.op_Colon_Equals pd uu____3985
              else ()  in
-           let rec collect_module uu___5_4139 =
-             match uu___5_4139 with
+           let rec collect_module uu___5_4145 =
+             match uu___5_4145 with
              | FStar_Parser_AST.Module (lid,decls) ->
                  (check_module_declaration_against_filename lid filename;
                   add_to_parsing_data (P_begin_module lid);
                   collect_decls decls)
-             | FStar_Parser_AST.Interface (lid,decls,uu____4150) ->
+             | FStar_Parser_AST.Interface (lid,decls,uu____4156) ->
                  (check_module_declaration_against_filename lid filename;
                   add_to_parsing_data (P_begin_module lid);
                   collect_decls decls)
@@ -1231,12 +1235,12 @@ let (collect_one :
                   collect_decl x.FStar_Parser_AST.d;
                   FStar_List.iter collect_term x.FStar_Parser_AST.attrs;
                   (match x.FStar_Parser_AST.d with
-                   | FStar_Parser_AST.Val uu____4169 when
+                   | FStar_Parser_AST.Val uu____4175 when
                        FStar_List.contains
                          FStar_Parser_AST.Inline_for_extraction
                          x.FStar_Parser_AST.quals
                        -> add_to_parsing_data P_inline_for_extraction
-                   | uu____4174 -> ())) decls
+                   | uu____4180 -> ())) decls
            
            and collect_decl d =
              match d with
@@ -1245,112 +1249,112 @@ let (collect_one :
              | FStar_Parser_AST.Open lid ->
                  add_to_parsing_data (P_open (false, lid))
              | FStar_Parser_AST.Friend lid ->
-                 let uu____4183 =
-                   let uu____4184 =
-                     let uu____4190 =
-                       let uu____4191 = lowercase_join_longident lid true  in
-                       FStar_All.pipe_right uu____4191 FStar_Ident.lid_of_str
+                 let uu____4189 =
+                   let uu____4190 =
+                     let uu____4196 =
+                       let uu____4197 = lowercase_join_longident lid true  in
+                       FStar_All.pipe_right uu____4197 FStar_Ident.lid_of_str
                         in
-                     (true, uu____4190)  in
-                   P_dep uu____4184  in
-                 add_to_parsing_data uu____4183
+                     (true, uu____4196)  in
+                   P_dep uu____4190  in
+                 add_to_parsing_data uu____4189
              | FStar_Parser_AST.ModuleAbbrev (ident,lid) ->
                  add_to_parsing_data (P_alias (ident, lid))
-             | FStar_Parser_AST.TopLevelLet (uu____4199,patterms) ->
+             | FStar_Parser_AST.TopLevelLet (uu____4205,patterms) ->
                  FStar_List.iter
-                   (fun uu____4221  ->
-                      match uu____4221 with
+                   (fun uu____4227  ->
+                      match uu____4227 with
                       | (pat,t) -> (collect_pattern pat; collect_term t))
                    patterms
              | FStar_Parser_AST.Main t -> collect_term t
-             | FStar_Parser_AST.Splice (uu____4230,t) -> collect_term t
-             | FStar_Parser_AST.Assume (uu____4236,t) -> collect_term t
+             | FStar_Parser_AST.Splice (uu____4236,t) -> collect_term t
+             | FStar_Parser_AST.Assume (uu____4242,t) -> collect_term t
              | FStar_Parser_AST.SubEffect
-                 { FStar_Parser_AST.msource = uu____4238;
-                   FStar_Parser_AST.mdest = uu____4239;
+                 { FStar_Parser_AST.msource = uu____4244;
+                   FStar_Parser_AST.mdest = uu____4245;
                    FStar_Parser_AST.lift_op =
                      FStar_Parser_AST.NonReifiableLift t;_}
                  -> collect_term t
              | FStar_Parser_AST.SubEffect
-                 { FStar_Parser_AST.msource = uu____4241;
-                   FStar_Parser_AST.mdest = uu____4242;
+                 { FStar_Parser_AST.msource = uu____4247;
+                   FStar_Parser_AST.mdest = uu____4248;
                    FStar_Parser_AST.lift_op = FStar_Parser_AST.LiftForFree t;_}
                  -> collect_term t
-             | FStar_Parser_AST.Val (uu____4244,t) -> collect_term t
+             | FStar_Parser_AST.Val (uu____4250,t) -> collect_term t
              | FStar_Parser_AST.SubEffect
-                 { FStar_Parser_AST.msource = uu____4246;
-                   FStar_Parser_AST.mdest = uu____4247;
+                 { FStar_Parser_AST.msource = uu____4252;
+                   FStar_Parser_AST.mdest = uu____4253;
                    FStar_Parser_AST.lift_op = FStar_Parser_AST.ReifiableLift
                      (t0,t1);_}
                  -> (collect_term t0; collect_term t1)
-             | FStar_Parser_AST.Tycon (uu____4251,tc,ts) ->
+             | FStar_Parser_AST.Tycon (uu____4257,tc,ts) ->
                  (if tc
                   then
                     add_to_parsing_data
                       (P_lid FStar_Parser_Const.mk_class_lid)
                   else ();
                   FStar_List.iter collect_tycon ts)
-             | FStar_Parser_AST.Exception (uu____4266,t) ->
+             | FStar_Parser_AST.Exception (uu____4272,t) ->
                  FStar_Util.iter_opt t collect_term
              | FStar_Parser_AST.NewEffect ed -> collect_effect_decl ed
              | FStar_Parser_AST.LayeredEffect ed -> collect_effect_decl ed
              | FStar_Parser_AST.Polymonadic_bind
-                 (uu____4274,uu____4275,uu____4276,bind1) ->
+                 (uu____4280,uu____4281,uu____4282,bind1) ->
                  collect_term bind1
-             | FStar_Parser_AST.Pragma uu____4278 -> ()
+             | FStar_Parser_AST.Pragma uu____4284 -> ()
              | FStar_Parser_AST.TopLevelModule lid ->
                  (FStar_Util.incr num_of_toplevelmods;
-                  (let uu____4281 =
-                     let uu____4283 = FStar_ST.op_Bang num_of_toplevelmods
+                  (let uu____4287 =
+                     let uu____4289 = FStar_ST.op_Bang num_of_toplevelmods
                         in
-                     uu____4283 > Prims.int_one  in
-                   if uu____4281
+                     uu____4289 > Prims.int_one  in
+                   if uu____4287
                    then
-                     let uu____4308 =
-                       let uu____4314 =
-                         let uu____4316 = string_of_lid lid true  in
+                     let uu____4314 =
+                       let uu____4320 =
+                         let uu____4322 = string_of_lid lid true  in
                          FStar_Util.format1
                            "Automatic dependency analysis demands one module per file (module %s not supported)"
-                           uu____4316
+                           uu____4322
                           in
-                       (FStar_Errors.Fatal_OneModulePerFile, uu____4314)  in
-                     let uu____4321 = FStar_Ident.range_of_lid lid  in
-                     FStar_Errors.raise_error uu____4308 uu____4321
+                       (FStar_Errors.Fatal_OneModulePerFile, uu____4320)  in
+                     let uu____4327 = FStar_Ident.range_of_lid lid  in
+                     FStar_Errors.raise_error uu____4314 uu____4327
                    else ()))
            
-           and collect_tycon uu___6_4324 =
-             match uu___6_4324 with
-             | FStar_Parser_AST.TyconAbstract (uu____4325,binders,k) ->
+           and collect_tycon uu___6_4330 =
+             match uu___6_4330 with
+             | FStar_Parser_AST.TyconAbstract (uu____4331,binders,k) ->
                  (collect_binders binders; FStar_Util.iter_opt k collect_term)
-             | FStar_Parser_AST.TyconAbbrev (uu____4337,binders,k,t) ->
+             | FStar_Parser_AST.TyconAbbrev (uu____4343,binders,k,t) ->
                  (collect_binders binders;
                   FStar_Util.iter_opt k collect_term;
                   collect_term t)
-             | FStar_Parser_AST.TyconRecord (uu____4351,binders,k,identterms)
+             | FStar_Parser_AST.TyconRecord (uu____4357,binders,k,identterms)
                  ->
                  (collect_binders binders;
                   FStar_Util.iter_opt k collect_term;
                   FStar_List.iter
-                    (fun uu____4384  ->
-                       match uu____4384 with
-                       | (uu____4389,t) -> collect_term t) identterms)
+                    (fun uu____4390  ->
+                       match uu____4390 with
+                       | (uu____4395,t) -> collect_term t) identterms)
              | FStar_Parser_AST.TyconVariant
-                 (uu____4391,binders,k,identterms) ->
+                 (uu____4397,binders,k,identterms) ->
                  (collect_binders binders;
                   FStar_Util.iter_opt k collect_term;
                   FStar_List.iter
-                    (fun uu____4440  ->
-                       match uu____4440 with
-                       | (uu____4450,t,uu____4452) ->
+                    (fun uu____4446  ->
+                       match uu____4446 with
+                       | (uu____4456,t,uu____4458) ->
                            FStar_Util.iter_opt t collect_term) identterms)
            
-           and collect_effect_decl uu___7_4459 =
-             match uu___7_4459 with
-             | FStar_Parser_AST.DefineEffect (uu____4460,binders,t,decls) ->
+           and collect_effect_decl uu___7_4465 =
+             match uu___7_4465 with
+             | FStar_Parser_AST.DefineEffect (uu____4466,binders,t,decls) ->
                  (collect_binders binders;
                   collect_term t;
                   collect_decls decls)
-             | FStar_Parser_AST.RedefineEffect (uu____4474,binders,t) ->
+             | FStar_Parser_AST.RedefineEffect (uu____4480,binders,t) ->
                  (collect_binders binders; collect_term t)
            
            and collect_binders binders =
@@ -1361,34 +1365,34 @@ let (collect_one :
              (match b with
               | {
                   FStar_Parser_AST.b = FStar_Parser_AST.Annotated
-                    (uu____4487,t);
-                  FStar_Parser_AST.brange = uu____4489;
-                  FStar_Parser_AST.blevel = uu____4490;
-                  FStar_Parser_AST.aqual = uu____4491;_} -> collect_term t
+                    (uu____4493,t);
+                  FStar_Parser_AST.brange = uu____4495;
+                  FStar_Parser_AST.blevel = uu____4496;
+                  FStar_Parser_AST.aqual = uu____4497;_} -> collect_term t
               | {
                   FStar_Parser_AST.b = FStar_Parser_AST.TAnnotated
-                    (uu____4494,t);
-                  FStar_Parser_AST.brange = uu____4496;
-                  FStar_Parser_AST.blevel = uu____4497;
-                  FStar_Parser_AST.aqual = uu____4498;_} -> collect_term t
-              | { FStar_Parser_AST.b = FStar_Parser_AST.NoName t;
+                    (uu____4500,t);
                   FStar_Parser_AST.brange = uu____4502;
                   FStar_Parser_AST.blevel = uu____4503;
                   FStar_Parser_AST.aqual = uu____4504;_} -> collect_term t
-              | uu____4507 -> ())
+              | { FStar_Parser_AST.b = FStar_Parser_AST.NoName t;
+                  FStar_Parser_AST.brange = uu____4508;
+                  FStar_Parser_AST.blevel = uu____4509;
+                  FStar_Parser_AST.aqual = uu____4510;_} -> collect_term t
+              | uu____4513 -> ())
            
-           and collect_aqual uu___8_4508 =
-             match uu___8_4508 with
+           and collect_aqual uu___8_4514 =
+             match uu___8_4514 with
              | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta t) ->
                  collect_term t
-             | uu____4512 -> ()
+             | uu____4518 -> ()
            
            and collect_term t = collect_term' t.FStar_Parser_AST.tm
            
-           and collect_constant uu___9_4516 =
-             match uu___9_4516 with
+           and collect_constant uu___9_4522 =
+             match uu___9_4522 with
              | FStar_Const.Const_int
-                 (uu____4517,FStar_Pervasives_Native.Some (signedness,width))
+                 (uu____4523,FStar_Pervasives_Native.Some (signedness,width))
                  ->
                  let u =
                    match signedness with
@@ -1400,65 +1404,65 @@ let (collect_one :
                    | FStar_Const.Int16  -> "16"
                    | FStar_Const.Int32  -> "32"
                    | FStar_Const.Int64  -> "64"  in
-                 let uu____4544 =
-                   let uu____4545 =
-                     let uu____4551 =
-                       let uu____4552 =
+                 let uu____4550 =
+                   let uu____4551 =
+                     let uu____4557 =
+                       let uu____4558 =
                          FStar_Util.format2 "fstar.%sint%s" u w  in
-                       FStar_All.pipe_right uu____4552 FStar_Ident.lid_of_str
+                       FStar_All.pipe_right uu____4558 FStar_Ident.lid_of_str
                         in
-                     (false, uu____4551)  in
-                   P_dep uu____4545  in
-                 add_to_parsing_data uu____4544
-             | FStar_Const.Const_char uu____4558 ->
-                 let uu____4560 =
-                   let uu____4561 =
-                     let uu____4567 =
+                     (false, uu____4557)  in
+                   P_dep uu____4551  in
+                 add_to_parsing_data uu____4550
+             | FStar_Const.Const_char uu____4564 ->
+                 let uu____4566 =
+                   let uu____4567 =
+                     let uu____4573 =
                        FStar_All.pipe_right "fstar.char"
                          FStar_Ident.lid_of_str
                         in
-                     (false, uu____4567)  in
-                   P_dep uu____4561  in
-                 add_to_parsing_data uu____4560
-             | FStar_Const.Const_float uu____4572 ->
-                 let uu____4573 =
-                   let uu____4574 =
-                     let uu____4580 =
+                     (false, uu____4573)  in
+                   P_dep uu____4567  in
+                 add_to_parsing_data uu____4566
+             | FStar_Const.Const_float uu____4578 ->
+                 let uu____4579 =
+                   let uu____4580 =
+                     let uu____4586 =
                        FStar_All.pipe_right "fstar.float"
                          FStar_Ident.lid_of_str
                         in
-                     (false, uu____4580)  in
-                   P_dep uu____4574  in
-                 add_to_parsing_data uu____4573
-             | uu____4585 -> ()
+                     (false, uu____4586)  in
+                   P_dep uu____4580  in
+                 add_to_parsing_data uu____4579
+             | uu____4591 -> ()
            
-           and collect_term' uu___12_4586 =
-             match uu___12_4586 with
+           and collect_term' uu___12_4592 =
+             match uu___12_4592 with
              | FStar_Parser_AST.Wild  -> ()
              | FStar_Parser_AST.Const c -> collect_constant c
              | FStar_Parser_AST.Op (s,ts) ->
-                 ((let uu____4595 =
-                     let uu____4597 = FStar_Ident.text_of_id s  in
-                     uu____4597 = "@"  in
-                   if uu____4595
+                 ((let uu____4601 =
+                     let uu____4603 = FStar_Ident.text_of_id s  in
+                     uu____4603 = "@"  in
+                   if uu____4601
                    then
-                     let uu____4602 =
-                       let uu____4603 =
-                         let uu____4604 =
+                     let uu____4608 =
+                       let uu____4609 =
+                         let uu____4610 =
                            FStar_Ident.path_of_text
                              "FStar.List.Tot.Base.append"
                             in
-                         FStar_Ident.lid_of_path uu____4604
+                         FStar_Ident.lid_of_path uu____4610
                            FStar_Range.dummyRange
                           in
-                       FStar_Parser_AST.Name uu____4603  in
-                     collect_term' uu____4602
+                       FStar_Parser_AST.Name uu____4609  in
+                     collect_term' uu____4608
                    else ());
                   FStar_List.iter collect_term ts)
-             | FStar_Parser_AST.Tvar uu____4608 -> ()
-             | FStar_Parser_AST.Uvar uu____4609 -> ()
+             | FStar_Parser_AST.Tvar uu____4614 -> ()
+             | FStar_Parser_AST.Uvar uu____4615 -> ()
              | FStar_Parser_AST.Var lid -> add_to_parsing_data (P_lid lid)
-             | FStar_Parser_AST.Projector (lid,uu____4612) ->
+             | FStar_Parser_AST.Projector (lid,uu____4618) ->
                  add_to_parsing_data (P_lid lid)
              | FStar_Parser_AST.Discrim lid ->
                  add_to_parsing_data (P_lid lid)
@@ -1466,19 +1470,19 @@ let (collect_one :
              | FStar_Parser_AST.Construct (lid,termimps) ->
                  (add_to_parsing_data (P_lid lid);
                   FStar_List.iter
-                    (fun uu____4637  ->
-                       match uu____4637 with
-                       | (t,uu____4643) -> collect_term t) termimps)
+                    (fun uu____4643  ->
+                       match uu____4643 with
+                       | (t,uu____4649) -> collect_term t) termimps)
              | FStar_Parser_AST.Abs (pats,t) ->
                  (collect_patterns pats; collect_term t)
-             | FStar_Parser_AST.App (t1,t2,uu____4653) ->
+             | FStar_Parser_AST.App (t1,t2,uu____4659) ->
                  (collect_term t1; collect_term t2)
-             | FStar_Parser_AST.Let (uu____4655,patterms,t) ->
+             | FStar_Parser_AST.Let (uu____4661,patterms,t) ->
                  (FStar_List.iter
-                    (fun uu____4705  ->
-                       match uu____4705 with
+                    (fun uu____4711  ->
+                       match uu____4711 with
                        | (attrs_opt,(pat,t1)) ->
-                           ((let uu____4734 =
+                           ((let uu____4740 =
                                FStar_Util.map_opt attrs_opt
                                  (FStar_List.iter collect_term)
                                 in
@@ -1488,7 +1492,7 @@ let (collect_one :
                   collect_term t)
              | FStar_Parser_AST.LetOpen (lid,t) ->
                  (add_to_parsing_data (P_open (true, lid)); collect_term t)
-             | FStar_Parser_AST.Bind (uu____4745,t1,t2) ->
+             | FStar_Parser_AST.Bind (uu____4751,t1,t2) ->
                  (collect_term t1; collect_term t2)
              | FStar_Parser_AST.Seq (t1,t2) ->
                  (collect_term t1; collect_term t2)
@@ -1507,53 +1511,53 @@ let (collect_one :
              | FStar_Parser_AST.Record (t,idterms) ->
                  (FStar_Util.iter_opt t collect_term;
                   FStar_List.iter
-                    (fun uu____4841  ->
-                       match uu____4841 with
-                       | (uu____4846,t1) -> collect_term t1) idterms)
-             | FStar_Parser_AST.Project (t,uu____4849) -> collect_term t
+                    (fun uu____4847  ->
+                       match uu____4847 with
+                       | (uu____4852,t1) -> collect_term t1) idterms)
+             | FStar_Parser_AST.Project (t,uu____4855) -> collect_term t
              | FStar_Parser_AST.Product (binders,t) ->
                  (collect_binders binders; collect_term t)
              | FStar_Parser_AST.Sum (binders,t) ->
                  (FStar_List.iter
-                    (fun uu___10_4878  ->
-                       match uu___10_4878 with
+                    (fun uu___10_4884  ->
+                       match uu___10_4884 with
                        | FStar_Util.Inl b -> collect_binder b
                        | FStar_Util.Inr t1 -> collect_term t1) binders;
                   collect_term t)
-             | FStar_Parser_AST.QForall (binders,(uu____4886,ts),t) ->
+             | FStar_Parser_AST.QForall (binders,(uu____4892,ts),t) ->
                  (collect_binders binders;
                   FStar_List.iter (FStar_List.iter collect_term) ts;
                   collect_term t)
-             | FStar_Parser_AST.QExists (binders,(uu____4920,ts),t) ->
+             | FStar_Parser_AST.QExists (binders,(uu____4926,ts),t) ->
                  (collect_binders binders;
                   FStar_List.iter (FStar_List.iter collect_term) ts;
                   collect_term t)
              | FStar_Parser_AST.Refine (binder,t) ->
                  (collect_binder binder; collect_term t)
-             | FStar_Parser_AST.NamedTyp (uu____4956,t) -> collect_term t
+             | FStar_Parser_AST.NamedTyp (uu____4962,t) -> collect_term t
              | FStar_Parser_AST.Paren t -> collect_term t
-             | FStar_Parser_AST.Requires (t,uu____4960) -> collect_term t
-             | FStar_Parser_AST.Ensures (t,uu____4968) -> collect_term t
-             | FStar_Parser_AST.Labeled (t,uu____4976,uu____4977) ->
+             | FStar_Parser_AST.Requires (t,uu____4966) -> collect_term t
+             | FStar_Parser_AST.Ensures (t,uu____4974) -> collect_term t
+             | FStar_Parser_AST.Labeled (t,uu____4982,uu____4983) ->
                  collect_term t
-             | FStar_Parser_AST.Quote (t,uu____4983) -> collect_term t
+             | FStar_Parser_AST.Quote (t,uu____4989) -> collect_term t
              | FStar_Parser_AST.Antiquote t -> collect_term t
              | FStar_Parser_AST.VQuote t -> collect_term t
              | FStar_Parser_AST.Attributes cattributes ->
                  FStar_List.iter collect_term cattributes
              | FStar_Parser_AST.CalcProof (rel,init1,steps) ->
-                 ((let uu____4997 =
-                     let uu____4998 =
-                       let uu____5004 = FStar_Ident.lid_of_str "FStar.Calc"
+                 ((let uu____5003 =
+                     let uu____5004 =
+                       let uu____5010 = FStar_Ident.lid_of_str "FStar.Calc"
                           in
-                       (false, uu____5004)  in
-                     P_dep uu____4998  in
-                   add_to_parsing_data uu____4997);
+                       (false, uu____5010)  in
+                     P_dep uu____5004  in
+                   add_to_parsing_data uu____5003);
                   collect_term rel;
                   collect_term init1;
                   FStar_List.iter
-                    (fun uu___11_5016  ->
-                       match uu___11_5016 with
+                    (fun uu___11_5022  ->
+                       match uu___11_5022 with
                        | FStar_Parser_AST.CalcStep (rel1,just,next) ->
                            (collect_term rel1;
                             collect_term just;
@@ -1563,27 +1567,27 @@ let (collect_one :
            
            and collect_pattern p = collect_pattern' p.FStar_Parser_AST.pat
            
-           and collect_pattern' uu___13_5026 =
-             match uu___13_5026 with
-             | FStar_Parser_AST.PatVar (uu____5027,aqual) ->
+           and collect_pattern' uu___13_5032 =
+             match uu___13_5032 with
+             | FStar_Parser_AST.PatVar (uu____5033,aqual) ->
                  collect_aqual aqual
-             | FStar_Parser_AST.PatTvar (uu____5033,aqual) ->
+             | FStar_Parser_AST.PatTvar (uu____5039,aqual) ->
                  collect_aqual aqual
              | FStar_Parser_AST.PatWild aqual -> collect_aqual aqual
-             | FStar_Parser_AST.PatOp uu____5042 -> ()
-             | FStar_Parser_AST.PatConst uu____5043 -> ()
+             | FStar_Parser_AST.PatOp uu____5048 -> ()
+             | FStar_Parser_AST.PatConst uu____5049 -> ()
              | FStar_Parser_AST.PatApp (p,ps) ->
                  (collect_pattern p; collect_patterns ps)
-             | FStar_Parser_AST.PatName uu____5051 -> ()
+             | FStar_Parser_AST.PatName uu____5057 -> ()
              | FStar_Parser_AST.PatList ps -> collect_patterns ps
              | FStar_Parser_AST.PatOr ps -> collect_patterns ps
-             | FStar_Parser_AST.PatTuple (ps,uu____5059) ->
+             | FStar_Parser_AST.PatTuple (ps,uu____5065) ->
                  collect_patterns ps
              | FStar_Parser_AST.PatRecord lidpats ->
                  FStar_List.iter
-                   (fun uu____5080  ->
-                      match uu____5080 with
-                      | (uu____5085,p) -> collect_pattern p) lidpats
+                   (fun uu____5086  ->
+                      match uu____5086 with
+                      | (uu____5091,p) -> collect_pattern p) lidpats
              | FStar_Parser_AST.PatAscribed
                  (p,(t,FStar_Pervasives_Native.None )) ->
                  (collect_pattern p; collect_term t)
@@ -1593,25 +1597,25 @@ let (collect_one :
            
            and collect_branches bs = FStar_List.iter collect_branch bs
            
-           and collect_branch uu____5130 =
-             match uu____5130 with
+           and collect_branch uu____5136 =
+             match uu____5136 with
              | (pat,t1,t2) ->
                  (collect_pattern pat;
                   FStar_Util.iter_opt t1 collect_term;
                   collect_term t2)
             in
-           let uu____5148 = FStar_Parser_Driver.parse_file filename  in
-           match uu____5148 with
-           | (ast,uu____5174) ->
+           let uu____5154 = FStar_Parser_Driver.parse_file filename  in
+           match uu____5154 with
+           | (ast,uu____5180) ->
                (collect_module ast;
                 (let pd1 =
-                   let uu____5191 =
-                     let uu____5194 = FStar_ST.op_Bang pd  in
-                     FStar_List.rev uu____5194  in
-                   Mk_pd uu____5191  in
-                 let uu____5220 = from_parsing_data pd1 original_map filename
+                   let uu____5197 =
+                     let uu____5200 = FStar_ST.op_Bang pd  in
+                     FStar_List.rev uu____5200  in
+                   Mk_pd uu____5197  in
+                 let uu____5226 = from_parsing_data pd1 original_map filename
                     in
-                 match uu____5220 with
+                 match uu____5226 with
                  | (deps,has_inline_for_extraction,mo_roots) ->
                      (pd1, deps, has_inline_for_extraction, mo_roots))))
   
@@ -1619,17 +1623,17 @@ let (collect_one_cache :
   (dependence Prims.list * dependence Prims.list * Prims.bool)
     FStar_Util.smap FStar_ST.ref)
   =
-  let uu____5279 = FStar_Util.smap_create Prims.int_zero  in
-  FStar_Util.mk_ref uu____5279 
+  let uu____5285 = FStar_Util.smap_create Prims.int_zero  in
+  FStar_Util.mk_ref uu____5285 
 let (set_collect_one_cache :
   (dependence Prims.list * dependence Prims.list * Prims.bool)
     FStar_Util.smap -> unit)
   = fun cache  -> FStar_ST.op_Colon_Equals collect_one_cache cache 
 let (dep_graph_copy : dependence_graph -> dependence_graph) =
   fun dep_graph  ->
-    let uu____5401 = dep_graph  in
-    match uu____5401 with
-    | Deps g -> let uu____5405 = FStar_Util.smap_copy g  in Deps uu____5405
+    let uu____5407 = dep_graph  in
+    match uu____5407 with
+    | Deps g -> let uu____5411 = FStar_Util.smap_copy g  in Deps uu____5411
   
 let (widen_deps :
   module_name Prims.list ->
@@ -1641,11 +1645,11 @@ let (widen_deps :
       fun file_system_map  ->
         fun widened  ->
           let widened1 = FStar_Util.mk_ref widened  in
-          let uu____5447 = dep_graph  in
-          match uu____5447 with
+          let uu____5453 = dep_graph  in
+          match uu____5453 with
           | Deps dg ->
-              let uu____5456 = deps_empty ()  in
-              (match uu____5456 with
+              let uu____5462 = deps_empty ()  in
+              (match uu____5462 with
                | Deps dg' ->
                    let widen_one deps =
                      FStar_All.pipe_right deps
@@ -1658,19 +1662,19 @@ let (widen_deps :
                                  ->
                                  (FStar_ST.op_Colon_Equals widened1 true;
                                   FriendImplementation m)
-                             | uu____5511 -> d))
+                             | uu____5517 -> d))
                       in
                    (FStar_Util.smap_fold dg
                       (fun filename  ->
                          fun dep_node  ->
-                           fun uu____5519  ->
-                             let uu____5521 =
-                               let uu___984_5522 = dep_node  in
-                               let uu____5523 = widen_one dep_node.edges  in
-                               { edges = uu____5523; color = White }  in
-                             FStar_Util.smap_add dg' filename uu____5521) ();
-                    (let uu____5524 = FStar_ST.op_Bang widened1  in
-                     (uu____5524, (Deps dg')))))
+                           fun uu____5525  ->
+                             let uu____5527 =
+                               let uu___985_5528 = dep_node  in
+                               let uu____5529 = widen_one dep_node.edges  in
+                               { edges = uu____5529; color = White }  in
+                             FStar_Util.smap_add dg' filename uu____5527) ();
+                    (let uu____5530 = FStar_ST.op_Bang widened1  in
+                     (uu____5530, (Deps dg')))))
   
 let (topological_dependences_of' :
   files_for_module_name ->
@@ -1684,70 +1688,70 @@ let (topological_dependences_of' :
       fun interfaces_needing_inlining  ->
         fun root_files  ->
           fun widened  ->
-            let rec all_friend_deps_1 dep_graph1 cycle uu____5690 filename =
-              match uu____5690 with
+            let rec all_friend_deps_1 dep_graph1 cycle uu____5696 filename =
+              match uu____5696 with
               | (all_friends,all_files) ->
                   let dep_node =
-                    let uu____5731 = deps_try_find dep_graph1 filename  in
-                    FStar_Util.must uu____5731  in
+                    let uu____5737 = deps_try_find dep_graph1 filename  in
+                    FStar_Util.must uu____5737  in
                   (match dep_node.color with
                    | Gray  ->
                        failwith
                          "Impossible: cycle detected after cycle detection has passed"
                    | Black  -> (all_friends, all_files)
                    | White  ->
-                       ((let uu____5762 =
+                       ((let uu____5768 =
                            FStar_Options.debug_at_level_no_module
                              (FStar_Options.Other "Dep")
                             in
-                         if uu____5762
+                         if uu____5768
                          then
-                           let uu____5766 =
-                             let uu____5768 =
+                           let uu____5772 =
+                             let uu____5774 =
                                FStar_List.map dep_to_string dep_node.edges
                                 in
-                             FStar_String.concat ", " uu____5768  in
+                             FStar_String.concat ", " uu____5774  in
                            FStar_Util.print2
                              "Visiting %s: direct deps are %s\n" filename
-                             uu____5766
+                             uu____5772
                          else ());
                         deps_add_dep dep_graph1 filename
-                          (let uu___1006_5779 = dep_node  in
-                           { edges = (uu___1006_5779.edges); color = Gray });
-                        (let uu____5780 =
-                           let uu____5791 =
+                          (let uu___1007_5785 = dep_node  in
+                           { edges = (uu___1007_5785.edges); color = Gray });
+                        (let uu____5786 =
+                           let uu____5797 =
                              dependences_of file_system_map dep_graph1
                                root_files filename
                               in
                            all_friend_deps dep_graph1 cycle
-                             (all_friends, all_files) uu____5791
+                             (all_friends, all_files) uu____5797
                             in
-                         match uu____5780 with
+                         match uu____5786 with
                          | (all_friends1,all_files1) ->
                              (deps_add_dep dep_graph1 filename
-                                (let uu___1012_5827 = dep_node  in
+                                (let uu___1013_5833 = dep_node  in
                                  {
-                                   edges = (uu___1012_5827.edges);
+                                   edges = (uu___1013_5833.edges);
                                    color = Black
                                  });
-                              (let uu____5829 =
+                              (let uu____5835 =
                                  FStar_Options.debug_at_level_no_module
                                    (FStar_Options.Other "Dep")
                                   in
-                               if uu____5829
+                               if uu____5835
                                then FStar_Util.print1 "Adding %s\n" filename
                                else ());
-                              (let uu____5836 =
-                                 let uu____5840 =
+                              (let uu____5842 =
+                                 let uu____5846 =
                                    FStar_List.collect
-                                     (fun uu___14_5847  ->
-                                        match uu___14_5847 with
+                                     (fun uu___14_5853  ->
+                                        match uu___14_5853 with
                                         | FriendImplementation m -> [m]
                                         | d -> []) dep_node.edges
                                     in
-                                 FStar_List.append uu____5840 all_friends1
+                                 FStar_List.append uu____5846 all_friends1
                                   in
-                               (uu____5836, (filename :: all_files1)))))))
+                               (uu____5842, (filename :: all_files1)))))))
             
             and all_friend_deps dep_graph1 cycle all_friends filenames =
               FStar_List.fold_left
@@ -1756,49 +1760,49 @@ let (topological_dependences_of' :
                      all_friend_deps_1 dep_graph1 (k :: cycle) all_friends1 k)
                 all_friends filenames
              in
-            let uu____5912 = all_friend_deps dep_graph [] ([], []) root_files
+            let uu____5918 = all_friend_deps dep_graph [] ([], []) root_files
                in
-            match uu____5912 with
+            match uu____5918 with
             | (friends,all_files_0) ->
-                ((let uu____5955 =
+                ((let uu____5961 =
                     FStar_Options.debug_at_level_no_module
                       (FStar_Options.Other "Dep")
                      in
-                  if uu____5955
+                  if uu____5961
                   then
-                    let uu____5959 =
-                      let uu____5961 =
+                    let uu____5965 =
+                      let uu____5967 =
                         FStar_Util.remove_dups (fun x  -> fun y  -> x = y)
                           friends
                          in
-                      FStar_String.concat ", " uu____5961  in
+                      FStar_String.concat ", " uu____5967  in
                     FStar_Util.print3
                       "Phase1 complete:\n\tall_files = %s\n\tall_friends=%s\n\tinterfaces_with_inlining=%s\n"
-                      (FStar_String.concat ", " all_files_0) uu____5959
+                      (FStar_String.concat ", " all_files_0) uu____5965
                       (FStar_String.concat ", " interfaces_needing_inlining)
                   else ());
-                 (let uu____5979 =
+                 (let uu____5985 =
                     widen_deps friends dep_graph file_system_map widened  in
-                  match uu____5979 with
+                  match uu____5985 with
                   | (widened1,dep_graph1) ->
-                      let uu____5997 =
-                        (let uu____6009 =
+                      let uu____6003 =
+                        (let uu____6015 =
                            FStar_Options.debug_at_level_no_module
                              (FStar_Options.Other "Dep")
                             in
-                         if uu____6009
+                         if uu____6015
                          then
                            FStar_Util.print_string
                              "==============Phase2==================\n"
                          else ());
                         all_friend_deps dep_graph1 [] ([], []) root_files  in
-                      (match uu____5997 with
-                       | (uu____6033,all_files) ->
-                           ((let uu____6048 =
+                      (match uu____6003 with
+                       | (uu____6039,all_files) ->
+                           ((let uu____6054 =
                                FStar_Options.debug_at_level_no_module
                                  (FStar_Options.Other "Dep")
                                 in
-                             if uu____6048
+                             if uu____6054
                              then
                                FStar_Util.print1
                                  "Phase2 complete: all_files = %s\n"
@@ -1815,18 +1819,18 @@ let (phase1 :
     fun dep_graph  ->
       fun interfaces_needing_inlining  ->
         fun for_extraction  ->
-          (let uu____6095 =
+          (let uu____6101 =
              FStar_Options.debug_at_level_no_module
                (FStar_Options.Other "Dep")
               in
-           if uu____6095
+           if uu____6101
            then
              FStar_Util.print_string
                "==============Phase1==================\n"
            else ());
           (let widened = false  in
-           let uu____6105 = (FStar_Options.cmi ()) && for_extraction  in
-           if uu____6105
+           let uu____6111 = (FStar_Options.cmi ()) && for_extraction  in
+           if uu____6111
            then
              widen_deps interfaces_needing_inlining dep_graph file_system_map
                widened
@@ -1844,11 +1848,11 @@ let (topological_dependences_of :
       fun interfaces_needing_inlining  ->
         fun root_files  ->
           fun for_extraction  ->
-            let uu____6172 =
+            let uu____6178 =
               phase1 file_system_map dep_graph interfaces_needing_inlining
                 for_extraction
                in
-            match uu____6172 with
+            match uu____6178 with
             | (widened,dep_graph1) ->
                 topological_dependences_of' file_system_map dep_graph1
                   interfaces_needing_inlining root_files widened
@@ -1864,16 +1868,16 @@ let (collect :
         FStar_All.pipe_right all_cmd_line_files
           (FStar_List.map
              (fun fn  ->
-                let uu____6249 = FStar_Options.find_file fn  in
-                match uu____6249 with
+                let uu____6255 = FStar_Options.find_file fn  in
+                match uu____6255 with
                 | FStar_Pervasives_Native.None  ->
-                    let uu____6255 =
-                      let uu____6261 =
+                    let uu____6261 =
+                      let uu____6267 =
                         FStar_Util.format1 "File %s could not be found\n" fn
                          in
-                      (FStar_Errors.Fatal_ModuleOrFileNotFound, uu____6261)
+                      (FStar_Errors.Fatal_ModuleOrFileNotFound, uu____6267)
                        in
-                    FStar_Errors.raise_err uu____6255
+                    FStar_Errors.raise_err uu____6261
                 | FStar_Pervasives_Native.Some fn1 -> fn1))
          in
       let dep_graph = deps_empty ()  in
@@ -1881,35 +1885,35 @@ let (collect :
       let interfaces_needing_inlining = FStar_Util.mk_ref []  in
       let add_interface_for_inlining l =
         let l1 = lowercase_module_name l  in
-        let uu____6291 =
-          let uu____6295 = FStar_ST.op_Bang interfaces_needing_inlining  in
-          l1 :: uu____6295  in
-        FStar_ST.op_Colon_Equals interfaces_needing_inlining uu____6291  in
+        let uu____6297 =
+          let uu____6301 = FStar_ST.op_Bang interfaces_needing_inlining  in
+          l1 :: uu____6301  in
+        FStar_ST.op_Colon_Equals interfaces_needing_inlining uu____6297  in
       let parse_results = FStar_Util.smap_create (Prims.of_int (40))  in
       let rec discover_one file_name =
-        let uu____6362 =
-          let uu____6364 = deps_try_find dep_graph file_name  in
-          uu____6364 = FStar_Pervasives_Native.None  in
-        if uu____6362
+        let uu____6368 =
+          let uu____6370 = deps_try_find dep_graph file_name  in
+          uu____6370 = FStar_Pervasives_Native.None  in
+        if uu____6368
         then
-          let uu____6370 =
-            let uu____6386 =
-              let uu____6400 = FStar_ST.op_Bang collect_one_cache  in
-              FStar_Util.smap_try_find uu____6400 file_name  in
-            match uu____6386 with
+          let uu____6376 =
+            let uu____6392 =
+              let uu____6406 = FStar_ST.op_Bang collect_one_cache  in
+              FStar_Util.smap_try_find uu____6406 file_name  in
+            match uu____6392 with
             | FStar_Pervasives_Native.Some cached -> ((Mk_pd []), cached)
             | FStar_Pervasives_Native.None  ->
-                let uu____6530 =
+                let uu____6536 =
                   collect_one file_system_map file_name
                     get_parsing_data_from_cache
                    in
-                (match uu____6530 with
+                (match uu____6536 with
                  | (parsing_data,deps,needs_interface_inlining,additional_roots)
                      ->
                      (parsing_data,
                        (deps, additional_roots, needs_interface_inlining)))
              in
-          match uu____6370 with
+          match uu____6376 with
           | (parsing_data,(deps,mo_roots,needs_interface_inlining)) ->
               (if needs_interface_inlining
                then add_interface_for_inlining file_name
@@ -1917,26 +1921,26 @@ let (collect :
                FStar_Util.smap_add parse_results file_name parsing_data;
                (let deps1 =
                   let module_name = lowercase_module_name file_name  in
-                  let uu____6624 =
+                  let uu____6630 =
                     (is_implementation file_name) &&
                       (has_interface file_system_map module_name)
                      in
-                  if uu____6624
+                  if uu____6630
                   then FStar_List.append deps [UseInterface module_name]
                   else deps  in
                 let dep_node =
-                  let uu____6632 = FStar_List.unique deps1  in
-                  { edges = uu____6632; color = White }  in
+                  let uu____6638 = FStar_List.unique deps1  in
+                  { edges = uu____6638; color = White }  in
                 deps_add_dep dep_graph file_name dep_node;
-                (let uu____6634 =
+                (let uu____6640 =
                    FStar_List.map
                      (file_of_dep file_system_map all_cmd_line_files1)
                      (FStar_List.append deps1 mo_roots)
                     in
-                 FStar_List.iter discover_one uu____6634)))
+                 FStar_List.iter discover_one uu____6640)))
         else ()  in
       profile
-        (fun uu____6644  -> FStar_List.iter discover_one all_cmd_line_files1)
+        (fun uu____6650  -> FStar_List.iter discover_one all_cmd_line_files1)
         "FStar.Parser.Dep.discover";
       (let cycle_detected dep_graph1 cycle filename =
          FStar_Util.print1
@@ -1944,28 +1948,28 @@ let (collect :
            (FStar_String.concat "\n`used by` " cycle);
          print_graph dep_graph1;
          FStar_Util.print_string "\n";
-         (let uu____6677 =
-            let uu____6683 =
+         (let uu____6683 =
+            let uu____6689 =
               FStar_Util.format1 "Recursive dependency on module %s\n"
                 filename
                in
-            (FStar_Errors.Fatal_CyclicDependence, uu____6683)  in
-          FStar_Errors.raise_err uu____6677)
+            (FStar_Errors.Fatal_CyclicDependence, uu____6689)  in
+          FStar_Errors.raise_err uu____6683)
           in
        let full_cycle_detection all_command_line_files file_system_map1 =
          let dep_graph1 = dep_graph_copy dep_graph  in
          let mo_files = FStar_Util.mk_ref []  in
          let rec aux cycle filename =
            let node =
-             let uu____6735 = deps_try_find dep_graph1 filename  in
-             match uu____6735 with
+             let uu____6741 = deps_try_find dep_graph1 filename  in
+             match uu____6741 with
              | FStar_Pervasives_Native.Some node -> node
              | FStar_Pervasives_Native.None  ->
-                 let uu____6739 =
+                 let uu____6745 =
                    FStar_Util.format1
                      "Impossible: Failed to find dependencies of %s" filename
                     in
-                 failwith uu____6739
+                 failwith uu____6745
               in
            let direct_deps =
              FStar_All.pipe_right node.edges
@@ -1973,61 +1977,61 @@ let (collect :
                   (fun x  ->
                      match x with
                      | UseInterface f ->
-                         let uu____6753 =
+                         let uu____6759 =
                            implementation_of_internal file_system_map1 f  in
-                         (match uu____6753 with
+                         (match uu____6759 with
                           | FStar_Pervasives_Native.None  -> [x]
                           | FStar_Pervasives_Native.Some fn when
                               fn = filename -> [x]
-                          | uu____6764 -> [x; UseImplementation f])
+                          | uu____6770 -> [x; UseImplementation f])
                      | PreferInterface f ->
-                         let uu____6770 =
+                         let uu____6776 =
                            implementation_of_internal file_system_map1 f  in
-                         (match uu____6770 with
+                         (match uu____6776 with
                           | FStar_Pervasives_Native.None  -> [x]
                           | FStar_Pervasives_Native.Some fn when
                               fn = filename -> [x]
-                          | uu____6781 -> [x; UseImplementation f])
-                     | uu____6785 -> [x]))
+                          | uu____6787 -> [x; UseImplementation f])
+                     | uu____6791 -> [x]))
               in
            match node.color with
            | Gray  -> cycle_detected dep_graph1 cycle filename
            | Black  -> ()
            | White  ->
                (deps_add_dep dep_graph1 filename
-                  (let uu___1133_6788 = node  in
+                  (let uu___1134_6794 = node  in
                    { edges = direct_deps; color = Gray });
-                (let uu____6790 =
+                (let uu____6796 =
                    dependences_of file_system_map1 dep_graph1
                      all_command_line_files filename
                     in
-                 FStar_List.iter (fun k  -> aux (k :: cycle) k) uu____6790);
+                 FStar_List.iter (fun k  -> aux (k :: cycle) k) uu____6796);
                 deps_add_dep dep_graph1 filename
-                  (let uu___1138_6801 = node  in
+                  (let uu___1139_6807 = node  in
                    { edges = direct_deps; color = Black });
-                (let uu____6802 = is_interface filename  in
-                 if uu____6802
+                (let uu____6808 = is_interface filename  in
+                 if uu____6808
                  then
-                   let uu____6805 =
-                     let uu____6809 = lowercase_module_name filename  in
-                     implementation_of_internal file_system_map1 uu____6809
+                   let uu____6811 =
+                     let uu____6815 = lowercase_module_name filename  in
+                     implementation_of_internal file_system_map1 uu____6815
                       in
-                   FStar_Util.iter_opt uu____6805
+                   FStar_Util.iter_opt uu____6811
                      (fun impl  ->
                         if
                           Prims.op_Negation
                             (FStar_List.contains impl all_command_line_files)
                         then
-                          let uu____6818 =
-                            let uu____6822 = FStar_ST.op_Bang mo_files  in
-                            impl :: uu____6822  in
-                          FStar_ST.op_Colon_Equals mo_files uu____6818
+                          let uu____6824 =
+                            let uu____6828 = FStar_ST.op_Bang mo_files  in
+                            impl :: uu____6828  in
+                          FStar_ST.op_Colon_Equals mo_files uu____6824
                         else ())
                  else ()))
             in
          FStar_List.iter (aux []) all_command_line_files;
-         (let uu____6884 = FStar_ST.op_Bang mo_files  in
-          FStar_List.iter (aux []) uu____6884)
+         (let uu____6890 = FStar_ST.op_Bang mo_files  in
+          FStar_List.iter (aux []) uu____6890)
           in
        full_cycle_detection all_cmd_line_files1 file_system_map;
        FStar_All.pipe_right all_cmd_line_files1
@@ -2037,23 +2041,23 @@ let (collect :
                FStar_Options.add_verify_module m));
        (let inlining_ifaces = FStar_ST.op_Bang interfaces_needing_inlining
            in
-        let uu____6956 =
+        let uu____6962 =
           profile
-            (fun uu____6975  ->
-               let uu____6976 =
-                 let uu____6978 = FStar_Options.codegen ()  in
-                 uu____6978 <> FStar_Pervasives_Native.None  in
+            (fun uu____6981  ->
+               let uu____6982 =
+                 let uu____6984 = FStar_Options.codegen ()  in
+                 uu____6984 <> FStar_Pervasives_Native.None  in
                topological_dependences_of file_system_map dep_graph
-                 inlining_ifaces all_cmd_line_files1 uu____6976)
+                 inlining_ifaces all_cmd_line_files1 uu____6982)
             "FStar.Parser.Dep.topological_dependences_of"
            in
-        match uu____6956 with
-        | (all_files,uu____6992) ->
-            ((let uu____7002 =
+        match uu____6962 with
+        | (all_files,uu____6998) ->
+            ((let uu____7008 =
                 FStar_Options.debug_at_level_no_module
                   (FStar_Options.Other "Dep")
                  in
-              if uu____7002
+              if uu____7008
               then
                 FStar_Util.print1 "Interfaces needing inlining: %s\n"
                   (FStar_String.concat ", " inlining_ifaces)
@@ -2071,16 +2075,16 @@ let (deps_of : deps -> Prims.string -> Prims.string Prims.list) =
 let (print_digest : (Prims.string * Prims.string) Prims.list -> Prims.string)
   =
   fun dig  ->
-    let uu____7056 =
+    let uu____7062 =
       FStar_All.pipe_right dig
         (FStar_List.map
-           (fun uu____7082  ->
-              match uu____7082 with
+           (fun uu____7088  ->
+              match uu____7088 with
               | (m,d) ->
-                  let uu____7096 = FStar_Util.base64_encode d  in
-                  FStar_Util.format2 "%s:%s" m uu____7096))
+                  let uu____7102 = FStar_Util.base64_encode d  in
+                  FStar_Util.format2 "%s:%s" m uu____7102))
        in
-    FStar_All.pipe_right uu____7056 (FStar_String.concat "\n")
+    FStar_All.pipe_right uu____7062 (FStar_String.concat "\n")
   
 let (print_make : deps -> unit) =
   fun deps  ->
@@ -2092,8 +2096,8 @@ let (print_make : deps -> unit) =
       (FStar_List.iter
          (fun f  ->
             let dep_node =
-              let uu____7131 = deps_try_find deps1 f  in
-              FStar_All.pipe_right uu____7131 FStar_Option.get  in
+              let uu____7137 = deps_try_find deps1 f  in
+              FStar_All.pipe_right uu____7137 FStar_Option.get  in
             let files =
               FStar_List.map (file_of_dep file_system_map all_cmd_line_files)
                 dep_node.edges
@@ -2106,28 +2110,28 @@ let (print_make : deps -> unit) =
   
 let (print_raw : deps -> unit) =
   fun deps  ->
-    let uu____7160 = deps.dep_graph  in
-    match uu____7160 with
+    let uu____7166 = deps.dep_graph  in
+    match uu____7166 with
     | Deps deps1 ->
-        let uu____7164 =
-          let uu____7166 =
+        let uu____7170 =
+          let uu____7172 =
             FStar_Util.smap_fold deps1
               (fun k  ->
                  fun dep_node  ->
                    fun out  ->
-                     let uu____7184 =
-                       let uu____7186 =
-                         let uu____7188 =
+                     let uu____7190 =
+                       let uu____7192 =
+                         let uu____7194 =
                            FStar_List.map dep_to_string dep_node.edges  in
-                         FStar_All.pipe_right uu____7188
+                         FStar_All.pipe_right uu____7194
                            (FStar_String.concat ";\n\t")
                           in
-                       FStar_Util.format2 "%s -> [\n\t%s\n] " k uu____7186
+                       FStar_Util.format2 "%s -> [\n\t%s\n] " k uu____7192
                         in
-                     uu____7184 :: out) []
+                     uu____7190 :: out) []
              in
-          FStar_All.pipe_right uu____7166 (FStar_String.concat ";;\n")  in
-        FStar_All.pipe_right uu____7164 FStar_Util.print_endline
+          FStar_All.pipe_right uu____7172 (FStar_String.concat ";;\n")  in
+        FStar_All.pipe_right uu____7170 FStar_Util.print_endline
   
 let (print_full : deps -> unit) =
   fun deps  ->
@@ -2138,13 +2142,13 @@ let (print_full : deps -> unit) =
       let visited_other_modules = FStar_Util.smap_create (Prims.of_int (41))
          in
       let should_visit lc_module_name =
-        (let uu____7260 =
+        (let uu____7266 =
            FStar_Util.smap_try_find remaining_output_files lc_module_name  in
-         FStar_Option.isSome uu____7260) ||
-          (let uu____7267 =
+         FStar_Option.isSome uu____7266) ||
+          (let uu____7273 =
              FStar_Util.smap_try_find visited_other_modules lc_module_name
               in
-           FStar_Option.isNone uu____7267)
+           FStar_Option.isNone uu____7273)
          in
       let mark_visiting lc_module_name =
         let ml_file_opt =
@@ -2156,31 +2160,31 @@ let (print_full : deps -> unit) =
         match ml_file_opt with
         | FStar_Pervasives_Native.None  -> ()
         | FStar_Pervasives_Native.Some ml_file ->
-            let uu____7310 =
-              let uu____7314 = FStar_ST.op_Bang order  in ml_file ::
-                uu____7314
+            let uu____7316 =
+              let uu____7320 = FStar_ST.op_Bang order  in ml_file ::
+                uu____7320
                in
-            FStar_ST.op_Colon_Equals order uu____7310
+            FStar_ST.op_Colon_Equals order uu____7316
          in
-      let rec aux uu___15_7377 =
-        match uu___15_7377 with
+      let rec aux uu___15_7383 =
+        match uu___15_7383 with
         | [] -> ()
         | lc_module_name::modules_to_extract ->
             let visit_file file_opt =
               match file_opt with
               | FStar_Pervasives_Native.None  -> ()
               | FStar_Pervasives_Native.Some file_name ->
-                  let uu____7405 = deps_try_find deps.dep_graph file_name  in
-                  (match uu____7405 with
+                  let uu____7411 = deps_try_find deps.dep_graph file_name  in
+                  (match uu____7411 with
                    | FStar_Pervasives_Native.None  ->
-                       let uu____7408 =
+                       let uu____7414 =
                          FStar_Util.format2
                            "Impossible: module %s: %s not found"
                            lc_module_name file_name
                           in
-                       failwith uu____7408
+                       failwith uu____7414
                    | FStar_Pervasives_Native.Some
-                       { edges = immediate_deps; color = uu____7412;_} ->
+                       { edges = immediate_deps; color = uu____7418;_} ->
                        let immediate_deps1 =
                          FStar_List.map
                            (fun x  ->
@@ -2189,14 +2193,14 @@ let (print_full : deps -> unit) =
                           in
                        aux immediate_deps1)
                in
-            ((let uu____7421 = should_visit lc_module_name  in
-              if uu____7421
+            ((let uu____7427 = should_visit lc_module_name  in
+              if uu____7427
               then
                 let ml_file_opt = mark_visiting lc_module_name  in
-                ((let uu____7429 = implementation_of deps lc_module_name  in
-                  visit_file uu____7429);
-                 (let uu____7434 = interface_of deps lc_module_name  in
-                  visit_file uu____7434);
+                ((let uu____7435 = implementation_of deps lc_module_name  in
+                  visit_file uu____7435);
+                 (let uu____7440 = interface_of deps lc_module_name  in
+                  visit_file uu____7440);
                  emit_output_file_opt ml_file_opt)
               else ());
              aux modules_to_extract)
@@ -2204,84 +2208,84 @@ let (print_full : deps -> unit) =
       let all_extracted_modules = FStar_Util.smap_keys orig_output_file_map
          in
       aux all_extracted_modules;
-      (let uu____7446 = FStar_ST.op_Bang order  in FStar_List.rev uu____7446)
+      (let uu____7452 = FStar_ST.op_Bang order  in FStar_List.rev uu____7452)
        in
     let sb =
-      let uu____7477 = FStar_BigInt.of_int_fs (Prims.of_int (10000))  in
-      FStar_StringBuffer.create uu____7477  in
+      let uu____7483 = FStar_BigInt.of_int_fs (Prims.of_int (10000))  in
+      FStar_StringBuffer.create uu____7483  in
     let pr str =
-      let uu____7487 = FStar_StringBuffer.add str sb  in
-      FStar_All.pipe_left (fun a1  -> ()) uu____7487  in
+      let uu____7493 = FStar_StringBuffer.add str sb  in
+      FStar_All.pipe_left (fun a1  -> ()) uu____7493  in
     let print_entry target first_dep all_deps =
       pr target; pr ": "; pr first_dep; pr "\\\n\t"; pr all_deps; pr "\n\n"
        in
     let keys = deps_keys deps.dep_graph  in
     let output_file ext fst_file =
       let ml_base_name =
-        let uu____7540 =
-          let uu____7542 =
-            let uu____7546 = FStar_Util.basename fst_file  in
-            check_and_strip_suffix uu____7546  in
-          FStar_Option.get uu____7542  in
-        FStar_Util.replace_chars uu____7540 46 "_"  in
-      let uu____7551 = FStar_String.op_Hat ml_base_name ext  in
-      FStar_Options.prepend_output_dir uu____7551  in
+        let uu____7546 =
+          let uu____7548 =
+            let uu____7552 = FStar_Util.basename fst_file  in
+            check_and_strip_suffix uu____7552  in
+          FStar_Option.get uu____7548  in
+        FStar_Util.replace_chars uu____7546 46 "_"  in
+      let uu____7557 = FStar_String.op_Hat ml_base_name ext  in
+      FStar_Options.prepend_output_dir uu____7557  in
     let norm_path s = FStar_Util.replace_chars s 92 "/"  in
     let output_ml_file f =
-      let uu____7573 = output_file ".ml" f  in norm_path uu____7573  in
+      let uu____7579 = output_file ".ml" f  in norm_path uu____7579  in
     let output_krml_file f =
-      let uu____7585 = output_file ".krml" f  in norm_path uu____7585  in
+      let uu____7591 = output_file ".krml" f  in norm_path uu____7591  in
     let output_cmx_file f =
-      let uu____7597 = output_file ".cmx" f  in norm_path uu____7597  in
+      let uu____7603 = output_file ".cmx" f  in norm_path uu____7603  in
     let cache_file f =
-      let uu____7609 = cache_file_name f  in norm_path uu____7609  in
-    let uu____7611 =
+      let uu____7615 = cache_file_name f  in norm_path uu____7615  in
+    let uu____7617 =
       phase1 deps.file_system_map deps.dep_graph
         deps.interfaces_with_inlining true
        in
-    match uu____7611 with
+    match uu____7617 with
     | (widened,dep_graph) ->
         let all_checked_files =
           FStar_All.pipe_right keys
             (FStar_List.fold_left
                (fun all_checked_files  ->
                   fun file_name  ->
-                    let process_one_key uu____7653 =
+                    let process_one_key uu____7659 =
                       let dep_node =
-                        let uu____7655 =
+                        let uu____7661 =
                           deps_try_find deps.dep_graph file_name  in
-                        FStar_All.pipe_right uu____7655 FStar_Option.get  in
+                        FStar_All.pipe_right uu____7661 FStar_Option.get  in
                       let iface_deps =
-                        let uu____7665 = is_interface file_name  in
-                        if uu____7665
+                        let uu____7671 = is_interface file_name  in
+                        if uu____7671
                         then FStar_Pervasives_Native.None
                         else
-                          (let uu____7676 =
-                             let uu____7680 = lowercase_module_name file_name
+                          (let uu____7682 =
+                             let uu____7686 = lowercase_module_name file_name
                                 in
-                             interface_of deps uu____7680  in
-                           match uu____7676 with
+                             interface_of deps uu____7686  in
+                           match uu____7682 with
                            | FStar_Pervasives_Native.None  ->
                                FStar_Pervasives_Native.None
                            | FStar_Pervasives_Native.Some iface ->
-                               let uu____7692 =
-                                 let uu____7695 =
-                                   let uu____7696 =
+                               let uu____7698 =
+                                 let uu____7701 =
+                                   let uu____7702 =
                                      deps_try_find deps.dep_graph iface  in
-                                   FStar_Option.get uu____7696  in
-                                 uu____7695.edges  in
-                               FStar_Pervasives_Native.Some uu____7692)
+                                   FStar_Option.get uu____7702  in
+                                 uu____7701.edges  in
+                               FStar_Pervasives_Native.Some uu____7698)
                          in
                       let iface_deps1 =
                         FStar_Util.map_opt iface_deps
                           (FStar_List.filter
                              (fun iface_dep  ->
-                                let uu____7713 =
+                                let uu____7719 =
                                   FStar_Util.for_some
                                     (dep_subsumed_by iface_dep)
                                     dep_node.edges
                                    in
-                                Prims.op_Negation uu____7713))
+                                Prims.op_Negation uu____7719))
                          in
                       let norm_f = norm_path file_name  in
                       let files =
@@ -2311,29 +2315,29 @@ let (print_full : deps -> unit) =
                       let files4 = FStar_String.concat "\\\n\t" files3  in
                       let cache_file_name1 = cache_file file_name  in
                       let all_checked_files1 =
-                        let uu____7778 =
-                          let uu____7780 =
-                            let uu____7782 = module_name_of_file file_name
+                        let uu____7784 =
+                          let uu____7786 =
+                            let uu____7788 = module_name_of_file file_name
                                in
-                            FStar_Options.should_be_already_cached uu____7782
+                            FStar_Options.should_be_already_cached uu____7788
                              in
-                          Prims.op_Negation uu____7780  in
-                        if uu____7778
+                          Prims.op_Negation uu____7786  in
+                        if uu____7784
                         then
                           (print_entry cache_file_name1 norm_f files4;
                            cache_file_name1
                            ::
                            all_checked_files)
                         else all_checked_files  in
-                      let uu____7792 =
-                        let uu____7801 = FStar_Options.cmi ()  in
-                        if uu____7801
+                      let uu____7798 =
+                        let uu____7807 = FStar_Options.cmi ()  in
+                        if uu____7807
                         then
                           profile
-                            (fun uu____7822  ->
-                               let uu____7823 = dep_graph_copy dep_graph  in
+                            (fun uu____7828  ->
+                               let uu____7829 = dep_graph_copy dep_graph  in
                                topological_dependences_of'
-                                 deps.file_system_map uu____7823
+                                 deps.file_system_map uu____7829
                                  deps.interfaces_with_inlining [file_name]
                                  widened)
                             "FStar.Parser.Dep.topological_dependences_of_2"
@@ -2352,15 +2356,15 @@ let (print_full : deps -> unit) =
                              | FStar_Pervasives_Native.Some iface_deps2 ->
                                  maybe_widen_deps iface_deps2
                               in
-                           let uu____7861 =
+                           let uu____7867 =
                              FStar_Util.remove_dups
                                (fun x  -> fun y  -> x = y)
                                (FStar_List.append fst_files
                                   fst_files_from_iface)
                               in
-                           (uu____7861, false))
+                           (uu____7867, false))
                          in
-                      match uu____7792 with
+                      match uu____7798 with
                       | (all_fst_files_dep,widened1) ->
                           let all_checked_fst_dep_files =
                             FStar_All.pipe_right all_fst_files_dep
@@ -2370,93 +2374,93 @@ let (print_full : deps -> unit) =
                             FStar_String.concat " \\\n\t"
                               all_checked_fst_dep_files
                              in
-                          ((let uu____7908 = is_implementation file_name  in
-                            if uu____7908
+                          ((let uu____7914 = is_implementation file_name  in
+                            if uu____7914
                             then
-                              ((let uu____7912 =
+                              ((let uu____7918 =
                                   (FStar_Options.cmi ()) && widened1  in
-                                if uu____7912
+                                if uu____7918
                                 then
-                                  ((let uu____7916 = output_ml_file file_name
+                                  ((let uu____7922 = output_ml_file file_name
                                        in
-                                    print_entry uu____7916 cache_file_name1
+                                    print_entry uu____7922 cache_file_name1
                                       all_checked_fst_dep_files_string);
-                                   (let uu____7918 =
+                                   (let uu____7924 =
                                       output_krml_file file_name  in
-                                    print_entry uu____7918 cache_file_name1
+                                    print_entry uu____7924 cache_file_name1
                                       all_checked_fst_dep_files_string))
                                 else
-                                  ((let uu____7923 = output_ml_file file_name
+                                  ((let uu____7929 = output_ml_file file_name
                                        in
-                                    print_entry uu____7923 cache_file_name1
+                                    print_entry uu____7929 cache_file_name1
                                       "");
-                                   (let uu____7926 =
+                                   (let uu____7932 =
                                       output_krml_file file_name  in
-                                    print_entry uu____7926 cache_file_name1
+                                    print_entry uu____7932 cache_file_name1
                                       "")));
                                (let cmx_files =
                                   let extracted_fst_files =
                                     FStar_All.pipe_right all_fst_files_dep
                                       (FStar_List.filter
                                          (fun df  ->
-                                            (let uu____7951 =
+                                            (let uu____7957 =
                                                lowercase_module_name df  in
-                                             let uu____7953 =
+                                             let uu____7959 =
                                                lowercase_module_name
                                                  file_name
                                                 in
-                                             uu____7951 <> uu____7953) &&
-                                              (let uu____7957 =
+                                             uu____7957 <> uu____7959) &&
+                                              (let uu____7963 =
                                                  lowercase_module_name df  in
                                                FStar_Options.should_extract
-                                                 uu____7957)))
+                                                 uu____7963)))
                                      in
                                   FStar_All.pipe_right extracted_fst_files
                                     (FStar_List.map output_cmx_file)
                                    in
-                                let uu____7967 =
-                                  let uu____7969 =
+                                let uu____7973 =
+                                  let uu____7975 =
                                     lowercase_module_name file_name  in
-                                  FStar_Options.should_extract uu____7969  in
-                                if uu____7967
+                                  FStar_Options.should_extract uu____7975  in
+                                if uu____7973
                                 then
                                   let cmx_files1 =
                                     FStar_String.concat "\\\n\t" cmx_files
                                      in
-                                  let uu____7975 = output_cmx_file file_name
+                                  let uu____7981 = output_cmx_file file_name
                                      in
-                                  let uu____7977 = output_ml_file file_name
+                                  let uu____7983 = output_ml_file file_name
                                      in
-                                  print_entry uu____7975 uu____7977
+                                  print_entry uu____7981 uu____7983
                                     cmx_files1
                                 else ()))
                             else
-                              (let uu____7983 =
-                                 (let uu____7987 =
-                                    let uu____7989 =
+                              (let uu____7989 =
+                                 (let uu____7993 =
+                                    let uu____7995 =
                                       lowercase_module_name file_name  in
                                     has_implementation deps.file_system_map
-                                      uu____7989
+                                      uu____7995
                                      in
-                                  Prims.op_Negation uu____7987) &&
+                                  Prims.op_Negation uu____7993) &&
                                    (is_interface file_name)
                                   in
-                               if uu____7983
+                               if uu____7989
                                then
-                                 let uu____7992 =
+                                 let uu____7998 =
                                    (FStar_Options.cmi ()) &&
                                      (widened1 || true)
                                     in
-                                 (if uu____7992
+                                 (if uu____7998
                                   then
-                                    let uu____7996 =
+                                    let uu____8002 =
                                       output_krml_file file_name  in
-                                    print_entry uu____7996 cache_file_name1
+                                    print_entry uu____8002 cache_file_name1
                                       all_checked_fst_dep_files_string
                                   else
-                                    (let uu____8000 =
+                                    (let uu____8006 =
                                        output_krml_file file_name  in
-                                     print_entry uu____8000 cache_file_name1
+                                     print_entry uu____8006 cache_file_name1
                                        ""))
                                else ()));
                            all_checked_files1)
@@ -2465,16 +2469,16 @@ let (print_full : deps -> unit) =
                       "FStar.Parser.Dep.process_one_key") [])
            in
         let all_fst_files =
-          let uu____8014 =
+          let uu____8020 =
             FStar_All.pipe_right keys (FStar_List.filter is_implementation)
              in
-          FStar_All.pipe_right uu____8014
+          FStar_All.pipe_right uu____8020
             (FStar_Util.sort_with FStar_String.compare)
            in
         let all_fsti_files =
-          let uu____8036 =
+          let uu____8042 =
             FStar_All.pipe_right keys (FStar_List.filter is_interface)  in
-          FStar_All.pipe_right uu____8036
+          FStar_All.pipe_right uu____8042
             (FStar_Util.sort_with FStar_String.compare)
            in
         let all_ml_files =
@@ -2483,11 +2487,11 @@ let (print_full : deps -> unit) =
             (FStar_List.iter
                (fun fst_file  ->
                   let mname = lowercase_module_name fst_file  in
-                  let uu____8077 = FStar_Options.should_extract mname  in
-                  if uu____8077
+                  let uu____8083 = FStar_Options.should_extract mname  in
+                  if uu____8083
                   then
-                    let uu____8080 = output_ml_file fst_file  in
-                    FStar_Util.smap_add ml_file_map mname uu____8080
+                    let uu____8086 = output_ml_file fst_file  in
+                    FStar_Util.smap_add ml_file_map mname uu____8086
                   else ()));
           sort_output_files ml_file_map  in
         let all_krml_files =
@@ -2496,8 +2500,8 @@ let (print_full : deps -> unit) =
             (FStar_List.iter
                (fun fst_file  ->
                   let mname = lowercase_module_name fst_file  in
-                  let uu____8107 = output_krml_file fst_file  in
-                  FStar_Util.smap_add krml_file_map mname uu____8107));
+                  let uu____8113 = output_krml_file fst_file  in
+                  FStar_Util.smap_add krml_file_map mname uu____8113));
           sort_output_files krml_file_map  in
         let print_all tag files =
           pr tag;
@@ -2513,15 +2517,15 @@ let (print_full : deps -> unit) =
   
 let (print : deps -> unit) =
   fun deps  ->
-    let uu____8157 = FStar_Options.dep ()  in
-    match uu____8157 with
+    let uu____8163 = FStar_Options.dep ()  in
+    match uu____8163 with
     | FStar_Pervasives_Native.Some "make" -> print_make deps
     | FStar_Pervasives_Native.Some "full" ->
-        profile (fun uu____8166  -> print_full deps)
+        profile (fun uu____8172  -> print_full deps)
           "FStar.Parser.Deps.print_full_deps"
     | FStar_Pervasives_Native.Some "graph" -> print_graph deps.dep_graph
     | FStar_Pervasives_Native.Some "raw" -> print_raw deps
-    | FStar_Pervasives_Native.Some uu____8172 ->
+    | FStar_Pervasives_Native.Some uu____8178 ->
         FStar_Errors.raise_err
           (FStar_Errors.Fatal_UnknownToolForDep, "unknown tool for --dep\n")
     | FStar_Pervasives_Native.None  -> ()
@@ -2533,38 +2537,38 @@ let (print_fsmap :
   fun fsmap  ->
     FStar_Util.smap_fold fsmap
       (fun k  ->
-         fun uu____8227  ->
+         fun uu____8233  ->
            fun s  ->
-             match uu____8227 with
+             match uu____8233 with
              | (v0,v1) ->
-                 let uu____8256 =
-                   let uu____8258 =
+                 let uu____8262 =
+                   let uu____8264 =
                      FStar_Util.format3 "%s -> (%s, %s)" k
                        (FStar_Util.dflt "_" v0) (FStar_Util.dflt "_" v1)
                       in
-                   FStar_String.op_Hat "; " uu____8258  in
-                 FStar_String.op_Hat s uu____8256) ""
+                   FStar_String.op_Hat "; " uu____8264  in
+                 FStar_String.op_Hat s uu____8262) ""
   
 let (module_has_interface : deps -> FStar_Ident.lident -> Prims.bool) =
   fun deps  ->
     fun module_name  ->
-      let uu____8279 =
-        let uu____8281 = FStar_Ident.string_of_lid module_name  in
-        FStar_String.lowercase uu____8281  in
-      has_interface deps.file_system_map uu____8279
+      let uu____8285 =
+        let uu____8287 = FStar_Ident.string_of_lid module_name  in
+        FStar_String.lowercase uu____8287  in
+      has_interface deps.file_system_map uu____8285
   
 let (deps_has_implementation : deps -> FStar_Ident.lident -> Prims.bool) =
   fun deps  ->
     fun module_name  ->
       let m =
-        let uu____8297 = FStar_Ident.string_of_lid module_name  in
-        FStar_String.lowercase uu____8297  in
+        let uu____8303 = FStar_Ident.string_of_lid module_name  in
+        FStar_String.lowercase uu____8303  in
       FStar_All.pipe_right deps.all_files
         (FStar_Util.for_some
            (fun f  ->
               (is_implementation f) &&
-                (let uu____8308 =
-                   let uu____8310 = module_name_of_file f  in
-                   FStar_String.lowercase uu____8310  in
-                 uu____8308 = m)))
+                (let uu____8314 =
+                   let uu____8316 = module_name_of_file f  in
+                   FStar_String.lowercase uu____8316  in
+                 uu____8314 = m)))
   

--- a/src/ocaml-output/FStar_TypeChecker_Common.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Common.ml
@@ -457,7 +457,7 @@ let (check_uvar_ctx_invariant :
   =
   fun reason  ->
     fun r  ->
-      fun should_check  ->
+      fun should_check1  ->
         fun g  ->
           fun bs  ->
             let print_gamma gamma =
@@ -487,11 +487,11 @@ let (check_uvar_ctx_invariant :
                 FStar_Util.format5
                   "Invariant violation: gamma and binders are out of sync\n\treason=%s, range=%s, should_check=%s\n\t\n                               gamma=%s\n\tbinders=%s\n"
                   reason uu____1774
-                  (if should_check then "true" else "false") uu____1776
+                  (if should_check1 then "true" else "false") uu____1776
                   uu____1778
                  in
               failwith uu____1772  in
-            if Prims.op_Negation should_check
+            if Prims.op_Negation should_check1
             then ()
             else
               (let uu____1791 =

--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -5990,7 +5990,7 @@ let (new_implicit_var_aux :
     fun r  ->
       fun env  ->
         fun k  ->
-          fun should_check  ->
+          fun should_check1  ->
             fun meta  ->
               let uu____27719 =
                 FStar_Syntax_Util.destruct k FStar_Parser_Const.range_of_lid
@@ -6018,7 +6018,7 @@ let (new_implicit_var_aux :
                       FStar_Syntax_Syntax.ctx_uvar_typ = k;
                       FStar_Syntax_Syntax.ctx_uvar_reason = reason;
                       FStar_Syntax_Syntax.ctx_uvar_should_check =
-                        should_check;
+                        should_check1;
                       FStar_Syntax_Syntax.ctx_uvar_range = r;
                       FStar_Syntax_Syntax.ctx_uvar_meta = meta
                     }  in

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -115,7 +115,7 @@ let (new_uvar :
         fun gamma  ->
           fun binders  ->
             fun k  ->
-              fun should_check  ->
+              fun should_check1  ->
                 fun meta  ->
                   let ctx_uvar =
                     let uu____570 = FStar_Syntax_Unionfind.fresh ()  in
@@ -126,7 +126,7 @@ let (new_uvar :
                       FStar_Syntax_Syntax.ctx_uvar_typ = k;
                       FStar_Syntax_Syntax.ctx_uvar_reason = reason;
                       FStar_Syntax_Syntax.ctx_uvar_should_check =
-                        should_check;
+                        should_check1;
                       FStar_Syntax_Syntax.ctx_uvar_range = r;
                       FStar_Syntax_Syntax.ctx_uvar_meta = meta
                     }  in

--- a/src/ocaml-output/FStar_Universal.ml
+++ b/src/ocaml-output/FStar_Universal.ml
@@ -1241,92 +1241,111 @@ let (tc_one_file :
                FStar_CheckedFiles.load_module_from_cache env fn  in
              match uu____1508 with
              | FStar_Pervasives_Native.None  ->
-                 ((let uu____1520 =
-                     let uu____1522 = FStar_Parser_Dep.module_name_of_file fn
+                 ((let uu____1530 =
+                     let uu____1532 = FStar_Parser_Dep.module_name_of_file fn
                         in
-                     FStar_Options.should_be_already_cached uu____1522  in
-                   if uu____1520
+                     FStar_Options.should_be_already_cached uu____1532  in
+                   if uu____1530
                    then
-                     let uu____1525 =
-                       let uu____1531 =
+                     let uu____1535 =
+                       let uu____1541 =
                          FStar_Util.format1
                            "Expected %s to already be checked" fn
                           in
                        (FStar_Errors.Error_AlreadyCachedAssertionFailure,
-                         uu____1531)
+                         uu____1541)
                         in
-                     FStar_Errors.raise_err uu____1525
+                     FStar_Errors.raise_err uu____1535
                    else ());
-                  (let uu____1538 =
-                     (let uu____1542 = FStar_Options.codegen ()  in
-                      FStar_Option.isSome uu____1542) &&
+                  (let uu____1548 =
+                     (let uu____1552 = FStar_Options.codegen ()  in
+                      FStar_Option.isSome uu____1552) &&
                        (FStar_Options.cmi ())
                       in
-                   if uu____1538
+                   if uu____1548
                    then
-                     let uu____1546 =
-                       let uu____1552 =
+                     let uu____1556 =
+                       let uu____1562 =
                          FStar_Util.format1
                            "Cross-module inlining expects all modules to be checked first; %s was not checked"
                            fn
                           in
                        (FStar_Errors.Error_AlreadyCachedAssertionFailure,
-                         uu____1552)
+                         uu____1562)
                         in
-                     FStar_Errors.raise_err uu____1546
+                     FStar_Errors.raise_err uu____1556
                    else ());
-                  (let uu____1558 = tc_source_file ()  in
-                   match uu____1558 with
+                  (let uu____1568 = tc_source_file ()  in
+                   match uu____1568 with
                    | (tc_result,mllib,env1) ->
-                       ((let uu____1583 =
-                           (let uu____1587 = FStar_Errors.get_err_count ()
+                       ((let uu____1593 =
+                           (let uu____1597 = FStar_Errors.get_err_count ()
                                in
-                            uu____1587 = Prims.int_zero) &&
+                            uu____1597 = Prims.int_zero) &&
                              ((FStar_Options.lax ()) ||
                                 (FStar_Options.should_verify
                                    ((tc_result.FStar_CheckedFiles.checked_module).FStar_Syntax_Syntax.name).FStar_Ident.str))
                             in
-                         if uu____1583
+                         if uu____1593
                          then
                            FStar_CheckedFiles.store_module_to_cache env1 fn
                              parsing_data tc_result
                          else ());
                         (tc_result, mllib, env1))))
-             | FStar_Pervasives_Native.Some tc_result ->
+             | FStar_Pervasives_Native.Some (tc_result,checked_fname) ->
                  let tcmod = tc_result.FStar_CheckedFiles.checked_module  in
                  let smt_decls = tc_result.FStar_CheckedFiles.smt_decls  in
-                 ((let uu____1606 =
+                 ((let uu____1624 =
                      FStar_Options.dump_module
                        (tcmod.FStar_Syntax_Syntax.name).FStar_Ident.str
                       in
-                   if uu____1606
+                   if uu____1624
                    then
-                     let uu____1609 =
+                     let uu____1627 =
                        FStar_Syntax_Print.modul_to_string tcmod  in
                      FStar_Util.print1 "Module after type checking:\n%s\n"
-                       uu____1609
+                       uu____1627
+                   else ());
+                  (let uu____1633 =
+                     (FStar_Options.should_check_file fn) &&
+                       (let uu____1636 = FStar_Options.codegen ()  in
+                        FStar_Option.isNone uu____1636)
+                      in
+                   if uu____1633
+                   then
+                     ((let uu____1641 =
+                         FStar_Options.debug_at_level_no_module
+                           (FStar_Options.Other "CheckedFiles")
+                          in
+                       if uu____1641
+                       then
+                         FStar_Util.print1
+                           "Updating timestamp on checked file %s\n"
+                           checked_fname
+                       else ());
+                      FStar_Util.touch_file checked_fname)
                    else ());
                   (let extend_tcenv tcmod1 tcenv =
-                     let uu____1629 =
-                       let uu____1634 =
+                     let uu____1665 =
+                       let uu____1670 =
                          FStar_ToSyntax_ToSyntax.add_modul_to_env tcmod1
                            tc_result.FStar_CheckedFiles.mii
                            (FStar_TypeChecker_Normalize.erase_universes tcenv)
                           in
                        FStar_All.pipe_left (with_dsenv_of_tcenv tcenv)
-                         uu____1634
+                         uu____1670
                         in
-                     match uu____1629 with
-                     | (uu____1650,tcenv1) ->
+                     match uu____1665 with
+                     | (uu____1686,tcenv1) ->
                          let env1 =
                            FStar_TypeChecker_Tc.load_checked_module tcenv1
                              tcmod1
                             in
                          (maybe_restore_opts ();
-                          (let uu____1655 =
-                             let uu____1657 = FStar_Options.lax ()  in
-                             Prims.op_Negation uu____1657  in
-                           if uu____1655
+                          (let uu____1691 =
+                             let uu____1693 = FStar_Options.lax ()  in
+                             Prims.op_Negation uu____1693  in
+                           if uu____1691
                            then
                              (FStar_SMTEncoding_Encode.encode_modul_from_cache
                                 env1 tcmod1 smt_decls;
@@ -1336,41 +1355,41 @@ let (tc_one_file :
                       in
                    let env1 =
                      FStar_Profiling.profile
-                       (fun uu____1666  ->
-                          let uu____1667 =
+                       (fun uu____1702  ->
+                          let uu____1703 =
                             with_tcenv_of_env env (extend_tcenv tcmod)  in
-                          FStar_All.pipe_right uu____1667
+                          FStar_All.pipe_right uu____1703
                             FStar_Pervasives_Native.snd)
                        FStar_Pervasives_Native.None
                        "FStar.Universal.extend_tcenv"
                       in
                    let mllib =
-                     let uu____1681 =
-                       ((let uu____1685 = FStar_Options.codegen ()  in
-                         uu____1685 <> FStar_Pervasives_Native.None) &&
+                     let uu____1717 =
+                       ((let uu____1721 = FStar_Options.codegen ()  in
+                         uu____1721 <> FStar_Pervasives_Native.None) &&
                           (FStar_Options.should_extract
                              (tcmod.FStar_Syntax_Syntax.name).FStar_Ident.str))
                          &&
                          ((Prims.op_Negation
                              tcmod.FStar_Syntax_Syntax.is_interface)
                             ||
-                            (let uu____1691 = FStar_Options.codegen ()  in
-                             uu____1691 =
+                            (let uu____1727 = FStar_Options.codegen ()  in
+                             uu____1727 =
                                (FStar_Pervasives_Native.Some
                                   FStar_Options.Kremlin)))
                         in
-                     if uu____1681
+                     if uu____1717
                      then
-                       let uu____1699 = maybe_extract_mldefs tcmod env1  in
-                       match uu____1699 with
+                       let uu____1735 = maybe_extract_mldefs tcmod env1  in
+                       match uu____1735 with
                        | (extracted_defs,_extraction_time) -> extracted_defs
                      else FStar_Pervasives_Native.None  in
-                   let uu____1719 = maybe_extract_ml_iface tcmod env1  in
-                   match uu____1719 with
+                   let uu____1755 = maybe_extract_ml_iface tcmod env1  in
+                   match uu____1755 with
                    | (env2,_time) -> (tc_result, mllib, env2)))
            else
-             (let uu____1741 = tc_source_file ()  in
-              match uu____1741 with
+             (let uu____1777 = tc_source_file ()  in
+              match uu____1777 with
               | (tc_result,mllib,env1) -> (tc_result, mllib, env1)))
   
 let (tc_one_file_for_ide :
@@ -1385,9 +1404,9 @@ let (tc_one_file_for_ide :
       fun fn  ->
         fun parsing_data  ->
           let env1 = env_of_tcenv env  in
-          let uu____1805 = tc_one_file env1 pre_fn fn parsing_data  in
-          match uu____1805 with
-          | (tc_result,uu____1819,env2) ->
+          let uu____1841 = tc_one_file env1 pre_fn fn parsing_data  in
+          match uu____1841 with
+          | (tc_result,uu____1855,env2) ->
               (tc_result, (env2.FStar_Extraction_ML_UEnv.env_tcenv))
   
 let (needs_interleaving : Prims.string -> Prims.string -> Prims.bool) =
@@ -1396,11 +1415,11 @@ let (needs_interleaving : Prims.string -> Prims.string -> Prims.bool) =
       let m1 = FStar_Parser_Dep.lowercase_module_name intf  in
       let m2 = FStar_Parser_Dep.lowercase_module_name impl  in
       ((m1 = m2) &&
-         (let uu____1847 = FStar_Util.get_file_extension intf  in
-          FStar_List.mem uu____1847 ["fsti"; "fsi"]))
+         (let uu____1883 = FStar_Util.get_file_extension intf  in
+          FStar_List.mem uu____1883 ["fsti"; "fsi"]))
         &&
-        (let uu____1856 = FStar_Util.get_file_extension impl  in
-         FStar_List.mem uu____1856 ["fst"; "fs"])
+        (let uu____1892 = FStar_Util.get_file_extension impl  in
+         FStar_List.mem uu____1892 ["fst"; "fs"])
   
 let (tc_one_file_from_remaining :
   Prims.string Prims.list ->
@@ -1413,32 +1432,32 @@ let (tc_one_file_from_remaining :
   fun remaining  ->
     fun env  ->
       fun deps  ->
-        let uu____1899 =
+        let uu____1935 =
           match remaining with
           | intf::impl::remaining1 when needs_interleaving intf impl ->
-              let uu____1940 =
-                let uu____1949 =
+              let uu____1976 =
+                let uu____1985 =
                   FStar_All.pipe_right impl
                     (FStar_Parser_Dep.parsing_data_of deps)
                    in
                 tc_one_file env (FStar_Pervasives_Native.Some intf) impl
-                  uu____1949
+                  uu____1985
                  in
-              (match uu____1940 with
+              (match uu____1976 with
                | (m,mllib,env1) -> (remaining1, (m, mllib, env1)))
           | intf_or_impl::remaining1 ->
-              let uu____1994 =
-                let uu____2003 =
+              let uu____2030 =
+                let uu____2039 =
                   FStar_All.pipe_right intf_or_impl
                     (FStar_Parser_Dep.parsing_data_of deps)
                    in
                 tc_one_file env FStar_Pervasives_Native.None intf_or_impl
-                  uu____2003
+                  uu____2039
                  in
-              (match uu____1994 with
+              (match uu____2030 with
                | (m,mllib,env1) -> (remaining1, (m, mllib, env1)))
           | [] -> failwith "Impossible: Empty remaining modules"  in
-        match uu____1899 with
+        match uu____1935 with
         | (remaining1,(nmods,mllib,env1)) -> (remaining1, nmods, mllib, env1)
   
 let rec (tc_fold_interleave :
@@ -1452,31 +1471,31 @@ let rec (tc_fold_interleave :
   fun deps  ->
     fun acc  ->
       fun remaining  ->
-        let as_list uu___0_2159 =
-          match uu___0_2159 with
+        let as_list uu___0_2195 =
+          match uu___0_2195 with
           | FStar_Pervasives_Native.None  -> []
           | FStar_Pervasives_Native.Some l -> [l]  in
         match remaining with
         | [] -> acc
-        | uu____2176 ->
-            let uu____2180 = acc  in
-            (match uu____2180 with
+        | uu____2212 ->
+            let uu____2216 = acc  in
+            (match uu____2216 with
              | (mods,mllibs,env) ->
-                 let uu____2212 =
+                 let uu____2248 =
                    tc_one_file_from_remaining remaining env deps  in
-                 (match uu____2212 with
+                 (match uu____2248 with
                   | (remaining1,nmod,mllib,env1) ->
-                      ((let uu____2251 =
-                          let uu____2253 =
+                      ((let uu____2287 =
+                          let uu____2289 =
                             FStar_Options.profile_group_by_decls ()  in
-                          Prims.op_Negation uu____2253  in
-                        if uu____2251
+                          Prims.op_Negation uu____2289  in
+                        if uu____2287
                         then
-                          let uu____2256 =
+                          let uu____2292 =
                             FStar_Ident.string_of_lid
                               (nmod.FStar_CheckedFiles.checked_module).FStar_Syntax_Syntax.name
                              in
-                          FStar_Profiling.report_and_clear uu____2256
+                          FStar_Profiling.report_and_clear uu____2292
                         else ());
                        tc_fold_interleave deps
                          ((FStar_List.append mods [nmod]),
@@ -1490,43 +1509,43 @@ let (batch_mode_tc :
   =
   fun filenames  ->
     fun dep_graph1  ->
-      (let uu____2293 =
+      (let uu____2329 =
          FStar_Options.debug_at_level_no_module (FStar_Options.Other "Dep")
           in
-       if uu____2293
+       if uu____2329
        then
          (FStar_Util.print_endline "Auto-deps kicked in; here's some info.";
           FStar_Util.print1
             "Here's the list of filenames we will process: %s\n"
             (FStar_String.concat " " filenames);
-          (let uu____2302 =
-             let uu____2304 =
+          (let uu____2338 =
+             let uu____2340 =
                FStar_All.pipe_right filenames
                  (FStar_List.filter FStar_Options.should_verify_file)
                 in
-             FStar_String.concat " " uu____2304  in
+             FStar_String.concat " " uu____2340  in
            FStar_Util.print1
-             "Here's the list of modules we will verify: %s\n" uu____2302))
+             "Here's the list of modules we will verify: %s\n" uu____2338))
        else ());
       (let env =
-         let uu____2320 = init_env dep_graph1  in
-         FStar_Extraction_ML_UEnv.mkContext uu____2320  in
-       let uu____2321 = tc_fold_interleave dep_graph1 ([], [], env) filenames
+         let uu____2356 = init_env dep_graph1  in
+         FStar_Extraction_ML_UEnv.mkContext uu____2356  in
+       let uu____2357 = tc_fold_interleave dep_graph1 ([], [], env) filenames
           in
-       match uu____2321 with
+       match uu____2357 with
        | (all_mods,mllibs,env1) ->
            (emit mllibs;
             (let solver_refresh env2 =
-               let uu____2365 =
+               let uu____2401 =
                  with_tcenv_of_env env2
                    (fun tcenv  ->
-                      (let uu____2374 =
+                      (let uu____2410 =
                          (FStar_Options.interactive ()) &&
-                           (let uu____2377 = FStar_Errors.get_err_count ()
+                           (let uu____2413 = FStar_Errors.get_err_count ()
                                in
-                            uu____2377 = Prims.int_zero)
+                            uu____2413 = Prims.int_zero)
                           in
-                       if uu____2374
+                       if uu____2410
                        then
                          (tcenv.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.refresh
                            ()
@@ -1535,6 +1554,6 @@ let (batch_mode_tc :
                            ());
                       ((), tcenv))
                   in
-               FStar_All.pipe_left FStar_Pervasives_Native.snd uu____2365  in
+               FStar_All.pipe_left FStar_Pervasives_Native.snd uu____2401  in
              (all_mods, env1, solver_refresh))))
   

--- a/src/parser/FStar.Parser.Dep.fs
+++ b/src/parser/FStar.Parser.Dep.fs
@@ -269,7 +269,15 @@ let cache_file_name =
                                 mname
                                 path
                                 (Options.prepend_cache_dir cache_fn));
-        path
+
+        (* This expression morally just returns [path], but prefers
+         * the path in [expected_cache_file] is possible to give
+         * preference to relative filenames. This is mostly since
+         * GNU make doesn't resolve paths in targets, so we try
+         * to keep target paths relative. See issue #1978. *)
+        if BU.file_exists expected_cache_file && BU.paths_to_same_file path expected_cache_file
+        then expected_cache_file
+        else path
       | None ->
           if mname |> Options.should_be_already_cached
           then

--- a/tests/friends/1/Makefile
+++ b/tests/friends/1/Makefile
@@ -12,7 +12,6 @@ verify-all: $(ALL_CHECKED_FILES)
 
 %.checked:
 	$(FSTAR) --cache_checked_modules $<
-	touch -c $@
 
 clean:
 	rm -f .depend *.checked

--- a/tests/friends/2/Makefile
+++ b/tests/friends/2/Makefile
@@ -12,7 +12,6 @@ verify-all: $(ALL_CHECKED_FILES)
 
 %.checked:
 	$(FSTAR) --cache_checked_modules $<
-	touch -c $@
 
 clean:
 	rm -f .depend *.checked

--- a/tests/friends/3/Makefile
+++ b/tests/friends/3/Makefile
@@ -12,7 +12,6 @@ verify-all: $(ALL_CHECKED_FILES)
 
 %.checked:
 	$(FSTAR) --cache_checked_modules $<
-	touch -c $@
 
 clean:
 	rm -f .depend *.checked

--- a/ulib/Makefile.extract
+++ b/ulib/Makefile.extract
@@ -18,7 +18,6 @@ MY_FSTAR=$(FSTAR) $(OTHERFLAGS) --lax --cache_checked_modules --use_extracted_in
 
 %.checked.lax:
 	$(MY_FSTAR) $< --already_cached "* -$(basename $(notdir $<))"
-	touch -c $@
 
 # And then, in a separate invocation, from each .checked.lax we
 # extract an .ml file

--- a/ulib/gmake/Makefile.tmpl
+++ b/ulib/gmake/Makefile.tmpl
@@ -27,12 +27,10 @@ KREMLIN_EXE=$(PROGRAM).exe
 # a.fst.checked is the binary, checked version of a.fst
 %.fst.checked: %.fst
 	$(MY_FSTAR) $*.fst
-	touch -c $@
 
 # a.fsti.checked is the binary, checked version of a.fsti
 %.fsti.checked: %.fsti
 	$(MY_FSTAR) $*.fsti
-	touch -c $@
 
 # The _tags file is a directive to ocamlbuild
 # The extracted ML files are precious, because you may want to examine them,


### PR DESCRIPTION
This fixes most of #1978 (though we should still talk about improvements there).

There's 3 main changes:
1- When F* finds a good up-to-date checked file for the module it was called on, instead of doing nothing, update the timestamp as if it had written it again. This simplifies the writing of efficient makefiles.

2- Since we now have (1), remove all the `touch -c` calls we had in our makefiles to do that.

3- When run with `--dep`, attempt to use target filenames in the shape the user provided them (be that absolute or relative) instead of using the filename from `.checked` files that were found. My last concern is that `--dep` should not at all depend on existing `.checked` flies, but that's more complicated.

----

With these changes, `ulib/` behaves sanely again. From a clean build (the odd invocation is the way to build a single checked file in ulib).
```
$ FSTAR_HOME=.. make -f Makefile.verify .cache/FStar.Tactics.fst.checked -j4
[DEPEND]
[CHECK     prims.fst]
[CHECK     FStar.Pervasives.Native.fst]
[CHECK     FStar.Pervasives.fsti]
[CHECK     FStar.Classical.fsti]
[CHECK     FStar.Range.fsti]
[CHECK     FStar.Reflection.Types.fsti]
[CHECK     FStar.Reflection.Const.fst]
[CHECK     FStar.Order.fst]
[CHECK     FStar.StrongExcludedMiddle.fst]
[CHECK     FStar.Squash.fsti]
[CHECK     FStar.PropositionalExtensionality.fst]
[CHECK     FStar.List.Tot.Base.fst]
[CHECK     FStar.Tactics.Types.fsti]
[CHECK     FStar.Reflection.Data.fst]
[CHECK     FStar.Tactics.Result.fst]
[CHECK     FStar.Tactics.Effect.fsti]
[CHECK     FStar.List.Tot.Properties.fst]
[CHECK     FStar.Tactics.Builtins.fst]
[CHECK     FStar.Reflection.Basic.fst]
[CHECK     FStar.Reflection.Derived.fst]
[CHECK     FStar.Reflection.Derived.Lemmas.fst]
[CHECK     FStar.Reflection.Formula.fst]
[CHECK     FStar.Reflection.fst]
[CHECK     FStar.Tactics.SyntaxHelpers.fst]
[CHECK     FStar.List.Tot.fst]
[CHECK     FStar.Tactics.Util.fst]
[CHECK     FStar.Tactics.Derived.fst]
[CHECK     FStar.Tactics.Logic.fst]
[CHECK     FStar.Tactics.fst]
guido@fox:~/r/fstar/guido_build/ulib(guido_build)$ FSTAR_HOME=.. make -f Makefile.verify .cache/FStar.Tactics.fst.checked -j4
make: '.cache/FStar.Tactics.fst.checked' is up to date.
guido@fox:~/r/fstar/guido_build/ulib(guido_build)$ touch FStar.Tactics.fst 
guido@fox:~/r/fstar/guido_build/ulib(guido_build)$ FSTAR_HOME=.. make -f Makefile.verify .cache/FStar.Tactics.fst.checked -j4
[DEPEND]
[CHECK     FStar.Tactics.fst]
guido@fox:~/r/fstar/guido_build/ulib(guido_build)$ touch FStar.Tactics.Derived.fst 
guido@fox:~/r/fstar/guido_build/ulib(guido_build)$ FSTAR_HOME=.. make -f Makefile.verify .cache/FStar.Tactics.fst.checked -j4
[DEPEND]
[CHECK     FStar.Tactics.Derived.fst]
[CHECK     FStar.Tactics.Logic.fst]
[CHECK     FStar.Tactics.fst]
guido@fox:~/r/fstar/guido_build/ulib(guido_build)$ touch FStar.Reflection.Derived.fst 
guido@fox:~/r/fstar/guido_build/ulib(guido_build)$ FSTAR_HOME=.. make -f Makefile.verify .cache/FStar.Tactics.fst.checked -j4
[DEPEND]
[CHECK     FStar.Reflection.Derived.fst]
[CHECK     FStar.Reflection.Derived.Lemmas.fst]
[CHECK     FStar.Reflection.Formula.fst]
[CHECK     FStar.Reflection.fst]
[CHECK     FStar.Tactics.SyntaxHelpers.fst]
[CHECK     FStar.Tactics.Derived.fst]
[CHECK     FStar.Tactics.Logic.fst]
[CHECK     FStar.Tactics.fst]
guido@fox:~/r/fstar/guido_build/ulib(guido_build)$ FSTAR_HOME=.. make -f Makefile.verify .cache/FStar.Tactics.fst.checked -j4
make: '.cache/FStar.Tactics.fst.checked' is up to date.
```

----

I expect a discussion that updating the timestamp causes a rebuild of the forward dependencies. Suppose I have modules `A.fst` and `B.fst`, and I just touch the source of `A.fst` without changing it (maybe use git to checkout a branch and come back).

The new behaviour will rebuild both modules (though fast, since the hashes will match). The old behaviour would not update `A.fst.checked`'s timestamp since the hash matches, and the rebuild would stop there.

*However*, this rebuild of `A.fst.checked` will keep happening every time I type `make` until it *does* get updated, since `make` will keep noticing the timestamp difference. Once it does get updated, I'll have to build `B.fst.checked` again *anyway*. That's why we added the `touch`'s in the first place I believe. So I'd much rather do a (fast) rebuild than having this unsynchronized state.

----


Tagging @nikswamy and @aseemr to see if they agree, and @msprotz since I think he wrote the `--dep` code.